### PR TITLE
feat: Add SPECIFY_SPECS_DIR for centralized specs directory and worktree support

### DIFF
--- a/scripts/bash/check-prerequisites.sh
+++ b/scripts/bash/check-prerequisites.sh
@@ -88,7 +88,8 @@ if $PATHS_ONLY; then
     if $JSON_MODE; then
         # Minimal JSON paths payload (no validation performed)
         printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s","SPECS_DIR":"%s"}\n' \
-            "$REPO_ROOT" "$CURRENT_BRANCH" "$FEATURE_DIR" "$FEATURE_SPEC" "$IMPL_PLAN" "$TASKS" "$SPECS_DIR"
+            "$(json_escape "$REPO_ROOT")" "$(json_escape "$CURRENT_BRANCH")" "$(json_escape "$FEATURE_DIR")" \
+            "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$IMPL_PLAN")" "$(json_escape "$TASKS")" "$(json_escape "$SPECS_DIR")"
     else
         echo "REPO_ROOT: $REPO_ROOT"
         echo "BRANCH: $CURRENT_BRANCH"
@@ -151,7 +152,7 @@ if $JSON_MODE; then
     fi
     
     SPECS_DIR="$(get_specs_dir "$REPO_ROOT")"
-    printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s,"SPECS_DIR":"%s"}\n' "$FEATURE_DIR" "$json_docs" "$SPECS_DIR"
+    printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s,"SPECS_DIR":"%s"}\n' "$(json_escape "$FEATURE_DIR")" "$json_docs" "$(json_escape "$SPECS_DIR")"
 else
     # Text output
     echo "FEATURE_DIR:$FEATURE_DIR"

--- a/scripts/bash/check-prerequisites.sh
+++ b/scripts/bash/check-prerequisites.sh
@@ -84,10 +84,11 @@ check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 
 # If paths-only mode, output paths and exit (support JSON + paths-only combined)
 if $PATHS_ONLY; then
+    SPECS_DIR="$(get_specs_dir "$REPO_ROOT")"
     if $JSON_MODE; then
         # Minimal JSON paths payload (no validation performed)
-        printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s"}\n' \
-            "$REPO_ROOT" "$CURRENT_BRANCH" "$FEATURE_DIR" "$FEATURE_SPEC" "$IMPL_PLAN" "$TASKS"
+        printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s","SPECS_DIR":"%s"}\n' \
+            "$REPO_ROOT" "$CURRENT_BRANCH" "$FEATURE_DIR" "$FEATURE_SPEC" "$IMPL_PLAN" "$TASKS" "$SPECS_DIR"
     else
         echo "REPO_ROOT: $REPO_ROOT"
         echo "BRANCH: $CURRENT_BRANCH"
@@ -95,6 +96,7 @@ if $PATHS_ONLY; then
         echo "FEATURE_SPEC: $FEATURE_SPEC"
         echo "IMPL_PLAN: $IMPL_PLAN"
         echo "TASKS: $TASKS"
+        echo "SPECS_DIR: $SPECS_DIR"
     fi
     exit 0
 fi
@@ -148,7 +150,8 @@ if $JSON_MODE; then
         json_docs="[${json_docs%,}]"
     fi
     
-    printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s}\n' "$FEATURE_DIR" "$json_docs"
+    SPECS_DIR="$(get_specs_dir "$REPO_ROOT")"
+    printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s,"SPECS_DIR":"%s"}\n' "$FEATURE_DIR" "$json_docs" "$SPECS_DIR"
 else
     # Text output
     echo "FEATURE_DIR:$FEATURE_DIR"

--- a/scripts/bash/check-prerequisites.sh
+++ b/scripts/bash/check-prerequisites.sh
@@ -84,7 +84,7 @@ check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 
 # If paths-only mode, output paths and exit (support JSON + paths-only combined)
 if $PATHS_ONLY; then
-    SPECS_DIR="$(get_specs_dir "$REPO_ROOT")"
+    SPECS_DIR="$(get_specs_dir "$REPO_ROOT")" || exit 1
     if $JSON_MODE; then
         # Minimal JSON paths payload (no validation performed)
         printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s","SPECS_DIR":"%s"}\n' \
@@ -151,7 +151,8 @@ if $JSON_MODE; then
         json_docs="[${json_docs%,}]"
     fi
     
