### PR TITLE
Fix: incorrect command formatting in agent context file

### DIFF
--- a/scripts/bash/update-agent-context.sh
+++ b/scripts/bash/update-agent-context.sh
@@ -250,7 +250,7 @@ get_commands_for_language() {
             echo "cargo test && cargo clippy"
             ;;
         *"JavaScript"*|*"TypeScript"*)
-            echo "npm test && npm run lint"
+            echo "npm test \&\& npm run lint"
             ;;
         *)
             echo "# Add commands for $lang"


### PR DESCRIPTION
The issue is that `sed` treats `&&` as a placeholder instead of a regular character. So in the CLAUDE.md file's "Commands" section, it incorrectly shows:

`npm test [ONLY COMMANDS FOR ACTIVE TECHNOLOGIES][ONLY COMMANDS FOR ACTIVE TECHNOLOGIES] npm run lint`

instead of the correct:

`npm test && npm run lint`