### PR TITLE
docs: Fix bad link in README.md for Detailed Walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Our research and experimentation focus on:
 
 - Validate the concept of parallel implementation exploration
 - Provide robust iterative feature development workflows
-- Extend processes to handle upgrades and modernization tasks  
+- Extend processes to handle upgrades and modernization tasks
 
 ## 🔧 Prerequisites
 
@@ -118,7 +118,7 @@ Our research and experimentation focus on:
 ## 📖 Learn more
 
 - **[Complete Spec-Driven Development Methodology](./spec-driven.md)** - Deep dive into the full process
-- **[Detailed Walkthrough](#detailed-process)** - Step-by-step implementation guide
+- **[Detailed Walkthrough](#-detailed-process)** - Step-by-step implementation guide
 
 ---
 


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file, specifically fixing the anchor link for the "Detailed Walkthrough" section to ensure it navigates correctly.