### PR TITLE
Fix #1148: Update plan-template path reference to be agent-agnostic

### DIFF
--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -3,7 +3,7 @@
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
 
-**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+**Note**: This template is filled in by the `/speckit.plan` command. The execution workflow is defined in your AI agent's command configuration (e.g., `.claude/commands/speckit.plan.md`, `.cursor/commands/speckit.plan.md`, `.codex/prompts/speckit.plan.md`, etc.).
 
 ## Summary
 


### PR DESCRIPTION
## Description

This PR fixes issue #1148 by updating the hardcoded path reference in `plan-template.md` to be agent-agnostic.

## Problem
The template contained a hardcoded reference to `.specify/templates/commands/plan.md` which doesn't exist. The actual location varies depending on which AI agent is being used:

- Claude: `.claude/commands/speckit.plan.md`
- Cursor: `.cursor/commands/speckit.plan.md`
- Codex: `.codex/prompts/speckit.plan.md`
- Qwen: `.qwen/commands/speckit.plan.toml`
- GitHub Copilot: `.github/agents/speckit.plan.agent.md`
- And others...

This caused confusion for users as the referenced path didn't match their setup.

## Solution
Updated the note to provide examples of agent-specific paths, making it clear that the location depends on the AI agent being used.

## Changes
- Modified `templates/plan-template.md` line 6
- Changed from hardcoded path to agent-agnostic description with examples

## Impact
- ✅ Removes confusion about where to find the plan command workflow
- ✅ Provides accurate, agent-agnostic guidance
- ✅ Users can easily locate their specific agent's configuration
- ✅ No breaking changes - purely documentation improvement

## Testing
This is a documentation-only change that doesn't affect any code logic.

Fixes #1148