### PR TITLE
feat(cli): add --force flag for specify init

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -728,6 +728,11 @@ def init(
     script_type: str = typer.Option(None, "--script", help="Script type to use: sh or ps"),
     ignore_agent_tools: bool = typer.Option(False, "--ignore-agent-tools", help="Skip checks for AI agent tools like Claude Code"),
     no_git: bool = typer.Option(False, "--no-git", help="Skip git repository initialization"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Continue even if the target directory already contains files when using --here",
+    ),
     here: bool = typer.Option(False, "--here", help="Initialize project in the current directory instead of creating a new one"),
     skip_tls: bool = typer.Option(False, "--skip-tls", help="Skip SSL/TLS verification (not recommended)"),
     debug: bool = typer.Option(False, "--debug", help="Show verbose diagnostic output for network and extraction failures"),
@@ -775,14 +780,19 @@ def init(
         # Check if current directory has any files
         existing_items = list(project_path.iterdir())
         if existing_items:
-            console.print(f"[yellow]Warning:[/yellow] Current directory is not empty ({len(existing_items)} items)")
-            console.print("[yellow]Template files will be merged with existing content and may overwrite existing files[/yellow]")
-            
-            # Ask for confirmation
-            response = typer.confirm("Do you want to continue?")
-            if not response:
-                console.print("[yellow]Operation cancelled[/yellow]")
-                raise typer.Exit(0)
+            console.print(
+                f"[yellow]Warning:[/yellow] Current directory is not empty ({len(existing_items)} items)"
+            )
+            console.print(
+                "[yellow]Template files will be merged with existing content and may overwrite existing files[/yellow]"
+            )
+
+            if not force:
+                # Ask for confirmation when not forcing the operation
+                response = typer.confirm("Do you want to continue?")
+                if not response:
+                    console.print("[yellow]Operation cancelled[/yellow]")
+                    raise typer.Exit(0)
     else:
         project_path = Path(project_name).resolve()
         # Check if project directory already exists


### PR DESCRIPTION
## Summary
- add a --force option to the specify init command
- allow scripted environments to skip the interactive confirmation when --here and the directory is non-empty

## Reasoning
During the work on #159 and #339 the initialisation of spec-kit in the harness container prompts the user with a warning about existing template files. There was no way to bypass this in non-interactive environments.

## Testing
- uvx --from git+https://github.com/github/spec-kit.git specify init sandbox --ai opencode --script sh --ignore-agent-tools --no-git --force