### PR TITLE
fix: correctly escape backslashes in TOML slash command outputs

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -91,6 +91,7 @@ generate_commands() {
     
     case $ext in
       toml)
+        body=$(printf '%s\n' "$body" | sed 's/\\/\\\\/g')
         { echo "description = \"$description\""; echo; echo "prompt = \"\"\""; echo "$body"; echo "\"\"\""; } > "$output_dir/speckit.$name.$ext" ;;
       md)
         echo "$body" > "$output_dir/speckit.$name.$ext" ;;


### PR DESCRIPTION
## Summary
- Ensure backslashes in generated Gemini (TOML) command prompts are escaped so they appear as \\ in the produced TOML files.

## Problem
- When command bodies contain backslashes (e.g. Windows paths or escape sequences), generated TOML prompt strings contained single backslashes which break TOML consumers or cause incorrect parsing of slash commands.

## Related
- Fixes #797