### PR TITLE
Fix case-sensitive project structure detection for Web applications

### DIFF
--- a/scripts/bash/update-agent-context.sh
+++ b/scripts/bash/update-agent-context.sh
@@ -232,7 +232,7 @@ format_technology_stack() {
 get_project_structure() {
     local project_type="$1"
     
-    if [[ "$project_type" == *"web"* ]]; then
+    if [[ "$project_type" == *"Web"* ]]; then
         echo "backend/\\nfrontend/\\ntests/"
     else
         echo "src/\\ntests/"


### PR DESCRIPTION
Correct project structure matching in agent context generation by updating the case sensitivity for "Web" to ensure proper directory structure is generated for Web applications.