### PR TITLE
Update V-Model Extension Pack to v0.2.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -8,8 +8,8 @@
       "id": "v-model",
       "description": "Enforces V-Model paired generation of development specs and test specs with full traceability.",
       "author": "leocamello",
-      "version": "0.1.0",
-      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.1.0.zip",
+      "version": "0.2.0",
+      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.2.0.zip",
       "repository": "https://github.com/leocamello/spec-kit-v-model",
       "homepage": "https://github.com/leocamello/spec-kit-v-model",
       "documentation": "https://github.com/leocamello/spec-kit-v-model/blob/main/README.md",
@@ -19,7 +19,7 @@
         "speckit_version": ">=0.1.0"
       },
       "provides": {
-        "commands": 3,
+        "commands": 5,
         "hooks": 1
       },
       "tags": ["v-model", "traceability", "testing", "compliance", "safety-critical"],


### PR DESCRIPTION
## Extension: V-Model Extension Pack — v0.2.0

**Repository**: https://github.com/leocamello/spec-kit-v-model
**Version**: 0.1.0 → **0.2.0**
**Release**: https://github.com/leocamello/spec-kit-v-model/releases/tag/v0.2.0
**License**: MIT
**Author**: @leocamello

### What's new in v0.2.0

Two new commands completing V-Model Level 2 (System Design ↔ System Testing):

| Command | Description |
|---------|-------------|
| `/speckit.v-model.system-design` | Decompose requirements into IEEE 1016-compliant system components with four design views |
| `/speckit.v-model.system-test` | Generate ISO 29119-compliant system test plans with named testing techniques |

Extended existing command:

| Command | Change |
|---------|--------|
| `/speckit.v-model.trace` | Now produces dual-matrix output (Matrix A: acceptance-level + Matrix B: system-level) |

### Quality & evaluation improvements

- 16 E2E evaluation tests invoking commands via LLM and judging output quality
- Structural evaluations in PR CI (26 deterministic tests, no API keys needed)
- System-level golden examples for medical-device (IEC 62304) and automotive-adas (ISO 26262)

### Catalog entry changes

Updates the existing `v-model` entry in `extensions/catalog.community.json`:
- `version`: 0.1.0 → 0.2.0
- `download_url`: points to v0.2.0 release tag
- `provides.commands`: 3 → 5

### Full changelog

https://github.com/leocamello/spec-kit-v-model/compare/v0.1.0...v0.2.0