### PR TITLE
fix: include the latest changelog in the `GitHub Release`'s  body

### DIFF
--- a/.github/workflows/scripts/generate-release-notes.sh
+++ b/.github/workflows/scripts/generate-release-notes.sh
@@ -30,6 +30,10 @@ fi
 cat > release_notes.md << EOF
 This is the latest set of releases that you can use with your agent of choice. We recommend using the Specify CLI to scaffold your projects, however you can download these independently and manage them yourself.
 
+## Changelog
+
+$COMMITS
+
 EOF
 
 echo "Generated release notes:"


### PR DESCRIPTION
The GitHub release's body was missing the commits that were actually collected during the release script execution.