### PR TITLE
fix: include 'src/**' path in release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'memory/**'
       - 'scripts/**'
+      - 'src/**'
       - 'templates/**'
       - '.github/workflows/**'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Adds `src/**` to the `paths:` trigger list in the release workflow so that CLI code changes merged to `main` properly trigger a release.

## Problem

The release workflow (`.github/workflows/release.yml`) triggers on `memory/**`, `scripts/**`, `templates/**`, and `.github/ but not `src/**`. Bug fixes to the Python CLI silently sit unreleased.workflows/**` 

Fixes #1645

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>