### PR TITLE
Refined wording in `plan-template.md` to ensure the Source Code section consistently works

### DIFF
--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -15,7 +15,7 @@ scripts:
 1. Load feature spec from Input path
    → If not found: ERROR "No feature spec at {path}"
 2. Fill Technical Context (scan for NEEDS CLARIFICATION)
-   → Detect Project Type from context (web=frontend+backend, mobile=app+api)
+   → Detect Project Type from file system structure or context (web=frontend+backend, mobile=app+api)
    → Set Structure Decision based on project type
 3. Fill the Constitution Check section based on the content of the constitution document.
 4. Evaluate Constitution Check section below
@@ -69,8 +69,14 @@ specs/[###-feature]/
 ```
 
 ### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
 ```
-# Option 1: Single project (DEFAULT)
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
 src/
 ├── models/
 ├── services/
@@ -82,7 +88,7 @@ tests/
 ├── integration/
 └── unit/
 
-# Option 2: Web application (when "frontend" + "backend" detected)
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
 backend/
 ├── src/
 │   ├── models/
@@ -97,15 +103,16 @@ frontend/
 │   └── services/
 └── tests/
 
-# Option 3: Mobile + API (when "iOS/Android" detected)
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
 api/
 └── [same as backend above]
 
 ios/ or android/
-└── [platform-specific structure]
+└── [platform-specific structure: feature modules, UI flows, platform tests]
 ```
 
-**Structure Decision**: [DEFAULT to Option 1 unless Technical Context indicates web/mobile app]
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
 
 ## Phase 0: Outline & Research
 1. **Extract unknowns from Technical Context** above:


### PR DESCRIPTION
Summary

  - Brownfield runs of specify (e.g. /specify Add feature XYZ to my project) produce plan.md files whose “Source Code (repository root)” section stays the hard-coded scaffold from plan-template.md, so generated implementation/test files land in the wrong directories.
  - The template often just copies the generic Options 1/2/3 block into plan.md, wasting context and leaving agents to guess the true structure.
  - Multiple /plan runs with GPT5 Codex High/Medium show inconsistent behavior: some keep the placeholder Option 2 snippet, others revert to the full generic block, which confirms the template is never interpolated and is unreliable for real repo layouts.
  - Updating plan-template.md to include explicit instructions for interpolating the Source Tree into the fenced code block resolves the problem; after that change every /plan run renders the correct repo structure.

  PR Focus

  - Teach the planning template to populate the Source Tree section with the project’s actual directory layout instead of shipping the static Options list, ensuring Spec Kit generates artifacts in the intended locations.

See https://github.com/github/spec-kit/issues/540