### PR TITLE
Update V-Model Extension Pack to v0.4.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-02-21T00:00:00Z",
+  "updated_at": "2026-02-22T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "v-model": {
@@ -8,8 +8,8 @@
       "id": "v-model",
       "description": "Enforces V-Model paired generation of development specs and test specs with full traceability.",
       "author": "leocamello",
-      "version": "0.3.0",
-      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.3.0.zip",
+      "version": "0.4.0",
+      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.4.0.zip",
       "repository": "https://github.com/leocamello/spec-kit-v-model",
       "homepage": "https://github.com/leocamello/spec-kit-v-model",
       "documentation": "https://github.com/leocamello/spec-kit-v-model/blob/main/README.md",
@@ -19,7 +19,7 @@
         "speckit_version": ">=0.1.0"
       },
       "provides": {
-        "commands": 7,
+        "commands": 9,
         "hooks": 1
       },
       "tags": ["v-model", "traceability", "testing", "compliance", "safety-critical"],
@@ -27,7 +27,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-02-20T00:00:00Z",
-      "updated_at": "2026-02-21T00:00:00Z"
+      "updated_at": "2026-02-22T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

Updates the V-Model Extension Pack entry in the community catalog to v0.4.0.

### Changes
- **Version**: 0.2.0 → 0.4.0
- **Commands**: 5 → 9 (new: `architecture-design`, `integration-test`, `module-design`, `unit-test`)
- **Download URL**: Updated to v0.4.0 tag

### What's new in v0.4.0
- **Module Design** command — DO-178C/ISO 26262-compliant low-level module designs with four mandatory views (Algorithmic/Logic, State Machine, Internal Data Structures, Error Handling & Return Codes)
- **Unit Test** command — ISO 29119-4 white-box unit test plans with five named techniques (Statement & Branch Coverage, BVA, EP, State Transition, Strict Isolation) and Dependency & Mock Registries
- **validate-module-coverage.sh/ps1** — Bidirectional ARCH→MOD→UTP→UTS coverage validation
- **Matrix D** (Unit Verification) in traceability matrix
- Renamed `validate-coverage` → `validate-requirement-coverage` for consistent naming
- 91 BATS + 91 Pester tests, 51 structural evals, 36 LLM-as-judge evals, 32 E2E evals — all passing
- `docs/id-schema-guide.md` — Comprehensive four-tier ID schema reference

### What was new in v0.3.0
- **Architecture Design** command — IEEE 42010/Kruchten 4+1 views
- **Integration Test** command — ISO 29119-4 integration techniques
- **Traceability Matrix C** — SYS → ARCH → ITP → ITS coverage

Release: https://github.com/leocamello/spec-kit-v-model/releases/tag/v0.4.0

> **Note**: This PR supersedes #1661 (v0.3.0) and #1656 (v0.2.0) which are still pending review.