### PR TITLE
fix: support Claude CLI installed via migrate-installer

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -332,6 +332,17 @@ def run_command(cmd: list[str], check_return: bool = True, capture: bool = False
 
 def check_tool(tool: str, install_hint: str) -> bool:
     """Check if a tool is installed."""
+    
+    # Special handling for Claude CLI after `claude migrate-installer`
+    # See: https://github.com/github/spec-kit/issues/123
+    # The migrate-installer command REMOVES the original executable from PATH
+    # and creates an alias at ~/.claude/local/claude instead
+    # This path should be prioritized over other claude executables in PATH
+    if tool == "claude":
+        claude_local_path = Path.home() / ".claude" / "local" / "claude"
+        if claude_local_path.exists() and claude_local_path.is_file():
+            return True
+    
     if shutil.which(tool):
         return True
     else:


### PR DESCRIPTION
After running `claude migrate-installer`, the Claude executable is moved from PATH to ~/.claude/local/claude. This change updates `check_tool()` to prioritize checking this local path before falling back to PATH lookup.

close: #123