### PR TITLE
🚧 [WIP] Add Terminal Bench benchmarking workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Global code owner
 * @localden
+/benchmarks @adam-paterson

--- a/README.md
+++ b/README.md
@@ -190,13 +190,16 @@ managed with uv and keeps heavy benchmarking dependencies separate from the main
 ```bash
 cd benchmarks/terminal_bench_agent
 uv sync
-ANTHROPIC_API_KEY=... uv run tb run \
+uv run tb run \
+  --dataset terminal-bench-core==head \
   --task-id hello-world \
-  --agent-import-path specify_terminal_bench.agent:SpecifyClaudeWorkflowAgent
+  --agent-import-path specify_terminal_bench.agent:SpecifyOpenCodeWorkflowAgent
 ```
 
-See [`benchmarks/terminal_bench_agent/README.md`](benchmarks/terminal_bench_agent/README.md)
-for more options (model selection, additional agent kwargs, troubleshooting).
+Set provider credentials only if you switch to a paid model (for example export
+`ANTHROPIC_API_KEY` before using the Claude workflow agent). See
+[`benchmarks/terminal_bench_agent/README.md`](benchmarks/terminal_bench_agent/README.md)
+for detailed options and overrides.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [🎯 Experimental goals](#-experimental-goals)
 - [🔧 Prerequisites](#-prerequisites)
 - [📖 Learn more](#-learn-more)
+- [📊 Benchmarking with Terminal Bench](#-benchmarking-with-terminal-bench)
 - [📋 Detailed process](#-detailed-process)
 - [🔍 Troubleshooting](#-troubleshooting)
 - [👥 Maintainers](#-maintainers)
@@ -179,6 +180,23 @@ Our research and experimentation focus on:
 
 - **[Complete Spec-Driven Development Methodology](./spec-driven.md)** - Deep dive into the full process
 - **[Detailed Walkthrough](#-detailed-process)** - Step-by-step implementation guide
+
+## 📊 Benchmarking with Terminal Bench
+
+Benchmark the Specify workflow without impacting end users by using the standalone
+Terminal Bench agent that lives in `benchmarks/terminal_bench_agent`. The project is
+managed with uv and keeps heavy benchmarking dependencies separate from the main CLI.
+
+```bash
+cd benchmarks/terminal_bench_agent
+uv sync
+ANTHROPIC_API_KEY=... uv run tb run \
+  --task-id hello-world \
+  --agent-import-path specify_terminal_bench.agent:SpecifyClaudeWorkflowAgent
+```
+
+See [`benchmarks/terminal_bench_agent/README.md`](benchmarks/terminal_bench_agent/README.md)
+for more options (model selection, additional agent kwargs, troubleshooting).
 
 ---
 

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+runs/

--- a/benchmarks/terminal_bench_agent/README.md
+++ b/benchmarks/terminal_bench_agent/README.md
@@ -1,0 +1,57 @@
+# Specify Terminal Bench Agent
+
+This package contains a Terminal Bench agent that wraps the stock Claude Code runner
+with the Specify spec -> plan -> tasks workflow. It allows you to benchmark the
+prompt set that ships with the Specify CLI without bundling the benchmarking tooling
+into the end-user package.
+
+## Project layout
+
+```
+benchmarks/
+  terminal_bench_agent/
+    pyproject.toml         # standalone uv project for benchmarking-only deps
+    README.md              # this guide
+    specify_terminal_bench/
+      agent.py             # SpecifyClaudeWorkflowAgent definition
+      __init__.py          # package export
+      prompt_templates/
+        specify_workflow.j2  # Spec->Plan->Tasks instruction template
+```
+
+## Getting started
+
+1. Create an isolated environment for the benchmarking tools:
+   ```bash
+   cd benchmarks/terminal_bench_agent
+   uv sync
+   ```
+2. Export the credentials required by your target CLI agent (for Claude Code this is
+   `ANTHROPIC_API_KEY`; optionally set `ANTHROPIC_MODEL`).
+3. Run Terminal Bench with the Specify workflow agent:
+   ```bash
+   uv run tb run \
+     --task-id hello-world \
+     --agent-import-path specify_terminal_bench.agent:SpecifyClaudeWorkflowAgent \
+     --agent-kwarg model_name=anthropic/claude-3-5-sonnet-20241022
+   ```
+   Replace the model with any Claude Code release supported in your account.
+
+## Customisation
+
+- The prompt template lives at
+  `specify_terminal_bench/prompt_templates/specify_workflow.j2`. Modify this file to
+  tweak the stage instructions or add additional guardrails.
+- Runtime keyword arguments passed via `--agent-kwarg` are forwarded to the underlying
+  `ClaudeCodeAgent`. For example you can select a different model or version.
+- To experiment with other Terminal Bench agents (e.g. Codex, Cursor) you can subclass
+  their installed-agent wrappers and point them at the same prompt template.
+
+## Tips
+
+- Terminal Bench requires Python 3.12+. The dedicated project keeps this dependency
+  separate from the end-user CLI which still targets Python 3.11.
+- The agent expects to run from the repository root so that the prompt template can
+  locate constitution files and other assets via relative paths.
+- `uv run tb --help` lists the available subcommands, including utilities for listing
+  tasks and resuming interrupted runs.

--- a/benchmarks/terminal_bench_agent/pyproject.toml
+++ b/benchmarks/terminal_bench_agent/pyproject.toml
@@ -17,3 +17,4 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["specify_terminal_bench"]
+include = ["specify_terminal_bench/**"]

--- a/benchmarks/terminal_bench_agent/pyproject.toml
+++ b/benchmarks/terminal_bench_agent/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "specify-terminal-bench-agent"
+version = "0.1.0"
+description = "Terminal Bench agent that applies the Specify spec-driven workflow"
+requires-python = ">=3.12"
+dependencies = [
+    "terminal-bench>=0.2.17",
+]
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["specify_terminal_bench"]

--- a/benchmarks/terminal_bench_agent/specify_terminal_bench/__init__.py
+++ b/benchmarks/terminal_bench_agent/specify_terminal_bench/__init__.py
@@ -1,0 +1,3 @@
+from .agent import SpecifyClaudeWorkflowAgent
+
+__all__ = ["SpecifyClaudeWorkflowAgent"]

--- a/benchmarks/terminal_bench_agent/specify_terminal_bench/__init__.py
+++ b/benchmarks/terminal_bench_agent/specify_terminal_bench/__init__.py
@@ -1,3 +1,3 @@
-from .agent import SpecifyClaudeWorkflowAgent
+from .agent import SpecifyClaudeWorkflowAgent, SpecifyOpenCodeWorkflowAgent
 
-__all__ = ["SpecifyClaudeWorkflowAgent"]
+__all__ = ["SpecifyClaudeWorkflowAgent", "SpecifyOpenCodeWorkflowAgent"]

--- a/benchmarks/terminal_bench_agent/specify_terminal_bench/agent.py
+++ b/benchmarks/terminal_bench_agent/specify_terminal_bench/agent.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from terminal_bench.agents.installed_agents.claude_code.claude_code_agent import (
+    ClaudeCodeAgent,
+)
+
+
+class SpecifyClaudeWorkflowAgent(ClaudeCodeAgent):
+    """Claude Code agent preconfigured with the Specify spec -> plan -> tasks prompt.
+
+    The agent reuses the stock Claude installer but injects our prompt template so that
+    benchmark runs automatically follow the specification-driven development workflow.
+    """
+
+    _DEFAULT_TEMPLATE = Path(__file__).parent / "prompt_templates" / "specify_workflow.j2"
+
+    @staticmethod
+    def name() -> str:
+        return "specify_claude_workflow"
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("prompt_template", str(self._DEFAULT_TEMPLATE))
+        super().__init__(*args, **kwargs)

--- a/benchmarks/terminal_bench_agent/specify_terminal_bench/agent.py
+++ b/benchmarks/terminal_bench_agent/specify_terminal_bench/agent.py
@@ -1,25 +1,174 @@
 from __future__ import annotations
 
+import os
+import shlex
+from functools import lru_cache
 from pathlib import Path
+from textwrap import dedent
 
 from terminal_bench.agents.installed_agents.claude_code.claude_code_agent import (
     ClaudeCodeAgent,
 )
+from terminal_bench.agents.installed_agents.opencode.opencode_agent import (
+    OpenCodeAgent,
+)
 
 
-class SpecifyClaudeWorkflowAgent(ClaudeCodeAgent):
-    """Claude Code agent preconfigured with the Specify spec -> plan -> tasks prompt.
+def _repo_root() -> Path:
+    """Return the root of the Spec Kit repository."""
 
-    The agent reuses the stock Claude installer but injects our prompt template so that
-    benchmark runs automatically follow the specification-driven development workflow.
-    """
+    return Path(__file__).resolve().parents[4]
 
-    _DEFAULT_TEMPLATE = Path(__file__).parent / "prompt_templates" / "specify_workflow.j2"
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text()
+    except FileNotFoundError as exc:  # pragma: no cover - fail fast during benchmarks
+        raise RuntimeError(
+            f"Required prompt asset missing: {path}"
+        ) from exc
+
+
+@lru_cache(maxsize=1)
+def _prompt_assets() -> dict[str, str]:
+    """Load the canonical Spec -> Plan -> Tasks prompts and templates."""
+
+    root = _repo_root()
+    return {
+        "spec_command": _read_text(root / "templates" / "commands" / "specify.md"),
+        "plan_command": _read_text(root / "templates" / "commands" / "plan.md"),
+        "tasks_command": _read_text(root / "templates" / "commands" / "tasks.md"),
+        "spec_template": _read_text(root / "templates" / "spec-template.md"),
+        "plan_template": _read_text(root / "templates" / "plan-template.md"),
+        "tasks_template": _read_text(root / "templates" / "tasks-template.md"),
+    }
+
+
+def _build_workflow_prompt(instruction: str) -> str:
+    assets = _prompt_assets()
+
+    return dedent(
+        f"""
+        You are the Specify Spec Kit benchmarking agent. Your job is to apply the
+        Spec -> Plan -> Tasks workflow exactly as defined by the CLI prompts before
+        attempting any implementation work in the Terminal Bench task container.
+
+        Task instruction from Terminal Bench:
+        ---
+        {instruction.strip()}
+        ---
+
+        ## Workflow expectations
+        1. Review repository context and any constitutions before acting.
+        2. Produce SPECIFICATION, PLAN, and TASKS sections in that order using the
+           canonical prompts below. Do not start execution until all three are
+           drafted.
+        3. After presenting the tasks list, print `BEGIN EXECUTION` and carry out the
+           tasks sequentially, announcing each task ID as you start and finish.
+        4. Keep artefacts up to date as understanding evolves and run relevant tests
+           before concluding.
+
+        ## Canonical command prompts
+        These excerpts are copied directly from the Specify CLI. Use them verbatim when
+        constructing the SPECIFICATION, PLAN, and TASKS artefacts.
+
+        ### templates/commands/specify.md
+        ```markdown
+        {assets['spec_command'].strip()}
+        ```
+
+        ### templates/commands/plan.md
+        ```markdown
+        {assets['plan_command'].strip()}
+        ```
+
+        ### templates/commands/tasks.md
+        ```markdown
+        {assets['tasks_command'].strip()}
+        ```
+
+        ## Canonical templates
+        Reference these structures while drafting the artefacts so they stay aligned
+        with the Specify CLI outputs.
+
+        ### templates/spec-template.md
+        ```markdown
+        {assets['spec_template'].strip()}
+        ```
+
+        ### templates/plan-template.md
+        ```markdown
+        {assets['plan_template'].strip()}
+        ```
+
+        ### templates/tasks-template.md
+        ```markdown
+        {assets['tasks_template'].strip()}
+        ```
+
+        Proceed only after you have completed the SPECIFICATION, PLAN, and TASKS
+        sections above. Once `BEGIN EXECUTION` has been emitted, follow the plan to
+        completion or explain any blockers.
+        """
+    ).strip()
+
+
+class SpecifyWorkflowMixin:
+    """Override instruction rendering to include Spec Kit workflow guidance."""
+
+    def _render_instruction(self, instruction: str) -> str:  # type: ignore[override]
+        return _build_workflow_prompt(instruction)
+
+
+class SpecifyClaudeWorkflowAgent(SpecifyWorkflowMixin, ClaudeCodeAgent):
+    """Claude Code agent preconfigured with the Spec -> Plan -> Tasks workflow."""
 
     @staticmethod
     def name() -> str:
         return "specify_claude_workflow"
 
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("prompt_template", str(self._DEFAULT_TEMPLATE))
-        super().__init__(*args, **kwargs)
+    def __init__(self, model_name: str | None = None, *args, **kwargs):
+        super().__init__(model_name=model_name, *args, **kwargs)
+
+
+class SpecifyOpenCodeWorkflowAgent(SpecifyWorkflowMixin, OpenCodeAgent):
+    """OpenCode agent that drives the Spec -> Plan -> Tasks workflow."""
+
+    _DEFAULT_MODEL = "opencode/grok-code-fast-1"
+
+    @staticmethod
+    def name() -> str:
+        return "specify_opencode_workflow"
+
+    def __init__(self, model_name: str | None = None, *args, **kwargs):
+        super().__init__(model_name=model_name or self._DEFAULT_MODEL, *args, **kwargs)
+
+    def _render_instruction(self, instruction: str) -> str:  # type: ignore[override]
+        # OpenCode uses stored prompts via `opencode run --command specify`, so pass
+        # through the raw task instruction and let the CLI command wrap it.
+        return instruction
+
+    def _run_agent_commands(self, instruction: str) -> list[TerminalCommand]:
+        escaped_instruction = shlex.quote(instruction)
+        return [
+            TerminalCommand(
+                command=(
+                    f"opencode --model {self._model_name} -p specify run --command specify {escaped_instruction}"
+                ),
+                min_timeout_sec=0.0,
+                max_timeout_sec=float("inf"),
+                block=True,
+                append_enter=True,
+            ),
+        ]
+
+    @property
+    def _env(self) -> dict[str, str]:  # type: ignore[override]
+        if getattr(self, "_provider", None) == "opencode":
+            # OpenCode public models do not require credentials, but allow an
+            # override if the user exports OPENCODE_API_KEY.
+            env: dict[str, str] = {}
+            if "OPENCODE_API_KEY" in os.environ:
+                env["OPENCODE_API_KEY"] = os.environ["OPENCODE_API_KEY"]
+            return env
+        return super()._env

--- a/benchmarks/terminal_bench_agent/specify_terminal_bench/claude-code-setup.sh.j2
+++ b/benchmarks/terminal_bench_agent/specify_terminal_bench/claude-code-setup.sh.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+apt-get update
+apt-get install -y curl
+
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+
+source "$HOME/.nvm/nvm.sh"
+
+nvm install 22
+npm -v
+
+npm install -g @anthropic-ai/claude-code@{{ version }}

--- a/benchmarks/terminal_bench_agent/specify_terminal_bench/opencode-setup.sh.j2
+++ b/benchmarks/terminal_bench_agent/specify_terminal_bench/opencode-setup.sh.j2
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+apt-get update
+apt-get install -y curl git python3 python3-venv
+
+# Install Node ecosystem for OpenCode CLI
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+
+source "$HOME/.nvm/nvm.sh"
+
+nvm install 22
+npm -v
+
+npm i -g opencode-ai@{{ version }}
+
+# Install uv for Specify CLI bootstrap
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+# Bootstrap Specify prompts inside the task repository
+cd /app
+uvx --from git+https://github.com/github/spec-kit.git specify init --no-git --ai opencode --script sh --ignore-agent-tools task-specification

--- a/benchmarks/terminal_bench_agent/specify_terminal_bench/prompt_templates/specify_workflow.j2
+++ b/benchmarks/terminal_bench_agent/specify_terminal_bench/prompt_templates/specify_workflow.j2
@@ -1,0 +1,49 @@
+{# Specify workflow template used by SpecifyClaudeWorkflowAgent #}
+You are the Specify CLI benchmarking agent. You are being evaluated on your ability to run
+a disciplined specification-driven workflow inside a terminal-only environment.
+
+Task instruction from the benchmark:
+{{ instruction }}
+
+Always follow the Spec -> Plan -> Tasks (SPT) workflow *before* writing or editing
+production code. Keep output concise and actionable for terminal use.
+
+Checklist before you begin coding:
+1. Inspect repository metadata (README, docs/, tests/) to understand context.
+2. If a constitution or non-negotiable guidelines file exists (COMMON PATHS:
+   `CONSTITUTION.md`, `/memory/constitution.md`, `.specify/constitution.md`), read it
+   and obey it throughout the session.
+3. Capture any missing information as questions rather than assumptions.
+
+Deliver the following artefacts in your first response *in this order*:
+
+SPECIFICATION
+- Summarise the desired behaviour and the user impact in plain language.
+- Highlight scope boundaries and success criteria.
+- Record open questions as bullet points prefixed with `NEEDS CLARIFICATION:`.
+
+PLAN
+- Produce an ordered implementation strategy (5-10 steps).
+- Note which files you expect to touch and why.
+- Identify validation steps (tests, linters, sanity checks).
+
+TASKS
+- Emit a numbered task list (T001, T002, ...) in dependency order.
+- Tag tasks that can run in parallel with `[P]`.
+- Each task must describe the concrete change plus the command(s) you will run.
+
+After you print the task list, explicitly write `BEGIN EXECUTION` and then carry out
+the tasks sequentially. While executing:
+- Announce the task ID when starting or finishing a task.
+- Keep artefacts up to date (update spec/plan/tasks sections in your messages when the
+  understanding changes).
+- Prefer small, reviewable commits; run repository tests when they exist.
+- Exit paging programs (`less`, editors) immediately after retrieving the needed output.
+
+Completion requirements:
+- All tasks have been executed or intentionally skipped with justification.
+- Tests relevant to the change have been run (and rerun after fixes).
+- Final message contains: summary of changes, test evidence, any follow-up work.
+
+If at any point requirements conflict with the constitution or repository tests fail,
+stop progressing and explain what blocks you.


### PR DESCRIPTION
## Summary
- add standalone benchmarking project under benchmarks/terminal_bench_agent using uv
- introduce Specify workflow mixin and OpenCode agent integration for Spec -> Plan -> Tasks runs
- document benchmark usage in main README and detailed benchmarking README

## TODO
- [ ] Cleanup installed agent runner
- [x] Add ability to specify end user tool to run benchmarks with (claude, opencode, codex)
- [x] Fix "Current directory is not empty" notifications during benchmark test run
- [ ] GitHub Actions for new releases

## Testing
- `uv run tb run --dataset terminal-bench-core==head --task-id hello-world --agent-import-path specify_terminal_bench.agent:SpecifyOpenCodeWorkflowAgent`
- `uv run tb run --dataset deveval==head --task-id python-particle-swarm-optimization-implementation --agent-import-path specify_terminal_bench.agent:SpecifyOpenCodeWorkflowAgent`(fails at dataset fetch due to remote availability)

[![asciicast](https://asciinema.org/a/HMP91OgNwG91WID9wmoryW2M9.svg)](https://asciinema.org/a/HMP91OgNwG91WID9wmoryW2M9)