### PR TITLE
fix: Remove duplicate options in specify.md

### DIFF
--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -9,8 +9,8 @@ handoffs:
     prompt: Clarify specification requirements
     send: true
 scripts:
-  sh: scripts/bash/create-new-feature.sh --json "{ARGS}"
-  ps: scripts/powershell/create-new-feature.ps1 -Json "{ARGS}"
+  sh: scripts/bash/create-new-feature.sh "{ARGS}"
+  ps: scripts/powershell/create-new-feature.ps1 "{ARGS}"
 ---
 
 ## User Input


### PR DESCRIPTION
## Description

- The scripts frontmatter in specify.md included `--json` / `-Json` flags directly in the script path assignment (e.g., `scripts/bash/create-new-feature.sh --json "{ARGS}"`).                             
- This caused the flag to appear twice when an agent ran the script — once baked into `{SCRIPT}` and again in the usage examples within the command body (e.g., `{SCRIPT} --json --number 5 ...`), producing commands like `create-new-feature.sh --json "$ARGUMENTS" --json --number 5 ...`.
- The fix removes `--json` / `-Json` from the scripts frontmatter, so `{SCRIPT}` resolves to just the script path.

## Testing

<!-- How did you test your changes? -->

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [x] I **did not** use AI assistance for this contribution
- [ ] I **did** use AI assistance (describe below)

<!-- If you used AI, briefly describe how (e.g., "Code generated by Copilot", "Consulted ChatGPT for approach"): -->

