### PR TITLE
fix(scripts): prevent create-new-feature branch-number parse failure

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -131,7 +131,7 @@ check_existing_branches() {
     local specs_dir="$1"
 
     # Fetch all remotes to get latest branch info (suppress errors if no remotes)
-    git fetch --all --prune 2>/dev/null || true
+    git fetch --all --prune >/dev/null 2>&1 || true
 
     # Get highest number from ALL branches (not just matching short name)
     local highest_branch=$(get_highest_from_branches)


### PR DESCRIPTION
## Summary
- prevent `create-new-feature.sh` from capturing `git fetch --all` output into `BRANCH_NUMBER`
- fix arithmetic expansion failure like `10#Fetching: value too great for base`

## Root Cause
`check_existing_branches` runs in command substitution and previously called:

```bash
git fetch --all --prune 2>/dev/null || true
```

This suppresses stderr but not stdout. In environments where fetch prints status text to stdout (for example `Fetching ...`), that text can be captured alongside the numeric return value and later break numeric parsing.

## Fix
Changed fetch redirection to suppress both stdout and stderr:

```bash
git fetch --all --prune >/dev/null 2>&1 || true
```

This keeps behavior the same while ensuring `check_existing_branches` emits only the intended numeric value.

## Validation
- Ran in `spec-kit` repo:
  - `bash scripts/bash/create-new-feature.sh --json "test fetch output capture fix"`
  - Result: JSON returned successfully, no `10#Fetching` error
- Ran from external repo (`vue-tailwind-datepicker`) against local `spec-kit` script:
  - `bash /Users/iremizov/code/spec-kit/scripts/bash/create-new-feature.sh --json "verify fetch output fix from external repo"`
  - Result: JSON returned successfully, no `10#Fetching` error

## AI Disclosure
This PR was prepared with AI assistance (OpenAI Codex `gpt-5.3-codex high`), then reviewed and validated by me.

Closes #1592
