### PR TITLE
docs: Add existing project initialization to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,15 @@ uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
 Then use the tool directly:
 
 ```bash
+# Create new project
 specify init <PROJECT_NAME>
+
+# Or initialize in existing project
+specify init . --ai claude
+# or
+specify init --here --ai claude
+
+# Check installed tools
 specify check
 ```
 


### PR DESCRIPTION
Add commands for initializing Spec Kit in existing projects directly in the installation section. Shows both `specify init .` and `specify init --here` options to make brownfield usage immediately discoverable.

Fixes #1285