### PR TITLE
fix: Use blank lines in template headers to prevent markdownlint stripping line breaks

### DIFF
--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -1,6 +1,7 @@
 # Implementation Plan: [FEATURE]
 
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
 
 **Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.

--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -1,8 +1,11 @@
 # Feature Specification: [FEATURE NAME]
 
-**Feature Branch**: `[###-feature-name]`  
-**Created**: [DATE]  
-**Status**: Draft  
+**Feature Branch**: `[###-feature-name]`
+
+**Created**: [DATE]
+
+**Status**: Draft
+
 **Input**: User description: "$ARGUMENTS"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -6,6 +6,7 @@ description: "Task list template for feature implementation"
 # Tasks: [FEATURE NAME]
 
 **Input**: Design documents from `/specs/[###-feature-name]/`
+
 **Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
 
 **Tests**: The examples below include test tasks. Tests are OPTIONAL - only include them if explicitly requested in the feature specification.


### PR DESCRIPTION
## Summary

Fixes template header fields rendering on a single line when trailing spaces are stripped by markdownlint (MD009 rule) or similar tools.

**Before**: Header fields use trailing double spaces for line breaks, which get stripped by linters
**After**: Header fields use blank lines, which are immune to linter auto-fix

## Root Cause

This issue is caused by **markdownlint's [MD009 rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/md009.md)** (no-trailing-spaces) which strips trailing whitespace from Markdown files.

[markdownlint](https://github.com/DavidAnson/markdownlint) is widely integrated across the ecosystem:

| Tool | Integration |
|------|-------------|
| **VS Code** | [vscode-markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) extension |
| **Sublime Text** | markdownlint plugin |
| **Vim/Neovim** | coc-markdownlint extension |
| **Emacs** | flymake-markdownlint-cli2 |
| **GitHub Actions** | [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) |

## Why blank lines are the better solution

Using blank lines instead of trailing spaces:
- Is immune to linter auto-fix behavior
- Is visually obvious in source files
- Works consistently across all Markdown parsers
- Follows the principle of explicit over implicit formatting

## Test plan

- [x] View `spec-template.md` in GitHub - header fields should render on separate lines
- [x] View `plan-template.md` in GitHub - header fields should render on separate lines
- [x] View `tasks-template.md` in GitHub - header fields should render on separate lines
- [x] Verify in JetBrains IDE markdown preview
- [x] Run markdownlint on templates - no MD009 violations

Fixes #1343

🤖 Generated with [Claude Code](https://claude.com/claude-code)