### PR TITLE
feat: add Dependabot configuration for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated dependency update monitoring.

## Changes

- Weekly update checks for **pip** ecosystem (typer, rich, httpx, platformdirs, readchar, truststore, pyyaml, packaging)
- Weekly update checks for **github-actions** ecosystem (workflow action versions)

## Motivation

Eight runtime dependencies plus GitHub Actions versions had no automated security or compatibility monitoring. Dependabot will now open PRs for version updates and security patches automatically.