### PR TITLE
feat: add cursor support

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -126,20 +126,38 @@ jobs:
           echo "⚠️ agent_templates/copilot folder not found"
         fi
         
+        # Create Cursor CLI package
+        echo "Creating Cursor CLI package..."
+        mkdir -p sdd-cursor-package
+        cp -r sdd-package-base/* sdd-cursor-package/
+        # Add any agent_templates/cursor files if you have them (optional)
+        # mkdir -p sdd-cursor-package/.cursor
+        # cp -r agent_templates/cursor sdd-cursor-package/.cursor
+        echo "✓ Created Cursor CLI package"
+
+        # Create Cursor IDE package
+        echo "Creating Cursor IDE package..."
+        mkdir -p sdd-cursor-ide-package
+        cp -r sdd-package-base/* sdd-cursor-ide-package/
+        mkdir -p sdd-cursor-ide-package/.cursor/commands
+        generate_commands "cursor-ide" "md" "$ARGUMENTS" "sdd-cursor-ide-package/.cursor/commands"
+        echo "✓ Created Cursor IDE package"
+
         # Create archive files for each package
         echo "Creating archive files..."
         cd sdd-claude-package && zip -r ../spec-kit-template-claude-${{ steps.version.outputs.new_version }}.zip . && cd ..
-        
         cd sdd-gemini-package && zip -r ../spec-kit-template-gemini-${{ steps.version.outputs.new_version }}.zip . && cd ..
-        
         cd sdd-copilot-package && zip -r ../spec-kit-template-copilot-${{ steps.version.outputs.new_version }}.zip . && cd ..
-        
+        cd sdd-cursor-package && zip -r ../spec-kit-template-cursor-${{ steps.version.outputs.new_version }}.zip . && cd ..
+        cd sdd-cursor-ide-package && zip -r ../spec-kit-template-cursor-ide-${{ steps.version.outputs.new_version }}.zip . && cd ..
+
         echo ""
         echo "📦 Packages created:"
         echo "Claude: $(ls -lh spec-kit-template-claude-*.zip | awk '{print $5}')"
         echo "Gemini: $(ls -lh spec-kit-template-gemini-*.zip | awk '{print $5}')"
         echo "Copilot: $(ls -lh spec-kit-template-copilot-*.zip | awk '{print $5}')"
-        echo "Copilot: $(ls -lh sdd-template-copilot-*.zip | awk '{print $5}')"
+        echo "Cursor: $(ls -lh spec-kit-template-cursor-*.zip | awk '{print $5}')"
+        echo "Cursor IDE: $(ls -lh spec-kit-template-cursor-ide-*.zip | awk '{print $5}')"
         
     - name: Generate detailed release notes
       run: |
@@ -164,15 +182,14 @@ jobs:
         cat > release_notes.md << EOF
         Template release ${{ steps.version.outputs.new_version }}
         
-        Updated specification-driven development templates for GitHub Copilot, Claude Code, and Gemini CLI.
+        Updated specification-driven development templates for GitHub Copilot, Claude Code, Gemini CLI, Cursor CLI, and Cursor IDE.
         
         Download the template for your preferred AI assistant:
         - spec-kit-template-copilot-${{ steps.version.outputs.new_version }}.zip
         - spec-kit-template-claude-${{ steps.version.outputs.new_version }}.zip
         - spec-kit-template-gemini-${{ steps.version.outputs.new_version }}.zip  
-        
-        Changes since $LAST_TAG:
-        $COMMITS
+        - spec-kit-template-cursor-${{ steps.version.outputs.new_version }}.zip
+        - spec-kit-template-cursor-ide-${{ steps.version.outputs.new_version }}.zip
         EOF
         
     - name: Create GitHub Release
@@ -185,6 +202,8 @@ jobs:
           spec-kit-template-copilot-${{ steps.version.outputs.new_version }}.zip \
           spec-kit-template-claude-${{ steps.version.outputs.new_version }}.zip \
           spec-kit-template-gemini-${{ steps.version.outputs.new_version }}.zip \
+          spec-kit-template-cursor-${{ steps.version.outputs.new_version }}.zip \
+          spec-kit-template-cursor-ide-${{ steps.version.outputs.new_version }}.zip \
           --title "Spec Kit Templates - $VERSION_NO_V" \
           --notes-file release_notes.md
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,13 +141,27 @@ jobs:
         generate_commands "copilot" "prompt.md" "\$ARGUMENTS" "sdd-copilot-package/.github/prompts"
         echo "Created GitHub Copilot package"
         
+        # Create Cursor CLI package
+        mkdir -p sdd-cursor-package
+        cp -r sdd-package-base/* sdd-cursor-package/
+        mkdir -p sdd-cursor-package/.cursor/commands
+        generate_commands "cursor" "md" "$ARGUMENTS" "sdd-cursor-package/.cursor/commands"
+        echo "Created Cursor CLI package"
+
+        # Create Cursor IDE package
+        mkdir -p sdd-cursor-ide-package
+        cp -r sdd-package-base/* sdd-cursor-ide-package/
+        mkdir -p sdd-cursor-ide-package/.cursor/commands
+        generate_commands "cursor-ide" "md" "$ARGUMENTS" "sdd-cursor-ide-package/.cursor/commands"
+        echo "Created Cursor IDE package"
+
         # Create archive files for each package
         cd sdd-claude-package && zip -r ../spec-kit-template-claude-${{ steps.get_tag.outputs.new_version }}.zip . && cd ..
-        
         cd sdd-gemini-package && zip -r ../spec-kit-template-gemini-${{ steps.get_tag.outputs.new_version }}.zip . && cd ..
-        
         cd sdd-copilot-package && zip -r ../spec-kit-template-copilot-${{ steps.get_tag.outputs.new_version }}.zip . && cd ..
-        
+        cd sdd-cursor-package && zip -r ../spec-kit-template-cursor-${{ steps.get_tag.outputs.new_version }}.zip . && cd ..
+        cd sdd-cursor-ide-package && zip -r ../spec-kit-template-cursor-ide-${{ steps.get_tag.outputs.new_version }}.zip . && cd ..
+
         # List contents for verification
         echo "Claude package contents:"
         unzip -l spec-kit-template-claude-${{ steps.get_tag.outputs.new_version }}.zip | head -10
@@ -155,6 +169,10 @@ jobs:
         unzip -l spec-kit-template-gemini-${{ steps.get_tag.outputs.new_version }}.zip | head -10
         echo "Copilot package contents:"
         unzip -l spec-kit-template-copilot-${{ steps.get_tag.outputs.new_version }}.zip | head -10
+        echo "Cursor CLI package contents:"
+        unzip -l spec-kit-template-cursor-${{ steps.get_tag.outputs.new_version }}.zip | head -10
+        echo "Cursor IDE package contents:"
+        unzip -l spec-kit-template-cursor-ide-${{ steps.get_tag.outputs.new_version }}.zip | head -10
         
     - name: Generate release notes
       if: steps.check_release.outputs.exists == 'false'
@@ -178,12 +196,14 @@ jobs:
         cat > release_notes.md << EOF
         Template release ${{ steps.get_tag.outputs.new_version }}
         
-        Updated specification-driven development templates for GitHub Copilot, Claude Code, and Gemini CLI.
+        Updated specification-driven development templates for GitHub Copilot, Claude Code, Gemini CLI, Cursor CLI, and Cursor IDE.
         
         Download the template for your preferred AI assistant:
         - spec-kit-template-copilot-${{ steps.get_tag.outputs.new_version }}.zip
         - spec-kit-template-claude-${{ steps.get_tag.outputs.new_version }}.zip
         - spec-kit-template-gemini-${{ steps.get_tag.outputs.new_version }}.zip  
+        - spec-kit-template-cursor-${{ steps.get_tag.outputs.new_version }}.zip
+        - spec-kit-template-cursor-ide-${{ steps.get_tag.outputs.new_version }}.zip
         EOF
         
         echo "Generated release notes:"
@@ -200,6 +220,8 @@ jobs:
           spec-kit-template-copilot-${{ steps.get_tag.outputs.new_version }}.zip \
           spec-kit-template-claude-${{ steps.get_tag.outputs.new_version }}.zip \
           spec-kit-template-gemini-${{ steps.get_tag.outputs.new_version }}.zip \
+          spec-kit-template-cursor-${{ steps.get_tag.outputs.new_version }}.zip \
+          spec-kit-template-cursor-ide-${{ steps.get_tag.outputs.new_version }}.zip \
           --title "Spec Kit Templates - $VERSION_NO_V" \
           --notes-file release_notes.md
       env:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Our research and experimentation focus on:
 ## 🔧 Prerequisites
 
 - **Linux/macOS** (or WSL2 on Windows)
-- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Cursor IDE](https://docs.cursor.com/), or [Cursor CLI](https://github.com/getcursor/cursor) (**experimental**)
 - [uv](https://docs.astral.sh/uv/) for package management
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
@@ -143,6 +143,8 @@ You will be prompted to select the AI agent you are using. You can also proactiv
 specify init <project_name> --ai claude
 specify init <project_name> --ai gemini
 specify init <project_name> --ai copilot
+specify init <project_name> --ai cursor-ide  # Cursor IDE 
+specify init <project_name> --ai cursor      # Cursor CLI (experimental)
 # Or in current directory:
 specify init --here --ai claude
 ```

--- a/scripts/update-agent-context.sh
+++ b/scripts/update-agent-context.sh
@@ -14,6 +14,8 @@ NEW_PLAN="$FEATURE_DIR/plan.md"
 CLAUDE_FILE="$REPO_ROOT/CLAUDE.md"
 GEMINI_FILE="$REPO_ROOT/GEMINI.md"
 COPILOT_FILE="$REPO_ROOT/.github/copilot-instructions.md"
+CURSOR_FILE="$REPO_ROOT/CURSOR.md"
+CURSOR_IDE_FILE="$REPO_ROOT/.github/cursor-instructions.md"
 
 # Allow override via argument
 AGENT_TYPE="$1"
@@ -197,20 +199,27 @@ case "$AGENT_TYPE" in
     "copilot")
         update_agent_file "$COPILOT_FILE" "GitHub Copilot"
         ;;
+    "cursor")
+        update_agent_file "$CURSOR_FILE" "Cursor CLI"
+        ;;
+    "cursor-ide")
+        update_agent_file "$CURSOR_IDE_FILE" "Cursor IDE"
+        ;;
     "")
         # Update all existing files
         [ -f "$CLAUDE_FILE" ] && update_agent_file "$CLAUDE_FILE" "Claude Code"
         [ -f "$GEMINI_FILE" ] && update_agent_file "$GEMINI_FILE" "Gemini CLI" 
         [ -f "$COPILOT_FILE" ] && update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-        
+        [ -f "$CURSOR_FILE" ] && update_agent_file "$CURSOR_FILE" "Cursor CLI"
+        [ -f "$CURSOR_IDE_FILE" ] && update_agent_file "$CURSOR_IDE_FILE" "Cursor IDE"
         # If no files exist, create based on current directory or ask user
-        if [ ! -f "$CLAUDE_FILE" ] && [ ! -f "$GEMINI_FILE" ] && [ ! -f "$COPILOT_FILE" ]; then
+        if [ ! -f "$CLAUDE_FILE" ] && [ ! -f "$GEMINI_FILE" ] && [ ! -f "$COPILOT_FILE" ] && [ ! -f "$CURSOR_FILE" ] && [ ! -f "$CURSOR_IDE_FILE" ]; then
             echo "No agent context files found. Creating Claude Code context file by default."
             update_agent_file "$CLAUDE_FILE" "Claude Code"
         fi
         ;;
     *)
-        echo "ERROR: Unknown agent type '$AGENT_TYPE'. Use: claude, gemini, copilot, or leave empty for all."
+        echo "ERROR: Unknown agent type '$AGENT_TYPE'. Use: claude, gemini, copilot, cursor, cursor-ide, or leave empty for all."
         exit 1
         ;;
 esac

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -16,7 +16,7 @@
    → Update Progress Tracking: Initial Constitution Check
 4. Execute Phase 0 → research.md
    → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
-5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, or `GEMINI.md` for Gemini CLI).
+5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, `GEMINI.md` for Gemini CLI, `CURSOR.md` for Cursor CLI, or `.github/cursor-instructions.md` for Cursor IDE).
 6. Re-evaluate Constitution Check section
    → If new violations: Refactor design, return to Phase 1
    → Update Progress Tracking: Post-Design Constitution Check
@@ -171,7 +171,7 @@ ios/ or android/
    - Quickstart test = story validation steps
 
 5. **Update agent file incrementally** (O(1) operation):
-   - Run `/scripts/update-agent-context.sh [claude|gemini|copilot]` for your AI assistant
+   - Run `/scripts/update-agent-context.sh [claude|gemini|copilot|cursor|cursor-ide]` for your AI assistant
    - If exists: Add only NEW tech from current plan
    - Preserve manual additions between markers
    - Update recent changes (keep last 3)


### PR DESCRIPTION
Pictures worth 1000 words

Example of it working in my Cursor IDE
<img width="363" height="330" alt="image" src="https://github.com/user-attachments/assets/8d958072-df38-4b6a-803e-3d2f4d28545f" />
Successful execution of the Cursor IDE option
<img width="886" height="1048" alt="image" src="https://github.com/user-attachments/assets/6978236f-10e3-4806-8824-373c1cc6532c" />
Here's an example release with the new templates
https://github.com/ETNOL/spec-kit/releases/tag/v0.0.1

I don't use Cursor CLI and couldn't find docs on if it supports custom commands so its following Cursor's pattern for their IDE's commands. I'll manually test the CLI side once I get the opportunity. 