### PR TITLE
chore: Add local template package testing utility

### DIFF
--- a/test-local-init.py
+++ b/test-local-init.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Test script to initialize a project with local template packages using monkey patching.
+This bypasses the GitHub download and uses locally built ZIPs from .genreleases/.
+
+Usage:
+    uv run test-local-init.py <project-path> --ai <ai> --script <script> --version <version>
+
+Example:
+    # Build local packages first
+    bash .github/workflows/scripts/create-release-packages.sh v0.0.70
+
+    # Test with local packages
+    uv run test-local-init.py /path/to/project --ai claude --script sh --version v0.0.70
+"""
+
+import sys
+import specify_cli
+from pathlib import Path
+
+def create_local_download(version):
+    """Create a mock download function that returns local ZIPs."""
+    def local_download(ai_assistant, download_dir, **kwargs):
+        script_type = kwargs.get('script_type', 'sh')
+        local_zip = Path(__file__).parent / f".genreleases/spec-kit-template-{ai_assistant}-{script_type}-{version}.zip"
+
+        if not local_zip.exists():
+            raise FileNotFoundError(f"Local package not found: {local_zip}")
+
+        return local_zip, {
+            "filename": local_zip.name,
+            "size": local_zip.stat().st_size,
+            "release": version
+        }
+    return local_download
+
+if __name__ == "__main__":
+    # Extract mandatory --version from args
+    if "--version" not in sys.argv:
+        print("Error: --version is required")
+        print("Usage: test-local-init.py <project> --ai <ai> --script <script> --version <version>")
+        print("\nExample:")
+        print("  uv run test-local-init.py /path/to/project --ai claude --script sh --version v0.0.70")
+        sys.exit(1)
+
+    idx = sys.argv.index("--version")
+    version = sys.argv[idx + 1]
+    sys.argv.pop(idx)  # Remove --version
+    sys.argv.pop(idx)  # Remove value
+
+    print(f"[test-local-init] Using local packages with version: {version}")
+
+    # Monkey patch the download function
+    specify_cli.download_template_from_github = create_local_download(version)
+
+    # Run the real init command - it will use our local packages!
+    specify_cli.main()


### PR DESCRIPTION
## Summary

Adds a local testing utility (`test-local-init.py`) and documentation to enable contributors to test template and script changes locally before submitting PRs, without having to manually copy files and configure directory structures.

## Problem

When running `uv run specify`, the CLI downloads the latest release packages from GitHub, which means local changes to templates, scripts, or memory files are not included. Previously, contributors had to manually:
- Copy files to the correct locations
- Rename them with appropriate prefixes (`.specify/`, `.claude/`, etc.)
- Configure agent-specific directory structures

This manual process is tedious, error-prone, and discourages thorough local testing.

## Solution

This PR introduces a streamlined local testing workflow:

1. **test-local-init.py**: A Python script that uses monkey patching to bypass GitHub downloads and load locally-built template packages from `.genreleases/`
2. **Documentation**: Comprehensive instructions in CONTRIBUTING.md explaining:
   - Prerequisites (bash 4+, zip)
   - How to build local packages using `create-release-packages.sh`
   - How to test with `test-local-init.py`
   - Optional environment variables to limit builds to specific agents/scripts

## How It Works

The `test-local-init.py` script:
- Takes the same arguments as `uv run specify` (project path, AI agent, script type)
- Requires an additional `--version` parameter matching the locally-built package version
- Monkey patches `specify_cli.download_template_from_github` to return local ZIPs instead of downloading from GitHub
- Runs the real `specify_cli.main()` command with local packages

## What's Included

### New Files
- **test-local-init.py** (57 lines): Local testing utility script

### Modified Files
- **CONTRIBUTING.md** (+63 lines): New section "Testing template and command changes locally" with complete workflow documentation

## Test Plan

Contributors can now:
1. Make changes to templates/scripts/memory files
2. Build local packages: `bash .github/workflows/scripts/create-release-packages.sh v0.0.70`
3. Test locally: `uv run test-local-init.py /path/to/project --ai claude --script sh --version v0.0.70`
4. Verify changes work as expected before submitting PR

## AI Assistance Disclosure

This PR was created with assistance from Claude Code (Anthropic). The solution was discussed, implemented, and tested with AI assistance for code generation and documentation. All changes have been reviewed and validated.

Fixes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
