### PR TITLE
Fix global branch numbering in specify command

### DIFF
--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -51,9 +51,10 @@ Given that feature description, do this:
       - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
       - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
       - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+      - Use the highest branch number found across all sources, or if none exists, set the number to one more than the count of existing specs
 
    c. Determine the next available number:
-      - Extract all numbers from all three sources
+      - Extract all numbers from all four sources
       - Find the highest number N
       - Use N+1 for the new branch number
 


### PR DESCRIPTION
Resolves #1454

Update the branch numbering logic to use globally sequential numbers across all branches rather than restarting from 001 for each unique short name. This allows users to track the chronological order of features added to the project.

Changes:
- Add fallback logic to use highest branch number from all sources
- If no numbered branches exist, use specs directory count + 1
- Update documentation to reflect the four-source checking approach