### PR TITLE
chore: add Copilot review instructions and docs AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# Copilot instructions for automated code reviews 🌱
+
+- Reference [AGENTS.md](../AGENTS.md) as the authoritative source for project conventions when reviewing any files changed in this repo.
+- For files in `docs/`, additionally consult the [./docs AGENTS.md](../docs/AGENTS.md) for additional requirements designed to promote consistency in independent documentation contributions.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md for Spec Kit documentation
+
+## Guidelines for consistent user documentation
+
+- The correct syntax for this project is "Spec Kit" (two words, capital S and K). Never use any other variation outside of code snippets.
+- Use active voice and present tense where possible.
+- Write for an audience familiar with AI and programming concepts, but new to Spec Kit.
+- Ensure an informal narrative, teaching voice: give a one-line "why" plus a one-line "how" and a minimal, copy‑pastable example/command when helpful.
+- User documentation files are expected to use kebab-case for the `.md` extension, except for special files like `README.md`.
+- Examples should be copy-pastable in fenced code blocks and accurate; if unsure, prefer not to change examples.
+
+## GitHub Pages Deployment Constraints
+
+- Documentation is hosted at `https://github.github.io/spec-kit/` via GitHub Pages deployment defined by `.github/docs.yml`.
+- The static site is generated with DocFX. Use library ID `/dotnet/docfx` if referencing `context7` MCP.
+- All documentation changes must be aligned with these standard flows, else deployments will fail.


### PR DESCRIPTION

- Add AGENTS.md with guidelines for consistent user documentation
- Add copilot-instructions.md for automated code review standards
- Include DocFX requirements and deployment constraints

Commimt-generated-by: GitHub Copilot <github.copilot@github.com>

---

This pull request introduces new AI documentation guidelines and instructions to ensure consistency and clarity in both code reviews and user documentation for the project. The changes focus on establishing authoritative sources for conventions and providing detailed standards for documentation contributions.

Documentation standards and conventions:

* Added a new `.github/copilot-instructions.md` file instructing code reviewers (including Copilot) to reference `AGENTS.md` as the authoritative source for project conventions, and to consult a separate `docs/AGENTS.md` for documentation-specific requirements when reviewing files in the `docs/` directory.

* Introduced a new `docs/AGENTS.md` file outlining guidelines for consistent user documentation, including naming conventions ("Spec Kit"), tone, syntax, example formatting, and kebab-case file naming for documentation files.

Documentation deployment process:

* Specified in `docs/AGENTS.md` that documentation is deployed via GitHub Pages using DocFX, with deployment constraints and requirements for alignment with standard flows to avoid deployment failures.