### PR TITLE
Add Crush CLI Support to Spec Kit

### DIFF
--- a/.github/workflows/scripts/create-github-release.sh
+++ b/.github/workflows/scripts/create-github-release.sh
@@ -38,5 +38,7 @@ gh release create "$VERSION" \
   .genreleases/spec-kit-template-auggie-ps-"$VERSION".zip \
   .genreleases/spec-kit-template-roo-sh-"$VERSION".zip \
   .genreleases/spec-kit-template-roo-ps-"$VERSION".zip \
+  .genreleases/spec-kit-template-crush-sh-"$VERSION".zip \
+  .genreleases/spec-kit-template-crush-ps-"$VERSION".zip \
   --title "Spec Kit Templates - $VERSION_NO_V" \
   --notes-file release_notes.md

--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -172,13 +172,16 @@ build_variant() {
     roo)
       mkdir -p "$base_dir/.roo/commands"
       generate_commands roo md "\$ARGUMENTS" "$base_dir/.roo/commands" "$script" ;;
+    crush)
+      mkdir -p "$base_dir/.crush/commands"
+      generate_commands crush md "\$ARGUMENTS" "$base_dir/.crush/commands" "$script" ;;
   esac
   ( cd "$base_dir" && zip -r "../spec-kit-template-${agent}-${script}-${NEW_VERSION}.zip" . )
   echo "Created $GENRELEASES_DIR/spec-kit-template-${agent}-${script}-${NEW_VERSION}.zip"
 }
 
 # Determine agent list
-ALL_AGENTS=(claude gemini copilot cursor qwen opencode windsurf codex kilocode auggie roo)
+ALL_AGENTS=(claude gemini copilot cursor qwen opencode windsurf codex kilocode auggie roo crush)
 ALL_SCRIPTS=(sh ps)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,185 @@
