### PR TITLE
Fix version command in documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     id: version
     attributes:
       label: Specify CLI Version
-      description: "Run `specify --version` or `pip show spec-kit`"
+      description: "Run `specify version` or `pip show spec-kit`"
       placeholder: "e.g., 1.3.0"
     validations:
       required: true

--- a/extensions/EXTENSION-USER-GUIDE.md
+++ b/extensions/EXTENSION-USER-GUIDE.md
@@ -46,7 +46,7 @@ Extensions are modular packages that add new commands and functionality to Spec 
 ### Check Your Version
 
 ```bash
-specify --version
+specify version
 # Should show 0.1.0 or higher
 ```
 


### PR DESCRIPTION
## Summary
- Change `specify --version` to `specify version` in documentation since the CLI uses a subcommand rather than a flag

## Test plan
- Verify the CLI accepts `specify version` command
- Confirm documentation now shows correct command

Fixes https://github.com/github/spec-kit/issues/1310