### PR TITLE
External config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ env/
 .env
 .env.local
 *.lock
+
+# Build artifacts
+spec-kit-template-*-*-v*.zip
+sdd-*-package-*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,36 @@ When working on spec-kit:
 3. Test script functionality in the `scripts/` directory
 4. Ensure memory files (`memory/constitution.md`) are updated if major process changes are made
 
+### Build and install locally
+
+Use these commands to build template ZIPs from your local checkout and run the CLI against them without publishing a release.
+
+- Build on Linux
+
+```bash
+chmod +x .github/workflows/scripts/create-release-packages.sh && \
+.github/workflows/scripts/create-release-packages.sh v0.0.1 && \
+chmod -x .github/workflows/scripts/create-release-packages.sh
+```
+
+- Build on macOS (using Docker for GNU tools)
+
+```bash
+docker run --rm -it -v "$PWD":/w -w /w ubuntu:24.04 bash -lc "apt-get update && apt-get install -y zip && chmod +x .github/workflows/scripts/create-release-packages.sh && .github/workflows/scripts/create-release-packages.sh v0.0.1 && chmod -x .github/workflows/scripts/create-release-packages.sh"
+```
+
+- Install/use the locally built ZIP with uvx
+
+```bash
+SPECIFY_TEMPLATE_ZIP=$SPECIFY_PROJECT_DIR/spec-kit-template-claude-sh-v0.0.1.zip \
+uvx --refresh --no-cache --from $SPECIFY_PROJECT_DIR specify init --here --ai claude --script sh --ignore-agent-tools
+```
+
+Notes:
+- Replace `$SPECIFY_PROJECT_DIR` with the absolute path to your spec-kit working directory.
+- `--refresh --no-cache` ensures uvx does not reuse an older cached build of the CLI.
+- Keep `--ai`/`--script` consistent with the ZIP variant you built.
+
 ## Resources
 
 - [Spec-Driven Development Methodology](./spec-driven.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Use these commands to build template ZIPs from your local checkout and run the C
 
 ```bash
 chmod +x .github/workflows/scripts/create-release-packages.sh && \
-.github/workflows/scripts/create-release-packages.sh v0.0.1 && \
+.github/workflows/scripts/create-release-packages.sh v0.0.1; \
 chmod -x .github/workflows/scripts/create-release-packages.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [⚡ Get started](#-get-started)
 - [📽️ Video Overview](#️-video-overview)
 - [🔧 Specify CLI Reference](#-specify-cli-reference)
+ - [🧩 Configuration](#-configuration)
 - [📚 Core philosophy](#-core-philosophy)
 - [🌟 Development phases](#-development-phases)
 - [🎯 Experimental goals](#-experimental-goals)
@@ -162,6 +163,37 @@ After running `specify init`, your AI coding agent will have access to these sla
 | `/plan`         | Create technical implementation plans with your chosen tech stack     |
 | `/tasks`        | Generate actionable task lists for implementation                     |
 | `/implement`    | Execute all tasks to build the feature according to the plan         |
+
+## 🧩 Configuration
+
+Spec Kit supports external configuration used by all slash commands to locate your constitution and any supplemental documents.
+
+- Lookup order:
+  1) `.specify.yaml` at the project root (if present)
+  2) `config-default.yaml` at the project root (fallback)
+- A minimal default is provided in `config-default.yaml` that sets only the constitution path to keep projects zero‑config by default.
+- A commented, full example is included at the top of `config-default.yaml` showing how to wire in architecture documents, front‑end specs, and other references to enrich the workflow. This example is an enhancement/extension and is not required.
+
+What you can configure under the top‑level `spec-kit` key:
+- `constitution.path`: Path to your constitution document
+- `specify.documents`: Documents to inform the `/specify` phase
+- `plan.documents`, `plan.technical_context`, `plan.additional_research`: Inputs to the `/plan` phase
+- `tasks.documents`: Inputs to the `/tasks` phase
+- `implement.documents`: Inputs to the `/implement` phase
+
+Minimal `.specify.yaml` example:
+```yaml
+spec-kit:
+  - constitution:
+      path: "/memory/constitution.md"
+```
+
+Notes:
+- Paths are resolved relative to your repository root.
+- Missing optional files are noted and skipped.
+- Each slash command loads configuration at start and prints the effective `SPEC_KIT_CONFIG` for operator visibility.
+
+For a deeper dive, see docs/configuration.md.
 
 ## 📚 Core philosophy
 

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -1,0 +1,46 @@
+# Specify default config file
+#
+# Below is a bloated example of a config file.
+#
+#spec-kit:
+#  - constitution:
+#      path: "CONSTITUTION.md"
+#      documents:
+#        - path: "docs/architecture.md"
+#          context: "Documents the architecture of the project and should be considered a primary source of truth."
+#        - path: "docs/ui-architecture.md"
+#          context: "Documents the UI architecture of the project and should be considered a primary source of truth."
+#  - specify:
+#      documents:
+#        - path: "docs/prd.md"
+#          context: "Documents the product requirements and should be considered a primary source of truth."
+#        - path: "docs/front-end-spec.md"
+#          context: "Documents the front-end specifications and should be considered a primary source of truth."
+#  - plan:
+#      technical_context:
+#        - "**Coding Standards**: [NEEDS CLARIFICATION]"
+#      additional_research:
+#        - "Analyse the architecture documents and prepare a summary of the relevant sections as they relate to the implementation of the plan."
+#      documents:
+#        - path: "docs/architecture.md"
+#          context: "Documents the architecture of the project and should be considered a primary source of truth."
+#        - path: "docs/ui-architecture.md"
+#          context: "Documents the UI architecture of the project and should be considered a primary source of truth."
+#        - path: "docs/front-end-spec.md"
+#          context: "Documents the front-end specifications and should be considered a primary source of truth."
+#  - tasks:
+#      documents:
+#        - path: "docs/architecture.md"
+#          context: "Documents the architecture of the project and should be considered a primary source of truth."
+#        - path: "docs/ui-architecture.md"
+#          context: "Documents the UI architecture of the project and should be considered a primary source of truth."
+#        - path: "docs/front-end-spec.md"
+#          context: "Documents the front-end specifications and should be considered a primary source of truth."
+#  - implement:
+#      documents:
+#        - path: "docs/work-flow.md"
+#          context: "Documents the implementation work-flow for the project and should be considered a primary source of truth."
+
+spec-kit:
+  - constitution:
+      path: "/memory/constitution.md"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,180 @@
+# Configuration
+
+Spec Kit supports external configuration that all slash commands read at startup to locate your constitution and any supplemental documents. Configuration is optional — projects work out of the box with a minimal default.
+
+## Lookup Order
+
+When a command runs, it loads configuration in this order:
+- `.specify.yaml` at the repository root (if present)
+- `config-default.yaml` at the repository root (fallback)
+
+If neither file is present, commands rely on hardcoded defaults in templates where applicable.
+
+## Files
+
+- `.specify.yaml` — Your project‑specific configuration. Commit this to your repo if you want to customize behavior.
+- `config-default.yaml` — Ships with Spec Kit. Contains:
+  - A minimal active default (sets only the constitution path) to keep projects zero‑config.
+  - A commented, full example demonstrating how to reference architecture docs, front‑end specs, and other documents. This example is an enhancement/extension and is not required.
+
+## Schema Overview
+
+Configuration is defined under the top‑level `spec-kit` key. The canonical structure is a YAML sequence where each item is a single section object:
+
+```yaml
+spec-kit:
+  - constitution:
+      path: "/memory/constitution.md"
+  - specify:
+      documents:
+        - path: "docs/prd.md"
+          context: "Product requirements"
+  - plan:
+      technical_context:
+        - "**Coding Standards**: [NEEDS CLARIFICATION]"
+      additional_research:
+        - "Analyse the architecture documents and prepare a summary of relevant sections as they relate to the implementation plan."
+      documents:
+        - path: "docs/architecture.md"
+          context: "Primary architecture reference"
+        - path: "docs/ui-architecture.md"
+          context: "UI architecture reference"
+        - path: "docs/front-end-spec.md"
+          context: "Front‑end specifications"
+  - tasks:
+      documents:
+        - path: "docs/architecture.md"
+          context: "Architecture reference"
+        - path: "docs/ui-architecture.md"
+          context: "UI architecture reference"
+        - path: "docs/front-end-spec.md"
+          context: "Front‑end specifications"
+  - implement:
+      documents:
+        - path: "docs/work-flow.md"
+          context: "Implementation workflow reference"
+```
+
+Notes:
+- Paths are resolved relative to the repository root.
+- Missing optional files are noted and skipped by the agent.
+- The commented example above mirrors the structure demonstrated in `config-default.yaml` and is meant as an enhancement; you do not need to include any of it to use Spec Kit.
+
+## Keys and Their Roles
+
+- `constitution.path`
+  - Absolute or repo‑relative path to your constitution Markdown file.
+  - Default (from `config-default.yaml`): `/memory/constitution.md`.
+
+- `specify.documents[]`
+  - Additional documents the `/specify` phase should consider (e.g., PRD, UX notes).
+  - Each item has:
+    - `path`: repo‑relative file path
+    - `context`: short description of how to use the document
+
+- `plan.documents[]`
+  - Design references the `/plan` phase should read (architecture, UI specs, etc.).
+  - Same item shape as `specify.documents`.
+
+- `plan.technical_context[]`
+  - Lines appended to the “Technical Context” section of the plan template. Keep `[NEEDS CLARIFICATION]` markers where appropriate to drive targeted research.
+
+- `plan.additional_research[]`
+  - Independent, plain‑text research instructions executed during Phase 0 of the `/plan` command.
+  - As defined in the plan template (see `templates/plan-template.md`, Phase 0, step 5), each instruction is run separately and its output is appended to `research.md` under a top‑level heading `## Additional Research`.
+  - For each instruction, the agent derives a concise section title from the output (do not repeat the instruction verbatim) and writes a section using the following structure:
+    - `### {Concise Title Derived From Output}`
+    - Summary and details produced by the instruction
+    - References or source notes (if applicable)
+  - Why this is useful: these focused, instruction‑driven sections turn open questions or context gathering (“unknowns”) into explicit, documented findings that inform the rest of Phase 1 (design & contracts) and later `/tasks` generation. For example, the instruction:
+    - "Analyse the architecture documents and prepare a summary of relevant sections as they relate to the implementation plan."
+    will typically yield a section such as:
+    - `### Architecture Implications for Plan`
+      - Key components and boundaries impacting the design
+      - Constraints (e.g., services, data flows, performance goals)
+      - Direct links into tasks (e.g., required services or integration points)
+
+- `tasks.documents[]`
+  - Supplemental references for `/tasks` generation (data model, contracts, UI specs, etc.).
+
+- `implement.documents[]`
+  - Additional references for `/implement` (workflow guides, operations runbooks, etc.).
+
+## Command Behavior and Configuration
+
+Every command loads configuration at the start, extracts the `spec-kit` section into an internal structure, and prints the effective configuration for visibility.
+
+- `/constitution`
+  - Reads `constitution.path` and optional `constitution.documents[]`.
+  - Treats the existing constitution (if found) as a primary source of truth.
+
+- `/specify`
+  - Reads `specify.documents[]` to inform specification writing.
+
+- `/plan`
+  - Reads `plan.documents[]`, `plan.technical_context[]`, and `plan.additional_research[]`.
+  - Uses `constitution.path` to perform the “Constitution Check”.
+
+- `/tasks`
+  - Reads `tasks.documents[]` plus the design artifacts generated in Phase 1 (contracts, data‑model, quickstart).
+
+- `/implement`
+  - Reads `implement.documents[]` and the artifacts produced in previous phases.
+
+## Examples
+
+Minimal (zero‑config) project — rely on defaults:
+```yaml
+spec-kit:
+  - constitution:
+      path: "/memory/constitution.md"
+```
+
+Product team with architecture & frontend specs:
+```yaml
+spec-kit:
+  - constitution:
+      path: "CONSTITUTION.md"
+      documents:
+        - path: "docs/architecture.md"
+          context: "Primary architecture reference"
+        - path: "docs/ui-architecture.md"
+          context: "UI architecture reference"
+  - specify:
+      documents:
+        - path: "docs/prd.md"
+          context: "Product requirements"
+        - path: "docs/front-end-spec.md"
+          context: "Front‑end specifications"
+  - plan:
+      technical_context:
+        - "**Testing**: pytest; CI required"
+        - "**Performance**: p95 < 200ms"
+      additional_research:
+        - "Benchmark ORM options vs raw SQL for our scale"
+      documents:
+        - path: "docs/architecture.md"
+          context: "Architecture reference"
+        - path: "docs/front-end-spec.md"
+          context: "Front‑end specifications"
+```
+
+## Best Practices
+
+- Start minimal; add documents only when they materially improve decision quality.
+- Keep `context` fields concise but directive — explain how the document should influence decisions.
+- Retain `[NEEDS CLARIFICATION]` markers in `plan.technical_context` to drive targeted research tasks.
+- Store stable, versioned references (e.g., link to in‑repo docs, not ephemeral sources).
+
+## Common Pitfalls
+
+- Confusing example with requirement: The commented full example in `config-default.yaml` is optional and not required.
+- Incorrect paths: All paths are resolved relative to the repo root; ensure files exist.
+- Overloading technical context: Keep entries crisp; lengthy prose belongs in dedicated docs referenced via `documents`.
+
+## Verification
+
+When you run a command, look for the printed `SPEC_KIT_CONFIG` in your agent’s output to confirm that your `.specify.yaml` was loaded. If you don’t see your changes reflected:
+- Verify `.specify.yaml` is at the repository root.
+- Validate YAML formatting (indentation, list markers).
+- Confirm there are no filename typos in `path` values.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,14 @@ Spec-Driven Development **flips the script** on traditional software development
 - [Quick Start Guide](quickstart.md)
 - [Local Development](local-development.md)
 
+## Configuration
+
+Commands read configuration from `.specify.yaml` at your project root when present, or fallback to `config-default.yaml` otherwise. The default file includes:
+- A minimal active config (constitution path) to keep things zero‑config.
+- A commented full example showing how to reference architecture docs, front‑end specs, and other materials to enhance the workflow. This example is optional and not required.
+
+See `config-default.yaml` in the repository root and [Configuration](configuration.md) for details.
+
 ## Core Philosophy
 
 Spec-Driven Development is a structured process that emphasizes:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,6 +57,12 @@ If you prefer to get the templates without checking for the right tools:
 uvx --from git+https://github.com/github/spec-kit.git specify init <project_name> --ai claude --ignore-agent-tools
 ```
 
+### Optional: Configure Spec Kit
+
+Commands load configuration from `.specify.yaml` at the project root when present; otherwise they fallback to `config-default.yaml`. The default file:
+- Activates only a minimal setting (constitution path) to keep initialization zero‑config.
+- Includes a commented full example showing how to reference your architecture docs, front‑end specs, and other materials. This example is optional and not required.
+
 ## Verification
 
 After initialization, you should see the following commands available in your AI agent:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,24 @@ uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME
 uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME> --script sh  # Force POSIX shell
 ```
 
+#### Optional: Project configuration
+
+By default, commands will use `config-default.yaml` at the project root. If you need to customize inputs (like where your constitution lives or which documents to read), add a `.specify.yaml`:
+
+```yaml
+spec-kit:
+  - constitution:
+      path: "/memory/constitution.md"
+  - specify:
+      documents:
+        - path: "docs/prd.md"
+          context: "Product requirements"
+```
+
+Notes:
+- Lookup order: `.specify.yaml` → `config-default.yaml`
+- `config-default.yaml` includes a commented full example (architecture docs, front‑end specs, etc.) to enrich the process. This example is an enhancement/extension and is not required.
+
 ### 2. Create the Spec
 
 Use the `/specify` command to describe what you want to build. Focus on the **what** and **why**, not the tech stack.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -9,6 +9,8 @@
       href: installation.md
     - name: Quick Start
       href: quickstart.md
+    - name: Configuration
+      href: configuration.md
 
 # Development workflows
 - name: Development

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -729,7 +729,7 @@ def download_and_extract_template(project_path: Path, ai_assistant: str, script_
                     console.print(f"Cleaned up: {zip_path.name}")
         else:
           tracker.complete("cleanup")
-    
+
     return project_path
 
 

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -3,15 +3,29 @@ description: Create or update the project constitution from interactive or provi
 # (No scripts section: constitution edits are manual authoring assisted by the agent)
 ---
 
-You are updating the project constitution at `/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+You are updating the project constitution at the path specified by `SPEC_KIT_CONFIG.constitution.path`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
 
 Follow this execution flow:
 
-1. Load the existing constitution template at `/memory/constitution.md`.
+1. Load Spec Kit configuration:
+   - Check for `/.specify.yaml` at the host project root; if it exists, load that file
+   - Otherwise load `/config-default.yaml`
+   - Extract the root `spec-kit` entry and store it as `SPEC_KIT_CONFIG`
+   - Output the resulting `SPEC_KIT_CONFIG` for operator visibility
+
+2. If defined, read documents from `SPEC_KIT_CONFIG.constitution.documents`:
+    - For each item, resolve `path` to an absolute path from the repo root
+    - Read the file and consider its `context` to guide constitutional decisions
+    - If a file is missing, note it and continue
+
+3. If the constitution file exists, load the existing constitution at the path specified by `SPEC_KIT_CONFIG.constitution.path`.
+    **IMPORTANT**: Consider the existing constitution as a primary source of truth to resolve placeholders in the constitution template.
+
+4. Load the constitution template at `/memory/constitution.md`.
    - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
    **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
 
-2. Collect/derive values for placeholders:
+5. Collect/derive values for placeholders:
    - If user input (conversation) supplies a value, use it.
    - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
    - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
@@ -21,20 +35,20 @@ Follow this execution flow:
      * PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
    - If version bump type ambiguous, propose reasoning before finalizing.
 
-3. Draft the updated constitution content:
+6. Draft the updated constitution content:
    - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
    - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
    - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
    - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
 
-4. Consistency propagation checklist (convert prior checklist into active validations):
+7. Consistency propagation checklist (convert prior checklist into active validations):
    - Read `/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
    - Read `/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
    - Read `/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
    - Read each command file in `/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
-5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+8. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
    - Version change: old → new
    - List of modified principles (old title → new title if renamed)
    - Added sections
@@ -42,18 +56,18 @@ Follow this execution flow:
    - Templates requiring updates (✅ updated / ⚠ pending) with file paths
    - Follow-up TODOs if any placeholders intentionally deferred.
 
-6. Validation before final output:
+9. Validation before final output:
    - No remaining unexplained bracket tokens.
    - Version line matches report.
    - Dates ISO format YYYY-MM-DD.
    - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
 
-7. Write the completed constitution back to `/memory/constitution.md` (overwrite).
+10. Write the completed constitution back to the path specified by `SPEC_KIT_CONFIG.constitution.path` (overwrite).
 
-8. Output a final summary to the user with:
-   - New version and bump rationale.
-   - Any files flagged for manual follow-up.
-   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+11. Output a final summary to the user with:
+12. New version and bump rationale.
+13. Any files flagged for manual follow-up.
+14. Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
 
 Formatting & Style Requirements:
 - Use Markdown headings exactly as in the template (do not demote/promote levels).
@@ -65,4 +79,6 @@ If the user supplies partial updates (e.g., only one principle revision), still 
 
 If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
 
-Do not create a new template; always operate on the existing `/memory/constitution.md` file.
+Do not create a new template; always operate on the existing file at the path specified by `SPEC_KIT_CONFIG.constitution.path`.
+
+Use absolute paths with the repository root for all file operations to avoid path issues.

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -7,9 +7,20 @@ scripts:
 
 Given the current feature context, do this:
 
-1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
+1. Load Spec Kit configuration:
+   - Check for `/.specify.yaml` at the host project root; if it exists, load that file
+   - Otherwise load `/config-default.yaml`
+   - Extract the root `spec-kit` entry and store it as `SPEC_KIT_CONFIG`
+   - Output the resulting `SPEC_KIT_CONFIG` for operator visibility
 
-2. Load and analyze the implementation context:
+2. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All future file paths must be absolute.
+
+3. If defined, read documents from `SPEC_KIT_CONFIG.implement.documents`:
+   - For each item, resolve `path` to an absolute path from the repo root
+   - Read the file and consider its `context` to guide implementation decisions
+   - If a file is missing, note it and continue
+
+4. Load and analyze the implementation context:
    - **REQUIRED**: Read tasks.md for the complete task list and execution plan
    - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
    - **IF EXISTS**: Read data-model.md for entities and relationships
@@ -17,27 +28,28 @@ Given the current feature context, do this:
    - **IF EXISTS**: Read research.md for technical decisions and constraints
    - **IF EXISTS**: Read quickstart.md for integration scenarios
 
-3. Parse tasks.md structure and extract:
+5. Parse tasks.md structure and extract:
    - **Task phases**: Setup, Tests, Core, Integration, Polish
    - **Task dependencies**: Sequential vs parallel execution rules
    - **Task details**: ID, description, file paths, parallel markers [P]
    - **Execution flow**: Order and dependency requirements
 
-4. Execute implementation following the task plan:
+6. Execute implementation following the task plan:
    - **Phase-by-phase execution**: Complete each phase before moving to the next
    - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
    - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
    - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Code Quality Gates**: Ensure code quality gates are satisfied quickly per task and extensively per phase
    - **Validation checkpoints**: Verify each phase completion before proceeding
 
-5. Implementation execution rules:
+7. Implementation execution rules:
    - **Setup first**: Initialize project structure, dependencies, configuration
    - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
    - **Core development**: Implement models, services, CLI commands, endpoints
    - **Integration work**: Database connections, middleware, logging, external services
-   - **Polish and validation**: Unit tests, performance optimization, documentation
+   - **Polish and validation**: Run code quality gates (e.g. lint and type checking, etc.), tests, performance optimization, documentation
 
-6. Progress tracking and error handling:
+8. Progress tracking and error handling:
    - Report progress after each completed task
    - Halt execution if any non-parallel task fails
    - For parallel tasks [P], continue with successful tasks, report failed ones
@@ -45,7 +57,7 @@ Given the current feature context, do this:
    - Suggest next steps if implementation cannot proceed
    - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
 
-7. Completion validation:
+9. Completion validation:
    - Verify all required tasks are completed
    - Check that implemented features match the original specification
    - Validate that tests pass and coverage meets requirements
@@ -53,3 +65,5 @@ Given the current feature context, do this:
    - Report final status with summary of completed work
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/tasks` first to regenerate the task list.
+
+Use absolute paths with the repository root for all file operations to avoid path issues.

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -7,16 +7,27 @@ scripts:
 
 Given the implementation details provided as an argument, do this:
 
-1. Run `{SCRIPT}` from the repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. All future file paths must be absolute.
-2. Read and analyze the feature specification to understand:
+1. Load Spec Kit configuration:
+   - Check for `/.specify.yaml` at the host project root; if it exists, load that file
+   - Otherwise load `/config-default.yaml`
+   - Extract the root `spec-kit` entry and store it as `SPEC_KIT_CONFIG`
+   - Output the resulting `SPEC_KIT_CONFIG` for operator visibility
+
+2. Run `{SCRIPT}` from the repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. All future file paths must be absolute.
+3. Read and analyze the feature specification to understand:
    - The feature requirements and user stories
    - Functional and non-functional requirements
    - Success criteria and acceptance criteria
    - Any technical constraints or dependencies mentioned
 
-3. Read the constitution at `/memory/constitution.md` to understand constitutional requirements.
+4. If defined, read documents from `SPEC_KIT_CONFIG.plan.documents`:
+   - For each item, resolve `path` to an absolute path from the repo root
+   - Read the file and consider its `context` to guide planning decisions
+   - If a file is missing, note it and continue
 
-4. Execute the implementation plan template:
+5. Read the constitution at the path specified by `SPEC_KIT_CONFIG.constitution.path` to understand constitutional requirements.
+
+6. Execute the implementation plan template:
    - Load `/templates/plan-template.md` (already copied to IMPL_PLAN path)
    - Set Input path to FEATURE_SPEC
    - Run the Execution Flow (main) function steps 1-9
@@ -29,11 +40,11 @@ Given the implementation details provided as an argument, do this:
    - Incorporate user-provided details from arguments into Technical Context: {ARGS}
    - Update Progress Tracking as you complete each phase
 
-5. Verify execution completed:
+7. Verify execution completed:
    - Check Progress Tracking shows all phases complete
    - Ensure all required artifacts were generated
    - Confirm no ERROR states in execution
 
-6. Report results with branch name, file paths, and generated artifacts.
+8. Report results with branch name, file paths, and generated artifacts.
 
 Use absolute paths with the repository root for all file operations to avoid path issues.

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -7,10 +7,26 @@ scripts:
 
 Given the feature description provided as an argument, do this:
 
-1. Run the script `{SCRIPT}` from repo root and parse its JSON output for BRANCH_NAME and SPEC_FILE. All file paths must be absolute.
+1. Load Spec Kit configuration:
+   - Check for `/.specify.yaml` at the host project root; if it exists, load that file
+   - Otherwise load `/config-default.yaml`
+   - Extract the root `spec-kit` entry and store it as `SPEC_KIT_CONFIG`
+   - Output the resulting `SPEC_KIT_CONFIG` for operator visibility
+
+2. Run the script `{SCRIPT}` from the repo root and parse its JSON output for BRANCH_NAME and SPEC_FILE. All future file paths must be absolute.
   **IMPORTANT** You must only ever run this script once. The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for.
-2. Load `templates/spec-template.md` to understand required sections.
-3. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
-4. Report completion with branch name, spec file path, and readiness for the next phase.
+
+3. If defined, read documents from `SPEC_KIT_CONFIG.specify.documents`:
+   - For each item, resolve `path` to an absolute path from the repo root
+   - Read the file and consider its `context` to guide specification details
+   - If a file is missing, note it and continue
+
+4. Load `/templates/spec-template.md` to understand required sections.
+
+5. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+6. Report completion with branch name, spec file path, and readiness for the next phase.
 
 Note: The script creates and checks out the new branch and initializes the spec file before writing.
+
+Use absolute paths with the repository root for all file operations to avoid path issues.

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -7,8 +7,20 @@ scripts:
 
 Given the context provided as an argument, do this:
 
-1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
-2. Load and analyze available design documents:
+1. Load Spec Kit configuration:
+   - Check for `/.specify.yaml` at the host project root; if it exists, load that file
+   - Otherwise load `/config-default.yaml`
+   - Extract the root `spec-kit` entry and store it as `SPEC_KIT_CONFIG`
+   - Output the resulting `SPEC_KIT_CONFIG` for operator visibility
+
+2. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All future file paths must be absolute.
+
+3. If defined, read documents from `SPEC_KIT_CONFIG.tasks.documents`:
+   - For each item, resolve `path` to an absolute path from the repo root
+   - Read the file and consider its `context` to guide task generation decisions
+   - If a file is missing, note it and continue
+
+4. Load and analyze available design documents:
    - Always read plan.md for tech stack and libraries
    - IF EXISTS: Read data-model.md for entities
    - IF EXISTS: Read contracts/ for API endpoints
@@ -20,7 +32,7 @@ Given the context provided as an argument, do this:
    - Simple libraries might not need data-model.md
    - Generate tasks based on what's available
 
-3. Generate tasks following the template:
+5. Generate tasks following the template:
    - Use `/templates/tasks-template.md` as the base
    - Replace example tasks with actual tasks based on:
      * **Setup tasks**: Project init, dependencies, linting
@@ -29,7 +41,7 @@ Given the context provided as an argument, do this:
      * **Integration tasks**: DB connections, middleware, logging
      * **Polish tasks [P]**: Unit tests, performance, docs
 
-4. Task generation rules:
+6. Task generation rules:
    - Each contract file → contract test task marked [P]
    - Each entity in data-model → model creation task marked [P]
    - Each endpoint → implementation task (not parallel if shared files)
@@ -37,7 +49,7 @@ Given the context provided as an argument, do this:
    - Different files = can be parallel [P]
    - Same file = sequential (no [P])
 
-5. Order tasks by dependencies:
+7. Order tasks by dependencies:
    - Setup before everything
    - Tests before implementation (TDD)
    - Models before services
@@ -45,11 +57,11 @@ Given the context provided as an argument, do this:
    - Core before integration
    - Everything before polish
 
-6. Include parallel execution examples:
+8. Include parallel execution examples:
    - Group [P] tasks that can run together
    - Show actual Task agent commands
 
-7. Create FEATURE_DIR/tasks.md with:
+9. Create FEATURE_DIR/tasks.md with:
    - Correct feature name from implementation plan
    - Numbered tasks (T001, T002, etc.)
    - Clear file paths for each task
@@ -59,3 +71,5 @@ Given the context provided as an argument, do this:
 Context for task generation: {ARGS}
 
 The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+Use absolute paths with the repository root for all file operations to avoid path issues.

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -108,12 +108,16 @@ ios/ or android/
 **Structure Decision**: [DEFAULT to Option 1 unless Technical Context indicates web/mobile app]
 
 ## Phase 0: Outline & Research
-1. **Extract unknowns from Technical Context** above:
+1. **Append configured Technical Context additions** (if available):
+   - If `SPEC_KIT_CONFIG.plan.technical_context` exists, append entries not already present in Technical Context
+   - Preserve formatting and `[NEEDS CLARIFICATION]` markers so they flow into research tasks
+
+2. **Extract unknowns from Technical Context** above:
    - For each NEEDS CLARIFICATION → research task
    - For each dependency → best practices task
    - For each integration → patterns task
 
-2. **Generate and dispatch research agents**:
+3. **Generate and dispatch research agents**:
    ```
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
@@ -121,12 +125,20 @@ ios/ or android/
      Task: "Find best practices for {tech} in {domain}"
    ```
 
-3. **Consolidate findings** in `research.md` using format:
+4. **Consolidate findings** in `research.md` using format:
    - Decision: [what was chosen]
    - Rationale: [why chosen]
    - Alternatives considered: [what else evaluated]
 
-**Output**: research.md with all NEEDS CLARIFICATION resolved
+5. **Execute Additional Research instructions (if configured)**:
+   - If `SPEC_KIT_CONFIG.plan.additional_research` exists, run each item as an independent research instruction using the available context (feature spec, constitution, and any plan documents)
+   - Append results to `research.md` under a top-level heading: `## Additional Research`
+   - For each instruction output, derive a clear section heading that summarizes the key subject (do not repeat the instruction verbatim). Use the following format for each section:
+     - `### {Concise Title Derived From Output}`
+     - Summary and details produced by the instruction
+     - References or source notes (if applicable)
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved and (if configured) an "Additional Research" section containing the instruction-driven findings
 
 ## Phase 1: Design & Contracts
 *Prerequisites: research.md complete*
@@ -214,4 +226,4 @@ ios/ or android/
 - [ ] Complexity deviations documented
 
 ---
-*Based on Constitution v2.1.1 - See `/memory/constitution.md`*
+*Based on Constitution v2.1.1 - See `SPEC_KIT_CONFIG.constitution.path`*


### PR DESCRIPTION
Added support for external configuration which allows you to utilise existing docs (PRD including stories, Architecture and Front End Spec, etc via configuration). The example shows a configuration of Spec Kit that incorporates the various documents into the full Spec Kit flow and tries to keep the `/implement` context minimal with the `Analyse the architecture documents and prepare a summary of relevant sections as they relate to the implementation plan.` amendment to the research doc.

Details available here: https://github.com/danwashusen/spec-kit-ext/blob/external-config/docs/configuration.md

The changes to Spec Kit are minimal, basically just loading up the appropriate documents at the appropriate time before handing off the the Spec Key templates.

Example `.specify.yaml` file:
```yaml
spec-kit:
  - constitution:
      path: "/memory/constitution.md"
  - specify:
      documents:
        - path: "docs/prd.md"
          context: "Product requirements"
  - plan:
      technical_context:
        - "**Coding Standards**: [NEEDS CLARIFICATION]"
      additional_research:
        - "Analyse the architecture documents and prepare a summary of relevant sections as they relate to the implementation plan."
      documents:
        - path: "docs/architecture.md"
          context: "Primary architecture reference"
        - path: "docs/ui-architecture.md"
          context: "UI architecture reference"
        - path: "docs/front-end-spec.md"
          context: "Front‑end specifications"
  - tasks:
      documents:
        - path: "docs/architecture.md"
          context: "Architecture reference"
        - path: "docs/ui-architecture.md"
          context: "UI architecture reference"
        - path: "docs/front-end-spec.md"
          context: "Front‑end specifications"
  - implement:
      documents:
        - path: "docs/work-flow.md"
          context: "Implementation workflow reference"
```