### PR TITLE
Update URLs to Contributing and Support Guides in Docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,8 +55,8 @@ Our research and experimentation focus on:
 
 ## Contributing
 
-Please see our [Contributing Guide](CONTRIBUTING.md) for information on how to contribute to this project.
+Please see our [Contributing Guide](https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md) for information on how to contribute to this project.
 
 ## Support
 
-For support, please check our [Support Guide](SUPPORT.md) or open an issue on GitHub.
+For support, please check our [Support Guide](https://github.com/github/spec-kit/blob/main/SUPPORT.md) or open an issue on GitHub.


### PR DESCRIPTION
## Problem

The links to the contributing and support guides at the bottom of [the docs site home page](https://github.github.com/spec-kit/index.html) currently take you to a 404 page.

## Solution

Update the links to the correct URLs, pointing to the guides that are currently in the repo's root directory rather than within the `docs` folder.