### PR TITLE
Refactor ESLint configuration checks in implement.md to address deprecation

### DIFF
--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -67,7 +67,8 @@ You **MUST** consider the user input before proceeding (if not empty).
      ```
 
    - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
-   - Check if .eslintrc*or eslint.config.* exists → create/verify .eslintignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
    - Check if .prettierrc* exists → create/verify .prettierignore
    - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
    - Check if terraform files (*.tf) exist → create/verify .terraformignore


### PR DESCRIPTION
## Summary
- stop regenerating deprecated `.eslintignore` when a flat `eslint.config.*` is present
- keep `.eslintignore` guidance for legacy `.eslintrc*` configs only
- direct flat-config projects to rely on the config’s own `ignores` entries for required patterns

## Testing
- n/a (docs change)

Fixes #1069