### PR TITLE
fix: prevent duplicate updates when multiple agents share the same file

### DIFF
--- a/scripts/bash/update-agent-context.sh
+++ b/scripts/bash/update-agent-context.sh
@@ -640,90 +640,105 @@ update_specific_agent() {
 update_all_existing_agents() {
     local found_agent=false
     # Track processed files to avoid duplicate processing when multiple variables point to the same file
-    declare -A processed_files
+    # Using regular array for bash 3.2 compatibility (associative arrays require bash 4.0+)
+    local processed_files=()
+    
+    # Helper function to check if a file has been processed (bash 3.2 compatible)
+    file_already_processed() {
+        local file_path="$1"
+        local processed_file
+        if [[ ${#processed_files[@]} -gt 0 ]]; then
+            for processed_file in "${processed_files[@]}"; do
+                if [[ "$processed_file" == "$file_path" ]]; then
+                    return 0  # File already processed
+                fi
+            done
+        fi
+        return 1  # File not yet processed
+    }
     
     # Check each possible agent file and update if it exists
-    if [[ -f "$CLAUDE_FILE" ]] && [[ -z "${processed_files[$CLAUDE_FILE]}" ]]; then
+    if [[ -f "$CLAUDE_FILE" ]] && ! file_already_processed "$CLAUDE_FILE"; then
         update_agent_file "$CLAUDE_FILE" "Claude Code"
-        processed_files["$CLAUDE_FILE"]=1
+        processed_files+=("$CLAUDE_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$GEMINI_FILE" ]] && [[ -z "${processed_files[$GEMINI_FILE]}" ]]; then
+    if [[ -f "$GEMINI_FILE" ]] && ! file_already_processed "$GEMINI_FILE"; then
         update_agent_file "$GEMINI_FILE" "Gemini CLI"
-        processed_files["$GEMINI_FILE"]=1
+        processed_files+=("$GEMINI_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$COPILOT_FILE" ]] && [[ -z "${processed_files[$COPILOT_FILE]}" ]]; then
+    if [[ -f "$COPILOT_FILE" ]] && ! file_already_processed "$COPILOT_FILE"; then
         update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-        processed_files["$COPILOT_FILE"]=1
+        processed_files+=("$COPILOT_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$CURSOR_FILE" ]] && [[ -z "${processed_files[$CURSOR_FILE]}" ]]; then
+    if [[ -f "$CURSOR_FILE" ]] && ! file_already_processed "$CURSOR_FILE"; then
         update_agent_file "$CURSOR_FILE" "Cursor IDE"
-        processed_files["$CURSOR_FILE"]=1
+        processed_files+=("$CURSOR_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$QWEN_FILE" ]] && [[ -z "${processed_files[$QWEN_FILE]}" ]]; then
+    if [[ -f "$QWEN_FILE" ]] && ! file_already_processed "$QWEN_FILE"; then
         update_agent_file "$QWEN_FILE" "Qwen Code"
-        processed_files["$QWEN_FILE"]=1
+        processed_files+=("$QWEN_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$AGENTS_FILE" ]] && [[ -z "${processed_files[$AGENTS_FILE]}" ]]; then
+    if [[ -f "$AGENTS_FILE" ]] && ! file_already_processed "$AGENTS_FILE"; then
         update_agent_file "$AGENTS_FILE" "Codex/opencode"
-        processed_files["$AGENTS_FILE"]=1
+        processed_files+=("$AGENTS_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$WINDSURF_FILE" ]] && [[ -z "${processed_files[$WINDSURF_FILE]}" ]]; then
+    if [[ -f "$WINDSURF_FILE" ]] && ! file_already_processed "$WINDSURF_FILE"; then
         update_agent_file "$WINDSURF_FILE" "Windsurf"
-        processed_files["$WINDSURF_FILE"]=1
+        processed_files+=("$WINDSURF_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$KILOCODE_FILE" ]] && [[ -z "${processed_files[$KILOCODE_FILE]}" ]]; then
+    if [[ -f "$KILOCODE_FILE" ]] && ! file_already_processed "$KILOCODE_FILE"; then
         update_agent_file "$KILOCODE_FILE" "Kilo Code"
-        processed_files["$KILOCODE_FILE"]=1
+        processed_files+=("$KILOCODE_FILE")
         found_agent=true
     fi
 
-    if [[ -f "$AUGGIE_FILE" ]] && [[ -z "${processed_files[$AUGGIE_FILE]}" ]]; then
+    if [[ -f "$AUGGIE_FILE" ]] && ! file_already_processed "$AUGGIE_FILE"; then
         update_agent_file "$AUGGIE_FILE" "Auggie CLI"
