### PR TITLE
feat: Add Kilo Code AI assistant support to Spec Kit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,8 @@ jobs:
           - spec-kit-template-gemini-ps-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-cursor-sh-${{ steps.get_tag.outputs.new_version }}.zip
           - spec-kit-template-cursor-ps-${{ steps.get_tag.outputs.new_version }}.zip
+          - spec-kit-template-kilocode-sh-${{ steps.get_tag.outputs.new_version }}.zip
+          - spec-kit-template-kilocode-ps-${{ steps.get_tag.outputs.new_version }}.zip
           EOF
           
           echo "Generated release notes:"
@@ -104,7 +106,7 @@ jobs:
           # Remove 'v' prefix from version for release title
           VERSION_NO_V=${{ steps.get_tag.outputs.new_version }}
           VERSION_NO_V=${VERSION_NO_V#v}
-          
+
           gh release create ${{ steps.get_tag.outputs.new_version }} \
             spec-kit-template-copilot-sh-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-copilot-ps-${{ steps.get_tag.outputs.new_version }}.zip \
@@ -114,6 +116,8 @@ jobs:
             spec-kit-template-gemini-ps-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-cursor-sh-${{ steps.get_tag.outputs.new_version }}.zip \
             spec-kit-template-cursor-ps-${{ steps.get_tag.outputs.new_version }}.zip \
+            spec-kit-template-kilocode-sh-${{ steps.get_tag.outputs.new_version }}.zip \
+            spec-kit-template-kilocode-ps-${{ steps.get_tag.outputs.new_version }}.zip \
             --title "Spec Kit Templates - $VERSION_NO_V" \
             --notes-file release_notes.md
         env:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The `specify` command supports the following options:
 | Argument/Option        | Type     | Description                                                                  |
 |------------------------|----------|------------------------------------------------------------------------------|
 | `<project-name>`       | Argument | Name for your new project directory (optional if using `--here`)            |
-| `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, or `cursor`             |
+| `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, `cursor`, or `kilocode` |
 | `--script`             | Option   | Script variant to use: `sh` (bash/zsh) or `ps` (PowerShell)                 |
 | `--ignore-agent-tools` | Flag     | Skip checks for AI agent tools like Claude Code                             |
 | `--no-git`             | Flag     | Skip git repository initialization                                          |
@@ -107,6 +107,9 @@ specify init my-project --ai claude
 
 # Initialize with Cursor support
 specify init my-project --ai cursor
+
+# Initialize with Kilo Code support
+specify init my-project --ai kilocode
 
 # Initialize with PowerShell scripts (Windows/cross-platform)
 specify init my-project --ai copilot --script ps
@@ -170,7 +173,7 @@ Our research and experimentation focus on:
 ## 🔧 Prerequisites
 
 - **Linux/macOS** (or WSL2 on Windows)
-- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), or [Cursor](https://cursor.sh/)
+- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Cursor](https://cursor.sh/), or [Kilo Code](https://kilocode.ai/)
 - [uv](https://docs.astral.sh/uv/) for package management
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)


### PR DESCRIPTION
## Summary

Add comprehensive support for Kilo Code as a new AI assistant option in Spec Kit, enabling users to bootstrap spec-driven development projects with seamless Kilo Code integration.

## Changes

### New Features
- **CLI Support**: Add `kilocode` option to `--ai` parameter with full validation
- **Dynamic Mode Generation**: Implement `generate_kilocode_modes_from_templates()` function that converts existing command templates to Kilo Code's JSON format (`.kilocodemodes` file)
- **Cross-Platform Compatibility**: Support both bash/zsh and PowerShell script variants
- **Template Integration**: Automatic generation of custom modes for `/specify`, `/plan`, and `/tasks` commands

### Technical Implementation
- **Core Logic**: Added Kilo Code mode generation to the `specify init` workflow alongside existing AI assistant integrations (Claude, Gemini, Copilot, Cursor)
- **UI Updates**: Enhanced help text and next steps instructions for Kilo Code users
- **Release Process**: Include Kilo Code template variants (`kilocode-sh` and `kilocode-ps`) in GitHub release workflow
- **Documentation**: Updated README with Kilo Code examples and prerequisites

### Files Modified
- `src/specify_cli/__init__.py`: Core implementation and UI updates
- `README.md`: Documentation and CLI examples
- `.github/workflows/release.yml`: Release process updates

## Usage

Users can now initialize Spec Kit projects with Kilo Code support:

```bash
specify init my-project --ai kilocode
