### PR TITLE
Fix constitution.md path to relative path in plan template

### DIFF
--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -222,4 +222,4 @@ directories captured above]
 - [ ] Complexity deviations documented
 
 ---
-*Based on Constitution v2.1.1 - See `/memory/constitution.md`*
+*Based on Constitution v2.1.1 - See `.specify/memory/constitution.md`*


### PR DESCRIPTION
Update constitution reference from absolute path
to relative path  since templates will be
located within the .specify folder structure.

From
```
See `/memory/constitution.md`*
```
To
```
See `.specify/memory/constitution.md`*
```