### PR TITLE
feat(extensions): add Jira Integration to community catalog

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -73,6 +73,7 @@ The following community-contributed extensions are available in [`catalog.commun
 | Extension | Purpose | URL |
 |-----------|---------|-----|
 | Cleanup Extension | Post-implementation quality gate that reviews changes, fixes small issues (scout rule), creates tasks for medium issues, and generates analysis for large issues | [spec-kit-cleanup](https://github.com/dsrednicki/spec-kit-cleanup) |
+| Jira Integration | Create Jira Epics, Stories, and Issues from spec-kit specifications and task breakdowns with configurable hierarchy and custom field support | [spec-kit-jira](https://github.com/mbachorik/spec-kit-jira) |
 | Retrospective Extension | Post-implementation retrospective with spec adherence scoring, drift analysis, and human-gated spec updates | [spec-kit-retrospective](https://github.com/emi-dm/spec-kit-retrospective) |
 | Spec Sync | Detect and resolve drift between specs and implementation. AI-assisted resolution with human approval | [spec-kit-sync](https://github.com/bgervin/spec-kit-sync) |
 | V-Model Extension Pack | Enforces V-Model paired generation of development specs and test specs with full traceability | [spec-kit-v-model](https://github.com/leocamello/spec-kit-v-model) |

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -52,7 +52,7 @@
       "verified": false,
       "downloads": 0,
       "stars": 0,
-      "created_at": "2026-01-28T00:00:00Z",
+      "created_at": "2026-03-05T00:00:00Z",
       "updated_at": "2026-03-05T00:00:00Z"
     },
     "retrospective": {


### PR DESCRIPTION
## Summary

Adds the **spec-kit-jira** extension to the community catalog.

## Extension Details

| Field | Value |
|-------|-------|
| Name | Jira Integration |
| Version | 2.1.0 |
| Author | mbachorik |
| License | MIT |
| Repository | https://github.com/mbachorik/spec-kit-jira |

## Features

- Create Jira Epics, Stories, and Issues from spec-kit specifications and task breakdowns
- **3-level hierarchy**: Epic → Stories → Tasks (default)
- **2-level mode**: Epic → Stories with embedded task checklists
- Configurable custom field support via field discovery
- Status synchronization between local tasks and Jira issues
- MCP server integration (works with any Jira/Atlassian MCP server)

## Commands Provided

| Command | Description |
|---------|-------------|
| `/speckit.jira.specstoissues` | Create Jira hierarchy from spec and tasks |
| `/speckit.jira.discover-fields` | Discover available Jira custom fields |
| `/speckit.jira.sync-status` | Sync task completion status to Jira |

## Hooks

- `after_tasks` - Optionally create Jira issues after task generation

## Test Plan

- [x] Extension repository is public and accessible
- [x] Release v2.1.0 exists with downloadable zip
- [x] README documentation is complete
- [x] CHANGELOG follows Keep a Changelog format
- [x] JSON validates successfully

---

🤖 This PR was prepared with the assistance of [Claude Code](https://claude.ai/code) (Anthropic).