### PR TITLE
fix(checklist): clarify file handling behavior for append vs create

### DIFF
--- a/templates/commands/checklist.md
+++ b/templates/commands/checklist.md
@@ -209,13 +209,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 6. **Structure Reference**: Generate the checklist following the canonical template in `templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
 
-7. **Report**: Output full path to created checklist, item count, and remind user that each run creates a new file. Summarize:
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
    - Focus areas selected
    - Depth level
    - Actor/timing
    - Any explicit user-specified must-have items incorporated
 
-**Important**: Each `/speckit.checklist` command invocation creates a checklist file using short, descriptive names unless file already exists. This allows:
+**Important**: Each `/speckit.checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
 
 - Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
 - Simple, memorable filenames that indicate checklist purpose


### PR DESCRIPTION
Resolves contradictory instructions in checklist.md lines 97-99 where the template stated both 'append to existing file' and 'creates a NEW file'.

Changes:
- Clarified that new files are created when they don't exist (starting at CHK001)
- Clarified that existing files are appended to (continuing from last CHK ID)
- Emphasized that existing content is never deleted or replaced

This PR was created with assistance from Augment Agent (Claude).