### PR TITLE
fix: commands format for qwen

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -145,7 +145,7 @@ build_variant() {
       generate_commands cursor md "\$ARGUMENTS" "$base_dir/.cursor/commands" "$script" ;;
     qwen)
       mkdir -p "$base_dir/.qwen/commands"
-      generate_commands qwen md "\$ARGUMENTS" "$base_dir/.qwen/commands" "$script"
+      generate_commands qwen toml "{{args}}" "$base_dir/.qwen/commands" "$script"
       [[ -f agent_templates/qwen/QWEN.md ]] && cp agent_templates/qwen/QWEN.md "$base_dir/QWEN.md" ;;
     opencode)
       mkdir -p "$base_dir/.opencode/command"


### PR DESCRIPTION
## Summary

`qwen-code` as a fork of `gemini-cli,` uses the same TOML format as command definitions.

## Test Plan

* `uv run specify init specify-demo --ai qwen` creates the template of toml commands.
* All subsequent specify operations should proceed as usual.