-    SPECS_DIR="$(get_specs_dir "$REPO_ROOT")"
+    SPECS_DIR="$(get_specs_dir "$REPO_ROOT")" || exit 1
+    # Note: $json_docs is not escaped because it is already a pre-formatted JSON array
     printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s,"SPECS_DIR":"%s"}\n' "$(json_escape "$FEATURE_DIR")" "$json_docs" "$(json_escape "$SPECS_DIR")"
 else
     # Text output

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -101,6 +101,12 @@ check_feature_branch() {
     local branch="$1"
     local has_git_repo="$2"
 
+    # When SPECIFY_SPECS_DIR is set (e.g., worktree mode), skip branch naming
+    # validation since the branch/worktree may not follow the NNN- convention.
+    if [[ -n "${SPECIFY_SPECS_DIR:-}" ]]; then
+        return 0
+    fi
+
     # For non-git repos, we can't enforce branch naming but still provide output
     if [[ "$has_git_repo" != "true" ]]; then
         echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -12,6 +12,12 @@ get_repo_root() {
     fi
 }
 
+# Get specs directory, with support for external location via SPECIFY_SPECS_DIR
+get_specs_dir() {
+    local repo_root="${1:-$(get_repo_root)}"
+    echo "${SPECIFY_SPECS_DIR:-$repo_root/specs}"
+}
+
 # Get current branch, with fallback for non-git repositories
 get_current_branch() {
     # First check if SPECIFY_FEATURE environment variable is set
@@ -28,7 +34,7 @@ get_current_branch() {
 
     # For non-git repos, try to find the latest feature directory
     local repo_root=$(get_repo_root)
-    local specs_dir="$repo_root/specs"
+    local specs_dir="$(get_specs_dir "$repo_root")"
 
     if [[ -d "$specs_dir" ]]; then
         local latest_feature=""
@@ -81,14 +87,14 @@ check_feature_branch() {
     return 0
 }
 
-get_feature_dir() { echo "$1/specs/$2"; }
+get_feature_dir() { echo "$(get_specs_dir "$1")/$2"; }
 
 # Find feature directory by numeric prefix instead of exact branch match
 # This allows multiple branches to work on the same spec (e.g., 004-fix-bug, 004-add-feature)
 find_feature_dir_by_prefix() {
     local repo_root="$1"
     local branch_name="$2"
-    local specs_dir="$repo_root/specs"
+    local specs_dir="$(get_specs_dir "$repo_root")"
 
     # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
     if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -5,6 +5,7 @@ set -e
 JSON_MODE=false
 SHORT_NAME=""
 BRANCH_NUMBER=""
+NO_BRANCH=false
 ARGS=()
 i=1
 while [ $i -le $# ]; do
@@ -12,6 +13,9 @@ while [ $i -le $# ]; do
     case "$arg" in
         --json) 
             JSON_MODE=true 
+            ;;
+        --no-branch)
+            NO_BRANCH=true
             ;;
         --short-name)
             if [ $((i + 1)) -gt $# ]; then
@@ -41,17 +45,19 @@ while [ $i -le $# ]; do
             BRANCH_NUMBER="$next_arg"
             ;;
         --help|-h) 
-            echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>"
+            echo "Usage: $0 [--json] [--short-name <name>] [--number N] [--no-branch] <feature_description>"
             echo ""
             echo "Options:"
             echo "  --json              Output in JSON format"
             echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
             echo "  --number N          Specify branch number manually (overrides auto-detection)"
+            echo "  --no-branch         Skip branch creation/checkout and git fetch"
             echo "  --help, -h          Show this help message"
             echo ""
             echo "Examples:"
             echo "  $0 'Add user authentication system' --short-name 'user-auth'"
             echo "  $0 'Implement OAuth2 integration for API' --number 5"
+            echo "  $0 --no-branch 'Fix payment timeout' --short-name 'fix-payment'"
             exit 0
             ;;
         *) 
@@ -248,21 +254,20 @@ else
     BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
 fi
 
-# When SPECIFY_SPECS_DIR is set, we assume an external specs directory (e.g., a
-# git worktree dedicated to this feature). Skip branch creation and git fetch
-# since the caller controls the branch lifecycle.
-WORKTREE_MODE=false
+# When SPECIFY_SPECS_DIR is set, automatically enable --no-branch since the
+# caller controls the branch lifecycle (e.g., a git worktree dedicated to this
+# feature).
 if [ -n "${SPECIFY_SPECS_DIR:-}" ]; then
-    WORKTREE_MODE=true
+    NO_BRANCH=true
 fi
 
 # Determine branch number
 if [ -z "$BRANCH_NUMBER" ]; then
-    if [ "$HAS_GIT" = true ] && [ "$WORKTREE_MODE" = false ]; then
+    if [ "$HAS_GIT" = true ] && [ "$NO_BRANCH" = false ]; then
         # Check existing branches on remotes
         BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
     else
-        # Fall back to local directory check (also used in worktree mode to
+        # Fall back to local directory check (also used in --no-branch mode to
         # avoid running git fetch --all --prune against the parent repo)
         HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
         BRANCH_NUMBER=$((HIGHEST + 1))
@@ -294,8 +299,8 @@ if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
 fi
 
-if [ "$WORKTREE_MODE" = true ]; then
-    >&2 echo "[specify] Worktree mode: skipping branch creation (SPECIFY_SPECS_DIR is set)"
+if [ "$NO_BRANCH" = true ]; then
+    >&2 echo "[specify] --no-branch: skipping branch creation"
 elif [ "$HAS_GIT" = true ]; then
     git checkout -b "$BRANCH_NAME"
 else
@@ -313,8 +318,8 @@ if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"
 export SPECIFY_FEATURE="$BRANCH_NAME"
 
 if $JSON_MODE; then
-    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s","SPECS_DIR":"%s","WORKTREE_MODE":%s}\n' \
-        "$(json_escape "$BRANCH_NAME")" "$(json_escape "$SPEC_FILE")" "$(json_escape "$FEATURE_NUM")" "$(json_escape "$SPECS_DIR")" "$WORKTREE_MODE"
+    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s","SPECS_DIR":"%s","NO_BRANCH":%s}\n' \
+        "$(json_escape "$BRANCH_NAME")" "$(json_escape "$SPEC_FILE")" "$(json_escape "$FEATURE_NUM")" "$(json_escape "$SPECS_DIR")" "$NO_BRANCH"
 else
     echo "BRANCH_NAME: $BRANCH_NAME"
     echo "SPEC_FILE: $SPEC_FILE"

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -177,6 +177,16 @@ cd "$REPO_ROOT"
 SPECS_DIR="$(get_specs_dir "$REPO_ROOT")" || exit 1
 mkdir -p "$SPECS_DIR"
 
+# Scaffold _shared directory with README if it doesn't exist yet
+SHARED_DIR="$SPECS_DIR/_shared"
+if [ ! -d "$SHARED_DIR" ]; then
+    mkdir -p "$SHARED_DIR"
+    SHARED_README="$REPO_ROOT/.specify/templates/_shared/README.md"
+    if [ -f "$SHARED_README" ]; then
+        cp "$SHARED_README" "$SHARED_DIR/README.md"
+    fi
+fi
+
 # Function to generate branch name with stop word filtering and length filtering
 generate_branch_name() {
     local description="$1"

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -174,7 +174,7 @@ fi
 
 cd "$REPO_ROOT"
 
-SPECS_DIR="$REPO_ROOT/specs"
+SPECS_DIR="${SPECIFY_SPECS_DIR:-$REPO_ROOT/specs}"
 mkdir -p "$SPECS_DIR"
 
 # Function to generate branch name with stop word filtering and length filtering

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -174,7 +174,7 @@ fi
 
 cd "$REPO_ROOT"
 
-SPECS_DIR="${SPECIFY_SPECS_DIR:-$REPO_ROOT/specs}"
+SPECS_DIR="$(get_specs_dir "$REPO_ROOT")" || exit 1
 mkdir -p "$SPECS_DIR"
 
 # Function to generate branch name with stop word filtering and length filtering

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -288,7 +288,8 @@ if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"
 export SPECIFY_FEATURE="$BRANCH_NAME"
 
 if $JSON_MODE; then
-    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
+    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s","SPECS_DIR":"%s"}\n' \
+        "$(json_escape "$BRANCH_NAME")" "$(json_escape "$SPEC_FILE")" "$(json_escape "$FEATURE_NUM")" "$(json_escape "$SPECS_DIR")"
 else
     echo "BRANCH_NAME: $BRANCH_NAME"
     echo "SPEC_FILE: $SPEC_FILE"

--- a/scripts/powershell/check-prerequisites.ps1
+++ b/scripts/powershell/check-prerequisites.ps1
@@ -66,6 +66,7 @@ if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit:$paths.HAS_GI
 # If paths-only mode, output paths and exit (support combined -Json -PathsOnly)
 if ($PathsOnly) {
     $specsDir = Get-SpecsDir -RepoRoot $paths.REPO_ROOT
+    if (-not $specsDir) { exit 1 }
     if ($Json) {
         [PSCustomObject]@{
             REPO_ROOT    = $paths.REPO_ROOT
@@ -131,6 +132,7 @@ if ($IncludeTasks -and (Test-Path $paths.TASKS)) {
 if ($Json) {
     # JSON output
     $specsDir = Get-SpecsDir -RepoRoot $paths.REPO_ROOT
+    if (-not $specsDir) { exit 1 }
     [PSCustomObject]@{ 
         FEATURE_DIR = $paths.FEATURE_DIR
         AVAILABLE_DOCS = $docs

--- a/scripts/powershell/check-prerequisites.ps1
+++ b/scripts/powershell/check-prerequisites.ps1
@@ -65,6 +65,7 @@ if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit:$paths.HAS_GI
 
 # If paths-only mode, output paths and exit (support combined -Json -PathsOnly)
 if ($PathsOnly) {
+    $specsDir = Get-SpecsDir -RepoRoot $paths.REPO_ROOT
     if ($Json) {
         [PSCustomObject]@{
             REPO_ROOT    = $paths.REPO_ROOT
@@ -73,6 +74,7 @@ if ($PathsOnly) {
             FEATURE_SPEC = $paths.FEATURE_SPEC
             IMPL_PLAN    = $paths.IMPL_PLAN
             TASKS        = $paths.TASKS
+            SPECS_DIR    = $specsDir
         } | ConvertTo-Json -Compress
     } else {
         Write-Output "REPO_ROOT: $($paths.REPO_ROOT)"
@@ -81,6 +83,7 @@ if ($PathsOnly) {
         Write-Output "FEATURE_SPEC: $($paths.FEATURE_SPEC)"
         Write-Output "IMPL_PLAN: $($paths.IMPL_PLAN)"
         Write-Output "TASKS: $($paths.TASKS)"
+        Write-Output "SPECS_DIR: $specsDir"
     }
     exit 0
 }
@@ -127,9 +130,11 @@ if ($IncludeTasks -and (Test-Path $paths.TASKS)) {
 # Output results
 if ($Json) {
     # JSON output
+    $specsDir = Get-SpecsDir -RepoRoot $paths.REPO_ROOT
     [PSCustomObject]@{ 
         FEATURE_DIR = $paths.FEATURE_DIR
-        AVAILABLE_DOCS = $docs 
+        AVAILABLE_DOCS = $docs
+        SPECS_DIR = $specsDir
     } | ConvertTo-Json -Compress
 } else {
     # Text output

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -15,6 +15,15 @@ function Get-RepoRoot {
     return (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
 }
 
+# Get specs directory, with support for external location via SPECIFY_SPECS_DIR
+function Get-SpecsDir {
+    param([string]$RepoRoot = (Get-RepoRoot))
+    if ($env:SPECIFY_SPECS_DIR) {
+        return $env:SPECIFY_SPECS_DIR
+    }
+    return Join-Path $RepoRoot "specs"
+}
+
 function Get-CurrentBranch {
     # First check if SPECIFY_FEATURE environment variable is set
     if ($env:SPECIFY_FEATURE) {
@@ -33,7 +42,7 @@ function Get-CurrentBranch {
     
     # For non-git repos, try to find the latest feature directory
     $repoRoot = Get-RepoRoot
-    $specsDir = Join-Path $repoRoot "specs"
+    $specsDir = Get-SpecsDir -RepoRoot $repoRoot
     
     if (Test-Path $specsDir) {
         $latestFeature = ""
@@ -89,7 +98,7 @@ function Test-FeatureBranch {
 
 function Get-FeatureDir {
     param([string]$RepoRoot, [string]$Branch)
-    Join-Path $RepoRoot "specs/$Branch"
+    Join-Path (Get-SpecsDir -RepoRoot $RepoRoot) $Branch
 }
 
 function Get-FeaturePathsEnv {

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -18,8 +18,20 @@ function Get-RepoRoot {
 # Get specs directory, with support for external location via SPECIFY_SPECS_DIR
 function Get-SpecsDir {
     param([string]$RepoRoot = (Get-RepoRoot))
+    
     if ($env:SPECIFY_SPECS_DIR) {
-        return $env:SPECIFY_SPECS_DIR
+        $specsDir = $env:SPECIFY_SPECS_DIR
+        # Require absolute path
+        if (-not [System.IO.Path]::IsPathRooted($specsDir)) {
+            Write-Error "[specify] ERROR: SPECIFY_SPECS_DIR must be an absolute path (got: '$specsDir')"
+            throw "SPECIFY_SPECS_DIR must be an absolute path"
+        }
+        # Block path traversal
+        if ($specsDir -match '\.\.') {
+            Write-Error "[specify] ERROR: SPECIFY_SPECS_DIR must not contain '..' (got: '$specsDir')"
+            throw "SPECIFY_SPECS_DIR must not contain '..'"
+        }
+        return $specsDir
     }
     return Join-Path $RepoRoot "specs"
 }

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -21,15 +21,9 @@ function Get-SpecsDir {
     
     if ($env:SPECIFY_SPECS_DIR) {
         $specsDir = $env:SPECIFY_SPECS_DIR
-        # Require absolute path
+        # Resolve relative paths against repo root
         if (-not [System.IO.Path]::IsPathRooted($specsDir)) {
-            Write-Error "[specify] ERROR: SPECIFY_SPECS_DIR must be an absolute path (got: '$specsDir')"
-            throw "SPECIFY_SPECS_DIR must be an absolute path"
-        }
-        # Block path traversal
-        if ($specsDir -match '\.\.') {
-            Write-Error "[specify] ERROR: SPECIFY_SPECS_DIR must not contain '..' (got: '$specsDir')"
-            throw "SPECIFY_SPECS_DIR must not contain '..'"
+            $specsDir = Join-Path $RepoRoot $specsDir
         }
         return $specsDir
     }

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -88,6 +88,12 @@ function Test-FeatureBranch {
         [bool]$HasGit = $true
     )
     
+    # When SPECIFY_SPECS_DIR is set (e.g., worktree mode), skip branch naming
+    # validation since the branch/worktree may not follow the NNN- convention.
+    if ($env:SPECIFY_SPECS_DIR) {
+        return $true
+    }
+    
     # For non-git repos, we can't enforce branch naming but still provide output
     if (-not $HasGit) {
         Write-Warning "[specify] Warning: Git repository not detected; skipped branch validation"

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -149,7 +149,11 @@ try {
 
 Set-Location $repoRoot
 
-$specsDir = if ($env:SPECIFY_SPECS_DIR) { $env:SPECIFY_SPECS_DIR } else { Join-Path $repoRoot 'specs' }
+$specsDir = Get-SpecsDir -RepoRoot $repoRoot
+if (-not $specsDir) {
+    Write-Host "`n[specify] ERROR: Invalid SPECIFY_SPECS_DIR configuration. Aborting." -ForegroundColor Red
+    exit 1
+}
 New-Item -ItemType Directory -Path $specsDir -Force | Out-Null
 
 # Function to generate branch name with stop word filtering and length filtering

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -149,7 +149,7 @@ try {
 
 Set-Location $repoRoot
 
-$specsDir = Join-Path $repoRoot 'specs'
+$specsDir = if ($env:SPECIFY_SPECS_DIR) { $env:SPECIFY_SPECS_DIR } else { Join-Path $repoRoot 'specs' }
 New-Item -ItemType Directory -Path $specsDir -Force | Out-Null
 
 # Function to generate branch name with stop word filtering and length filtering

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -156,6 +156,16 @@ if (-not $specsDir) {
 }
 New-Item -ItemType Directory -Path $specsDir -Force | Out-Null
 
+# Scaffold _shared directory with README if it doesn't exist yet
+$sharedDir = Join-Path $specsDir '_shared'
+if (-not (Test-Path $sharedDir)) {
+    New-Item -ItemType Directory -Path $sharedDir -Force | Out-Null
+    $sharedReadme = Join-Path $repoRoot '.specify/templates/_shared/README.md'
+    if (Test-Path $sharedReadme) {
+        Copy-Item $sharedReadme (Join-Path $sharedDir 'README.md') -Force
+    }
+}
+
 # Function to generate branch name with stop word filtering and length filtering
 function Get-BranchName {
     param([string]$Description)

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -271,6 +271,7 @@ if ($Json) {
         SPEC_FILE = $specFile
         FEATURE_NUM = $featureNum
         HAS_GIT = $hasGit
+        SPECS_DIR = $specsDir
     }
     $obj | ConvertTo-Json -Compress
 } else {

--- a/templates/_shared/README.md
+++ b/templates/_shared/README.md
@@ -1,0 +1,39 @@
+# Shared Context
+
+This directory holds project-wide standards and conventions that apply across
+all feature specs. Every `.md` file placed here is automatically loaded as
+read-only context by the following Spec Kit commands:
+
+- **specify** -- informs spec structure and alignment with project standards
+- **clarify** -- validates spec alignment and informs ambiguity detection
+- **plan** -- guides technical decisions in implementation plans
+- **tasks** -- informs task structure and sequencing
+- **implement** -- guides implementation decisions and coding patterns
+- **checklist** -- incorporates project-wide requirements into validation
+- **analyze** -- uses standards as additional validation criteria
+
+## What to put here
+
+Create `.md` files for any project-wide standards you want consistently applied:
+
+- **Architecture decisions** -- system boundaries, data flow, service topology
+- **API conventions** -- endpoint naming, versioning, request/response patterns
+- **Coding standards** -- naming, formatting, error handling, logging patterns
+- **Security requirements** -- authentication, authorization, input validation
+- **Accessibility standards** -- WCAG compliance, ARIA patterns
+- **Testing conventions** -- coverage expectations, mocking strategies, test naming
+
+## Example
+
+```
+specs/_shared/
+  api-conventions.md
+  coding-standards.md
+  security-requirements.md
+```
+
+## Notes
+
+- Files are **read-only** -- Spec Kit commands never modify shared context.
+- Only `.md` files are loaded; other file types are ignored.
+- This directory is optional. If absent, commands proceed without shared context.

--- a/templates/commands/analyze.md
+++ b/templates/commands/analyze.md
@@ -67,6 +67,10 @@ Load only the minimal necessary context from each artifact:
 
 - Load `/memory/constitution.md` for principle validation
 
+**From shared context (if available):**
+
+- **IF `SPECS_DIR/_shared/` exists**: Read all `.md` files for project-wide standards (architecture decisions, coding conventions, security requirements). Use these as additional validation criteria alongside the constitution.
+
 ### 3. Build Semantic Models
 
 Create internal representations (do not include raw artifacts in output):

--- a/templates/commands/checklist.md
+++ b/templates/commands/checklist.md
@@ -82,6 +82,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - spec.md: Feature requirements and scope
    - plan.md (if exists): Technical details, dependencies
    - tasks.md (if exists): Implementation tasks
+   - **IF `SPECS_DIR/_shared/` exists**: Read all `.md` files for project-wide standards (security requirements, accessibility standards, coding conventions). Incorporate these into checklist generation to ensure project-wide requirements are validated.
 
    **Context Loading Strategy**:
    - Load only necessary portions relevant to active focus areas (avoid full-file dumping)

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -32,7 +32,11 @@ Execution steps:
    - If JSON parsing fails, abort and instruct user to re-run `/speckit.specify` or verify feature branch environment.
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. Load the current spec file. **IF `SPECS_DIR/_shared/` exists** (SPECS_DIR is in the JSON output): Read all `.md` files from it for project-wide context (architecture decisions, conventions, standards). Use this to validate spec alignment with project standards and inform ambiguity detection. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+2. Load the current spec file from `FEATURE_SPEC`.
+
+3. Load shared project context. **IF `SPECS_DIR/_shared/` exists** (SPECS_DIR is in the JSON output): Read all `.md` files from it for project-wide context (architecture decisions, conventions, standards). Use this shared context to validate spec alignment with project standards and inform ambiguity detection in the next step. If the directory does not exist, proceed without shared context.
+
+4. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
 
    Functional Scope & Behavior:
    - Core user goals & success criteria
@@ -88,7 +92,7 @@ Execution steps:
    - Clarification would not materially change implementation or validation strategy
    - Information is better deferred to planning phase (note internally)
 
-3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+5. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
     - Maximum of 10 total questions across the whole session.
     - Each question must be answerable with EITHER:
        - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
@@ -99,7 +103,7 @@ Execution steps:
     - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
     - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
 
-4. Sequential questioning loop (interactive):
+6. Sequential questioning loop (interactive):
     - Present EXACTLY ONE question at a time.
     - For multiple‑choice questions:
        - **Analyze all options** and determine the **most suitable option** based on:
@@ -135,7 +139,7 @@ Execution steps:
     - Never reveal future queued questions in advance.
     - If no valid questions exist at start, immediately report no critical ambiguities.
 
-5. Integration after EACH accepted answer (incremental update approach):
+7. Integration after EACH accepted answer (incremental update approach):
     - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
     - For the first integrated answer in this session:
        - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
@@ -153,7 +157,7 @@ Execution steps:
     - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
     - Keep each inserted clarification minimal and testable (avoid narrative drift).
 
-6. Validation (performed after EACH write plus final pass):
+8. Validation (performed after EACH write plus final pass):
    - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
    - Total asked (accepted) questions ≤ 5.
    - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
@@ -161,9 +165,9 @@ Execution steps:
    - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
    - Terminology consistency: same canonical term used across all updated sections.
 
-7. Write the updated spec back to `FEATURE_SPEC`.
+9. Write the updated spec back to `FEATURE_SPEC`.
 
-8. Report completion (after questioning loop ends or early termination):
+10. Report completion (after questioning loop ends or early termination):
    - Number of questions asked & answered.
    - Path to updated spec.
    - Sections touched (list names).

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -32,7 +32,7 @@ Execution steps:
    - If JSON parsing fails, abort and instruct user to re-run `/speckit.specify` or verify feature branch environment.
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+2. Load the current spec file. **IF `SPECS_DIR/_shared/` exists** (SPECS_DIR is in the JSON output): Read all `.md` files from it for project-wide context (architecture decisions, conventions, standards). Use this to validate spec alignment with project standards and inform ambiguity detection. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
 
    Functional Scope & Behavior:
    - Core user goals & success criteria

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -55,6 +55,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **IF EXISTS**: Read contracts/ for API specifications and test requirements
    - **IF EXISTS**: Read research.md for technical decisions and constraints
    - **IF EXISTS**: Read quickstart.md for integration scenarios
+   - **IF `SPECS_DIR/_shared/` exists**: Read all `.md` files for project-wide context (coding standards, API conventions, security requirements). Use this to guide implementation decisions and ensure alignment with established patterns.
 
 4. **Project Setup Verification**:
    - **REQUIRED**: Create/verify ignore files based on actual project setup:

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -28,7 +28,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load context**: Read FEATURE_SPEC and `/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+2. **Load context**: Read FEATURE_SPEC and `/memory/constitution.md`. Load IMPL_PLAN template (already copied). **IF `SPECS_DIR/_shared/` exists**: Read all `.md` files from it for project-wide context (architecture decisions, API conventions, coding standards). Use this to inform technical decisions and ensure alignment with established patterns.
 
 3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
    - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -41,6 +41,8 @@ Given that feature description, do this:
 
 2. **Check for existing branches before creating new one**:
 
+   **IF the environment variable `SPECIFY_SPECS_DIR` is set** (worktree mode), skip steps 2a-2c entirely and go directly to 2d. The script will detect worktree mode automatically and skip branch creation/checkout. The feature directory and spec file will still be created under the custom specs directory.
+
    a. First, fetch all remote branches to ensure we have the latest information:
 
       ```bash
@@ -50,7 +52,7 @@ Given that feature description, do this:
    b. Find the highest feature number across all sources for the short-name:
       - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
       - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+      - Specs directories: Check for directories matching the specs directory for `[0-9]+-<short-name>`
 
    c. Determine the next available number:
       - Extract all numbers from all three sources
@@ -69,6 +71,7 @@ Given that feature description, do this:
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
+   - If WORKTREE_MODE is true in the JSON output, the script skipped branch creation/checkout (the current branch is used as-is)
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
 
 3. Load `templates/spec-template.md` to understand required sections.
@@ -197,7 +200,7 @@ Given that feature description, do this:
 
 8. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
-**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
+**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing. In worktree mode (WORKTREE_MODE is true in JSON output), the script skips branch creation/checkout since the worktree already represents the feature branch.
 
 ## General Guidelines
 

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -39,9 +39,11 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Set up feature branch and run the create-new-feature script**:
 
-   a. First, fetch all remote branches to ensure we have the latest information:
+   **IF `--no-branch` is NOT present in the user's input**, perform branch scanning first:
+
+   a. Fetch all remote branches to ensure we have the latest information:
 
       ```bash
       git fetch --all --prune
@@ -57,19 +59,24 @@ Given that feature description, do this:
       - Find the highest number N
       - Use N+1 for the new branch number
 
+   **IF `--no-branch` IS present in the user's input**, skip steps 2a-2c entirely. The script will determine the feature number from local directories only and will not create or switch git branches. Pass `--no-branch` through to the script.
+
    d. Run the script `{SCRIPT}` with the calculated number and short-name:
       - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
+      - If `--no-branch` was specified, also pass `--no-branch` to the script
       - Bash example: `{SCRIPT} --json --number 5 --short-name "user-auth" "Add user authentication"`
+      - Bash example (no-branch): `{SCRIPT} --json --no-branch --short-name "user-auth" "Add user authentication"`
       - PowerShell example: `{SCRIPT} -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+      - PowerShell example (no-branch): `{SCRIPT} -Json -NoBranch -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
+   - When doing branch scanning (steps 2a-2c), check all three sources (remote branches, local branches, specs directories) to find the highest number
    - Only match branches/directories with the exact short-name pattern
    - If no existing branches/directories found with this short-name, start with number 1
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
-   - If WORKTREE_MODE is true in the JSON output, the script skipped branch creation/checkout (the current branch is used as-is)
+   - If NO_BRANCH is true in the JSON output, the script skipped branch creation/checkout (the current branch is used as-is)
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
 
 3. Load `templates/spec-template.md` to understand required sections.
@@ -198,7 +205,7 @@ Given that feature description, do this:
 
 8. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
-**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing. If `WORKTREE_MODE` is `true` in the JSON output, the script skipped branch creation/checkout because the user has configured a custom specs directory -- the current branch is used as-is. When reporting completion in worktree mode, note that the branch was not created by the script.
+**NOTE:** By default, the script creates and checks out a new branch and initializes the spec file before writing. If `NO_BRANCH` is `true` in the JSON output (set by `--no-branch` flag or automatically when the user has configured a custom specs directory via `SPECIFY_SPECS_DIR`), the script skipped branch creation/checkout -- the current branch is used as-is. When reporting completion in no-branch mode, note that the branch was not created by the script.
 
 ## General Guidelines
 

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -41,8 +41,6 @@ Given that feature description, do this:
 
 2. **Check for existing branches before creating new one**:
 
-   **IF the environment variable `SPECIFY_SPECS_DIR` is set** (worktree mode), skip steps 2a-2c entirely and go directly to 2d. The script will detect worktree mode automatically and skip branch creation/checkout. The feature directory and spec file will still be created under the custom specs directory.
-
    a. First, fetch all remote branches to ensure we have the latest information:
 
       ```bash
@@ -200,7 +198,7 @@ Given that feature description, do this:
 
 8. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
-**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing. In worktree mode (WORKTREE_MODE is true in JSON output), the script skips branch creation/checkout since the worktree already represents the feature branch.
+**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing. If `WORKTREE_MODE` is `true` in the JSON output, the script skipped branch creation/checkout because the user has configured a custom specs directory -- the current branch is used as-is. When reporting completion in worktree mode, note that the branch was not created by the script.
 
 ## General Guidelines
 

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -73,7 +73,7 @@ Given that feature description, do this:
 
 3. Load `templates/spec-template.md` to understand required sections.
 
-4. **Load shared context (if available)**: Check if `SPECS_DIR/_shared/` directory exists (SPECS_DIR is returned in the script JSON output). If it exists, read all `.md` files from it. These contain project-wide standards (architecture decisions, API conventions, coding standards, security requirements). Use this context to inform spec structure and ensure alignment with established patterns. Do not modify shared files.
+4. **Load shared context (if available)**: Check if `SPECS_DIR/_shared/` directory exists (SPECS_DIR is provided in the JSON output from the setup script). If it exists, read all `.md` files from it. These contain project-wide standards (architecture decisions, API conventions, coding standards, security requirements). Use this context to inform spec structure and ensure alignment with established patterns. Do not modify shared files.
 
 5. Follow this execution flow:
 

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -73,7 +73,9 @@ Given that feature description, do this:
 
 3. Load `templates/spec-template.md` to understand required sections.
 
-4. Follow this execution flow:
+4. **Load shared context (if available)**: Check if `SPECS_DIR/_shared/` directory exists (SPECS_DIR is returned in the script JSON output). If it exists, read all `.md` files from it. These contain project-wide standards (architecture decisions, API conventions, coding standards, security requirements). Use this context to inform spec structure and ensure alignment with established patterns. Do not modify shared files.
+
+5. Follow this execution flow:
 
     1. Parse user description from Input
        If empty: ERROR "No feature description provided"
@@ -99,9 +101,9 @@ Given that feature description, do this:
     7. Identify Key Entities (if data involved)
     8. Return: SUCCESS (spec ready for planning)
 
-5. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
 
-6. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
 
    a. **Create Spec Quality Checklist**: Generate a checklist file at `FEATURE_DIR/checklists/requirements.md` using the checklist template structure with these validation items:
 
@@ -193,7 +195,7 @@ Given that feature description, do this:
 
    d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
 
-7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
+8. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
 **NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
 

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -29,6 +29,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 2. **Load design documents**: Read from FEATURE_DIR:
    - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
    - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
+   - **IF `SPECS_DIR/_shared/` exists**: Read all `.md` files for project-wide context (coding standards, conventions). Use this to inform task structure and ensure alignment with established patterns.
    - Note: Not all projects have all documents. Generate tasks based on what's available.
 
 3. **Execute task generation workflow**:


### PR DESCRIPTION
## Summary

This PR adds support for a centralized specs directory via the `SPECIFY_SPECS_DIR` environment variable, enabling powerful workflows for git worktrees, multi-feature development, and team collaboration.

## Motivation

This addresses the use case discussed in #1547 (worktree support) with a simpler, more flexible approach. Rather than embedding worktree management into git-spec, this PR decouples git-spec from specific git workflows by letting users control where specs are stored.

## Key Features

### 1. External Specs Directory
Set `SPECIFY_SPECS_DIR` to store specs outside the repository:
```bash
export SPECIFY_SPECS_DIR="/path/to/myrepo.specs"
export SPECIFY_FEATURE="my-feature"
```

### 2. Shared Project Context
A `_shared/` subdirectory within the specs directory provides project-wide context that all commands automatically incorporate:
```
myrepo.specs/
    _shared/                    # Project-wide standards
        architecture.md
        api-conventions.md
        coding-standards.md
    001-feature-a/
        spec.md
        plan.md
    002-feature-b/
        spec.md
```

### 3. Worktree Compatibility
Works seamlessly with git worktrees - all worktrees can share the same specs directory:
```bash
# In any worktree:
export SPECIFY_SPECS_DIR="${HOME}/clones/myrepo.specs"
# All git-spec commands use the centralized specs
```

## Benefits

- **Cross-feature visibility**: See all feature specs when working on any feature
- **Spec survival**: Specs persist when worktrees are deleted
- **Spec-first development**: Create specs before branches exist
- **Shared standards**: Project-wide guidance incorporated into all commands
- **100% backward compatible**: No changes when env var is not set

## Changes

| Component | Files | Changes |
|-----------|-------|---------|
| Bash scripts | `common.sh`, `create-new-feature.sh`, `check-prerequisites.sh` | Add `get_specs_dir()`, update references, add `SPECS_DIR` to JSON |
| PowerShell scripts | `common.ps1`, `create-new-feature.ps1`, `check-prerequisites.ps1` | Add `Get-SpecsDir`, update references, add `SPECS_DIR` to JSON |
| Command templates | 7 files | Add `_shared/` loading to context step |

**Total: ~50 lines across 13 files**

## Testing

Tested scenarios:
- Default behavior (no env vars): Works exactly as before
- With `SPECIFY_SPECS_DIR` set: Correctly uses external directory
- JSON output includes `SPECS_DIR` for command templates
- Feature auto-numbering works with external specs directory

## Relationship to #1547

This is an alternative approach to #1547's embedded worktree support. Instead of git-spec managing worktrees, this lets users manage git however they want while git-spec focuses on spec management. The key insight from #1547's discussion was correct: "rip out branch management and let the user do it how they want."