### PR TITLE
resolves #1454 - remove branch numbering logic from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ To upgrade Specify, see the [Upgrade Guide](./docs/upgrade.md) for detailed inst
 uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git
 ```
 
+**Note**: To use custom templates from your own fork, install from your fork URL:
+
+```bash
+uv tool install specify-cli --from git+https://github.com/gouzhuang/spec-kit.git
+```
+
 #### Option 2: One-time Usage
 
 Run directly without installing:
@@ -188,6 +194,7 @@ The `specify` command supports the following options:
 | `--skip-tls`           | Flag     | Skip SSL/TLS verification (not recommended)                                                                                                                                                  |
 | `--debug`              | Flag     | Enable detailed debug output for troubleshooting                                                                                                                                             |
 | `--github-token`       | Option   | GitHub token for API requests (or set GH_TOKEN/GITHUB_TOKEN env variable)                                                                                                                    |
+| `--template-repo`      | Option   | Custom template repository in `owner/repo` format (e.g., `gouzhuang/spec-kit`)                                                                                                              |
 
 ### Examples
 
@@ -237,6 +244,9 @@ specify init my-project --ai claude --debug
 
 # Use GitHub token for API requests (helpful for corporate environments)
 specify init my-project --ai claude --github-token ghp_your_token_here
+
+# Use custom template repository (for forks or private deployments)
+specify init my-project --ai claude --template-repo gouzhuang/spec-kit
 
 # Check system requirements
 specify check

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -39,33 +39,14 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Create new feature branch**:
 
-   a. First, fetch all remote branches to ensure we have the latest information:
-
-      ```bash
-      git fetch --all --prune
-      ```
-
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
-
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `{SCRIPT}` with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `{SCRIPT} --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `{SCRIPT} -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   Run the script `{SCRIPT}` with short-name:
+      - Pass `--short-name "your-short-name"` along with the feature description
+      - Bash example: `{SCRIPT} --json --short-name "user-auth" "Add user authentication"`
+      - PowerShell example: `{SCRIPT} -Json -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths


### PR DESCRIPTION
Resolves #1454

The branch numbering logic can be removed from the template entirely, since this functionality is already contained within the script.