### PR TITLE
docs: Add claude PATH troubleshooting section

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,6 +51,20 @@ After initialization, you should see the following commands available in your AI
 
 ## Troubleshooting
 
+### Claude CLI Not Found Error
+
+If you have Claude installed but see `⚠️  claude not found`, the installation cannot find the `claude` command in PATH.
+
+**Quick fix:**
+```bash
+PATH="$HOME/.claude/local:$PATH" uvx --from git+https://github.com/github/spec-kit.git specify init --here
+```
+
+**Other solutions:**
+- Find claude location: `which claude`
+- Add to shell permanently: `export PATH="$HOME/.claude/local:$PATH"` in `~/.bashrc`/`~/.zshrc`
+- Create symlink: `ln -s ~/.claude/local/claude /usr/local/bin/claude`
+
 ### Git Credential Manager on Linux
 
 If you're having issues with Git authentication on Linux, you can install Git Credential Manager:


### PR DESCRIPTION
## Summary
- Adds troubleshooting section for "claude not found" error when using uvx
- Documents PATH-based solution for subprocess environments that don't inherit shell aliases
- Includes alternative solutions for permanent PATH setup and symlinks

## Problem
Users with Claude installed were encountering `⚠️  claude not found` errors when running:
```bash
uvx --from git+https://github.com/github/spec-kit.git specify init --here
```

This occurs because uvx creates subprocess environments that don't inherit shell aliases, and claude is often installed in non-standard PATH locations.

## Solution
Added concise troubleshooting section with:
- Quick fix using PATH prefix
- Alternative solutions for permanent setup
- Clear indication this applies when Claude is installed but not found

## Testing
All documented solutions were tested and verified to work correctly.