### PR TITLE
fix: incorrect logic to create release packages

### DIFF
--- a/.github/workflows/scripts/create-release-packages.sh
+++ b/.github/workflows/scripts/create-release-packages.sh
@@ -196,22 +196,22 @@ ALL_AGENTS=(claude gemini copilot cursor-agent qwen opencode windsurf codex kilo
 ALL_SCRIPTS=(sh ps)
 
 norm_list() {
-  # convert comma+space separated -> space separated unique while preserving order of first occurrence
-  tr ',\n' '  ' | awk '{for(i=1;i<=NF;i++){if(!seen[$i]++){printf((out?" ":"") $i)}}}END{printf("\n")}'
+  # convert comma+space separated -> line separated unique while preserving order of first occurrence
+  tr ',\n' '  ' | awk '{for(i=1;i<=NF;i++){if(!seen[$i]++){printf((out?"\n":"") $i);out=1}}}END{printf("\n")}'
 }
 
 validate_subset() {
   local type=$1; shift; local -n allowed=$1; shift; local items=("$@")
-  local ok=1
+  local invalid=0
   for it in "${items[@]}"; do
     local found=0
     for a in "${allowed[@]}"; do [[ $it == "$a" ]] && { found=1; break; }; done
     if [[ $found -eq 0 ]]; then
       echo "Error: unknown $type '$it' (allowed: ${allowed[*]})" >&2
-      ok=0
+      invalid=1
     fi
   done
-  return $ok
+  return $invalid
 }
 
 if [[ -n ${AGENTS:-} ]]; then


### PR DESCRIPTION
## Problem

When creating release packages with a subset of AGENTS or SCRIPTS, the logic was not working.

## Solution

Fixed the incorrect logic in the release package creation script by:

1. Updating the `norm_list` function to properly handle comma-separated values and convert them to unique line-separated values (`mapfile` required)
2. Correcting the return logic in `validate_subset` function to use `invalid` variable instead of `ok` for better clarity and correct behavior

## Changes

- Modified `norm_list` function  to correctly convert comma+space separated values to line separated unique values
- Updated `validate_subset` function to use `invalid` variable instead of `ok` for validation status
- Changed return statement to use `$invalid` instead of `$ok`

## Example

**Testing script**

```
AGENTS="copilot,gemini" SCRIPTS=sh .github/workflows/scripts/create-release-packages.sh v0.2.0
```

**Before (buggy behavior):**
The script would not properly handle subset AGENTS or SCRIPTS when creating release packages due to incorrect parsing and validation logic.

**After (correct behavior):**
The script now correctly creates release packages with subset AGENTS or SCRIPTS by properly parsing the input and validating against allowed values.

## Related

None