### PR TITLE
feat: add documentation for upgrading specify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ specify init <PROJECT_NAME>
 specify check
 ```
 
+To upgrade specify run:
+
+```bash
+uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git
+```
+
 #### Option 2: One-time Usage
 
 Run directly without installing:


### PR DESCRIPTION
### Description

I've found that readme doesn't relay how to upgrade the package, this simple addition should solve that
<img width="1512" height="179" alt="image" src="https://github.com/user-attachments/assets/67821cd2-a608-48f1-aca4-834ff3b6e203" />
