### PR TITLE
feat: Add update command to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@ wheels/
 venv/
 ENV/
 env/
-.venv
+.venv/
+
+test_project/
 
 # IDE
 .vscode/
@@ -38,3 +40,7 @@ env/
 .env
 .env.local
 *.lock
+
+
+# Spec-kit manifest for updates
+.spec-kit/

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Our research and experimentation focus on:
 ## 📖 Learn more
 
 - **[Complete Spec-Driven Development Methodology](./spec-driven.md)** - Deep dive into the full process
+- **[CLI Commands](./docs/cli-commands.md)** - Detailed documentation for the `specify-cli` tool.
 - **[Detailed Walkthrough](#-detailed-process)** - Step-by-step implementation guide
 
 ---

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,0 +1,48 @@
+# CLI Commands
+
+The `specify` command-line interface (CLI) is a tool for initializing and managing `spec-kit` projects.
+
+## `specify init`
+
+Initializes a new `spec-kit` project.
+
+### Usage
+
+```bash
+specify init [PROJECT_NAME] [OPTIONS]
+```
+
+### Arguments
+
+-   `PROJECT_NAME`: The name of the new project directory. If not provided, you must use the `--here` flag.
+
+### Options
+
+-   `--ai [claude|gemini|copilot]`: The AI assistant to use.
+-   `--ignore-agent-tools`: Skip checks for AI agent tools.
+-   `--no-git`: Skip git repository initialization.
+-   `--here`: Initialize the project in the current directory.
+
+## `specify update`
+
+Updates an existing `spec-kit` project with the latest templates.
+
+### Usage
+
+```bash
+specify update [OPTIONS]
+```
+
+### Options
+
+-   `--force`: Force the update without confirmation.
+
+## `specify check`
+
+Checks that all required tools for `spec-kit` are installed.
+
+### Usage
+
+```bash
+specify check
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Spec-Driven Development **flips the script** on traditional software development
 
 - [Installation Guide](installation.md)
 - [Quick Start Guide](quickstart.md)
+- [CLI Commands](cli-commands.md)
 
 ## Core Philosophy
 


### PR DESCRIPTION
This commit introduces a new `update` command to the `specify-cli`.

The `update` command allows users to update their existing `spec-kit` projects with the latest templates from the `spec-kit` repository.

This commit also includes the following changes:
- The `init` command now creates a `.spec-kit/manifest.json` file to track template files and the selected AI assistant.
- The `.spec-kit` directory is now ignored by Git.
- A new `docs/cli-commands.md` file has been created to document the CLI commands.
- Links to the new documentation have been added to `README.md` and `docs/index.md`.