### PR TITLE
docs: Update script type choices with platform details

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -228,7 +228,7 @@ AGENT_CONFIG = {
     },
 }
 
-SCRIPT_TYPE_CHOICES = {"sh": "POSIX Shell (bash/zsh)", "ps": "PowerShell"}
+SCRIPT_TYPE_CHOICES = {"sh": "POSIX Shell (bash/zsh) [macOS/Linux]", "ps": "PowerShell [Windows]"}
 
 CLAUDE_LOCAL_PATH = Path.home() / ".claude" / "local" / "claude"
 


### PR DESCRIPTION
Attempts to address #1378 by adding the relevant operating systems to the human-readable labels in this screen.

Full disclosure: I didn't test this manually, because I'm not sure how to compile the project. But in case it's helpful for others, wanted to drop it here for review.