### PR TITLE
feat: add --version / -V flag to CLI

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -490,12 +490,7 @@ def show_banner():
 def _version_callback(value: bool):
     """Print CLI version and exit."""
     if value:
-        import importlib.metadata
-
-        try:
-            ver = importlib.metadata.version("specify-cli")
-        except Exception:
-            ver = "unknown"
+        ver = get_speckit_version()
         print(f"specify {ver}")
         raise typer.Exit()
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -487,8 +487,26 @@ def show_banner():
     console.print(Align.center(Text(TAGLINE, style="italic bright_yellow")))
     console.print()
 
+def _version_callback(value: bool):
+    """Print CLI version and exit."""
+    if value:
+        import importlib.metadata
+
+        try:
+            ver = importlib.metadata.version("specify-cli")
+        except Exception:
+            ver = "unknown"
+        print(f"specify {ver}")
+        raise typer.Exit()
+
+
 @app.callback()
-def callback(ctx: typer.Context):
+def callback(
+    ctx: typer.Context,
+    version: Optional[bool] = typer.Option(
+        None, "--version", "-V", help="Show version and exit.", callback=_version_callback, is_eager=True
+    ),
+):
     """Show banner when no subcommand is provided."""
     if ctx.invoked_subcommand is None and "--help" not in sys.argv and "-h" not in sys.argv:
         show_banner()

--- a/tests/test_ai_skills.py
+++ b/tests/test_ai_skills.py
@@ -664,7 +664,7 @@ class TestVersionFlag:
         assert result.output.strip().startswith("specify ")
 
     def test_version_flag_appears_in_help(self):
-        """--version should appear in the help output."""
+        """--version and -V should appear in the help output."""
         from typer.testing import CliRunner
 
         runner = CliRunner()
@@ -672,6 +672,7 @@ class TestVersionFlag:
 
         plain = re.sub(r'\x1b\[[0-9;]*m', '', result.output)
         assert "--version" in plain
+        assert "-V" in plain
 
 
 class TestParameterOrderingIssue:

--- a/tests/test_ai_skills.py
+++ b/tests/test_ai_skills.py
@@ -632,6 +632,48 @@ class TestCliValidation:
         assert "agent skills" in plain.lower()
 
 
+class TestVersionFlag:
+    """Test --version flag (GitHub issue #486)."""
+
+    def test_version_flag_exits_zero(self):
+        """--version should exit with code 0."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["--version"])
+
+        assert result.exit_code == 0
+
+    def test_version_flag_prints_version(self):
+        """--version should print 'specify <version>'."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["--version"])
+
+        assert result.output.strip().startswith("specify ")
+
+    def test_short_version_flag(self):
+        """-V should behave the same as --version."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["-V"])
+
+        assert result.exit_code == 0
+        assert result.output.strip().startswith("specify ")
+
+    def test_version_flag_appears_in_help(self):
+        """--version should appear in the help output."""
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["--help"])
+
+        plain = re.sub(r'\x1b\[[0-9;]*m', '', result.output)
+        assert "--version" in plain
+
+
 class TestParameterOrderingIssue:
     """Test fix for GitHub issue #1641: parameter ordering issues."""
 


### PR DESCRIPTION
## Summary

Adds the standard `--version` / `-V` flag to the `specify` CLI. Previously, running `specify --version` returned an error:

```
No such option: --version
```

Users had to know about the `specify version` subcommand instead, which is not the standard CLI convention.

**Now:**
```bash
$ specify --version
specify 0.1.6

$ specify -V
specify 0.1.6
```

The existing `specify version` subcommand (which shows detailed system info including template version, platform, and architecture) remains unchanged.

Closes #486

## Test plan

- [x] `specify --version` prints version and exits with code 0
- [x] `specify -V` behaves the same as `--version`
- [x] `specify version` subcommand still works (detailed output)
- [x] `specify --help` shows `--version -V` in options
- [x] All tests pass (99/99 — 95 existing + 4 new)
- [x] Added 4 tests in `TestVersionFlag`:
  - `test_version_flag_exits_zero`
  - `test_version_flag_prints_version`
  - `test_short_version_flag`
  - `test_version_flag_appears_in_help`

## AI Assistance Disclosure

This PR was drafted with assistance from Claude Code (Anthropic). All changes were reviewed and validated manually by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)