-        processed_files["$AUGGIE_FILE"]=1
+        processed_files+=("$AUGGIE_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$ROO_FILE" ]] && [[ -z "${processed_files[$ROO_FILE]}" ]]; then
+    if [[ -f "$ROO_FILE" ]] && ! file_already_processed "$ROO_FILE"; then
         update_agent_file "$ROO_FILE" "Roo Code"
-        processed_files["$ROO_FILE"]=1
+        processed_files+=("$ROO_FILE")
         found_agent=true
     fi
 
-    if [[ -f "$CODEBUDDY_FILE" ]] && [[ -z "${processed_files[$CODEBUDDY_FILE]}" ]]; then
+    if [[ -f "$CODEBUDDY_FILE" ]] && ! file_already_processed "$CODEBUDDY_FILE"; then
         update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
-        processed_files["$CODEBUDDY_FILE"]=1
+        processed_files+=("$CODEBUDDY_FILE")
         found_agent=true
     fi
 
-    if [[ -f "$SHAI_FILE" ]] && [[ -z "${processed_files[$SHAI_FILE]}" ]]; then
+    if [[ -f "$SHAI_FILE" ]] && ! file_already_processed "$SHAI_FILE"; then
         update_agent_file "$SHAI_FILE" "SHAI"
-        processed_files["$SHAI_FILE"]=1
+        processed_files+=("$SHAI_FILE")
         found_agent=true
     fi
 
-    if [[ -f "$Q_FILE" ]] && [[ -z "${processed_files[$Q_FILE]}" ]]; then
+    if [[ -f "$Q_FILE" ]] && ! file_already_processed "$Q_FILE"; then
         update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
-        processed_files["$Q_FILE"]=1
+        processed_files+=("$Q_FILE")
         found_agent=true
     fi
     
-    if [[ -f "$BOB_FILE" ]] && [[ -z "${processed_files[$BOB_FILE]}" ]]; then
+    if [[ -f "$BOB_FILE" ]] && ! file_already_processed "$BOB_FILE"; then
         update_agent_file "$BOB_FILE" "IBM Bob"
-        processed_files["$BOB_FILE"]=1
+        processed_files+=("$BOB_FILE")
         found_agent=true
     fi
     


### PR DESCRIPTION
This PR was created with the help of Cursor

## Problem Summary

The `update_all_existing_agents()` function in `.specify/scripts/bash/update-agent-context.sh` processes the same file multiple times when multiple variables point to the same file path. This can cause the "Recent Changes" section in agent context files to be incorrect.

## Root Cause

### Multiple Variables Point to Same File

The following variables all point to the same file (`$REPO_ROOT/AGENTS.md`):

```bash
AGENTS_FILE="$REPO_ROOT/AGENTS.md"  # Line 67
AMP_FILE="$REPO_ROOT/AGENTS.md"     # Line 73
Q_FILE="$REPO_ROOT/AGENTS.md"      # Line 75
BOB_FILE="$REPO_ROOT/AGENTS.md"    # Line 76
```

### Function Processes File Multiple Times

In `update_all_existing_agents()` (lines 640-719), the function checks each variable independently:

```bash
if [[ -f "$AGENTS_FILE" ]]; then
    update_agent_file "$AGENTS_FILE" "Codex/opencode"
    found_agent=true
fi

# ... later ...

if [[ -f "$Q_FILE" ]]; then
    update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
    found_agent=true
fi

# ... later ...

if [[ -f "$BOB_FILE" ]]; then
    update_agent_file "$BOB_FILE" "IBM Bob"
    found_agent=true
fi
```

Since all three variables point to the same file, when `AGENTS.md` exists, it gets processed **three times** in a single function call.

## Impact

### Data Loss
- **May lead to incorrect `AGENTS.md file`**

### Functional Impact
- **Code generation may still work**: Active Technologies, Commands, and Code Style sections are protected by `grep` checks
- **AI agents get confused**: Corrupted `AGENTS.md` file may lead to misleading context about what each feature added
- **Project history becomes unreliable**: Can't trust the change log to understand technology additions over time

### Affected Files
- `AGENTS.md` - processed 3 times
- Any other file that multiple variables point to (currently only `AGENTS.md`)

### How the Fix Works

1. **file_already_processed helper function**: Checks if a file has been processed
2. **Result**: Each file is processed exactly once, regardless of how many variables point to it

### Testing

Tested by setting up a minimum test environment with dummy `AGENTS.md` and `plan.md` files and ran the `update_all_existing_agents()` function to verify the contents of the `AGENTS.md` update


