### PR TITLE
Add Mistral Vibe CLI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,20 @@ env/
 sdd-*/
 docs/dev
 
+# Local development (Mistral Vibe)
+local-templates/
+*-vibe-test/
+*-vibe-init/
+test-vibe-project/
+mon-projet-vibe-test/
+install-local.sh
+create-local-vibe-template.sh
+create-vibe-release-packages.sh
+test-vibe-init.sh
+DEVELOPPEMENT_LOCAL.md
+QUICK_START.md
+MISTRAL_VIBE_IMPLEMENTATION.md
+
 # Extension system
 .specify/extensions/.cache/
 .specify/extensions/.backup/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Specify supports multiple AI agents by generating agent-specific command files a
 | **Amp**                    | `.agents/commands/`    | Markdown | `amp`           | Amp CLI                     |
 | **SHAI**                   | `.shai/commands/`      | Markdown | `shai`          | SHAI CLI                    |
 | **IBM Bob**                | `.bob/commands/`       | Markdown | N/A (IDE-based) | IBM Bob IDE                 |
+| **Mistral Vibe CLI**       | `.vibe/skills/`        | Markdown | `vibe`          | Mistral Vibe CLI            |
 
 ### Step-by-Step Integration Guide
 
@@ -67,6 +68,13 @@ AGENT_CONFIG = {
         "folder": ".newagent/",  # Directory for agent files
         "install_url": "https://example.com/install",  # URL for installation docs (or None if IDE-based)
         "requires_cli": True,  # True if CLI tool required, False for IDE-based agents
+    },
+    # Example: Mistral Vibe CLI
+    "vibe": {
+        "name": "Mistral Vibe CLI",
+        "folder": ".vibe/",
+        "install_url": "https://docs.mistral.ai/mistral-vibe/introduction/install",
+        "requires_cli": True,
     },
 }
 ```
@@ -90,7 +98,7 @@ This eliminates the need for special-case mappings throughout the codebase.
 Update the `--ai` parameter help text in the `init()` command to include the new agent:
 
 ```python
-ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, copilot, cursor-agent, qwen, opencode, codex, windsurf, kilocode, auggie, codebuddy, new-agent-cli, or q"),
+ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, copilot, cursor-agent, qwen, opencode, codex, windsurf, kilocode, auggie, codebuddy, vibe, new-agent-cli, or q"),
 ```
 
 Also update any function docstrings, examples, and error messages that list available agents.
@@ -316,6 +324,7 @@ Require a command-line tool to be installed:
 - **Qoder CLI**: `qoder` CLI
 - **Amp**: `amp` CLI
 - **SHAI**: `shai` CLI
+- **Mistral Vibe CLI**: `vibe` CLI
 
 ### IDE-Based Agents
 
@@ -329,7 +338,7 @@ Work within integrated development environments:
 
 ### Markdown Format
 
-Used by: Claude, Cursor, opencode, Windsurf, Amazon Q Developer, Amp, SHAI, IBM Bob
+Used by: Claude, Cursor, opencode, Windsurf, Amazon Q Developer, Amp, SHAI, IBM Bob, Mistral Vibe
 
 **Standard format:**
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Want to see Spec Kit in action? Watch our [video overview](https://www.youtube.c
 | [SHAI (OVHcloud)](https://github.com/ovh/shai)                                       | ✅      |                                                                                                                                           |
 | [Windsurf](https://windsurf.com/)                                                    | ✅      |                                                                                                                                           |
 | [Antigravity (agy)](https://agy.ai/)                                                 | ✅      |                                                                                                                                           |
+| [Mistral Vibe CLI](https://docs.mistral.ai/mistral-vibe/introduction)               | ✅      |                                                                                                                                           |
 
 ## 🔧 Specify CLI Reference
 
@@ -173,14 +174,14 @@ The `specify` command supports the following options:
 | Command | Description                                                                                                                                             |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `init`  | Initialize a new Specify project from the latest template                                                                                               |
-| `check` | Check for installed tools (`git`, `claude`, `gemini`, `code`/`code-insiders`, `cursor-agent`, `windsurf`, `qwen`, `opencode`, `codex`, `shai`, `qoder`) |
+| `check` | Check for installed tools (`git`, `claude`, `gemini`, `code`/`code-insiders`, `cursor-agent`, `windsurf`, `qwen`, `opencode`, `codex`, `shai`, `qoder`, `vibe`) |
 
 ### `specify init` Arguments & Options
 
 | Argument/Option        | Type     | Description                                                                                                                                                                                  |
 | ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<project-name>`       | Argument | Name for your new project directory (optional if using `--here`, or use `.` for current directory)                                                                                           |
