### PR TITLE
docs: Refine 'What is Spec-Driven Development?' section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,15 @@
 
 ## 🤔 What is Spec-Driven Development?
 
-Spec-Driven Development **flips the script** on traditional software development. For decades, code has been king — specifications were just scaffolding we built and discarded once the "real work" of coding began. Spec-Driven Development changes this: **specifications become executable**, directly generating working implementations rather than just guiding them.
+Spec-Driven Development is a **classic engineering discipline** where a **rigorous specification** serves as the authoritative blueprint for a system. For decades, it was the foundation upon which the world's most reliable and mission-critical software was built. This is a return to that tradition.
+
+For a time, this approach was overshadowed by Agile methodologies, which—while valuable for rapid iteration—often led to the neglect of comprehensive documentation. The specification became a secondary artifact, quickly falling out of sync with the "real" work of coding.
+
+Today, AI allows us to reunite the discipline of the past with the speed of the present.
+
+With spec-kit, the specification is restored as the **single source of truth**. You craft the system's design in structured natural language, and an AI engine generates the code directly from it. The specification is no longer a static document; it is the living source from which the implementation is derived.
+
+This ensures that the final product is a perfect reflection of the plan, reviving a glorious tradition of engineering excellence for the modern era, supercharged by GenAI.
 
 ## ⚡ Get started
 


### PR DESCRIPTION
Hello team,

This pull request proposes a revision to the "What is Spec-Driven Development?" section of the README to strengthen the project's core message.

This change is not just a stylistic update; it's a strategic improvement to the project's positioning.

**Why This Change Matters**

This revision makes the introduction more powerful on three key fronts:

- **Adds Historical Credibility:** It frames `spec-kit` as the modern revival of a proven, time-tested discipline. This resonates strongly with experienced engineers and provides valuable context for all developers, positioning the project as a mature, serious solution rather than a fleeting trend.

- **Improves Technical Precision:** It corrects the potentially misleading phrase "specifications become executable." The new text clarifies the true relationship: the spec is the authoritative source from which AI generates the executable code. This accuracy is vital for managing expectations and building long-term trust with our users.

- **Strengthens Project Positioning:** By grounding the project in engineering fundamentals and using precise language, we move the narrative away from potential "AI hype" and towards professional rigour. This tone is crucial for widespread adoption and credibility within the technical community.

In short, this change helps transform the introduction from a simple explanation into a compelling and accurate manifesto that honors our industry's past while confidently looking to its future.

Happy to discuss any feedback.

Ning