### PR TITLE
Feature: Add ability to tell specify to use the current branch instead of making a new one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,15 @@ The toolkit supports multiple AI coding assistants, allowing teams to use their 
 ## General practices
 
 - Any changes to `__init__.py` for the Specify CLI require a version rev in `pyproject.toml` and addition of entries to `CHANGELOG.md`.
+- Environment variables that affect script behavior should be documented in both `README.md` and `CHANGELOG.md`.
+
+### Environment Variables
+
+The Spec Kit workflow recognizes the following environment variables:
+
+- **`SPECIFY_FEATURE`**: Override feature detection. Set to a specific feature directory name (e.g., `001-photo-albums`) to work on that feature regardless of git branch or directory scan results. This has the highest priority in feature detection.
+
+- **`SPECIFY_USE_CURRENT_BRANCH`**: Use the current git branch name as the feature identifier without creating a new branch. Useful when working on existing branches that don't follow the `###-name` convention. Works with any branch name. Priority: below `SPECIFY_FEATURE`, above default git detection.
 
 ## Adding New Agent Support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to the Specify CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Git Branch Integration with `SPECIFY_USE_CURRENT_BRANCH`**: New environment variable to use the current git branch name as the feature identifier without creating a new branch
+  - Enables working on existing branches that don't follow the `###-name` convention
+  - Handles edge cases: detached HEAD state, non-git repositories, git command failures
+  - Maintains existing priority chain: `SPECIFY_FEATURE` > `SPECIFY_USE_CURRENT_BRANCH` > git branch > directory scan > "main"
+  - Single git command execution (no redundancy)
+  - Examples:
+    - `export SPECIFY_USE_CURRENT_BRANCH=1` (bash)
+    - `$env:SPECIFY_USE_CURRENT_BRANCH="1"` (PowerShell)
+  - Works with any branch naming pattern (feature/, bugfix/, hotfix/, main, master, develop, etc.)
+  - Available in both bash and PowerShell scripts
+
 ## [0.0.20] - 2025-10-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Additional commands for enhanced quality and validation:
 | Variable         | Description                                                                                    |
 |------------------|------------------------------------------------------------------------------------------------|
 | `SPECIFY_FEATURE` | Override feature detection for non-Git repositories. Set to the feature directory name (e.g., `001-photo-albums`) to work on a specific feature when not using Git branches.<br/>**Must be set in the context of the agent you're working with prior to using `/speckit.plan` or follow-up commands. |
+| `SPECIFY_USE_CURRENT_BRANCH` | Use the current git branch name as the feature identifier without creating a new branch. Useful when working on existing branches that don't follow the `###-name` convention.<br/>**Example:** `export SPECIFY_USE_CURRENT_BRANCH=1` (bash) or `$env:SPECIFY_USE_CURRENT_BRANCH="1"` (PowerShell)<br/>**Note:** `SPECIFY_FEATURE` takes precedence if both are set. |
 
 ## 📚 Core Philosophy
 

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -12,6 +12,29 @@ get_repo_root() {
     fi
 }
 