-| `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, `cursor-agent`, `qwen`, `opencode`, `codex`, `windsurf`, `kilocode`, `auggie`, `roo`, `codebuddy`, `amp`, `shai`, `q`, `agy`, `bob`, or `qoder` |
+| `--ai`                 | Option   | AI assistant to use: `claude`, `gemini`, `copilot`, `cursor-agent`, `qwen`, `opencode`, `codex`, `windsurf`, `kilocode`, `auggie`, `roo`, `codebuddy`, `amp`, `shai`, `q`, `agy`, `bob`, `vibe`, or `qoder` |
 | `--script`             | Option   | Script variant to use: `sh` (bash/zsh) or `ps` (PowerShell)                                                                                                                                  |
 | `--ignore-agent-tools` | Flag     | Skip checks for AI agent tools like Claude Code                                                                                                                                              |
 | `--no-git`             | Flag     | Skip git repository initialization                                                                                                                                                           |
@@ -216,6 +217,9 @@ specify init my-project --ai shai
 
 # Initialize with IBM Bob support
 specify init my-project --ai bob
+
+# Initialize with Mistral Vibe CLI support
+specify init my-project --ai vibe
 
 # Initialize with PowerShell scripts (Windows/cross-platform)
 specify init my-project --ai copilot --script ps
@@ -366,6 +370,7 @@ You will be prompted to select the AI agent you are using. You can also proactiv
 specify init <project_name> --ai claude
 specify init <project_name> --ai gemini
 specify init <project_name> --ai copilot
+specify init <project_name> --ai vibe
 
 # Or in current directory:
 specify init . --ai claude
@@ -382,7 +387,7 @@ specify init . --force --ai claude
 specify init --here --force --ai claude
 ```
 
-The CLI will check if you have Claude Code, Gemini CLI, Cursor CLI, Qwen CLI, opencode, Codex CLI, Qoder CLI, or Amazon Q Developer CLI installed. If you do not, or you prefer to get the templates without checking for the right tools, use `--ignore-agent-tools` with your command:
+The CLI will check if you have Claude Code, Gemini CLI, Cursor CLI, Qwen CLI, opencode, Codex CLI, Qoder CLI, Mistral Vibe CLI, or Amazon Q Developer CLI installed. If you do not, or you prefer to get the templates without checking for the right tools, use `--ignore-agent-tools` with your command:
 
 ```bash
 specify init <project_name> --ai claude --ignore-agent-tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.1.0"
+version = "0.0.95"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -232,6 +232,12 @@ AGENT_CONFIG = {
         "install_url": None,  # IDE-based
         "requires_cli": False,
     },
+    "vibe": {
+        "name": "Mistral Vibe CLI",
+        "folder": ".vibe/",
+        "install_url": "https://docs.mistral.ai/mistral-vibe/introduction/install",
+        "requires_cli": True,
+    },
 }
 
 SCRIPT_TYPE_CHOICES = {"sh": "POSIX Shell (bash/zsh)", "ps": "PowerShell"}
@@ -986,7 +992,7 @@ def ensure_constitution_from_template(project_path: Path, tracker: StepTracker |
 @app.command()
 def init(
     project_name: str = typer.Argument(None, help="Name for your new project directory (optional if using --here, or use '.' for current directory)"),
-    ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, copilot, cursor-agent, qwen, opencode, codex, windsurf, kilocode, auggie, codebuddy, amp, shai, q, agy, bob, or qoder "),
+    ai_assistant: str = typer.Option(None, "--ai", help="AI assistant to use: claude, gemini, copilot, cursor-agent, qwen, opencode, codex, windsurf, kilocode, auggie, codebuddy, amp, shai, q, agy, bob, vibe, or qoder "),
     script_type: str = typer.Option(None, "--script", help="Script type to use: sh or ps"),
     ignore_agent_tools: bool = typer.Option(False, "--ignore-agent-tools", help="Skip checks for AI agent tools like Claude Code"),
     no_git: bool = typer.Option(False, "--no-git", help="Skip git repository initialization"),

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -676,6 +676,12 @@ class CommandRegistrar:
             "format": "markdown",
             "args": "$ARGUMENTS",
             "extension": ".md"
+        },
+        "vibe": {
+            "dir": ".vibe/skills",
+            "format": "markdown",
+            "args": "$ARGUMENTS",
+            "extension": ".md"
         }
     }
 


### PR DESCRIPTION
- Add vibe to AGENT_CONFIG with .vibe/ folder structure
- Add vibe to extensions.py with skills directory support
- Update README with Mistral Vibe CLI documentation
- Update AGENTS.md with integration guide
- Set version to 0.0.95 for compatibility

Mistral Vibe uses a unique skills system in .vibe/skills/ where each skill is a directory with SKILL.md containing frontmatter metadata (user-invocable: true) for discovery.

This adds autonomous Mistral Vibe support while maintaining compatibility with upstream spec-kit workflows.