### PR TITLE
Standardize Spec Kit command templates to use repository-root paths (fixes Codex)

### DIFF
--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -159,3 +159,7 @@ Behavior rules:
  - If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
 
 Context for prioritization: {ARGS}
+
+Use repository-root anchored paths in generated docs (e.g., `/frontend/src/components/`). Avoid host-specific prefixes
+like `/Users/...` or `/home/...`; treat the repository root as `/` for display. Continue using full absolute paths when
+running shell/file operations.

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -71,3 +71,7 @@ If the user supplies partial updates (e.g., only one principle revision), still 
 If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
 
 Do not create a new template; always operate on the existing `/memory/constitution.md` file.
+
+Use repository-root anchored paths in generated docs (e.g., `/frontend/src/components/`). Avoid host-specific prefixes
+like `/Users/...` or `/home/...`; treat the repository root as `/` for display. Continue using full absolute paths when
+running shell/file operations.

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -57,3 +57,7 @@ $ARGUMENTS
    - Report final status with summary of completed work
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/tasks` first to regenerate the task list.
+
+Use repository-root anchored paths in generated docs (e.g., `/frontend/src/components/`). Avoid host-specific prefixes
+like `/Users/...` or `/home/...`; treat the repository root as `/` for display. Continue using full absolute paths when
+running shell/file operations.

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -43,4 +43,6 @@ Given the implementation details provided as an argument, do this:
 
 6. Report results with branch name, file paths, and generated artifacts.
 
-Use absolute paths with the repository root for all file operations to avoid path issues.
+Use repository-root anchored paths in generated docs (e.g., `/frontend/src/components/`). Avoid host-specific prefixes
+like `/Users/...` or `/home/...`; treat the repository root as `/` for display. Continue using full absolute paths when
+running shell/file operations.

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -22,3 +22,7 @@ Given that feature description, do this:
 4. Report completion with branch name, spec file path, and readiness for the next phase.
 
 Note: The script creates and checks out the new branch and initializes the spec file before writing.
+
+Use repository-root anchored paths in generated docs (e.g., `/frontend/src/components/`). Avoid host-specific prefixes
+like `/Users/...` or `/home/...`; treat the repository root as `/` for display. Continue using full absolute paths when
+running shell/file operations.

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -63,3 +63,7 @@ $ARGUMENTS
 Context for task generation: {ARGS}
 
 The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+Use repository-root anchored paths in generated docs (e.g., `/frontend/src/components/`). Avoid host-specific prefixes
+like `/Users/...` or `/home/...`; treat the repository root as `/` for display. Continue using full absolute paths when
+running shell/file operations.


### PR DESCRIPTION
Some agents (e.g. Codex) previously emitted host-specific paths such as `/Users/danwas/Development/Projects/spec-kit-ext/src/foo.py`, which break when teammates receive action items.

This fix;
- Add explicit guidance in every command template to present repository-root anchored paths (e.g., /
  src/cli/main.py) in generated docs so instructions remain portable.
- Clarify that real absolute paths are still expected for shell/file operations, preserving automation
  behaviour.