### PR TITLE
docs: fix inconsistencies between README.md and documentation site

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,72 @@
+# Specify CLI Reference
+
+The `specify` command supports the following options:
+
+## Commands
+
+| Command     | Description                                                    |
+|-------------|----------------------------------------------------------------|
+| `init`      | Initialize a new Specify project from the latest template      |
+| `check`     | Check for installed tools (`git`, `claude`, `gemini`, `code`/`code-insiders`, `cursor-agent`, `windsurf`, `qwen`, `opencode`, `codex`) |
+
+## `specify init` Arguments & Options
+
+| Argument/Option        | Type     | Description                                                                  |
+|------------------------|----------|------------------------------------------------------------------------------|
+| `<project-name>`       | Argument | Name for your new project directory (optional if using `--here`, or use `.` for current directory) |
+| `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, `cursor`, `qwen`, `opencode`, `codex`, `windsurf`, `kilocode`, `auggie`, or `roo` |
+| `--script`             | Option   | Script variant to use: `sh` (bash/zsh) or `ps` (PowerShell)                 |
+| `--ignore-agent-tools` | Flag     | Skip checks for AI agent tools like Claude Code                             |
+| `--no-git`             | Flag     | Skip git repository initialization                                          |
+| `--here`               | Flag     | Initialize project in the current directory instead of creating a new one   |
+| `--force`              | Flag     | Force merge/overwrite when initializing in current directory (skip confirmation) |
+| `--skip-tls`           | Flag     | Skip SSL/TLS verification (not recommended)                                 |
+| `--debug`              | Flag     | Enable detailed debug output for troubleshooting                            |
+| `--github-token`       | Option   | GitHub token for API requests (or set GH_TOKEN/GITHUB_TOKEN env variable)  |
+
+## Examples
+
+```bash
+# Basic project initialization
+specify init my-project
+
+# Initialize with specific AI assistant
+specify init my-project --ai claude
+
+# Initialize with Cursor support
+specify init my-project --ai cursor
+
+# Initialize with Windsurf support
+specify init my-project --ai windsurf
+
+# Initialize with PowerShell scripts (Windows/cross-platform)
+specify init my-project --ai copilot --script ps
+
+# Initialize in current directory
+specify init . --ai copilot
+# or use the --here flag
+specify init --here --ai copilot
+
+# Force merge into current (non-empty) directory without confirmation
+specify init . --force --ai copilot
+# or 
+specify init --here --force --ai copilot
+
+# Skip git initialization
+specify init my-project --ai gemini --no-git
+
+# Enable debug output for troubleshooting
+specify init my-project --ai claude --debug
+
+# Use GitHub token for API requests (helpful for corporate environments)
+specify init my-project --ai claude --github-token ghp_your_token_here
+
+# Check system requirements
+specify check
+```
+
+## Environment Variables
+
+| Variable         | Description                                                                                    |
+|------------------|------------------------------------------------------------------------------------------------|
+| `SPECIFY_FEATURE` | Override feature detection for non-Git repositories. Set to the feature directory name (e.g., `001-photo-albums`) to work on a specific feature when not using Git branches.<br/>**Must be set in the context of the agent you're working with prior to using `/plan` or follow-up commands. |

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -9,6 +9,12 @@
       },
       {
         "files": [
+          "cli-reference.md"
+        ],
+        "dest": "cli-reference.md"
+      },
+      {
+        "files": [
           "../README.md",
           "../CONTRIBUTING.md",
           "../CODE_OF_CONDUCT.md",

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,27 @@
 
 Spec-Driven Development **flips the script** on traditional software development. For decades, code has been king — specifications were just scaffolding we built and discarded once the "real work" of coding began. Spec-Driven Development changes this: **specifications become executable**, directly generating working implementations rather than just guiding them.
 
+## Supported AI Agents
+
+| Agent                                                     | Support | Notes                                             |
+|-----------------------------------------------------------|---------|---------------------------------------------------|
+| [Claude Code](https://www.anthropic.com/claude-code)      | ✅ |                                                   |
+| [GitHub Copilot](https://code.visualstudio.com/)          | ✅ |                                                   |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | ✅ |                                                   |
+| [Cursor](https://cursor.sh/)                              | ✅ |                                                   |
+| [Qwen Code](https://github.com/QwenLM/qwen-code)          | ✅ |                                                   |
+| [opencode](https://opencode.ai/)                          | ✅ |                                                   |
+| [Codex CLI](https://github.com/openai/codex)              | ⚠️ | Codex [does not support](https://github.com/openai/codex/issues/2890) custom arguments for slash commands.  |
+| [Windsurf](https://windsurf.com/)                         | ✅ |                                                   |
+| [Kilo Code](https://github.com/Kilo-Org/kilocode)         | ✅ |                                                   |
+| [Auggie CLI](https://docs.augmentcode.com/cli/overview)   | ✅ |                                                   |
+| [Roo Code](https://roocode.com/)                          | ✅ |                                                   |
+
 ## Getting Started
 
 - [Installation Guide](installation.md)
 - [Quick Start Guide](quickstart.md)
+- [CLI Reference](cli-reference.md)
 - [Local Development](local-development.md)
 
 ## Core Philosophy

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,17 +2,41 @@
 
 ## Prerequisites
 
-- **Linux/macOS** (or Windows; PowerShell scripts now supported without WSL)
-- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- **Linux/macOS** (or WSL2 on Windows)
+- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Cursor](https://cursor.sh/), [Qwen Code](https://github.com/QwenLM/qwen-code), [opencode](https://opencode.ai/), [Codex CLI](https://github.com/openai/codex), [Windsurf](https://windsurf.com/), [Kilo Code](https://github.com/Kilo-Org/kilocode), [Auggie CLI](https://docs.augmentcode.com/cli/overview), or [Roo Code](https://roocode.com/)
 - [uv](https://docs.astral.sh/uv/) for package management
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
 
 ## Installation
 
-### Initialize a New Project
+### Choose your preferred installation method:
 
-The easiest way to get started is to initialize a new project:
+#### Option 1: Persistent Installation (Recommended)
+
+Install once and use everywhere:
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+```
+
+Then use the tool directly:
+
+```bash
+specify init <PROJECT_NAME>
+specify check
+```
+
+**Benefits of persistent installation:**
+
+- Tool stays installed and available in PATH
+- No need to create shell aliases
+- Better tool management with `uv tool list`, `uv tool upgrade`, `uv tool uninstall`
+- Cleaner shell configuration
+
+#### Option 2: One-time Usage
+
+Initialize a new project without persistent installation:
 
 ```bash
 uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME>

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -52,7 +52,17 @@ Re-running after code edits requires no reinstall because of editable mode.
 `uvx` can run from a local path (or a Git ref) to simulate user flows:
 
 ```bash
