### PR TITLE
Fix branch numbering to increment globally across all features

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -134,21 +134,23 @@ check_existing_branches() {
     # Fetch all remotes to get latest branch info (suppress errors if no remotes)
     git fetch --all --prune 2>/dev/null || true
     
-    # Find all branches matching the pattern using git ls-remote (more reliable)
-    local remote_branches=$(git ls-remote --heads origin 2>/dev/null | grep -E "refs/heads/[0-9]+-${short_name}$" | sed 's/.*\/\([0-9]*\)-.*/\1/' | sort -n)
+    # Find all feature branches using git ls-remote (check all branches, not just matching short-name)
+    local remote_branches=$(git ls-remote --heads origin 2>/dev/null | grep -E "refs/heads/[0-9]+-" | sed 's/.*\/\([0-9]*\)-.*/\1/' | sort -n)
     
-    # Also check local branches
-    local local_branches=$(git branch 2>/dev/null | grep -E "^[* ]*[0-9]+-${short_name}$" | sed 's/^[* ]*//' | sed 's/-.*//' | sort -n)
+    # Also check local branches (all feature branches)
+    local local_branches=$(git branch 2>/dev/null | grep -E "^[* ]*[0-9]+-" | sed 's/^[* ]*//' | sed 's/-.*//' | sort -n)
     
-    # Check specs directory as well
+    # Check specs directory as well (all feature directories)
     local spec_dirs=""
     if [ -d "$specs_dir" ]; then
-        spec_dirs=$(find "$specs_dir" -maxdepth 1 -type d -name "[0-9]*-${short_name}" 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/-.*//' | sort -n)
+        spec_dirs=$(find "$specs_dir" -maxdepth 1 -type d -name "[0-9]*-*" 2>/dev/null | xargs -n1 basename 2>/dev/null | sed 's/-.*//' | sort -n)
     fi
     
     # Combine all sources and get the highest number
     local max_num=0
     for num in $remote_branches $local_branches $spec_dirs; do
+        # Convert from potential octal (leading zeros) to decimal
+        num=$((10#$num))
         if [ "$num" -gt "$max_num" ]; then
             max_num=$num
         fi

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -112,12 +112,12 @@ function Get-NextBranchNumber {
         # Ignore fetch errors
     }
     
-    # Find remote branches matching the pattern using git ls-remote
+    # Find all feature branches using git ls-remote (check all branches, not just matching short-name)
     $remoteBranches = @()
     try {
         $remoteRefs = git ls-remote --heads origin 2>$null
         if ($remoteRefs) {
-            $remoteBranches = $remoteRefs | Where-Object { $_ -match "refs/heads/(\d+)-$([regex]::Escape($ShortName))$" } | ForEach-Object {
+            $remoteBranches = $remoteRefs | Where-Object { $_ -match "refs/heads/(\d+)-" } | ForEach-Object {
                 if ($_ -match "refs/heads/(\d+)-") {
                     [int]$matches[1]
                 }
@@ -127,12 +127,12 @@ function Get-NextBranchNumber {
         # Ignore errors
     }
     
-    # Check local branches
+    # Check local branches (all feature branches)
     $localBranches = @()
     try {
         $allBranches = git branch 2>$null
         if ($allBranches) {
-            $localBranches = $allBranches | Where-Object { $_ -match "^\*?\s*(\d+)-$([regex]::Escape($ShortName))$" } | ForEach-Object {
+            $localBranches = $allBranches | Where-Object { $_ -match "^\*?\s*(\d+)-" } | ForEach-Object {
                 if ($_ -match "(\d+)-") {
                     [int]$matches[1]
                 }
@@ -142,11 +142,11 @@ function Get-NextBranchNumber {
         # Ignore errors
     }
     
-    # Check specs directory
+    # Check specs directory (all feature directories)
     $specDirs = @()
     if (Test-Path $SpecsDir) {
         try {
-            $specDirs = Get-ChildItem -Path $SpecsDir -Directory | Where-Object { $_.Name -match "^(\d+)-$([regex]::Escape($ShortName))$" } | ForEach-Object {
+            $specDirs = Get-ChildItem -Path $SpecsDir -Directory | Where-Object { $_.Name -match "^(\d+)-" } | ForEach-Object {
                 if ($_.Name -match "^(\d+)-") {
                     [int]$matches[1]
                 }

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -46,14 +46,14 @@ Given that feature description, do this:
       git fetch --all --prune
       ```
    
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+   b. Find the highest feature number across all feature branches:
+      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-'`
+      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-'`
+      - Specs directories: Check for directories matching `specs/[0-9]+-*`
    
    c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
+      - Extract all numbers from all three sources (all feature branches, not just matching short-name)
+      - Find the highest number N across ALL features
       - Use N+1 for the new branch number
    
    d. Run the script `{SCRIPT}` with the calculated number and short-name:
@@ -63,8 +63,8 @@ Given that feature description, do this:
    
    **IMPORTANT**:
    - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
+   - Search across ALL feature branches (pattern: `[0-9]+-*`), not just branches matching the short-name
+   - Branch numbers increment globally across all features (001, 002, 003, etc.)
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths


### PR DESCRIPTION
The `/specify` command was always creating branches starting at `001`, ignoring existing feature branches with different short-names.

## Problem

Given existing branches `001-user-auth`, `002-payment-flow`, `003-dashboard`, creating a new feature would incorrectly produce `001-admin-panel` instead of `004-admin-panel`.

## Root Cause

The `check_existing_branches()` (bash) and `Get-NextBranchNumber()` (PowerShell) functions filtered by exact short-name match:

```bash
# Before: Only finds branches matching the specific short-name
grep -E "refs/heads/[0-9]+-${short_name}$"

# After: Finds all feature branches
grep -E "refs/heads/[0-9]+-"
```

This meant each unique short-name started its numbering from 001, rather than continuing the global sequence.

## Changes

### Bash (`scripts/bash/create-new-feature.sh`)
- Changed remote, local, and specs directory searches to match pattern `[0-9]+-*` instead of `[0-9]+-${short_name}`
- Added octal-to-decimal conversion (`10#$num`) to handle leading zeros correctly

### PowerShell (`scripts/powershell/create-new-feature.ps1`)
- Applied equivalent regex changes to match all feature branches
- Maintains parity with bash implementation

### Documentation (`templates/commands/specify.md`)
- Updated instructions to clarify branch numbers increment globally across all features

## Behavior

Branch numbers now increment sequentially regardless of short-name:
- `001-user-auth` → `002-payment-flow` → `003-dashboard` → `004-admin-panel`

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> Fix the branch numbering issue with /specify command. Currently, when creating a new branch with /specify, it doesn't correctly find the right branch number and always starts at 001. The command should properly detect existing branches and increment the branch number correctly based on the highest existing branch number.


</details>

*This pull request was created as a result of the following prompt from Copilot chat.*
> Fix the branch numbering issue with /specify command. Currently, when creating a new branch with /specify, it doesn't correctly find the right branch number and always starts at 001. The command should properly detect existing branches and increment the branch number correctly based on the highest existing branch number.