### PR TITLE
Feature :  Remote catalogue of constitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ All notable changes to the Specify CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Remote Constitutions Feature**: New capability to fetch and apply constitutions from remote GitHub repositories during project initialization
+  - `list-constitutions` command to browse available constitutions from a GitHub repository
+  - `--constitution-repo` option for `init` command to specify a GitHub repository containing constitutions
+  - `--constitution-name` option to directly specify which constitution to use
+  - `--constitution-interactive` flag to interactively select from available constitutions
+  - `--constitution-path` option to specify subdirectory within the constitution repository
+  - `--constitution-branch` option to fetch from a specific branch (default: main)
+  - Support for both public and private repositories (with GitHub token authentication)
+  - Comprehensive documentation in `docs/remote-constitutions.md`
+  - Example constitution repository guide in `docs/example-constitutions-repo.md`
+- New helper functions `fetch_remote_constitutions_list()` and `fetch_remote_constitution_content()` to handle GitHub API interactions
+- Constitution fetching integrated into the project initialization workflow with progress tracking
+
+### Changed
+
+- Enhanced `init` command help text to include remote constitution examples
+- Updated README.md with remote constitution feature documentation and usage examples
+- Added remote constitution options to CLI reference table in README.md
+
 ## [0.0.18] - 2025-10-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The `specify` command supports the following options:
 |-------------|----------------------------------------------------------------|
 | `init`      | Initialize a new Specify project from the latest template      |
 | `check`     | Check for installed tools (`git`, `claude`, `gemini`, `code`/`code-insiders`, `cursor-agent`, `windsurf`, `qwen`, `opencode`, `codex`) |
+| `list-constitutions` | List available constitutions from a remote GitHub repository |
 
 ### `specify init` Arguments & Options
 
@@ -166,6 +167,11 @@ The `specify` command supports the following options:
 | `--skip-tls`           | Flag     | Skip SSL/TLS verification (not recommended)                                 |
 | `--debug`              | Flag     | Enable detailed debug output for troubleshooting                            |
 | `--github-token`       | Option   | GitHub token for API requests (or set GH_TOKEN/GITHUB_TOKEN env variable)  |
+| `--constitution-repo`  | Option   | GitHub repository containing constitutions (format: 'owner/repo')           |
+| `--constitution-name`  | Option   | Name of the constitution to use from the remote repository                  |
+| `--constitution-path`  | Option   | Path within constitution repository where constitutions are stored          |
+| `--constitution-branch`| Option   | Branch to fetch constitution from (default: main)                           |
+| `--constitution-interactive` | Flag | Interactively select a constitution from the remote repository        |
 
 ### Examples
 
@@ -197,6 +203,19 @@ specify init --here --force --ai copilot
 
 # Skip git initialization
 specify init my-project --ai gemini --no-git