+uvx --from . specify init demo-uvx --ai claude --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai gemini --ignore-agent-tools --script sh
 uvx --from . specify init demo-uvx --ai copilot --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai cursor --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai qwen --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai opencode --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai codex --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai windsurf --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai kilocode --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai auggie --ignore-agent-tools --script sh
+uvx --from . specify init demo-uvx --ai roo --ignore-agent-tools --script sh
 ```
 
 You can also point uvx at a specific branch without merging:
@@ -75,12 +85,33 @@ uvx --from /mnt/c/GitHub/spec-kit specify init demo-anywhere --ai copilot --igno
 Set an environment variable for convenience:
 ```bash
 export SPEC_KIT_SRC=/mnt/c/GitHub/spec-kit
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai claude --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai gemini --ignore-agent-tools --script ps
 uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai copilot --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai cursor --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai qwen --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai opencode --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai codex --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai windsurf --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai kilocode --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai auggie --ignore-agent-tools --script ps
+uvx --from "$SPEC_KIT_SRC" specify init demo-env --ai roo --ignore-agent-tools --script ps
 ```
 
-(Optional) Define a shell function:
+(Optional) Define shell functions:
 ```bash
 specify-dev() { uvx --from /mnt/c/GitHub/spec-kit specify "$@"; }
+specify-dev-claude() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai claude; }
+specify-dev-gemini() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai gemini; }
+specify-dev-copilot() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai copilot; }
+specify-dev-cursor() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai cursor; }
+specify-dev-qwen() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai qwen; }
+specify-dev-opencode() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai opencode; }
+specify-dev-codex() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai codex; }
+specify-dev-windsurf() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai windsurf; }
+specify-dev-kilocode() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai kilocode; }
+specify-dev-auggie() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai auggie; }
+specify-dev-roo() { uvx --from /mnt/c/GitHub/spec-kit specify "$@" --ai roo; }
 # Then
 specify-dev --help
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,11 +4,30 @@ This guide will help you get started with Spec-Driven Development using Spec Kit
 
 > NEW: All automation scripts now provide both Bash (`.sh`) and PowerShell (`.ps1`) variants. The `specify` CLI auto-selects based on OS unless you pass `--script sh|ps`.
 
-## The 4-Step Process
+## The 6-Step Process
 
 ### 1. Install Specify
 
-Initialize your project depending on the coding agent you're using:
+Choose your preferred installation method:
+
+#### Option 1: Persistent Installation (Recommended)
+
+Install once and use everywhere:
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+```
+
+Then use the tool directly:
+
+```bash
+specify init <PROJECT_NAME>
+specify check
+```
+
+#### Option 2: One-time Usage
+
+Initialize your project without persistent installation:
 
 ```bash
 uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME>
