### PR TITLE
fix: Skip CLI checks for IDE-based agents in check command

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -1093,18 +1093,25 @@ def check():
 
     tracker.add("git", "Git version control")
     git_ok = check_tool("git", tracker=tracker)
-    
+
     agent_results = {}
     for agent_key, agent_config in AGENT_CONFIG.items():
         agent_name = agent_config["name"]
-        
+        requires_cli = agent_config["requires_cli"]
+
         tracker.add(agent_key, agent_name)
-        agent_results[agent_key] = check_tool(agent_key, tracker=tracker)
-    
+
+        if requires_cli:
+            agent_results[agent_key] = check_tool(agent_key, tracker=tracker)
+        else:
+            # IDE-based agent - skip CLI check and mark as optional
+            tracker.skip(agent_key, "IDE-based, no CLI check")
+            agent_results[agent_key] = False  # Don't count IDE agents as "found"
+
     # Check VS Code variants (not in agent config)
     tracker.add("code", "Visual Studio Code")
     code_ok = check_tool("code", tracker=tracker)
-    
+
     tracker.add("code-insiders", "Visual Studio Code Insiders")
     code_insiders_ok = check_tool("code-insiders", tracker=tracker)
 


### PR DESCRIPTION
Fixed #926.

- Add requires_cli field handling to check() command
- IDE-based agents (copilot, cursor-agent, windsurf, kilocode, roo) now properly skip CLI checks
- Prevents false errors when checking for IDE-integrated agents that don't require CLI tools

This PR will show below that will help us have more insight from agent supportability.

<img width="657" height="459" alt="image" src="https://github.com/user-attachments/assets/1d707e94-b29f-44bd-9abf-a547cc65de72" />
