### PR TITLE
Change loop condition to include last argument

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -6,7 +6,7 @@ JSON_MODE=false
 SHORT_NAME=""
 ARGS=()
 i=0
-while [ $i -lt $# ]; do
+while [ $i -le $# ]; do
     arg="${!i}"
     case "$arg" in
         --json) 


### PR DESCRIPTION
The last argument is not processed. 
e.g. create-new-feature.sh -h doesn't show the help information.