### PR TITLE
fix: use RELEASE_PAT so tag push triggers release workflow

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Configure Git
         run: |
@@ -141,7 +141,7 @@ jobs:
 
       - name: Open pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           gh pr create \
             --base main \


### PR DESCRIPTION
## Problem

When `release-trigger.yml` pushes a tag using `GITHUB_TOKEN`, GitHub intentionally suppresses downstream workflow triggers to prevent infinite loops. This means `release.yml` (triggered by `push: tags: v*`) never fires.

## Fix

Use `RELEASE_PAT` (a fine-grained PAT stored as a repository secret) for the `checkout` step and the `gh pr create` step. A push made with a PAT is not subject to the trigger suppression.

## Required setup

Add a repository secret before running the workflow:
- **Name**: `RELEASE_PAT`
- **Value**: A fine-grained PAT with **Contents: Read & Write** and **Pull requests: Read & Write** on this repository

> **Note**: `v0.1.11` was already tagged via the previous workflow run but `release.yml` did not fire for the same reason this PR fixes. Once this merges and `RELEASE_PAT` is added, that tag can be re-pushed or a new release triggered.
