### PR TITLE
Use `/usr/bin/env bash` instead of `/bin/bash` for shebang

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Once the implementation step is done, ask Claude Code to try to run the applicat
 If you're having issues with Git authentication on Linux, you can install Git Credential Manager:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 echo "Downloading Git Credential Manager v2.6.1..."
 wget https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.6.1/gcm-linux_amd64.2.6.1.deb

--- a/scripts/check-task-prerequisites.sh
+++ b/scripts/check-task-prerequisites.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check that implementation plan exists and find optional design documents
 # Usage: ./check-task-prerequisites.sh [--json]
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Common functions and variables for all scripts
 
 # Get repository root

--- a/scripts/create-new-feature.sh
+++ b/scripts/create-new-feature.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create a new feature with branch, directory structure, and template
 # Usage: ./create-new-feature.sh "feature description"
 #        ./create-new-feature.sh --json "feature description"

--- a/scripts/get-feature-paths.sh
+++ b/scripts/get-feature-paths.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Get paths for current feature branch without creating anything
 # Used by commands that need to find existing feature files
 

--- a/scripts/setup-plan.sh
+++ b/scripts/setup-plan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Setup implementation plan structure for current branch
 # Returns paths needed for implementation plan generation
 # Usage: ./setup-plan.sh [--json]

--- a/scripts/update-agent-context.sh
+++ b/scripts/update-agent-context.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Incrementally update agent context files based on new feature plan
 # Supports: CLAUDE.md, GEMINI.md, and .github/copilot-instructions.md
 # O(1) operation - only reads current context file and new plan.md


### PR DESCRIPTION
Some systems like NixOS don't have `/bin/bash`.
Ref: https://discourse.nixos.org/t/add-bin-bash-to-avoid-unnecessary-pain/5673

This changes allow to run scripts in those systems.

Fixes #43.