### PR TITLE
Fix release script agent templates

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -143,6 +143,8 @@ build_variant() {
       generate_commands gemini toml "{{args}}" "$base_dir/.gemini/commands" "$script"
       [[ -f agent_templates/gemini/GEMINI.md ]] && cp agent_templates/gemini/GEMINI.md "$base_dir/GEMINI.md" ;;
     copilot)
+      mkdir -p "$base_dir/.github/prompts"
+      generate_commands copilot md "\$ARGUMENTS" "$base_dir/.github/prompts" "$script"
       [[ -f agent_templates/copilot/copilot-instructions.md ]] && cp agent_templates/copilot/copilot-instructions.md "$base_dir/.github/copilot-instructions.md" ;;
     cursor)
       mkdir -p "$base_dir/.cursor/commands"

--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -136,14 +136,14 @@ build_variant() {
   case $agent in
     claude)
       mkdir -p "$base_dir/.claude/commands"
-      generate_commands claude md "\$ARGUMENTS" "$base_dir/.claude/commands" "$script" ;;
+      generate_commands claude md "\$ARGUMENTS" "$base_dir/.claude/commands" "$script"
+      [[ -f agent_templates/claude/CLAUDE.md ]] && cp agent_templates/claude/CLAUDE.md "$base_dir/CLAUDE.md" ;;
     gemini)
       mkdir -p "$base_dir/.gemini/commands"
       generate_commands gemini toml "{{args}}" "$base_dir/.gemini/commands" "$script"
       [[ -f agent_templates/gemini/GEMINI.md ]] && cp agent_templates/gemini/GEMINI.md "$base_dir/GEMINI.md" ;;
     copilot)
-      mkdir -p "$base_dir/.github/prompts"
-      generate_commands copilot prompt.md "\$ARGUMENTS" "$base_dir/.github/prompts" "$script" ;;
+      [[ -f agent_templates/copilot/copilot-instructions.md ]] && cp agent_templates/copilot/copilot-instructions.md "$base_dir/.github/copilot-instructions.md" ;;
     cursor)
       mkdir -p "$base_dir/.cursor/commands"
       generate_commands cursor md "\$ARGUMENTS" "$base_dir/.cursor/commands" "$script" ;;


### PR DESCRIPTION
## Fix: Release Script Agent Templates

### Problem
The release script was missing agent template files for Claude and Copilot in package creation, causing incomplete packages.

### Solution
- Add Claude agent template file copying to release script
- Fix Copilot agent template file copying with correct path
- Ensure all agent templates are properly included in packages

### Changes
- Updated `.github/workflows/scripts/create-release-packages.sh`
- Added proper agent template file handling for Claude and Copilot

### Testing
- Verified agent template files are included in release packages
- Confirmed proper file paths and copying logic

Fixes #420