### PR TITLE
fix: correct step reference in specify.md to prevent validation loop

### DIFF
--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -148,7 +148,7 @@ Given that feature description, do this:
 
    c. **Handle Validation Results**:
 
-      - **If all items pass**: Mark checklist complete and proceed to step 6
+      - **If all items pass**: Mark checklist complete and proceed to step 7
 
       - **If items fail (excluding [NEEDS CLARIFICATION])**:
         1. List the failing items and specific issues


### PR DESCRIPTION
## Summary
- Step 6c in the specify template incorrectly referenced "proceed to step 6" (itself), creating an infinite validation loop
- Changed to "proceed to step 7" (the completion report step)

Closes #1509

## Test plan
- [x] Verified `specify.md` step 6c now references step 7
- [x] Confirmed step 7 is the "Completion Report" step

🤖 Generated with [Claude Code](https://claude.com/code)