### PR TITLE
Remove trailing whitespace from tasks.md template

### DIFF
--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -13,10 +13,10 @@ Given the context provided as an argument, do this:
 2. Load and analyze available design documents:
    - Always read plan.md for tech stack and libraries
    - IF EXISTS: Read data-model.md for entities
-   - IF EXISTS: Read contracts/ for API endpoints  
+   - IF EXISTS: Read contracts/ for API endpoints
    - IF EXISTS: Read research.md for technical decisions
    - IF EXISTS: Read quickstart.md for test scenarios
-   
+
    Note: Not all projects have all documents. For example:
    - CLI tools might not have contracts/
    - Simple libraries might not need data-model.md


### PR DESCRIPTION
  ## Summary
  Remove trailing whitespace from tasks.md template to improve code consistency.

  ## What changed
  - Cleaned up trailing spaces in `templates/commands/tasks.md`
  - Fixed line ending inconsistencies