### PR TITLE
fix: check all git branches for feature numbering to prevent duplicates

### DIFF
--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -232,15 +232,15 @@ $maxBranchLength = 244
 if ($branchName.Length -gt $maxBranchLength) {
     # Calculate how much we need to trim from suffix
     # Account for: feature number (3) + hyphen (1) = 4 chars
-    $maxSuffixLength = $maxBranchLength - 4;
+    $maxSuffixLength = $maxBranchLength - 4
     
     # Truncate suffix
     $truncatedSuffix = $branchSuffix.Substring(0, [Math]::Min($branchSuffix.Length, $maxSuffixLength))
     # Remove trailing hyphen if truncation created one
     $truncatedSuffix = $truncatedSuffix -replace '-$', ''
     
-    $originalBranchName = $branchName;
-    $branchName = "$featureNum-$truncatedSuffix";
+    $originalBranchName = $branchName
+    $branchName = "$featureNum-$truncatedSuffix"
     
     Write-Warning "[specify] Branch name exceeded GitHub's 244-byte limit"
     Write-Warning "[specify] Original: $originalBranchName ($($originalBranchName.Length) bytes)"


### PR DESCRIPTION
Fixes #975

## Problem
The `Get-NextBranchNumber` function was checking only branches with the same short name when determining the next feature number, causing duplicate feature numbers when multiple feature branches exist that haven't been merged to main.

## Solution
Updated the function to check ALL existing git branches matching the pattern `^\d{3}-` instead of only branches with the same short name.

## Changes
- Removed `$ShortName` parameter from `Get-NextBranchNumber` function
- Updated regex patterns to match ALL feature branches:
  - Remote: `refs/heads/(\d{3})-`
  - Local: `^\*?\s*(\d{3})-`
  - Specs: `^(\d{3})-`
- Updated function call to remove `-ShortName` parameter
- Now correctly finds highest feature number across ALL features