### PR TITLE
docs: Switch logo in readme to be the larger one, to be crisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img src="./media/logo_large.webp" alt="Spec Kit Logo"/>
+    <img src="./media/logo_large.webp" alt="Spec Kit Logo" width="200" height="200"/>
     <h1>🌱 Spec Kit</h1>
     <h3><em>Build high-quality software faster.</em></h3>
 </div>


### PR DESCRIPTION
Switching the logo in the readme to a larger one, while still being the same 200x200 pixel size. Just to be crisper and not so blurry.

Hopefully more visible side-by-side:

<img width="3835" height="2028" alt="image" src="https://github.com/user-attachments/assets/06decec4-f97e-4926-8a55-991adba900c9" />

---

> I consulted ChatGPT to look up how to set the width and height on an img tag (😤)