@@ -20,31 +39,71 @@ uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME
 uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME> --script sh  # Force POSIX shell
 ```
 
-### 2. Create the Spec
+### 2. Establish project principles
 
-Use the `/specify` command to describe what you want to build. Focus on the **what** and **why**, not the tech stack.
+Use the **`/constitution`** command to create your project's governing principles and development guidelines that will guide all subsequent development.
+
+```bash
+/constitution Create principles focused on code quality, testing standards, user experience consistency, and performance requirements
+```
+
+### 3. Create the spec
+
+Use the **`/specify`** command to describe what you want to build. Focus on the **what** and **why**, not the tech stack.
 
 ```bash
 /specify Build an application that can help me organize my photos in separate photo albums. Albums are grouped by date and can be re-organized by dragging and dropping on the main page. Albums are never in other nested albums. Within each album, photos are previewed in a tile-like interface.
 ```
 
-### 3. Create a Technical Implementation Plan
+### 4. Create a technical implementation plan
 
-Use the `/plan` command to provide your tech stack and architecture choices.
+Use the **`/plan`** command to provide your tech stack and architecture choices.
 
 ```bash
 /plan The application uses Vite with minimal number of libraries. Use vanilla HTML, CSS, and JavaScript as much as possible. Images are not uploaded anywhere and metadata is stored in a local SQLite database.
 ```
 
-### 4. Break Down and Implement
+### 5. Break down into tasks
 
-Use `/tasks` to create an actionable task list, then ask your agent to implement the feature.
+Use **`/tasks`** to create an actionable task list from your implementation plan.
+
+```bash
+/tasks
+```
+
+### 6. Execute implementation
+
+Use **`/implement`** to execute all tasks and build your feature according to the plan.
+
+```bash
+/implement
+```
+
+## Available Slash Commands
+
+After running `specify init`, your AI coding agent will have access to these slash commands for structured development:
+
+| Command         | Description                                                           |
+|-----------------|-----------------------------------------------------------------------|
+| `/constitution` | Create or update project governing principles and development guidelines |
+| `/specify`      | Define what you want to build (requirements and user stories)        |
+| `/clarify`      | Clarify underspecified areas (must be run before `/plan` unless explicitly skipped; formerly `/quizme`) |
+| `/plan`         | Create technical implementation plans with your chosen tech stack     |
+| `/tasks`        | Generate actionable task lists for implementation                     |
+| `/analyze`      | Cross-artifact consistency & coverage analysis (run after /tasks, before /implement) |
+| `/implement`    | Execute all tasks to build the feature according to the plan         |
 
 ## Detailed Example: Building Taskify
 
 Here's a complete example of building a team productivity platform:
 
-### Step 1: Define Requirements with `/specify`
+### Step 1: Define Project Principles with `/constitution`
+
+```text
+/constitution Create principles focused on code quality, testing standards, user experience consistency, and performance requirements. Include governance for how these principles should guide technical decisions and implementation choices.
+```
+
+### Step 2: Define Requirements with `/specify`
 
 ```text
 Develop Taskify, a team productivity platform. It should allow users to create projects, add team members,
@@ -65,7 +124,7 @@ see yours. You can edit any comments that you make, but you can't edit comments 
 delete any comments that you made, but you can't delete comments anybody else made.
 ```
 
-### Step 2: Refine the Specification
+### Step 3: Refine the Specification
 
 After the initial specification is created, clarify any missing requirements:
 
@@ -81,7 +140,7 @@ Also validate the specification checklist:
 Read the review and acceptance checklist, and check off each item in the checklist if the feature spec meets the criteria. Leave it empty if it does not.
 ```
 
-### Step 3: Generate Technical Plan with `/plan`
+### Step 4: Generate Technical Plan with `/plan`
 
 Be specific about your tech stack and technical requirements:
 
@@ -91,7 +150,13 @@ Blazor server with drag-and-drop task boards, real-time updates. There should be
 tasks API, and a notifications API.
 ```
 
-### Step 4: Validate and Implement
+### Step 5: Validate and Analyze
+
+Before implementation, use `/analyze` to perform cross-artifact consistency and coverage analysis:
+
+```text
+/analyze
+```
 
 Have your AI agent audit the implementation plan:
 
@@ -101,10 +166,12 @@ Read through it with an eye on determining whether or not there is a sequence of
 to be doing that are obvious from reading this. Because I don't know if there's enough here.
 ```
 
+### Step 6: Implement
+
 Finally, implement the solution:
 
 ```text
-implement specs/002-create-taskify/plan.md
+/implement
 ```
 
 ## Key Principles

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -9,6 +9,8 @@
       href: installation.md
     - name: Quick Start
       href: quickstart.md
+    - name: CLI Reference
+      href: cli-reference.md
 
 # Development workflows
 - name: Development


### PR DESCRIPTION
This PR fixes inconsistencies between the main README.md and the documentation site. 

Fixes #530 

Previously, the docs were missing important details that were present in README, which caused confusion for users.  

## Changes Made
- Updated installation.md to include persistent installation option and all supported AI agents  
- Enhanced quickstart.md with full 6-step process including missing `/constitution` and `/analyze` commands  
- Added comprehensive CLI reference documentation as a new page  
- Updated local-development.md with examples for all supported AI agents  
- Added Supported AI Agents table to index.md  
- Updated table of contents and docfx.json to include new documentation  

## Why This Matters
- Ensures consistency between README.md and docs site  
- Properly documents missing features and commands  
- Reflects actual capabilities across all docs  
- Provides new users with complete installation and usage instructions  

## Testing
- Verified all links work correctly  
- Confirmed documentation builds successfully with changes  