### PR TITLE
docs: add /speckit.tasks walkthrough step

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,26 @@ You can also ask Claude Code (if you have the [GitHub CLI](https://docs.github.c
 >[!NOTE]
 >Before you have the agent implement it, it's also worth prompting Claude Code to cross-check the details to see if there are any over-engineered pieces (remember - it can be over-eager). If over-engineered components or decisions exist, you can ask Claude Code to resolve them. Ensure that Claude Code follows the [constitution](base/memory/constitution.md) as the foundational piece that it must adhere to when establishing the plan.
 
-### STEP 6: Implementation
+### **STEP 6:** Generate task breakdown with /speckit.tasks
+
+With the implementation plan validated, you can now break down the plan into specific, actionable tasks that can be executed in the correct order. Use the `/speckit.tasks` command to automatically generate a detailed task breakdown from your implementation plan:
+
+```text
+/speckit.tasks
+```
+
+This step creates a `tasks.md` file in your feature specification directory that contains:
+
+- **Task breakdown organized by user story** - Each user story becomes a separate implementation phase with its own set of tasks
+- **Dependency management** - Tasks are ordered to respect dependencies between components (e.g., models before services, services before endpoints)
+- **Parallel execution markers** - Tasks that can run in parallel are marked with `[P]` to optimize development workflow
+- **File path specifications** - Each task includes the exact file paths where implementation should occur
+- **Test-driven development structure** - If tests are requested, test tasks are included and ordered to be written before implementation
+- **Checkpoint validation** - Each user story phase includes checkpoints to validate independent functionality
+
+The generated tasks.md provides a clear roadmap for the `/speckit.implement` command, ensuring systematic implementation that maintains code quality and allows for incremental delivery of user stories.
+
+### **STEP 7:** Implementation
 
 Once ready, use the `/speckit.implement` command to execute your implementation plan:
 


### PR DESCRIPTION
## Overview

This PR addresses a missing step in the detailed step-by-step walkthrough section of the README.md. The /speckit.tasks command was referenced in the quick start section and mentioned as a prerequisite for the implementation step, but was completely absent from the detailed walkthrough.

## Changes Made

- Added **STEP 6: Generate task breakdown with /speckit.tasks** section
- Renumbered the existing STEP 6 (Implementation) to become STEP 7
- Included detailed description of what the /speckit.tasks command does and generates
- Used consistent formatting with existing steps (heading style, code blocks, bullet points)

## Context

The /speckit.tasks step is crucial for the Spec-Driven Development workflow as it:
- Breaks down implementation plans into specific, actionable tasks
- Organizes tasks by user story for independent development
- Includes dependency management and parallel execution markers
- Provides clear file path specifications for implementation
- Sets up the task roadmap that /speckit.implement uses

This step should logically occur after plan validation (current STEP 5) and before implementation (now STEP 7).

## AI Assistance Disclosure

This PR was written with AI assistance (Claude via Anthropic). I reviewed and tested all changes to ensure they align with the project's documentation standards and the Spec-Driven Development methodology.