### PR TITLE
feat: Add support for custom repository via environment variables

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -635,8 +635,9 @@ def merge_json_files(existing_path: Path, new_content: dict, verbose: bool = Fal
     return merged
 
 def download_template_from_github(ai_assistant: str, download_dir: Path, *, script_type: str = "sh", verbose: bool = True, show_progress: bool = True, client: httpx.Client = None, debug: bool = False, github_token: str = None) -> Tuple[Path, dict]:
-    repo_owner = "github"
-    repo_name = "spec-kit"
+    # Support custom repository via environment variables for testing and enterprise use
+    repo_owner = os.getenv("SPEC_KIT_REPO_OWNER", "github")
+    repo_name = os.getenv("SPEC_KIT_REPO_NAME", "spec-kit")
     if client is None:
         client = httpx.Client(verify=ssl_context)
 
@@ -1307,8 +1308,9 @@ def version():
             pass
     
     # Fetch latest template release version
-    repo_owner = "github"
-    repo_name = "spec-kit"
+    # Support custom repository via environment variables for testing and enterprise use
+    repo_owner = os.getenv("SPEC_KIT_REPO_OWNER", "github")
+    repo_name = os.getenv("SPEC_KIT_REPO_NAME", "spec-kit")
     api_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest"
     
     template_version = "unknown"


### PR DESCRIPTION
Add SPEC_KIT_REPO_OWNER and SPEC_KIT_REPO_NAME environment variables to allow users to:
- Test with custom forks before production rollout
- Use internal mirrors in restricted network environments
- Validate new agent support locally
- Support enterprise deployments with custom repositories

Example usage:
  export SPEC_KIT_REPO_OWNER=mycompany export SPEC_KIT_REPO_NAME=spec-kit-fork specify init my-project --ai claude

This change maintains full backward compatibility with default values (github/spec-kit).