+# Sanitize branch name for use as directory name
+# Replaces filesystem-forbidden and problematic characters with safe alternatives
+sanitize_branch_name() {
+    local branch="$1"
+
+    # Replace problematic characters:
+    # / → - (prevents nesting on all platforms, Windows forbidden)
+    # \ → - (Windows forbidden)
+    # : → - (Windows forbidden, macOS translated)
+    # * → - (Windows forbidden, shell wildcard)
+    # ? → - (Windows forbidden, shell wildcard)
+    # " → - (Windows forbidden)
+    # < → - (Windows forbidden, shell redirect)
+    # > → - (Windows forbidden, shell redirect)
+    # | → - (Windows forbidden, shell pipe)
+    echo "$branch" | sed \
+        -e 's/[\/\\:*?"<>|]/-/g' \
+        -e 's/  */-/g' \
+        -e 's/^[. -]*//' \
+        -e 's/[. -]*$//' \
+        -e 's/--*/-/g'
+}
+
 # Get current branch, with fallback for non-git repositories
 get_current_branch() {
     # First check if SPECIFY_FEATURE environment variable is set
@@ -108,6 +131,14 @@ find_feature_dir_by_prefix() {
     local repo_root="$1"
     local branch_name="$2"
     local specs_dir="$repo_root/specs"
+
+    # When using current branch, do exact match only (no prefix matching)
+    if [[ -n "${SPECIFY_USE_CURRENT_BRANCH:-}" ]]; then
+        # Sanitize branch name for filesystem compatibility
+        local sanitized_name=$(sanitize_branch_name "$branch_name")
+        echo "$specs_dir/$sanitized_name"
+        return
+    fi
 
     # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
     if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -85,6 +85,11 @@ check_feature_branch() {
         return 0
     fi
 
+    # If SPECIFY_USE_CURRENT_BRANCH is set, skip pattern validation
+    if [[ -n "${SPECIFY_USE_CURRENT_BRANCH:-}" ]]; then
+        return 0
+    fi
+
     if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
         echo "Feature branches should be named like: 001-feature-name" >&2

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -20,6 +20,19 @@ get_current_branch() {
         return
     fi
 
+    # Check if SPECIFY_USE_CURRENT_BRANCH is set to use current git branch
+    # without creating a new feature branch
+    if [[ -n "${SPECIFY_USE_CURRENT_BRANCH:-}" ]]; then
+        local current_git_branch
+        current_git_branch=$(git rev-parse --abbrev-ref HEAD 2>&1)
+        if [[ $? -eq 0 && "$current_git_branch" != "HEAD" ]]; then
+            # Valid branch (not detached HEAD) - use it
+            echo "$current_git_branch"
+            return
+        fi
+        # Detached HEAD or git command failed - fall through to normal behavior
+    fi
+
     # Then check git if available
     if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
         git rev-parse --abbrev-ref HEAD

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -24,11 +24,12 @@ get_current_branch() {
     # without creating a new feature branch
     if [[ -n "${SPECIFY_USE_CURRENT_BRANCH:-}" ]]; then
         local current_git_branch
-        current_git_branch=$(git rev-parse --abbrev-ref HEAD 2>&1)
-        if [[ $? -eq 0 && "$current_git_branch" != "HEAD" ]]; then
-            # Valid branch (not detached HEAD) - use it
-            echo "$current_git_branch"
-            return
+        if current_git_branch=$(git rev-parse --abbrev-ref HEAD 2>&1); then
+            if [[ "$current_git_branch" != "HEAD" ]]; then
+                # Valid branch (not detached HEAD) - use it
+                echo "$current_git_branch"
+                return
+            fi
         fi
         # Detached HEAD or git command failed - fall through to normal behavior
     fi

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -214,11 +214,13 @@ fi
 if [[ -n "${SPECIFY_USE_CURRENT_BRANCH:-}" ]]; then
     if [ "$HAS_GIT" = true ]; then
         # Use current branch name
-        BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>&1)
-        if [[ $? -ne 0 || "$BRANCH_NAME" == "HEAD" ]]; then
+        branch_name_output=$(git rev-parse --abbrev-ref HEAD 2>&1)
+        branch_name_status=$?
+        if [[ $branch_name_status -ne 0 || "$branch_name_output" == "HEAD" ]]; then
             >&2 echo "[specify] Error: Cannot determine current branch name"
             exit 1
         fi
+        BRANCH_NAME="$branch_name_output"
         >&2 echo "[specify] Using current branch: $BRANCH_NAME"
     else
         >&2 echo "[specify] Error: SPECIFY_USE_CURRENT_BRANCH requires a git repository"

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -221,6 +221,7 @@ if [[ -n "${SPECIFY_USE_CURRENT_BRANCH:-}" ]]; then
             exit 1
         fi
         BRANCH_NAME="$branch_name_output"
+        FEATURE_NUM="N/A"
         >&2 echo "[specify] Using current branch: $BRANCH_NAME"
     else
         >&2 echo "[specify] Error: SPECIFY_USE_CURRENT_BRANCH requires a git repository"

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -87,13 +87,18 @@ function Test-FeatureBranch {
         [string]$Branch,
         [bool]$HasGit = $true
     )
-    
+
     # For non-git repos, we can't enforce branch naming but still provide output
     if (-not $HasGit) {
         Write-Warning "[specify] Warning: Git repository not detected; skipped branch validation"
         return $true
     }
-    
+
+    # If SPECIFY_USE_CURRENT_BRANCH is set, skip pattern validation
+    if ($env:SPECIFY_USE_CURRENT_BRANCH) {
+        return $true
+    }
+
     if ($Branch -notmatch '^[0-9]{3}-') {
         Write-Output "ERROR: Not on a feature branch. Current branch: $Branch"
         Write-Output "Feature branches should be named like: 001-feature-name"

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -20,7 +20,22 @@ function Get-CurrentBranch {
     if ($env:SPECIFY_FEATURE) {
         return $env:SPECIFY_FEATURE
     }
-    
+
+    # Check if SPECIFY_USE_CURRENT_BRANCH is set to use current git branch
+    # without creating a new feature branch
+    if ($env:SPECIFY_USE_CURRENT_BRANCH) {
+        try {
+            $currentGitBranch = git rev-parse --abbrev-ref HEAD 2>&1
+            if ($LASTEXITCODE -eq 0 -and $currentGitBranch -ne 'HEAD') {
+                # Valid branch (not detached HEAD) - use it
+                return $currentGitBranch
+            }
+            # Detached HEAD - fall through to normal behavior
+        } catch {
+            # Git command failed, fall through
+        }
+    }
+
     # Then check git if available
     try {
         $result = git rev-parse --abbrev-ref HEAD 2>$null

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -24,16 +24,12 @@ function Get-CurrentBranch {
     # Check if SPECIFY_USE_CURRENT_BRANCH is set to use current git branch
     # without creating a new feature branch
     if ($env:SPECIFY_USE_CURRENT_BRANCH) {
-        try {
-            $currentGitBranch = git rev-parse --abbrev-ref HEAD 2>&1
-            if ($LASTEXITCODE -eq 0 -and $currentGitBranch -ne 'HEAD') {
-                # Valid branch (not detached HEAD) - use it
-                return $currentGitBranch
-            }
-            # Detached HEAD - fall through to normal behavior
-        } catch {
-            # Git command failed, fall through
+        $currentGitBranch = git rev-parse --abbrev-ref HEAD 2>&1
+        if ($LASTEXITCODE -eq 0 -and $currentGitBranch -ne 'HEAD') {
+            # Valid branch (not detached HEAD) - use it
+            return $currentGitBranch
         }
+        # Detached HEAD or git command failed - fall through to normal behavior
     }
 
     # Then check git if available

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -233,6 +233,7 @@ if ($env:SPECIFY_USE_CURRENT_BRANCH) {
             Write-Error "[specify] Error: Cannot determine current branch name"
             exit 1
         }
+        $featureNum = "N/A"
         Write-Warning "[specify] Using current branch: $branchName"
     } else {
         Write-Error "[specify] Error: SPECIFY_USE_CURRENT_BRANCH requires a git repository"

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -228,17 +228,12 @@ if ($Number -eq 0) {
 if ($env:SPECIFY_USE_CURRENT_BRANCH) {
     if ($hasGit) {
         # Use current branch name
-        try {
-            $branchName = git rev-parse --abbrev-ref HEAD 2>&1
-            if ($LASTEXITCODE -ne 0 -or $branchName -eq 'HEAD') {
-                Write-Error "[specify] Error: Cannot determine current branch name"
-                exit 1
-            }
-            Write-Warning "[specify] Using current branch: $branchName"
-        } catch {
+        $branchName = git rev-parse --abbrev-ref HEAD 2>&1
+        if ($LASTEXITCODE -ne 0 -or $branchName -eq 'HEAD') {
             Write-Error "[specify] Error: Cannot determine current branch name"
             exit 1
         }
+        Write-Warning "[specify] Using current branch: $branchName"
     } else {
         Write-Error "[specify] Error: SPECIFY_USE_CURRENT_BRANCH requires a git repository"
         exit 1


### PR DESCRIPTION
Added the ability to set SPECIFY_USE_CURRENT_BRANCH=1 to have speckit use your current branch for specs instead of making a new one. 

This is extremely useful for teams that already have their own way of branching, and don't want to have more branches get created for no reason. 

I have gone through and tested the full flow on MacOS.

Closes #1104 

Some of the code was edited by Claude Code.