+# Spec Kit Development Makefile
+# Provides easy commands for local development and testing
+
+.PHONY: help install-dev test-agent test-all clean check-tools dev-setup validate test-packages
+
+# Default target
+help: ## Show this help message
+	@echo "Spec Kit Development Commands"
+	@echo "============================="
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install-dev: ## Install Spec Kit CLI in development mode as specify-dev
+	@echo "Installing Spec Kit CLI in development mode as 'specify-dev'..."
+	pip install -e . --force-reinstall
+	@echo "✅ Spec Kit CLI installed as 'specify-dev'"
+	@echo "Run 'specify-dev --help' to test"
+
+uninstall-dev: ## Uninstall Spec Kit CLI development version
+	@echo "Uninstalling Spec Kit CLI development version..."
+	pip uninstall specify-cli -y
+	@echo "✅ Spec Kit CLI uninstalled"
+
+check-tools: ## Check if all required tools are installed
+	@echo "Checking required tools..."
+	@echo ""
+	@echo "🔍 Tool Status:"
+	@echo "==============="
+	@if command -v git >/dev/null 2>&1; then \
+		echo "✅ git: $$(git --version)"; \
+	else \
+		echo "❌ git: Not installed"; \
+	fi
+	@if command -v python3 >/dev/null 2>&1; then \
+		echo "✅ python3: $$(python3 --version)"; \
+	else \
+		echo "❌ python3: Not installed"; \
+	fi
+	@if command -v pip >/dev/null 2>&1; then \
+		echo "✅ pip: $$(pip --version)"; \
+	else \
+		echo "❌ pip: Not installed"; \
+	fi
+	@if command -v specify-dev >/dev/null 2>&1; then \
+		echo "✅ specify-dev: Installed"; \
+	else \
+		echo "❌ specify-dev: Not installed (run 'make install-dev')"; \
+	fi
+
+test-agent: ## Test agent integration with Spec Kit (usage: make test-agent AGENT=crush)
+	@if [ -z "$(AGENT)" ]; then \
+		echo "❌ Please specify an agent: make test-agent AGENT=crush"; \
+		echo "Available agents: claude, gemini, copilot, cursor, qwen, opencode, codex, windsurf, kilocode, auggie, roo, crush"; \
+		exit 1; \
+	fi
+	@echo "Testing $(AGENT) integration..."
+	@echo ""
+	@echo "🧪 Test 1: Check tool detection"
+	@echo "==============================="
+	@if command -v specify-dev >/dev/null 2>&1; then \
+		specify-dev check | grep -E "($(AGENT)|$(shell echo $(AGENT) | tr '[:lower:]' '[:upper:]'))" || echo "❌ $(AGENT) not detected"; \
+	else \
+		echo "❌ Specify-dev CLI not installed. Run 'make install-dev' first"; \
+	fi
+	@echo ""
+	@echo "🧪 Test 2: Create test project"
+	@echo "=============================="
+	@if [ -d "test-$(AGENT)-project" ]; then \
+		echo "⚠️  Removing existing test project..."; \
+		rm -rf test-$(AGENT)-project; \
+	fi
+	@if command -v specify-dev >/dev/null 2>&1; then \
+		specify-dev init test-$(AGENT)-project --ai $(AGENT) --no-git; \
+		echo "✅ Test project created"; \
+	else \
+		echo "❌ Specify-dev CLI not installed. Run 'make install-dev' first"; \
+	fi
+	@echo ""
+	@echo "🧪 Test 3: Verify project structure"
+	@echo "=================================="
+	@case "$(AGENT)" in \
+		claude) dir=".claude/commands" ;; \
+		gemini) dir=".gemini/commands" ;; \
+		copilot) dir=".github/prompts" ;; \
+		cursor) dir=".cursor/commands" ;; \
+		qwen) dir=".qwen/commands" ;; \
+		opencode) dir=".opencode/command" ;; \
+		windsurf) dir=".windsurf/workflows" ;; \
+		codex) dir=".codex/prompts" ;; \
+		kilocode) dir=".kilocode/workflows" ;; \
+		auggie) dir=".augment/commands" ;; \
+		roo) dir=".roo/commands" ;; \
+		crush) dir=".crush/commands" ;; \
+		*) echo "❌ Unknown agent directory structure"; exit 1 ;; \
+	esac; \
+	if [ -d "test-$(AGENT)-project/$$dir" ]; then \
+		echo "✅ $$dir directory created"; \
+		echo "📁 Command files:"; \
+		ls -1 test-$(AGENT)-project/$$dir/ | sed 's/^/   - /'; \
+	else \
+		echo "❌ $$dir directory not found"; \
+	fi
+	@echo ""
+	@echo "🧪 Test 4: Test agent context script"
+	@echo "==================================="
+	@if [ -f "test-$(AGENT)-project/.specify/scripts/bash/update-agent-context.sh" ]; then \
+		cd test-$(AGENT)-project && ./.specify/scripts/bash/update-agent-context.sh $(AGENT); \
+		echo "✅ Agent context script executed"; \
+	else \
+		echo "❌ Agent context script not found"; \
+	fi
+
+test-all: ## Run all tests (usage: make test-all AGENT=crush)
+	@echo "Running all tests..."
+	@echo ""
+	@$(MAKE) check-tools
+	@echo ""
+	@if [ -z "$(AGENT)" ]; then \
+		echo "⚠️  No agent specified for test-all. Run 'make test-agent AGENT=crush' instead"; \
+	else \
+		$(MAKE) test-agent AGENT=$(AGENT); \
+	fi
+	@echo ""
+	@echo "🎉 All tests completed!"
+
+dev-setup: install-dev ## Complete development setup
+	@echo ""
+	@echo "🎉 Development setup complete!"
+	@echo ""
+	@echo "Next steps:"
+	@echo "1. Run 'make test-agent AGENT=crush' to test an agent integration"
+	@echo "2. Run 'make test-all AGENT=crush' for comprehensive testing"
+	@echo "3. Use 'specify-dev init my-project --ai crush' to create projects"
+
+clean: ## Clean up test files (usage: make clean AGENT=crush)
+	@echo "Cleaning up test files..."
+	@if [ -n "$(AGENT)" ]; then \
+		if [ -d "test-$(AGENT)-project" ]; then \
+			rm -rf test-$(AGENT)-project; \
+			echo "✅ Removed test-$(AGENT)-project"; \
+		fi; \
+	else \
+		echo "🧹 Cleaning up all test projects..."; \
+		for dir in test-*-project; do \
+			if [ -d "$$dir" ]; then \
+				rm -rf "$$dir"; \
+				echo "✅ Removed $$dir"; \
+			fi; \
+		done; \
+	fi
+	@if [ -d ".genreleases" ]; then \
+		rm -rf .genreleases; \
+		echo "✅ Removed .genreleases"; \
+	fi
+	@echo "🧹 Cleanup complete"
+
+# Package testing (advanced)
+test-packages: ## Test package generation
+	@echo "Testing package generation..."
+	@if [ -f ".github/workflows/scripts/create-release-packages.sh" ]; then \
+		.github/workflows/scripts/create-release-packages.sh v0.1.0-test; \
+		echo "✅ Packages generated in .genreleases/"; \
+		ls -la .genreleases/spec-kit-template-crush-* 2>/dev/null || echo "❌ Crush packages not found"; \
+	else \
+		echo "❌ Package generation script not found"; \
+	fi
+
+# Quick validation
+validate: ## Quick validation of changes
+	@echo "Validating changes..."
+	@echo ""
+	@echo "🔍 Python syntax check:"
+	python -m py_compile src/specify_cli/__init__.py && echo "✅ Python syntax OK"
+	@echo ""
+	@echo "🔍 Bash script syntax check:"
+	bash -n scripts/bash/update-agent-context.sh && echo "✅ Bash syntax OK"
+	@echo ""
+	@echo "🔍 PowerShell script syntax check:"
+	@if command -v pwsh >/dev/null 2>&1; then \
+		pwsh -NoProfile -Command "& { Get-Content scripts/powershell/update-agent-context.ps1 | Out-Null }" && echo "✅ PowerShell syntax OK"; \
+	else \
+		echo "⚠️  PowerShell Core not found, skipping PowerShell validation"; \
+	fi
+	@echo ""
+	@echo "✅ All validations passed!"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Want to see Spec Kit in action? Watch our [video overview](https://www.youtube.c
 | [Kilo Code](https://github.com/Kilo-Org/kilocode)         | ✅ |                                                   |
 | [Auggie CLI](https://docs.augmentcode.com/cli/overview)   | ✅ |                                                   |
 | [Roo Code](https://roocode.com/)                          | ✅ |                                                   |
+| [Crush CLI](https://github.com/charmbracelet/crush)       | ⚠️ | Slash commands [not yet implemented](https://github.com/charmbracelet/crush/issues/523) |
 | [Codex CLI](https://github.com/openai/codex)              | ⚠️ | Codex [does not support](https://github.com/openai/codex/issues/2890) custom arguments for slash commands.  |
 
 ## 🔧 Specify CLI Reference
@@ -144,14 +145,14 @@ The `specify` command supports the following options:
 | Command     | Description                                                    |
 |-------------|----------------------------------------------------------------|
 | `init`      | Initialize a new Specify project from the latest template      |
-| `check`     | Check for installed tools (`git`, `claude`, `gemini`, `code`/`code-insiders`, `cursor-agent`, `windsurf`, `qwen`, `opencode`, `codex`) |
+| `check`     | Check for installed tools (`git`, `claude`, `gemini`, `code`/`code-insiders`, `cursor-agent`, `windsurf`, `qwen`, `opencode`, `codex`, `crush`) |
 
 ### `specify init` Arguments & Options
 
 | Argument/Option        | Type     | Description                                                                  |
 |------------------------|----------|------------------------------------------------------------------------------|
 | `<project-name>`       | Argument | Name for your new project directory (optional if using `--here`, or use `.` for current directory) |
-| `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, `cursor`, `qwen`, `opencode`, `codex`, `windsurf`, `kilocode`, `auggie`, or `roo` |
+| `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, `cursor`, `qwen`, `opencode`, `codex`, `windsurf`, `kilocode`, `auggie`, `roo`, or `crush` |
 | `--script`             | Option   | Script variant to use: `sh` (bash/zsh) or `ps` (PowerShell)                 |
 | `--ignore-agent-tools` | Flag     | Skip checks for AI agent tools like Claude Code                             |
 | `--no-git`             | Flag     | Skip git repository initialization                                          |
@@ -175,6 +176,9 @@ specify init my-project --ai cursor
 
 # Initialize with Windsurf support
 specify init my-project --ai windsurf
+
+# Initialize with Crush support
+specify init my-project --ai crush
 
 # Initialize with PowerShell scripts (Windows/cross-platform)
 specify init my-project --ai copilot --script ps
@@ -268,7 +272,7 @@ Our research and experimentation focus on:
 ## 🔧 Prerequisites
 
 - **Linux/macOS** (or WSL2 on Windows)
-- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Cursor](https://cursor.sh/), [Qwen CLI](https://github.com/QwenLM/qwen-code), [opencode](https://opencode.ai/), [Codex CLI](https://github.com/openai/codex), or [Windsurf](https://windsurf.com/)
+- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Cursor](https://cursor.sh/), [Qwen CLI](https://github.com/QwenLM/qwen-code), [opencode](https://opencode.ai/), [Codex CLI](https://github.com/openai/codex), [Windsurf](https://windsurf.com/), or [Crush CLI](https://github.com/charmbracelet/crush)
 - [uv](https://docs.astral.sh/uv/) for package management
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
@@ -318,9 +322,11 @@ specify init <project_name> --ai qwen
 specify init <project_name> --ai opencode
 specify init <project_name> --ai codex
 specify init <project_name> --ai windsurf
+specify init <project_name> --ai crush
 # Or in current directory:
 specify init . --ai claude
 specify init . --ai codex
+specify init . --ai crush
 # or use --here flag
 specify init --here --ai claude
 specify init --here --ai codex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 
 [project.scripts]
 specify = "specify_cli:main"
+specify-dev = "specify_cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/bash/update-agent-context.sh
+++ b/scripts/bash/update-agent-context.sh
@@ -69,6 +69,7 @@ WINDSURF_FILE="$REPO_ROOT/.windsurf/rules/specify-rules.md"
 KILOCODE_FILE="$REPO_ROOT/.kilocode/rules/specify-rules.md"
 AUGGIE_FILE="$REPO_ROOT/.augment/rules/specify-rules.md"
 ROO_FILE="$REPO_ROOT/.roo/rules/specify-rules.md"
+CRUSH_FILE="$REPO_ROOT/.crush/rules/specify-rules.md"
 
 # Template file
 TEMPLATE_FILE="$REPO_ROOT/.specify/templates/agent-file-template.md"
@@ -580,9 +581,12 @@ update_specific_agent() {
         roo)
             update_agent_file "$ROO_FILE" "Roo Code"
             ;;
+        crush)
+            update_agent_file "$CRUSH_FILE" "Crush CLI"
+            ;;
         *)
             log_error "Unknown agent type '$agent_type'"
-            log_error "Expected: claude|gemini|copilot|cursor|qwen|opencode|codex|windsurf|kilocode|auggie|roo"
+            log_error "Expected: claude|gemini|copilot|cursor|qwen|opencode|codex|windsurf|kilocode|auggie|roo|crush"
             exit 1
             ;;
     esac
@@ -642,6 +646,11 @@ update_all_existing_agents() {
         found_agent=true
     fi
     
+    if [[ -f "$CRUSH_FILE" ]]; then
+        update_agent_file "$CRUSH_FILE" "Crush CLI"
+        found_agent=true
+    fi
+    
     # If no agent files exist, create a default Claude file
     if [[ "$found_agent" == false ]]; then
         log_info "No existing agent files found, creating default Claude file..."
@@ -665,7 +674,7 @@ print_summary() {
     fi
     
     echo
-    log_info "Usage: $0 [claude|gemini|copilot|cursor|qwen|opencode|codex|windsurf|kilocode|auggie|roo]"
+    log_info "Usage: $0 [claude|gemini|copilot|cursor|qwen|opencode|codex|windsurf|kilocode|auggie|roo|crush]"
 }
 
 #==============================================================================

--- a/scripts/powershell/update-agent-context.ps1
+++ b/scripts/powershell/update-agent-context.ps1
@@ -25,7 +25,7 @@ Relies on common helper functions in common.ps1
 #>
 param(
     [Parameter(Position=0)]
-    [ValidateSet('claude','gemini','copilot','cursor','qwen','opencode','codex','windsurf','kilocode','auggie','roo')]
+    [ValidateSet('claude','gemini','copilot','cursor','qwen','opencode','codex','windsurf','kilocode','auggie','roo','crush')]
     [string]$AgentType
 )
 
@@ -54,6 +54,7 @@ $WINDSURF_FILE = Join-Path $REPO_ROOT '.windsurf/rules/specify-rules.md'
 $KILOCODE_FILE = Join-Path $REPO_ROOT '.kilocode/rules/specify-rules.md'
 $AUGGIE_FILE   = Join-Path $REPO_ROOT '.augment/rules/specify-rules.md'
 $ROO_FILE      = Join-Path $REPO_ROOT '.roo/rules/specify-rules.md'
+$CRUSH_FILE    = Join-Path $REPO_ROOT '.crush/rules/specify-rules.md'
 
 $TEMPLATE_FILE = Join-Path $REPO_ROOT '.specify/templates/agent-file-template.md'
 
@@ -376,7 +377,8 @@ function Update-SpecificAgent {
         'kilocode' { Update-AgentFile -TargetFile $KILOCODE_FILE -AgentName 'Kilo Code' }
         'auggie'   { Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI' }
         'roo'      { Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code' }
-        default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|cursor|qwen|opencode|codex|windsurf|kilocode|auggie|roo'; return $false }
+        'crush'    { Update-AgentFile -TargetFile $CRUSH_FILE   -AgentName 'Crush CLI' }
+        default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|cursor|qwen|opencode|codex|windsurf|kilocode|auggie|roo|crush'; return $false }
     }
 }
 
@@ -393,6 +395,7 @@ function Update-AllExistingAgents {
     if (Test-Path $KILOCODE_FILE) { if (-not (Update-AgentFile -TargetFile $KILOCODE_FILE -AgentName 'Kilo Code')) { $ok = $false }; $found = $true }
     if (Test-Path $AUGGIE_FILE)   { if (-not (Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI')) { $ok = $false }; $found = $true }
     if (Test-Path $ROO_FILE)      { if (-not (Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code')) { $ok = $false }; $found = $true }
+    if (Test-Path $CRUSH_FILE)    { if (-not (Update-AgentFile -TargetFile $CRUSH_FILE    -AgentName 'Crush CLI')) { $ok = $false }; $found = $true }
     if (-not $found) {
         Write-Info 'No existing agent files found, creating default Claude file...'
         if (-not (Update-AgentFile -TargetFile $CLAUDE_FILE -AgentName 'Claude Code')) { $ok = $false }
@@ -407,7 +410,7 @@ function Print-Summary {
     if ($NEW_FRAMEWORK) { Write-Host "  - Added framework: $NEW_FRAMEWORK" }
     if ($NEW_DB -and $NEW_DB -ne 'N/A') { Write-Host "  - Added database: $NEW_DB" }
     Write-Host ''
-    Write-Info 'Usage: ./update-agent-context.ps1 [-AgentType claude|gemini|copilot|cursor|qwen|opencode|codex|windsurf|kilocode|auggie|roo]'
+    Write-Info 'Usage: ./update-agent-context.ps1 [-AgentType claude|gemini|copilot|cursor|qwen|opencode|codex|windsurf|kilocode|auggie|roo|crush]'
 }
 
 function Main {

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -77,6 +77,7 @@ AI_CHOICES = {
     "kilocode": "Kilo Code",
     "auggie": "Auggie CLI",
     "roo": "Roo Code",
+    "crush": "Crush CLI",
 }
 # Add script type choices
 SCRIPT_TYPE_CHOICES = {"sh": "POSIX Shell (bash/zsh)", "ps": "PowerShell"}
@@ -750,7 +751,7 @@ def ensure_executable_scripts(project_path: Path, tracker: StepTracker | None = 
 @app.command()
 def init(
     project_name: str = typer.Argument(None, help="Name for your new project directory (optional if using --here, or use '.' for current directory)"),
-    ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, copilot, cursor, qwen, opencode, codex, windsurf, kilocode, or auggie"),
+    ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, copilot, cursor, qwen, opencode, codex, windsurf, kilocode, auggie, roo, or crush"),
     script_type: str = typer.Option(None, "--script", help="Script type to use: sh or ps"),
     ignore_agent_tools: bool = typer.Option(False, "--ignore-agent-tools", help="Skip checks for AI agent tools like Claude Code"),
     no_git: bool = typer.Option(False, "--no-git", help="Skip git repository initialization"),
@@ -765,7 +766,7 @@ def init(
     
     This command will:
     1. Check that required tools are installed (git is optional)
-    2. Let you choose your AI assistant (Claude Code, Gemini CLI, GitHub Copilot, Cursor, Qwen Code, opencode, Codex CLI, Windsurf, Kilo Code, or Auggie CLI)
+    2. Let you choose your AI assistant (Claude Code, Gemini CLI, GitHub Copilot, Cursor, Qwen Code, opencode, Codex CLI, Windsurf, Kilo Code, Auggie CLI, Roo Code, or Crush CLI)
     3. Download the appropriate template from GitHub
     4. Extract the template to a new project directory or current directory
     5. Initialize a fresh git repository (if not --no-git and no existing repo)
@@ -782,6 +783,8 @@ def init(
         specify init my-project --ai codex
         specify init my-project --ai windsurf
         specify init my-project --ai auggie
+        specify init my-project --ai roo
+        specify init my-project --ai crush
         specify init --ignore-agent-tools my-project
         specify init . --ai claude         # Initialize in current directory
         specify init .                     # Initialize in current directory (interactive AI selection)
@@ -905,6 +908,10 @@ def init(
         elif selected_ai == "auggie":
             if not check_tool("auggie", "https://docs.augmentcode.com/cli/setup-auggie/install-auggie-cli"):
                 install_url = "https://docs.augmentcode.com/cli/setup-auggie/install-auggie-cli"
+                agent_tool_missing = True
+        elif selected_ai == "crush":
+            if not check_tool("crush", "https://github.com/charmbracelet/crush"):
+                install_url = "https://github.com/charmbracelet/crush"
                 agent_tool_missing = True
         # GitHub Copilot and Cursor checks are not needed as they're typically available in supported IDEs
 
@@ -1030,7 +1037,8 @@ def init(
         "kilocode": ".kilocode/",
         "auggie": ".augment/",
         "copilot": ".github/",
-        "roo": ".roo/"
+        "roo": ".roo/",
+        "crush": ".crush/"
     }
     
     if selected_ai in agent_folder_map:
@@ -1119,6 +1127,7 @@ def check():
     tracker.add("opencode", "opencode")
     tracker.add("codex", "Codex CLI")
     tracker.add("auggie", "Auggie CLI")
+    tracker.add("crush", "Crush CLI")
     
     git_ok = check_tool_for_tracker("git", tracker)
     claude_ok = check_tool_for_tracker("claude", tracker)  
@@ -1132,6 +1141,7 @@ def check():
     opencode_ok = check_tool_for_tracker("opencode", tracker)
     codex_ok = check_tool_for_tracker("codex", tracker)
     auggie_ok = check_tool_for_tracker("auggie", tracker)
+    crush_ok = check_tool_for_tracker("crush", tracker)
 
     console.print(tracker.render())
 
@@ -1139,7 +1149,7 @@ def check():
 
     if not git_ok:
         console.print("[dim]Tip: Install git for repository management[/dim]")
-    if not (claude_ok or gemini_ok or cursor_ok or qwen_ok or windsurf_ok or kilocode_ok or opencode_ok or codex_ok or auggie_ok):
+    if not (claude_ok or gemini_ok or cursor_ok or qwen_ok or windsurf_ok or kilocode_ok or opencode_ok or codex_ok or auggie_ok or crush_ok):
         console.print("[dim]Tip: Install an AI assistant for the best experience[/dim]")
 
 


### PR DESCRIPTION
## What

This PR adds comprehensive support for [Crush CLI](https://github.com/charmbracelet/crush) to the Spec Kit framework, following the same integration patterns as other CLI-based agents like Claude Code and Cursor.

## Why

Crush is a popular terminal-based AI coding assistant from Charmbracelet that provides:
- Multi-model LLM support (Anthropic, OpenAI, Groq, etc.)
- Session-based context management
- LSP-enhanced code understanding
- Extensible capabilities via MCPs
- Cross-platform support (macOS, Linux, Windows)

Adding Crush support expands the Spec Kit ecosystem and provides users with another high-quality AI coding assistant option for Spec-Driven Development.

## How

### Core Integration Changes

1. **CLI Integration** (`src/specify_cli/__init__.py`):
   - Added `crush` to `AI_CHOICES` constant
   - Added `.crush/` to `agent_folder_map` for security notices
   - Updated CLI help text and examples to include Crush
   - Added Crush CLI tool validation in `init` and `check` commands

2. **Documentation Updates** (`README.md`):
   - Added Crush to Supported AI Agents table
   - Marked as ⚠️ **Partial Support** due to missing slash commands
   - Added Crush examples in CLI reference section
   - Updated prerequisites section

3. **Release Package Support**:
   - Updated `create-release-packages.sh` to include Crush in `ALL_AGENTS` array
   - Added Crush case in agent directory structure generation (`.crush/commands/`)
   - Updated `create-github-release.sh` to include Crush packages

4. **Agent Context Scripts**:
   - Updated both bash and PowerShell agent context update scripts
   - Added Crush file path (`$CRUSH_FILE` / `$CRUSH_FILE`)
   - Added Crush case in agent selection logic
   - Updated help text and validation sets

5. **Development Tools**:
   - Added generic Makefile for easy local testing
   - Supports testing any agent with `make test-agent AGENT=<name>`
   - Installs as `specify-dev` to avoid conflicts with global installation

### Technical Implementation

- **Directory Structure**: `.crush/commands/` (following Markdown format like Claude/Cursor)
- **Command Format**: Uses `$ARGUMENTS` placeholder (Markdown-based)
- **CLI Tool**: Requires `crush` command to be installed
- **Installation URL**: https://github.com/charmbracelet/crush

### Current Limitation

⚠️ **Partial Support**: Crush doesn't yet support slash commands as noted in [charmbracelet/crush#523](https://github.com/charmbracelet/crush/issues/523). Once slash commands are implemented in Crush, the status can be updated to full support (✅).

The integration is designed to work similarly to how GitHub Copilot currently works - the framework is ready, but the actual slash command functionality depends on Crush implementing that feature.

## Testing

The implementation follows established patterns and should work like other CLI-based agents:

```bash
# Initialize a project with Crush support
specify init my-project --ai crush

# Check if Crush is installed
specify check

# Test locally with development tools
make install-dev
make test-agent AGENT=crush
```

**Note**: Full testing requires:
1. Crush CLI to be installed
2. Slash commands to be implemented in Crush (pending [charmbracelet/crush#523](https://github.com/charmbracelet/crush/issues/523))

## Files Changed

- `src/specify_cli/__init__.py` - Core CLI integration
- `README.md` - Documentation updates
- `.github/workflows/scripts/create-release-packages.sh` - Package generation
- `.github/workflows/scripts/create-github-release.sh` - Release creation
- `scripts/bash/update-agent-context.sh` - Bash agent context updates
- `scripts/powershell/update-agent-context.ps1` - PowerShell agent context updates
- `Makefile` - Generic development tools for testing any agent
- `pyproject.toml` - Added specify-dev entry point

## Future Work

Once [charmbracelet/crush#523](https://github.com/charmbracelet/crush/issues/523) is resolved:
1. Update README.md to mark Crush as ✅ Full Support
2. Test slash command functionality
3. Verify end-to-end Spec-Driven Development workflow

## Related Issues

- [charmbracelet/crush#523](https://github.com/charmbracelet/crush/issues/523) - Slash commands not yet implemented in Crush