### PR TITLE
Fix tasktoissues.md to use the 'github/github-mcp-server/issue_write' tool

### DIFF
--- a/templates/commands/taskstoissues.md
+++ b/templates/commands/taskstoissues.md
@@ -1,6 +1,6 @@
 ---
 description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
-tools: ['github/github-mcp-server/create_issue']
+tools: ['github/github-mcp-server/issue_write']
 scripts:
   sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
   ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks


### PR DESCRIPTION
I tested the `speckit.taskstoissues` and found that it was not using the latest tool. The MCP server in VSCode extensions does not have a `create_issue` tool, but it does have `issue_write`.