### PR TITLE
Add spec-kit-owl to community catalog

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -74,6 +74,7 @@ The following community-contributed extensions are available in [`catalog.commun
 |-----------|---------|-----|
 | V-Model Extension Pack | Enforces V-Model paired generation of development specs and test specs with full traceability | [spec-kit-v-model](https://github.com/leocamello/spec-kit-v-model) |
 | Cleanup Extension | Post-implementation quality gate that reviews changes, fixes small issues (scout rule), creates tasks for medium issues, and generates analysis for large issues | [spec-kit-cleanup](https://github.com/dsrednicki/spec-kit-cleanup) |
+| Spec Kit Owl | Spec-to-code metrics: line counts, character counts, and percentages | [spec-kit-owl](https://github.com/healthkowshik/spec-kit-owl) |
 
 ## Adding Your Extension
 

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-02-24T00:00:00Z",
+  "updated_at": "2026-03-03T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "cleanup": {
@@ -28,6 +28,32 @@
       "stars": 0,
       "created_at": "2026-02-22T00:00:00Z",
       "updated_at": "2026-02-22T00:00:00Z"
+    },
+    "owl": {
+      "name": "Spec Kit Owl",
+      "id": "owl",
+      "description": "Spec-to-code metrics: line counts, character counts, and percentages",
+      "author": "Health Kowshik",
+      "version": "1.0.0",
+      "download_url": "https://github.com/healthkowshik/spec-kit-owl/archive/refs/tags/v1.0.0.zip",
+      "repository": "https://github.com/healthkowshik/spec-kit-owl",
+      "homepage": "https://github.com/healthkowshik/spec-kit-owl",
+      "documentation": "https://github.com/healthkowshik/spec-kit-owl/blob/main/README.md",
+      "changelog": "https://github.com/healthkowshik/spec-kit-owl/blob/main/CHANGELOG.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.1.0"
+      },
+      "provides": {
+        "commands": 1,
+        "hooks": 0
+      },
+      "tags": ["metrics", "spec-code", "analysis", "lines-of-code"],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-03-03T00:00:00Z",
+      "updated_at": "2026-03-03T00:00:00Z"
     },
     "retrospective": {
       "name": "Retrospective Extension",


### PR DESCRIPTION
## Extension Details

- **Name**: Spec Kit Owl
- **ID**: owl
- **Version**: 1.0.0
- **Author**: Health Kowshik
- **Repository**: https://github.com/healthkowshik/spec-kit-owl
- **Description**: Spec-to-code metrics: line counts, character counts, and percentages

## What it does

Watches your Specs vs Code — prints spec lines, non-spec lines, character counts, and spec percentages for any repository that uses spec-kit conventions (`specs/` and `.specify/` directories).

## Checklist

- [x] Valid `extension.yml` manifest (all required fields, description under 100 chars)
- [x] README.md with installation and usage instructions
- [x] LICENSE file present (MIT)
- [x] CHANGELOG.md with version history
- [x] GitHub release created with download archive (`v1.0.0`)
- [x] Tested on macOS (Bash 4+) — 9 automated tests passing
- [x] All commands working as documented