### PR TITLE
Add --local flag for testing templates locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ When working on spec-kit:
 2. Verify templates are working correctly in `templates/` directory
 3. Test script functionality in the `scripts/` directory
 4. Ensure memory files (`memory/constitution.md`) are updated if major process changes are made
+5. When testing template changes locally, use `uv run specify init --local` to copy templates from your local repository instead of downloading from GitHub
 
 ## AI contributions in Spec Kit
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The `specify` command supports the following options:
 | `--skip-tls`           | Flag     | Skip SSL/TLS verification (not recommended)                                 |
 | `--debug`              | Flag     | Enable detailed debug output for troubleshooting                            |
 | `--github-token`       | Option   | GitHub token for API requests (or set GH_TOKEN/GITHUB_TOKEN env variable)  |
+| `--local`              | Flag     | Use local templates from repository instead of downloading from GitHub (for testing) |
 
 ### Examples
 
@@ -198,6 +199,9 @@ specify init my-project --ai claude --debug
 
 # Use GitHub token for API requests (helpful for corporate environments)
 specify init my-project --ai claude --github-token ghp_your_token_here
+
+# Test local template changes (for contributors)
+uv run specify init test-project --local
 
 # Check system requirements
 specify check


### PR DESCRIPTION
## Summary

- Add `--local` flag to `specify init` command to copy templates from local repository instead of downloading from GitHub
- Add documentation for the new flag in CONTRIBUTING.md and README.md

## Changes

### Core functionality (src/specify_cli/__init__.py)
- Add `copy_local_templates()` function that copies templates from the local spec-kit repository
- Modify `init` command to support `--local` flag
- When `--local` is enabled, skip GitHub fetch/download/extract steps and copy from local repo instead

### Documentation updates
- CONTRIBUTING.md: Add step 5 to Development workflow about testing template changes locally
- README.md: Add `--local` flag to options table and usage example

## Use case

This flag is intended for contributors who want to test template changes locally without pushing to GitHub and downloading from there. It streamlines the development workflow for template modifications.

## Test plan

- [ ] Test `uv run specify init test-project --local` from spec-kit repository
- [ ] Verify templates are copied correctly from local repository
- [ ] Verify all directory structures (.specify/memory, .specify/scripts, agent-specific commands) are created properly
- [ ] Test with different AI assistants and script types

🤖 Generated with [Claude Code](https://claude.com/claude-code)