+
+# Use a remote constitution from your company's repository
+specify init my-project --constitution-repo myorg/constitutions --constitution-name python-microservices
+
+# Interactively select a remote constitution
+specify init my-project --constitution-repo myorg/constitutions --constitution-interactive
+
+# List available constitutions
+specify list-constitutions myorg/constitutions
+specify list-constitutions myorg/constitutions --path backend
+```
+
+For more details on remote constitutions, see the [Remote Constitutions Guide](docs/remote-constitutions.md).
 
 # Enable debug output for troubleshooting
 specify init my-project --ai claude --debug

--- a/docs/example-constitutions-repo.md
+++ b/docs/example-constitutions-repo.md
@@ -1,0 +1,368 @@
+# Example Constitution Repository
+
+This is an example structure for creating a constitution repository that can be used with spec-kit's remote constitutions feature.
+
+## Repository Structure
+
+```
+my-constitutions/
+├── README.md                          # Overview and usage guide
+├── python-microservices.md            # Python microservices constitution
+├── golang-api.md                      # Go API services constitution
+├── react-frontend.md                  # React frontend constitution
+├── nodejs-backend.md                  # Node.js backend constitution
+├── data-pipeline.md                   # Data pipeline constitution
+└── mobile-app.md                      # Mobile app constitution
+```
+
+## Example Constitution Files
+
+### python-microservices.md
+
+```markdown
+# Python Microservices Constitution
+
+## Core Principles
+
+### I. API-First Design
+Every microservice must define its API contract using OpenAPI 3.0 specification before implementation begins. APIs must be versioned and maintain backward compatibility.
+
+### II. Test-Driven Development (NON-NEGOTIABLE)
+- Unit test coverage must be >= 80%
+- Integration tests required for all API endpoints
+- Tests must pass before merging to main branch
+- TDD cycle: Red → Green → Refactor
+
+### III. Observability
+All services must implement:
+- Structured logging using Python's `structlog` library (JSON format)
+- Distributed tracing via OpenTelemetry
+- Metrics exposure in Prometheus format
+- Health check endpoints (`/health`, `/ready`)
+- Request ID propagation across service boundaries
+
+### IV. Cloud Native Standards
+Services must:
+- Run in Docker containers (Alpine-based for size optimization)
+- Follow 12-factor app principles
+- Use Kubernetes for orchestration
+- Store configuration in environment variables
+- Be stateless and horizontally scalable
+
+### V. Security Requirements
+- All external communications must use TLS 1.3+
+- Secrets managed via HashiCorp Vault or Kubernetes Secrets
+- No credentials in code, config files, or container images
+- Regular dependency scanning (weekly) using `safety` and `snyk`
+- Input validation on all API endpoints
+- Rate limiting on public endpoints
+
+### VI. Code Quality Standards
+- Type hints required for all functions (use `mypy` for static checking)
+- Code formatted with `black` (line length: 100)
+- Import sorting with `isort`
+- Linting with `ruff` (or `pylint` + `flake8`)
+- Pre-commit hooks enforced for all the above
+
+### VII. Dependency Management
+- Use `Poetry` or `uv` for dependency management
+- Pin all dependencies to specific versions
+- Monthly dependency updates
+- Security patches applied within 72 hours of disclosure
+
+## Development Workflow
+
+### Branching Strategy
+- Main branch protected, requires PR
+- Feature branches: `feature/description`
+- Bug fixes: `fix/description`
+- Hotfixes: `hotfix/description`
+
+### Code Review Process
+- Minimum 2 approvers required
+- Architecture review for new services or major changes
+- Security review for authentication/authorization changes
+- Performance review for database-heavy features
+
+### Testing Requirements
+- Unit tests: pytest with fixtures
+- Integration tests: testcontainers for dependencies
+- Contract tests: Pact for service-to-service
+- Load tests: Locust for performance validation
+
+### CI/CD Pipeline
+- Automated testing on every PR
+- Automated security scanning (SAST, dependency check)
+- Automated Docker image building and scanning
+- Blue-green deployments for zero downtime
+- Automated rollback on health check failures
+
+## Technology Stack
+
+### Required
+- **Language**: Python 3.11+
+- **Framework**: FastAPI or Flask
+- **ORM**: SQLAlchemy
+- **Database**: PostgreSQL (primary), Redis (cache/queue)
+- **Message Queue**: RabbitMQ or Apache Kafka
+- **Observability**: OpenTelemetry + Prometheus + Grafana
+
+### Recommended
+- **Testing**: pytest, pytest-asyncio, httpx (for async tests)
+- **Validation**: Pydantic for data validation
+- **Documentation**: Swagger UI (auto-generated from OpenAPI)
+
+## Governance
+
+This constitution supersedes all other development practices for Python microservices. Amendments require approval from:
+- Tech Lead
+- Architecture Review Board
+- Security Team representative
+
+All amendments must be documented with:
+- Rationale for change
+- Impact assessment
+- Migration plan for existing services
+
+**Version**: 1.0.0 | **Ratified**: 2025-01-15 | **Last Amended**: 2025-01-15
+```
+
+### react-frontend.md
+
+```markdown
+# React Frontend Constitution
+
+## Core Principles
+
+### I. Component-First Development
+- Build reusable, self-contained components
+- Follow atomic design principles (atoms, molecules, organisms)
+- Components must be documented with Storybook
+- Prop types required (TypeScript interfaces)
+
+### II. Type Safety (NON-NEGOTIABLE)
+- TypeScript strict mode enabled
+- No `any` types allowed (use `unknown` if necessary)
+- All props, state, and API responses must be typed
+- Type definitions in separate `.types.ts` files
+
+### III. Testing Strategy
+- Unit tests for business logic (>= 80% coverage)
+- Component tests using React Testing Library
+- E2E tests for critical user flows (Playwright)
+- Visual regression tests for UI components (Chromatic)
+
+### IV. Performance Standards
+- Lighthouse score >= 90 (all categories)
+- Time to Interactive (TTI) < 3.5s on 4G
+- First Contentful Paint (FCP) < 1.8s
+- Cumulative Layout Shift (CLS) < 0.1
+- Lazy loading for routes and heavy components
+- Code splitting at route level minimum
+
+### V. Accessibility (NON-NEGOTIABLE)
+- WCAG 2.1 Level AA compliance required
+- Semantic HTML elements
+- Proper ARIA labels where needed
+- Keyboard navigation support
+- Screen reader tested
+- Color contrast ratios compliant
+
+### VI. State Management
+- Use React Context for simple, localized state
+- Use Zustand or Redux Toolkit for complex global state
+- Server state managed by TanStack Query (React Query)
+- Form state with React Hook Form
+- URL as source of truth for navigation state
+
+### VII. Code Quality
+- ESLint with Airbnb or Standard config
+- Prettier for formatting (single quotes, semicolons)
+- Husky for pre-commit hooks
+- No console.log statements in production code
+- Custom hooks for shared logic
+
+## Development Workflow
+
+### Project Structure
+```
+src/
+├── components/      # Reusable UI components
+├── features/        # Feature-specific modules
+├── hooks/          # Custom React hooks
+├── pages/          # Route components
+├── services/       # API clients
+├── store/          # Global state
+├── types/          # TypeScript types
+├── utils/          # Utility functions
+└── styles/         # Global styles
+```
+
+### Component Guidelines
+- One component per file
+- Use functional components with hooks
+- Extract custom hooks for complex logic
+- Props destructured in function signature
+- Default exports for components
+
+### Styling Approach
+- Tailwind CSS for utility-first styling
+- CSS Modules for component-specific styles
+- styled-components for dynamic styling needs
+- No inline styles except for dynamic values
+
+### API Integration
+- Centralize API calls in service modules
+- Use TanStack Query for data fetching
+- Implement request/response interceptors
+- Handle loading, error, and success states
+- Optimistic updates where appropriate
+
+### Code Review Process
+- Minimum 1 reviewer (2 for major changes)
+- UI/UX review for new components
+- Accessibility review for interactive elements
+- Performance review for data-heavy features
+
+### CI/CD Pipeline
+- Type checking with TypeScript
+- Linting with ESLint
+- Unit and component tests
+- Build verification
+- Deploy preview for every PR
+- Automated deployment to staging
+
+## Technology Stack
+
+### Required
+- **Framework**: React 18+
+- **Language**: TypeScript 5+
+- **Build Tool**: Vite
+- **Styling**: Tailwind CSS
+- **State**: Zustand + TanStack Query
+- **Routing**: React Router v6
+- **Forms**: React Hook Form + Zod
+- **Testing**: Vitest + React Testing Library + Playwright
+
+### Recommended
+- **UI Library**: shadcn/ui or Radix UI
+- **Icons**: Lucide React or Heroicons
+- **Date Handling**: date-fns
+- **HTTP Client**: ky or axios
+
+## Governance
+
+This constitution applies to all React-based frontends. Amendments require approval from:
+- Frontend Tech Lead
+- UX Lead
+- Accessibility Champion
+
+All amendments must include:
+- Rationale and benefits
+- Migration guide for existing code
+- Update to component library if needed
+
+**Version**: 1.2.0 | **Ratified**: 2024-09-01 | **Last Amended**: 2025-01-20
+```
+
+## Using These Constitutions
+
+1. Create a GitHub repository (public or private)
+2. Add your constitution markdown files
+3. Team members can list them:
+   ```bash
+   specify list-constitutions myorg/constitutions-repo
+   ```
+
+4. Initialize projects with a constitution:
+   ```bash
+   specify init my-app --constitution-repo myorg/constitutions-repo --constitution-name react-frontend
+   ```
+
+5. Or select interactively:
+   ```bash
+   specify init my-app --constitution-repo myorg/constitutions-repo --constitution-interactive
+   ```
+
+## Best Practices for Constitution Repositories
+
+1. **Keep constitutions focused**: Each should target a specific use case or tech stack
+2. **Version your constitutions**: Include version numbers and dates
+3. **Document rationale**: Explain *why* rules exist, not just *what* they are
+4. **Make them actionable**: Include specific tools, commands, and examples
+5. **Review regularly**: Update constitutions as practices evolve
+6. **Collect feedback**: Encourage teams to suggest improvements
+7. **Maintain a changelog**: Track what changed and why
+8. **Add a README**: Explain the purpose and usage of each constitution
+
+## Example README.md for Constitution Repository
+
+```markdown
+# Engineering Constitutions
+
+This repository contains standardized project constitutions for [Your Company Name].
+
+## Available Constitutions
+
+| Constitution | Use Case | Last Updated |
+|--------------|----------|--------------|
+| `python-microservices.md` | Backend microservices in Python | 2025-01-15 |
+| `golang-api.md` | High-performance APIs in Go | 2025-01-10 |
+| `react-frontend.md` | Web frontends using React | 2025-01-20 |
+| `nodejs-backend.md` | Node.js backend services | 2025-01-12 |
+| `data-pipeline.md` | ETL and data processing pipelines | 2024-12-20 |
+| `mobile-app.md` | React Native mobile apps | 2025-01-05 |
+
+## Usage
+
+### List Available Constitutions
+
+```bash
+specify list-constitutions yourorg/engineering-constitutions
+```
+
+### Initialize New Project with Constitution
+
+```bash
+specify init my-new-service \
+  --constitution-repo yourorg/engineering-constitutions \
+  --constitution-name python-microservices
+```
+
+### Interactive Selection
+
+```bash
+specify init my-new-service \
+  --constitution-repo yourorg/engineering-constitutions \
+  --constitution-interactive
+```
+
+## Contributing
+
+To propose changes to a constitution:
+
+1. Create a new branch
+2. Update the relevant constitution file
+3. Include rationale in commit message
+4. Open a PR with:
+   - What changed
+   - Why it changed
+   - Impact on existing projects
+   - Migration guidance if needed
+
+## Approval Process
+
+Constitution changes require approval from:
+- Tech Lead of relevant domain
+- Architecture Review Board representative
+- At least 2 engineers who use that constitution
+
+## Questions?
+
+Contact the Architecture Team at #architecture-help
+```
+
+## Additional Resources
+
+- [Remote Constitutions Guide](../docs/remote-constitutions.md)
+- [spec-kit Documentation](../README.md)

--- a/docs/remote-constitutions.md
+++ b/docs/remote-constitutions.md
@@ -1,0 +1,411 @@
+# Remote Constitutions
+
+## Overview
+
+The Remote Constitutions feature allows organizations to maintain a centralized catalog of project constitutions in a GitHub repository. This enables teams to easily bootstrap new projects with pre-approved, standardized governance principles and development guidelines.
+
+## Why Remote Constitutions?
+
+At large companies or within development teams, there are often:
+- **Standard practices** that should be followed across projects
+- **Compliance requirements** that must be met
+- **Technology standards** for cloud environments, CICD pipelines, etc.
+- **Quality guidelines** that ensure consistency across the organization
+
+Instead of requiring developers to recreate or copy-paste these constitutions, remote constitutions allow them to:
+1. Browse available constitutions from a central repository
+2. Select the appropriate constitution for their project type
+3. Automatically apply it during project initialization
+
+## Setting Up a Constitutions Repository
+
+### Repository Structure
+
+Create a GitHub repository to store your constitutions. The recommended structure is:
+
+```
+my-constitutions-repo/
+├── README.md
+├── python-microservices.md
+├── react-frontend.md
+├── golang-api.md
+├── data-pipeline.md
+└── mobile-app.md
+```
+
+Or organize them in directories:
+
+```
+my-constitutions-repo/
+├── README.md
+├── backend/
+│   ├── python-microservices.md
+│   ├── golang-api.md
+│   └── java-spring.md
+├── frontend/
+│   ├── react-spa.md
+│   └── vue-pwa.md
+└── data/
+    ├── batch-pipeline.md
+    └── streaming-pipeline.md
+```
+
+### Constitution File Format
+
+Each constitution file should be a markdown file (`.md`) following the structure defined in the spec-kit template. See `memory/constitution.md` in any initialized project for the template format.
+
+Example constitution for a Python microservices project:
+
+```markdown
+# Python Microservices Constitution
+
+## Core Principles
+
+### I. API-First Design
+Every microservice must define its API contract using OpenAPI 3.0 specification before implementation begins. APIs must be versioned and maintain backward compatibility.
+
+### II. Test-Driven Development (NON-NEGOTIABLE)
+- Unit test coverage must be >= 80%
+- Integration tests required for all API endpoints
+- Tests must pass before merging to main branch
+
+### III. Observability
+All services must implement:
+- Structured logging (JSON format)
+- Distributed tracing (OpenTelemetry)
+- Metrics exposure (Prometheus format)
+- Health check endpoints (/health, /ready)
+
+### IV. Cloud Native Standards
+Services must:
+- Run in Docker containers
+- Follow 12-factor app principles
+- Use Kubernetes for orchestration
+- Store configs in environment variables
+
+### V. Security Requirements
+- All external communications must use TLS
+- Secrets managed via HashiCorp Vault
+- No credentials in code or config files
+- Regular dependency scanning for vulnerabilities
+
+## Development Workflow
+
+### Code Review Process
+- Minimum 2 approvers required
+- Architecture review for new services
+- Security review for authentication changes
+
+### CI/CD Pipeline
+- Automated testing on every PR
+- Automated security scanning
+- Blue-green deployments for zero downtime
+
+## Governance
+
+This constitution supersedes all other development practices. Amendments require approval from the architecture steering committee and must be documented with rationale and migration plans.
+
+**Version**: 1.0.0 | **Ratified**: 2025-01-15 | **Last Amended**: 2025-01-15
+```
+
+### Access Control
+
+- **Public repositories**: Anyone can access the constitutions
+- **Private repositories**: Users need a GitHub token with appropriate permissions
+
+## Using Remote Constitutions
+
+### Listing Available Constitutions
+
+To see what constitutions are available in a repository:
+
+```bash
+specify list-constitutions myorg/constitutions-repo
+```
+
+With a custom path:
+
+```bash
+specify list-constitutions myorg/constitutions-repo --path backend
+```
+
+From a specific branch:
+
+```bash
+specify list-constitutions myorg/constitutions-repo --branch develop
+```
+
+For private repositories:
+
+```bash
+specify list-constitutions myorg/private-constitutions --github-token $GITHUB_TOKEN
+```
+
+Or set the token as an environment variable:
+
+```bash
+export GITHUB_TOKEN="ghp_your_token_here"
+specify list-constitutions myorg/private-constitutions
+```
+
+### Applying a Constitution During Init
+
+#### Interactive Selection
+
+Browse and select interactively:
+
+```bash
+specify init my-project --constitution-repo myorg/constitutions --constitution-interactive
+```
+
+#### Direct Specification
+
+Specify the constitution name directly:
+
+```bash
+specify init my-project \
+  --constitution-repo myorg/constitutions \
+  --constitution-name python-microservices
+```
+
+#### With Custom Path
+
+If constitutions are in a subdirectory:
+
+```bash
+specify init my-project \
+  --constitution-repo myorg/constitutions \
+  --constitution-path backend \
+  --constitution-name python-microservices
+```
+
+#### From Non-Main Branch
+
+Use a specific branch:
+
+```bash
+specify init my-project \
+  --constitution-repo myorg/constitutions \
+  --constitution-branch develop \
+  --constitution-name experimental-python
+```
+
+#### Complete Example with All Options
+
+```bash
+specify init my-new-api \
+  --ai claude \
+  --script sh \
+  --constitution-repo mycompany/engineering-standards \
+  --constitution-path constitutions/backend \
+  --constitution-name python-microservices \
+  --github-token $GITHUB_TOKEN
+```
+
+## Best Practices
+
+### For Constitution Repository Maintainers
+
+1. **Clear Naming**: Use descriptive, hyphenated names for constitution files
+   - ✅ `python-microservices.md`
+   - ✅ `react-spa-enterprise.md`
+   - ❌ `const1.md`
+   - ❌ `v2.md`
+
+2. **Version Your Constitutions**: Include version numbers in the constitution content itself
+
+3. **Add a README**: Create a comprehensive README.md explaining:
+   - Purpose of each constitution
+   - When to use which constitution
+   - How to contribute updates
+   - Change approval process
+
+4. **Use Examples**: Include practical examples in your constitutions
+
+5. **Keep Them Updated**: Regular reviews to ensure constitutions reflect current practices
+
+6. **Document Changes**: Use Git commit messages to explain constitution changes
+
+### For Constitution Users
+
+1. **Review Before Using**: Always review the constitution content before applying it
+
+2. **Customize as Needed**: Remote constitutions are starting points; customize them for your specific project needs after initialization
+
+3. **Stay Updated**: Periodically check if your constitution source has updates
+
+4. **Provide Feedback**: Report issues or suggest improvements to constitution maintainers
+
+## Security Considerations
+
+### GitHub Tokens
+
+When using private repositories, you'll need a GitHub Personal Access Token:
+
+1. **Create a token** at https://github.com/settings/tokens
+2. **Required scopes**: `repo` (for private repos) or `public_repo` (for public repos)
+3. **Store securely**: Use environment variables, never hardcode tokens
+
+```bash
+# Set as environment variable
+export GITHUB_TOKEN="ghp_your_token_here"
+
+# Or pass directly (less secure)
+specify init my-project --constitution-repo myorg/repo --github-token "ghp_your_token_here"
+```
+
+### Constitution Content Security
+
+- **Review constitutions**: Ensure they come from trusted sources
+- **Check for secrets**: Constitutions should never contain credentials or API keys
+- **Validate practices**: Ensure recommended practices align with your security policies
+
+## Troubleshooting
+
+### "Repository or path not found"
+
+**Cause**: The repository URL or path is incorrect, or you don't have access.
+
+**Solutions**:
+- Verify the repository exists: `https://github.com/owner/repo`
+- Check if it's private and you need a token
+- Verify the path within the repository is correct
+
+### "No constitutions found"
+
+**Cause**: No `.md` files in the specified path.
+
+**Solutions**:
+- Check the `--path` parameter
+- Verify files have `.md` extension
+- Use `list-constitutions` command to see what's available
+
+### "Constitution 'name' not found"
+
+**Cause**: The specified constitution name doesn't match any files.
+
+**Solutions**:
+- Run `list-constitutions` to see available names
+- Constitution names are file names without the `.md` extension
+- Check for typos in the name
+
+### Rate Limiting
+
+**Cause**: GitHub API has rate limits (60 requests/hour for unauthenticated users).
+
+**Solution**:
+- Use a GitHub token to get higher limits (5000 requests/hour)
+- Wait before retrying
+
+## Examples
+
+### Example 1: Company-Wide Standards
+
+**Scenario**: Your company has standardized on specific architectures and practices.
+
+**Setup**: Create a `engineering-standards` repository with constitutions for each tech stack.
+
+**Usage**:
+```bash
+# New Python microservice
+specify init payment-service \
+  --constitution-repo acme-corp/engineering-standards \
+  --constitution-name python-microservices
+
+# New React frontend
+specify init customer-portal \
+  --constitution-repo acme-corp/engineering-standards \
+  --constitution-name react-spa-enterprise
+```
+
+### Example 2: Team-Specific Templates
+
+**Scenario**: Your data engineering team has specific requirements.
+
+**Setup**: Create a `data-team-constitutions` repository with pipelines, schemas, etc.
+
+**Usage**:
+```bash
+specify init customer-analytics \
+  --constitution-repo data-team/data-team-constitutions \
+  --constitution-name spark-batch-pipeline \
+  --constitution-interactive
+```
+
+### Example 3: Open Source Best Practices
+
+**Scenario**: You want to share best practices publicly.
+
+**Setup**: Create a public repository with example constitutions.
+
+**Usage**:
+```bash
+# Anyone can use without authentication
+specify init my-open-source-lib \
+  --constitution-repo awesome-org/spec-kit-constitutions \
+  --constitution-name python-library-best-practices
+```
+
+## Integration with CI/CD
+
+You can automate project initialization with remote constitutions in your CI/CD pipelines:
+
+```yaml
+# GitHub Actions example
+name: Bootstrap New Service
+
+on:
+  workflow_dispatch:
+    inputs:
+      service_name:
+        description: 'Name of the new service'
+        required: true
+      constitution:
+        description: 'Constitution to use'
+        required: true
+        type: choice
+        options:
+          - python-microservices
+          - golang-api
+          - nodejs-service
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install specify-cli
+        run: uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+      
+      - name: Initialize project
+        run: |
+          specify init ${{ inputs.service_name }} \
+            --ai copilot \
+            --constitution-repo ${{ github.repository_owner }}/engineering-standards \
+            --constitution-name ${{ inputs.constitution }} \
+            --github-token ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Create repository
+        # ... additional steps to create and push to new repo
+```
+
+## Future Enhancements
+
+Potential future improvements to this feature:
+
+- **Constitution metadata**: Support for metadata files describing constitutions
+- **Constitution search**: Search within constitution content
+- **Version locking**: Pin specific versions of constitutions
+- **Constitution validation**: Validate constitution format before applying
+- **Diff preview**: Show what will change when applying a constitution
+- **Constitution inheritance**: Base constitutions that extend others
+- **Custom protocols**: Support for other sources beyond GitHub (GitLab, Bitbucket, etc.)
+
+## Contributing
+
+To contribute improvements to the remote constitutions feature, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Related Documentation
+
+- [Installation](installation.md)
+- [Quickstart](quickstart.md)
+- [Constitution Command](../templates/commands/constitution.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -9,6 +9,10 @@
       href: installation.md
     - name: Quick Start
       href: quickstart.md
+    - name: Remote Constitutions
+      href: remote-constitutions.md
+    - name: Example Constitution Repository
+      href: example-constitutions-repo.md
 
 # Development workflows
 - name: Development

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -1117,7 +1117,7 @@ def init(
             if remote_constitution_content:
                 tracker.add("constitution", "Apply remote constitution")
                 tracker.start("constitution")
-                constitution_file = project_path / "memory" / "constitution.md"
+                constitution_file = project_path / ".specify" / "memory" / "constitution.md"
                 try:
                     # Ensure memory directory exists
                     constitution_file.parent.mkdir(parents=True, exist_ok=True)
@@ -1209,7 +1209,7 @@ def init(
 
     # Add note about remote constitution if used
     if remote_constitution_content:
-        steps_lines.append(f"{step_num}. [green]✓[/green] Constitution '{selected_constitution_name}' has been applied to [cyan]memory/constitution.md[/cyan]")
+        steps_lines.append(f"{step_num}. [green]✓[/green] Constitution '{selected_constitution_name}' has been applied to [cyan].specify/memory/constitution.md[/cyan]")
         step_num += 1
 
     # Add Codex-specific setup step if needed


### PR DESCRIPTION
The intention here is to allow support for fetching pre-made constitutions from a remote github repository. It would be beneficial to allow a dev group or company to have well curated constitutions that contain all of the  steering guidelines, best practices, and company specifics to allow the specify-cli to read from a remote repo and allow the user to select one, instead of starting from scratch each time.

This feature adds a few new cli arguments to facilitate.

Screenshot in action.  
<img width="843" height="264" alt="image" src="https://github.com/user-attachments/assets/002be721-7a82-4e45-92eb-4c82620a9504" />



**File Modified**: `src/specify_cli/__init__.py`

**New Functions**:
- `fetch_remote_constitutions_list()` - Fetches list of constitutions from GitHub
- `fetch_remote_constitution_content()` - Downloads specific constitution content

**New Command**:
- `list-constitutions` - Browse available constitutions from a repository

**Enhanced Command**:
- `init` - Now supports 5 new options for remote constitutions:
  - `--constitution-repo`
  - `--constitution-name`
  - `--constitution-path`
  - `--constitution-branch`
  - `--constitution-interactive`


