### PR TITLE
fix minor typo in constitution's Article I

### DIFF
--- a/spec-driven.md
+++ b/spec-driven.md
@@ -256,7 +256,7 @@ The constitution defines nine articles that shape every aspect of the developmen
 #### Article I: Library-First Principle
 Every feature must begin as a standalone library—no exceptions. This forces modular design from the start:
 ```
-Every feature in Specify2 MUST begin its existence as a standalone library. 
+Every feature in Specify MUST begin its existence as a standalone library. 
 No feature shall be implemented directly within application code without 
 first being abstracted into a reusable library component.
 ```


### PR DESCRIPTION
This pull request updates the documentation to reflect the correct product name in the constitution's first article. The change ensures consistency in naming conventions throughout the documentation.

* Documentation update: Changed the product name from `Specify2` to `Specify` in Article I to maintain accurate and consistent terminology.