### PR TITLE
Added 2 new commands that work well in Codex to replace /specify

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -1067,9 +1067,11 @@ def init(
     if selected_ai == "codex":
         warning_text = """[bold yellow]Important Note:[/bold yellow]
 
-Custom prompts do not yet support arguments in Codex. You may need to manually specify additional project instructions directly in prompt files located in [cyan].codex/prompts/[/cyan].
+Custom prompts do not yet support arguments in Codex. In the short-term (until Codex supports arguments) use this workaround pattern:
 
-For more information, see: [cyan]https://github.com/openai/codex/issues/2890[/cyan]"""
+Instead of using [cyan]/specify[/cyan] with arguments, you can use the command [cyan]/discuss[/cyan] where you will discuss the feature back and forth with the LLM to align on the basics. Then you can use the [cyan]/feature[/cyan] command to create the specification from the previous discussion, just like [cyan]/specify[/cyan] would.
+
+To upvote the feature request for argument support in Codex, see: [cyan]https://github.com/openai/codex/issues/2890[/cyan]"""
         
         warning_panel = Panel(warning_text, title="Slash Commands in Codex", border_style="yellow", padding=(1,2))
         console.print()

--- a/templates/commands/discuss.md
+++ b/templates/commands/discuss.md
@@ -1,0 +1,7 @@
+---
+description: Discuss an upcoming feature with the user to clarify requirements.
+---
+
+The user wants to discuss a potential new feature with you. Your job is to understand the nature of the feature and its requirements, ask questions one-by-one to the user and confirm the requirements are clear.
+
+After asking the user clarifying questions one-at-a-time, then summarize the feature back to the user and ask for confirmation. Then tell the user that the next step is to run the `/feature` command to create the feature specification.

--- a/templates/commands/feature.md
+++ b/templates/commands/feature.md
@@ -1,0 +1,17 @@
+---
+description: Create or update the feature specification from a natural language feature description.
+---
+
+The user has described a new feature they want to build. Your job is to create a feature specification from that description.
+
+The previous conversation you had with the user about the feature **is** the feature description. Insert the feature description into the variable `$FEATURE_DESCRIPTION` below when running the script.
+
+Given that feature description, do this:
+
+1. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$FEATURE_DESCRIPTION"` from repo root and parse its JSON output for BRANCH_NAME and SPEC_FILE. All file paths must be absolute.
+   **IMPORTANT** You must only ever run this script once. The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for.
+1. Load `.specify/templates/spec-template.md` to understand required sections.
+1. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+1. Report completion with branch name, spec file path, and readiness for the next phase.
+
+Note: The script creates and checks out the new branch and initializes the spec file before writing.


### PR DESCRIPTION
I was digging into your Codex support this morning, and without the ability to use $ARGUMENTS when invoking a command in Codex, I create another 2-command step that works around that problem. I have tested this and it seems to work pretty well.

Steps: 
1. Invoke `/new` to clear the context
2. Invoke `/discuss`, Codex will ask a question like "Happy to help! To start, what’s the high-level goal for this new feature?" to which you can respond with a simple description. The agent will go back and forth with the user to clarify requirements one question at a time and then output a summary and prompt the user to continue with the next command
3. Invoke `/feature` which will take the above discussion and summary and execute the same process that `/specify` would have done. 
4. Continue on with `/plan` > `/tasks` > `/implement` as normal

> **Bonus** This process should also work fine with other agents, tho I did not test it all out yet. 

I have tested this by implementing 2 new features already this morning. Another added benefit that I can see is that maybe the discussion phase irons out a lot of the possible `NEEDS CLARIFICATION` segments during the planning phase.

I added some description to the Codex-specific warning text when initializing the project. But maybe some up-for-discussion thoughts:
1. Should we see if we can reduce this to a single step, call it `/specify-codex` and copy it into the project instead of the original `specify`? Could be cleaner than this, but I thought to keep them separate for the time being, in case OpenAI decides to implement command arguments in the near future, this might all be moot.
2. Anywhere else we should document this change, since it is Codex-specific, but also it could work well in others?
3. Other ideas?