### PR TITLE
fix(clarify): correct conflicting question limit from 10 to 5

### DIFF
--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -89,7 +89,7 @@ Execution steps:
    - Information is better deferred to planning phase (note internally)
 
 3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
-    - Maximum of 10 total questions across the whole session.
+    - Maximum of 5 total questions across the whole session.
     - Each question must be answerable with EITHER:
        - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
        - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").


### PR DESCRIPTION
Resolves inconsistency where line 92 stated 'Maximum of 10 total questions' while all other references (lines 2, 91, 100, 134, 158, 178) consistently specify a maximum of 5 questions.