### PR TITLE
docs: add steps for testing template and command changes locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ To test your templates, commands, and other changes locally, follow these steps:
 2. **Copy the relevant package to your test project**
 
    ```
-   cp -r .genreleases/sdd-copilot-package-sh/. /PATH_TO/test-project/
+   cp -r .genreleases/sdd-copilot-package-sh/. <path-to-test-project>/
    ```
 
 3. **Open and test the agent**


### PR DESCRIPTION
Closes #729 

## Summary

Add section documenting how to test template and command changes locally. This PR is based on a [helpful comment](https://github.com/github/spec-kit/pull/941#issuecomment-3429785995) by @localden which helped me. Opening this PR to share this knowledge with other contributors who may encounter the same workflow challenge.

## Test plan

  - [x] Verified documentation accuracy against current workflow
  - [x] Confirmed script paths exist and are correct
  - [x] Tested local package generation process

## Details

The change adds a new "Testing template and command changes locally" subsection under the Development workflow section that explains:

  1. The Problem: Running uv run specify init pulls released packages which don't include local changes
  2. The Solution: Creating packages locally, copying them them over and testing them
