### PR TITLE
docs: remove constitution_update_checklist from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,7 @@ At this stage, your project folder contents should resemble the following:
 
 ```text
 ├── memory
-│	 ├── constitution.md
-│	 └── constitution_update_checklist.md
+│	 └── constitution.md
 ├── scripts
 │	 ├── check-prerequisites.sh
 │	 ├── common.sh
@@ -391,8 +390,7 @@ The output of this step will include a number of implementation detail documents
 .
 ├── CLAUDE.md
 ├── memory
-│	 ├── constitution.md
-│	 └── constitution_update_checklist.md
+│	 └── constitution.md
 ├── scripts
 │	 ├── check-prerequisites.sh
 │	 ├── common.sh


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file to correct the listed contents of the `memory` directory. The change removes the reference to `constitution_update_checklist.md`, ensuring the documentation accurately reflects the current project structure.

ref: https://github.com/github/spec-kit/commit/2f043ef6826c2ca78c45d2af5b6e1b58c1b6ec21
