### PR TITLE
feat: allow custom specs directory via --specs-dir; default to specs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ Or initialize in the current directory:
 specify init --here
 ```
 
+Or with a custom specs directory:
+
+```bash
+specify init --here --specs-dir docs/specs
+```
+
 ![Specify CLI bootstrapping a new project in the terminal](./media/specify_cli.gif)
 
 You will be prompted to select the AI agent you are using. You can also proactively specify it directly in the terminal:
@@ -145,6 +151,9 @@ specify init <project_name> --ai gemini
 specify init <project_name> --ai copilot
 # Or in current directory:
 specify init --here --ai claude
+# Use a custom specs directory (defaults to specs/ if not set)
+specify init <project_name> --specs-dir docs/specs
+specify init --here --specs-dir docs/specs
 ```
 
 The CLI will check if you have Claude Code or Gemini CLI installed. If you do not, or you prefer to get the templates without checking for the right tools, use `--ignore-agent-tools` with your command:
@@ -157,7 +166,6 @@ specify init <project_name> --ai claude --ignore-agent-tools
 
 Go to the project folder and run your AI agent. In our example, we're using `claude`.
 
-![Bootstrapping Claude Code environment](./media/bootstrap-claude-code.gif)
 
 You will know that things are configured correctly if you see the `/specify`, `/plan`, and `/tasks` commands available.
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -27,7 +27,10 @@ check_feature_branch() {
 get_feature_dir() {
     local repo_root="$1"
     local branch="$2"
-    echo "$repo_root/specs/$branch"
+    # Check git config for custom specs directory, default to specs
+    local specs_dir
+    specs_dir=$(git -C "$repo_root" config --local --get spec-kit.specsDir 2>/dev/null || echo "specs")
+    echo "$repo_root/$specs_dir/$branch"
 }
 
 # Get all standard paths for a feature

--- a/scripts/create-new-feature.sh
+++ b/scripts/create-new-feature.sh
@@ -2,12 +2,13 @@
 # Create a new feature with branch, directory structure, and template
 # Usage: ./create-new-feature.sh "feature description"
 #        ./create-new-feature.sh --json "feature description"
+ 
 
 set -e
 
 JSON_MODE=false
 
-# Collect non-flag args
+# Collect non-flag args and parse options
 ARGS=()
 for arg in "$@"; do
     case "$arg" in
@@ -29,7 +30,10 @@ fi
 
 # Get repository root
 REPO_ROOT=$(git rev-parse --show-toplevel)
-SPECS_DIR="$REPO_ROOT/specs"
+
+# Resolve specs base dir from config or default  
+specs_dir=$(git -C "$REPO_ROOT" config --local --get spec-kit.specsDir 2>/dev/null || echo "specs")
+SPECS_DIR="$REPO_ROOT/$specs_dir"
 
 # Create specs directory if it doesn't exist
 mkdir -p "$SPECS_DIR"

--- a/scripts/update-agent-context.sh
+++ b/scripts/update-agent-context.sh
@@ -7,7 +7,8 @@ set -e
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-FEATURE_DIR="$REPO_ROOT/specs/$CURRENT_BRANCH"
+specs_dir=$(git -C "$REPO_ROOT" config --local --get spec-kit.specsDir 2>/dev/null || echo "specs")
+FEATURE_DIR="$REPO_ROOT/$specs_dir/$CURRENT_BRANCH"
 NEW_PLAN="$FEATURE_DIR/plan.md"
 
 # Determine which agent context files to update

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -642,6 +642,7 @@ def init(
     ignore_agent_tools: bool = typer.Option(False, "--ignore-agent-tools", help="Skip checks for AI agent tools like Claude Code"),
     no_git: bool = typer.Option(False, "--no-git", help="Skip git repository initialization"),
     here: bool = typer.Option(False, "--here", help="Initialize project in the current directory instead of creating a new one"),
+    specs_dir: Optional[str] = typer.Option(None, "--specs-dir", help="Directory to store specs (e.g. docs/specs). Saved to git config as spec-kit.specsDir"),
 ):
     """
     Initialize a new Specify project from the latest template.
@@ -662,6 +663,7 @@ def init(
         specify init --ignore-agent-tools my-project
         specify init --here --ai claude
         specify init --here
+        specify init my-project --specs-dir docs/specs
     """
     # Show banner first
     show_banner()
@@ -800,6 +802,10 @@ def init(
     # Final static tree (ensures finished state visible after Live context ends)
     console.print(tracker.render())
     console.print("\n[bold green]Project ready.[/bold green]")
+    
+    # Save specs dir to git config if provided
+    if specs_dir and is_git_repo(project_path):
+        subprocess.run(["git", "-C", str(project_path), "config", "--local", "spec-kit.specsDir", specs_dir])
     
     # Boxed "Next steps" section
     steps_lines = []


### PR DESCRIPTION
## Summary
- Adds --specs-dir to specify init and saves it to git config (spec-kit.specsDir).
- Scripts resolve the specs base directory from git config; default remains specs/.

## Motivation
- Make it easier to align with project documentation structures (e.g., docs/specs) while keeping backwards compatibility.

## Changes
- src/specify_cli/__init__.py: add --specs-dir to init; persist to git config when repo exists.
- scripts/common.sh: get_feature_dir() reads spec-kit.specsDir (fallback to specs).
- scripts/update-agent-context.sh: FEATURE_DIR resolves via spec-kit.specsDir.
- scripts/create-new-feature.sh: SPECS_DIR resolves via spec-kit.specsDir.
- README.md: minimal usage examples and optional post-copy note.

## Usage
- New: uvx --from git+https://github.com/github/spec-kit.git specify init my-app --specs-dir docs/specs
- Here: specify init --here --specs-dir tmp/specs

## Compatibility
- No breaking changes; defaults to specs/ if unset.

## Testing
- Verified end-to-end with the Spec-Driven Development workflow on Claude Code, Gemini CLI and GitHub Copilot
- To test script functionality, the following command executed:
```
uvx --from path/to/spec-kit/ specify init --here --specs-dir docs/specs \
&& rsync -a --delete path/to/spec-kit/scripts/ ./scripts/ \
&& chmod +x ./scripts/*.sh
```
