### PR TITLE
Fix incorrect phase numbering in plan.md

### DIFF
--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -28,8 +28,8 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Evaluate gates (ERROR if violations unjustified)
    - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md
-   - Phase 1: Update agent context by running the agent script
-   - Re-evaluate Constitution Check post-design
+   - Phase 2: Update agent context by running the agent script
+   - Phase 2: Re-evaluate Constitution Check post-design
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
 


### PR DESCRIPTION
Fixes #1036

## Changes
- Changed second occurrence of 'Phase 1' to 'Phase 2' for agent context update step
- Added 'Phase 2:' prefix to constitution re-evaluation step

## Problem
The template had inconsistent phase numbering where two different items were labeled as "Phase 1" and the outline referenced "Phase 2" but no such phase existed.

## Solution
Corrected the numbering to be consistent:
- **Phase 0**: Outline & Research
- **Phase 1**: Design & Contracts  
- **Phase 2**: Agent context update and constitution re-evaluation

This now matches the instruction 'ends after Phase 2 planning' in the outline.