### PR TITLE
Add Hindsight MCP memory integration with migration command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ All notable changes to the Specify CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.23] - 2026-01-25
+
+### Added
+
+- **Hindsight MCP Integration**: New `--hindsight` flag for `specify init` enables persistent project memory via Hindsight MCP
+  - `--hindsight`: Use Hindsight MCP for project memory instead of local files
+  - `--hindsight-bank`: Custom Hindsight bank ID (default: `speckit-{project-name}`)
+  - Generates `.specify/config.json` with memory provider configuration
+- **Memory Provider Detection**: All `/speckit.*` commands now detect memory provider from config
+  - Hindsight mode: Uses `mcp__hindsight__retain`, `mcp__hindsight__recall`, and `mcp__hindsight__reflect`
+  - Local mode: Falls back to `/memory/constitution.md` (backward compatible)
+  - Automatic fallback if Hindsight unavailable
+- **New `/speckit.migrate-memory` command**: Migrate existing projects from local files to Hindsight
+  - Preserves local files as backup
+  - Migrates constitution, principles, governance
+  - Optionally migrates existing feature specs
+- **Enhanced Commands with Hindsight Support**:
+  - `/speckit.constitution`: Stores principles individually for better semantic search
+  - `/speckit.plan`: Recalls constitution, stores tech stack decisions
+  - `/speckit.specify`: Recalls related specs, stores feature summaries
+  - `/speckit.implement`: Stores implementation decisions, learnings, and patterns
+  - `/speckit.analyze`: Uses reflect for deeper constitution compliance analysis
+
+### Changed
+
+- All commands now check `.specify/config.json` for memory provider configuration
+- Commands gracefully fallback to local files when Hindsight is unavailable
+
 ## [0.0.22] - 2025-11-07
 
 - Support for VS Code/Copilot agents, and moving away from prompts to proper agents with hand-offs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.0.22"
