### PR TITLE
Fix release workflow to work with repository rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
         
     - name: Get latest tag
       id: get_tag


### PR DESCRIPTION
- Remove problematic direct push to main branch
- Keep version updates only for release artifacts
- Add pull-requests permission for future flexibility
- Releases/tags created via API don't require branch pushes