### PR TITLE
Add uv tool install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,37 @@ Spec-Driven Development **flips the script** on traditional software development
 
 ### 1. Install Specify
 
-Initialize your project depending on the coding agent you're using:
+Choose your preferred installation method:
+
+#### Option 1: Persistent Installation (Recommended)
+
+Install once and use everywhere:
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+```
+
+Then use the tool directly:
+
+```bash
+specify init <PROJECT_NAME>
+specify check
+```
+
+#### Option 2: One-time Usage
+
+Run directly without installing:
 
 ```bash
 uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME>
 ```
+
+**Benefits of persistent installation:**
+
+- Tool stays installed and available in PATH
+- No need to create shell aliases
+- Better tool management with `uv tool list`, `uv tool upgrade`, `uv tool uninstall`
+- Cleaner shell configuration
 
 ### 2. Establish project principles
 


### PR DESCRIPTION
## Summary

This PR adds `uv tool install` instructions to the README as requested in #476. The update provides users with both persistent installation and one-time usage options for the Specify CLI.

## Changes

- **Added persistent installation option**: Users can now install the tool once using `uv tool install specify-cli --from git+https://github.com/github/spec-kit.git` and use it directly
- **Kept existing one-time usage option**: The original `uvx` command remains available for users who prefer one-time execution
- **Reorganized installation section**: Clear "Option 1" and "Option 2" headers make it easy to choose between methods
- **Added benefits section**: Explains the advantages of persistent installation including better tool management and cleaner shell configuration

## Benefits of this change

As outlined in the issue, the persistent installation method provides:
- Tool stays installed and available in PATH until explicitly uninstalled
- No need for shell aliases or custom scripts
- Better tool management with `uv tool list`, `uv tool upgrade`, `uv tool uninstall`
- Cleaner shell configuration without modifying `.zshrc` or `.bashrc`

## Testing

- Verified that the `uv tool install` command syntax is correct and supported
- Confirmed that both installation methods work as documented

Fixes #476