### PR TITLE
Update V-Model Extension Pack to v0.3.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-02-20T00:00:00Z",
+  "updated_at": "2026-02-21T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "v-model": {
@@ -8,8 +8,8 @@
       "id": "v-model",
       "description": "Enforces V-Model paired generation of development specs and test specs with full traceability.",
       "author": "leocamello",
-      "version": "0.2.0",
-      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.2.0.zip",
+      "version": "0.3.0",
+      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.3.0.zip",
       "repository": "https://github.com/leocamello/spec-kit-v-model",
       "homepage": "https://github.com/leocamello/spec-kit-v-model",
       "documentation": "https://github.com/leocamello/spec-kit-v-model/blob/main/README.md",
@@ -19,7 +19,7 @@
         "speckit_version": ">=0.1.0"
       },
       "provides": {
-        "commands": 5,
+        "commands": 7,
         "hooks": 1
       },
       "tags": ["v-model", "traceability", "testing", "compliance", "safety-critical"],
@@ -27,7 +27,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-02-20T00:00:00Z",
-      "updated_at": "2026-02-20T00:00:00Z"
+      "updated_at": "2026-02-21T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

Updates the V-Model Extension Pack entry in the community catalog to v0.3.0.

### Changes
- **Version**: 0.2.0 → 0.3.0
- **Commands**: 5 → 7 (new: `architecture-design`, `integration-test`)
- **Download URL**: Updated to v0.3.0 tag

### What's new in v0.3.0
- **Architecture Design** command — IEEE 42010/Kruchten 4+1 views (Logical, Process, Interface, Data Flow)
- **Integration Test** command — ISO 29119-4 techniques (CDCT, Data Flow, Fault Injection, Concurrency)
- **Traceability Matrix C** — SYS → ARCH → ITP → ITS coverage
- 67 BATS + 67 Pester tests, 37 structural evals, 26 LLM-as-judge evals, 24 E2E evals — all passing

Release: https://github.com/leocamello/spec-kit-v-model/releases/tag/v0.3.0