+version = "0.0.23"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [

--- a/templates/commands/analyze.md
+++ b/templates/commands/analyze.md
@@ -13,6 +13,15 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Memory Provider Detection
+
+Before loading constitution:
+1. Check for `.specify/config.json` in repo root
+2. Parse JSON and read `memory.provider`:
+   - If `"hindsight"`: Use Hindsight MCP tools with `bank_id` from `memory.hindsight.bank_id`
+   - If `"local"` or config missing: Use `/memory/constitution.md` file
+3. If Hindsight configured but MCP tools unavailable: Warn user and fallback to local file
+
 ## Goal
 
 Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit.tasks` has successfully produced a complete `tasks.md`.
@@ -65,7 +74,15 @@ Load only the minimal necessary context from each artifact:
 
 **From constitution:**
 
-- Load `/memory/constitution.md` for principle validation
+- **Hindsight Mode** (when `memory.provider == "hindsight"`):
+  ```
+  mcp__hindsight__recall(
+    query: "constitution principles MUST SHOULD requirements governance",
+    bank_id: {bank_id from config}
+  )
+  ```
+- **Local Mode** (default): Load `/memory/constitution.md` for principle validation
+- **Fallback**: If Hindsight unavailable, use local file
 
 ### 3. Build Semantic Models
 
@@ -113,6 +130,21 @@ Focus on high-signal findings. Limit to 50 findings total; aggregate remainder i
 - Data entities referenced in plan but absent in spec (or vice versa)
 - Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
 - Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 4.5 Hindsight Mode: Deep Analysis (Optional)
+
+When `memory.provider == "hindsight"`, optionally use reflect for deeper constitution alignment analysis:
+
+```
+mcp__hindsight__reflect(
+  query: "Based on these artifacts, are there any patterns or decisions that conflict with project principles? Spec summary: {brief spec summary}. Plan choices: {tech stack choices}. Task coverage: {coverage gaps if any}",
+  context: "Cross-artifact consistency analysis for {feature name}",
+  budget: "mid",
+  bank_id: {bank_id from config}
+)
+```
+
+This can surface non-obvious conflicts by reasoning across stored project knowledge.
 
 ### 5. Severity Assignment
 

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -13,6 +13,30 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Memory Provider Detection
+
+Before implementation:
+1. Check for `.specify/config.json` in repo root
+2. Parse JSON and read `memory.provider`:
+   - If `"hindsight"`: Use Hindsight MCP tools with `bank_id` from `memory.hindsight.bank_id`
+   - If `"local"` or config missing: Continue without Hindsight features
+3. If Hindsight configured but MCP tools unavailable: Warn user and continue
+
+## Hindsight Mode: Pre-Implementation Guidance (Optional)
+
+Before starting implementation, optionally query Hindsight for relevant patterns and learnings:
+
+```
+mcp__hindsight__reflect(
+  query: "What patterns and learnings are relevant for implementing {feature type}?",
+  context: "Pre-implementation guidance for {feature name}",
+  budget: "mid",
+  bank_id: {bank_id from config}
+)
+```
+
+This may surface useful patterns from previous implementations.
+
 ## Outline
 
 1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
@@ -134,5 +158,41 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Validate that tests pass and coverage meets requirements
    - Confirm the implementation follows the technical plan
    - Report final status with summary of completed work
+
+10. **Hindsight Mode: Store Implementation Knowledge** (when `memory.provider == "hindsight"`):
+
+    After implementation completes, store valuable knowledge for future reference:
+
+    a. **Implementation Decisions** (for significant architectural choices):
+    ```
+    mcp__hindsight__retain(
+      content: "Decision: {decision title}\nFeature: {feature name}\nContext: {why this decision was needed}\nChoice: {what was chosen}\nAlternatives considered: {other options}\nRationale: {why this choice}",
+      context: "implementation-decision",
+      bank_id: {bank_id from config}
+    )
+    ```
+
+    b. **Implementation Learnings** (for problems encountered and solutions):
+    ```
+    mcp__hindsight__retain(
+      content: "Learning: {title}\nFeature: {feature name}\nProblem: {what went wrong or was challenging}\nSolution: {how it was resolved}\nPrevention: {how to avoid in future}",
+      context: "implementation-learning",
+      bank_id: {bank_id from config}
+    )
+    ```
+
+    c. **Code Patterns** (for reusable patterns discovered):
+    ```
+    mcp__hindsight__retain(
+      content: "Pattern: {pattern name}\nFeature: {feature name}\nUse case: {when to use this pattern}\nStructure: {brief description of the pattern}\nExample files: {file paths where pattern is implemented}",
+      context: "implementation-pattern",
+      bank_id: {bank_id from config}
+    )
+    ```
+
+    **Note**: Only store genuinely valuable insights. Not every implementation needs all three types. Focus on:
+    - Decisions that others might question later
+    - Problems that took significant time to solve
+    - Patterns that are likely to be reused
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.

--- a/templates/commands/migrate-memory.md
+++ b/templates/commands/migrate-memory.md
@@ -1,0 +1,199 @@
+---
+description: Migrate existing local project memory to Hindsight MCP for persistent, semantic search capabilities.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Goal
+
+Migrate an existing Spec Kit project from local file-based memory (`/memory/constitution.md`) to Hindsight MCP, enabling semantic search and cross-session persistence.
+
+## Prerequisites
+
+- Project must have been initialized with `specify init`
+- Hindsight MCP server must be configured and accessible
+- Existing `/memory/constitution.md` file (optional but recommended)
+
+## Execution Steps
+
+### 1. Verify Hindsight Availability
+
+First, verify that Hindsight MCP tools are accessible:
+
+```
+mcp__hindsight__list_banks()
+```
+
+If this fails, inform the user:
+- "Hindsight MCP is not available. Please ensure the Hindsight server is running and configured in your AI agent."
+- Provide setup instructions or link to Hindsight documentation
+- **STOP** execution
+
+### 2. Determine Bank ID
+
+Check for user-provided bank ID in arguments, or generate default:
+
+- If user specified: Use that bank ID
+- If not specified: Generate `speckit-{project-directory-name}` (lowercase, hyphens)
+
+Example: Project in `/Users/dev/my-awesome-app` → bank ID: `speckit-my-awesome-app`
+
+### 3. Create or Verify Hindsight Bank
+
+```
+mcp__hindsight__create_bank(
+  bank_id: {determined bank ID},
+  name: "Spec Kit - {project name}",
+  background: "Project memory for Spec Kit SDD workflow. Contains constitution, tech decisions, feature specs, implementation learnings, and code patterns."
+)
+```
+
+### 4. Update Project Configuration
+
+Create or update `.specify/config.json`:
+
+```json
+{
+  "version": "1.0.0",
+  "memory": {
+    "provider": "hindsight",
+    "hindsight": {
+      "bank_id": "{determined bank ID}"
+    }
+  }
+}
+```
+
+If config already exists with `provider: "local"`, update it. If already `provider: "hindsight"`, warn user and ask if they want to re-migrate.
+
+### 5. Migrate Constitution (if exists)
+
+If `/memory/constitution.md` exists:
+
+1. **Parse constitution content**:
+   - Extract project metadata (name, version, dates)
+   - Extract each principle (name, description, rationale)
+   - Extract governance rules
+
+2. **Store in Hindsight**:
+
+   a. **Project metadata**:
+   ```
+   mcp__hindsight__retain(
+     content: "Project: {PROJECT_NAME}, Version: {VERSION}, Ratified: {RATIFICATION_DATE}, Last Amended: {LAST_AMENDED_DATE}",
+     context: "constitution-metadata",
+     bank_id: {bank ID}
+   )
+   ```
+
+   b. **Each principle**:
+   ```
+   mcp__hindsight__retain(
+     content: "Principle {N}: {NAME}\n{DESCRIPTION}\nRationale: {RATIONALE}",
+     context: "constitution-principle",
+     bank_id: {bank ID}
+   )
+   ```
+
+   c. **Governance rules**:
+   ```
+   mcp__hindsight__retain(
+     content: "{Full governance section}",
+     context: "constitution-governance",
+     bank_id: {bank ID}
+   )
+   ```
+
+### 6. Migrate Existing Specs
+
+Scan for existing feature specifications in `specs/*/spec.md`:
+
+For each spec found, create a summary and store:
+
+```
+mcp__hindsight__retain(
+  content: "Feature: {feature name from spec}\nPath: {spec file path}\nSummary: {2-3 sentence summary}\nKey Requirements: {top 3 requirements}",
+  context: "feature-spec",
+  bank_id: {bank ID}
+)
+```
+
+Limit to 10 most recent specs to avoid overwhelming the bank.
+
+### 7. Verify Migration
+
+Verify the migration by recalling stored content:
+
+```
+mcp__hindsight__recall(
+  query: "constitution principles project metadata",
+  bank_id: {bank ID}
+)
+```
+
+Check that:
+- Constitution metadata is retrievable
+- At least one principle is retrievable
+- Response is coherent and matches source content
+
+### 8. Report Results
+
+Output a migration summary:
+
+```markdown
+## Migration Complete
+
+**Bank ID**: {bank ID}
+**Config Updated**: .specify/config.json
+
+### Migrated Content
+
+| Content Type | Count | Status |
+|--------------|-------|--------|
+| Constitution Metadata | 1 | ✓ |
+| Principles | {N} | ✓ |
+| Governance | 1 | ✓ |
+| Feature Specs | {N} | ✓ |
+
+### Verification
+
+Constitution recall: ✓ Success
+
+### Next Steps
+
+1. All `/speckit.*` commands will now use Hindsight for memory
+2. Run `/speckit.constitution` to update principles - they'll be stored in Hindsight
+3. New feature specs will be searchable across sessions
+4. Implementation decisions and learnings will accumulate over time
+
+### Local Files
+
+Local files (`/memory/constitution.md`) are preserved as backup.
+Hindsight is now the primary memory source.
+```
+
+## Error Handling
+
+- **Hindsight unavailable**: Stop and provide setup instructions
+- **Bank creation fails**: Report error, suggest checking permissions
+- **Partial migration**: Report which items succeeded/failed, allow retry
+- **Config write fails**: Report error, provide manual config content
+
+## Rollback
+
+To revert to local memory:
+1. Edit `.specify/config.json`
+2. Change `"provider": "hindsight"` to `"provider": "local"`
+3. Local files remain intact and will be used again
+
+## Notes
+
+- Migration is additive - it doesn't delete local files
+- Re-running migration will add duplicate entries (warn user)
+- Bank can be shared across multiple projects if desired (advanced use case)

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -24,11 +24,33 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Memory Provider Detection
+
+Before loading constitution:
+1. Check for `.specify/config.json` in repo root
+2. Parse JSON and read `memory.provider`:
+   - If `"hindsight"`: Use Hindsight MCP tools with `bank_id` from `memory.hindsight.bank_id`
+   - If `"local"` or config missing: Use `/memory/constitution.md` file
+3. If Hindsight configured but MCP tools unavailable: Warn user and fallback to local file
+
 ## Outline
 
 1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load context**: Read FEATURE_SPEC and `/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+2. **Load context**: Read FEATURE_SPEC. Load IMPL_PLAN template (already copied). For constitution:
+
+   **Hindsight Mode** (when `memory.provider == "hindsight"`):
+   ```
+   mcp__hindsight__recall(
+     query: "constitution principles MUST SHOULD requirements governance",
+     bank_id: {bank_id from config}
+   )
+   ```
+
+   **Local Mode** (default):
+   Read `/memory/constitution.md` directly.
+
+   **Fallback**: If Hindsight unavailable, try local file. Warn if both fail.
 
 3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
    - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
@@ -38,6 +60,18 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Phase 1: Generate data-model.md, contracts/, quickstart.md
    - Phase 1: Update agent context by running the agent script
    - Re-evaluate Constitution Check post-design
+
+   **Hindsight Mode - Constitution Validation** (optional, when `memory.provider == "hindsight"`):
+   For deeper Constitution Check validation, use `mcp__hindsight__reflect`:
+   ```
+   mcp__hindsight__reflect(
+     query: "Do these technical choices violate any project principles? Choices: {list of tech stack decisions}",
+     context: "Constitution compliance check for {feature name}",
+     budget: "mid",
+     bank_id: {bank_id from config}
+   )
+   ```
+   This provides reasoned analysis beyond simple fact retrieval.
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
 
@@ -88,6 +122,20 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Preserve manual additions between markers
 
 **Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+
+### Phase 1: Hindsight Memory (when `memory.provider == "hindsight"`)
+
+After completing Phase 1, store tech stack decisions in Hindsight for cross-project learning:
+
+```
+mcp__hindsight__retain(
+  content: "Tech Stack for {feature name}:\n- Languages: {languages}\n- Frameworks: {frameworks}\n- Database: {database}\n- Key libraries: {libraries}\n- Architecture: {patterns used}\n\nRationale: {why these choices}",
+  context: "project-tech-stack",
+  bank_id: {bank_id from config}
+)
+```
+
+This enables future `/speckit.plan` commands to recall relevant technology choices.
 
 ## Key rules
 

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -21,6 +21,28 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Memory Provider Detection
+
+Before performing any memory operations:
+1. Check for `.specify/config.json` in repo root
+2. Parse JSON and read `memory.provider`:
+   - If `"hindsight"`: Use Hindsight MCP tools with `bank_id` from `memory.hindsight.bank_id`
+   - If `"local"` or config missing: Use local file operations only
+3. If Hindsight configured but MCP tools unavailable: Warn user and continue without memory features
+
+## Hindsight Mode: Related Context (Optional)
+
+When creating a new spec in Hindsight mode, optionally recall related context:
+
+```
+mcp__hindsight__recall(
+  query: "{keywords from feature description} feature requirements patterns",
+  bank_id: {bank_id from config}
+)
+```
+
+This may surface related specs, patterns, or decisions that inform the new specification.
+
 ## Outline
 
 The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `{ARGS}` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
@@ -194,6 +216,23 @@ Given that feature description, do this:
    d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
 
 7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
+
+8. **Hindsight Mode: Store Feature Spec Summary** (when `memory.provider == "hindsight"`):
+
+   After successfully writing the specification, store a summary in Hindsight:
+
+   ```
+   mcp__hindsight__retain(
+     content: "Feature: {FEATURE_NAME}\nBranch: {BRANCH_NAME}\nSpec: {SPEC_FILE_PATH}\n\nSummary: {2-3 sentence summary of what the feature does}\n\nKey Requirements:\n- {requirement 1}\n- {requirement 2}\n- {requirement 3}\n\nSuccess Criteria: {main success criteria}",
+     context: "feature-spec",
+     bank_id: {bank_id from config}
+   )
+   ```
+
+   This enables:
+   - Cross-feature pattern discovery
+   - Semantic search for related specifications
+   - Learning from past feature designs
 
 **NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
 


### PR DESCRIPTION
- Add `--hindsight` and `--hindsight-bank` options to `specify init` for persistent project memory
- Generate `.specify/config.json` to configure memory provider as Hindsight or local
- Update all `/speckit.*` commands to detect memory provider and use Hindsight MCP APIs when enabled
- Introduce `/speckit.migrate-memory` command to migrate existing local memory to Hindsight MCP
- Preserve backward compatibility with local file memory and fallback logic
- Enhance command templates with guidance on memory provider detection and usage