### PR TITLE
fix: use global branch numbering instead of per-short-name detection

### DIFF
--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -39,13 +39,14 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Create the feature branch** by running the script with only `--short-name` (do NOT pass `--number` — the script auto-detects the next globally available number across all branches and spec directories):
+2. **Create the feature branch** by running the script with `--short-name` (and `--json`), and do NOT pass `--number` (the script auto-detects the next globally available number across all branches and spec directories):
 
    - Bash example: `{SCRIPT} --json --short-name "user-auth" "Add user authentication"`
    - PowerShell example: `{SCRIPT} -Json -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
    - Do NOT pass `--number` — the script determines the correct next number automatically
+   - Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -39,33 +39,13 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Create the feature branch** by running the script with only `--short-name` (do NOT pass `--number` — the script auto-detects the next globally available number across all branches and spec directories):
 
-   a. First, fetch all remote branches to ensure we have the latest information:
-
-      ```bash
-      git fetch --all --prune
-      ```
-
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
-
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `{SCRIPT}` with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `{SCRIPT} --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `{SCRIPT} -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   - Bash example: `{SCRIPT} --json --short-name "user-auth" "Add user authentication"`
+   - PowerShell example: `{SCRIPT} -Json -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
+   - Do NOT pass `--number` — the script determines the correct next number automatically
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths


### PR DESCRIPTION
## Summary
- The `specify.md` prompt instructed the AI to search for existing branches filtered by exact short-name, so every new feature started at `001` since no branches matched the new short-name
- The underlying `create-new-feature.sh` already has correct global numbering logic via `check_existing_branches()` that searches ALL branches and spec directories
- Simplified step 2 to tell the AI to NOT pass `--number`, letting the script auto-detect the next globally available number

Closes #1744
Closes #1468

## Root cause
The prompt at step 2b told the AI to grep for branches matching the exact short-name:
```
git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'
```
And step 2c said: "If no existing branches/directories found **with this short-name**, start with number 1". Since each new feature has a unique short-name, the search always returned empty and numbering reset to 001.

## Test plan
- [x] Verified the script correctly assigns `001`, `002`, `003` to 3 different features when `--number` is NOT passed
- [x] Reproduced the bug: passing `--number 1` manually causes duplicate `001` prefixes (confirming the AI override was the problem)
- [x] Full test suite passes (120 tests)
- [x] Verified the change is a net removal of 24 lines of flawed logic, replaced with 4 lines of clear instructions

🤖 Generated with [Claude Code](https://claude.com/code)