### PR TITLE
Refactor HTTP client usage to utilize truststore for SSL context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "httpx",
     "platformdirs",
     "readchar",
+    "truststore>=0.10.4",
 ]
 
 [project.scripts]


### PR DESCRIPTION
When `specify` command is run behind a proxy (enterprise proxy like zscalar, or anti-virus web scan proxy, etc.), it hangs on `Fetch latest release` step, saying "contacting GitHub API". This PR fixes that issue with the use of local truststore with `httpx` and makes it work provided python is cert settings are configured according to the proxy provider's documentation. For example: https://help.zscaler.com/zia/adding-custom-certificate-application-specific-trust-store