### PR TITLE
Fix template path in plan command

### DIFF
--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -19,7 +19,7 @@ Given the implementation details provided as an argument, do this:
 3. Read the constitution at `/memory/constitution.md` to understand constitutional requirements.
 
 4. Execute the implementation plan template:
-   - Load `/templates/implementation-plan-template.md` (already copied to IMPL_PLAN path)
+   - Load `/templates/plan-template.md` (already copied to IMPL_PLAN path)
    - Set Input path to FEATURE_SPEC
    - Run the Execution Flow (main) function steps 1-10
    - The template is self-contained and executable


### PR DESCRIPTION
The plan command was referencing `/templates/implementation-plan-template.md`, but the actual template filename is `/templates/plan-template.md`. 