### PR TITLE
fix(clarify,specify): improve question UX and simplify feature numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Recent changes to the Specify CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.14] - 2026-03-07
+
+### Fixed
+
+- **Clarify Question Ordering**: The `/speckit.clarify` command now always prints the question text before presenting recommendations or answer options, so users see what is being asked before being shown choices.
+- **Specify Feature Numbering**: The `/speckit.specify` command no longer precomputes feature numbers manually. It delegates this entirely to the `create-new-feature` script, which already checks all branches and spec directories globally to assign the next unique number. This prevents redundant logic and eliminates collision errors caused by stale branch caches.
+
 ## [0.1.13] - 2026-03-03
 
 ### Changed

--- a/spec-driven.md
+++ b/spec-driven.md
@@ -78,7 +78,7 @@ The SDD methodology is significantly enhanced through three powerful commands th
 
 This command transforms a simple feature description (the user-prompt) into a complete, structured specification with automatic repository management:
 
-1. **Automatic Feature Numbering**: Scans existing specs to determine the next feature number (e.g., 001, 002, 003)
+1. **Automatic Feature Numbering**: Scans all branches and spec directories to assign the next globally unique feature number (e.g., 001, 002, 003)
 2. **Branch Creation**: Generates a semantic branch name from your description and creates it automatically
 3. **Template-Based Generation**: Copies and customizes the feature specification template with your requirements
 4. **Directory Structure**: Creates the proper `specs/[branch-name]/` structure for all related documents

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -101,13 +101,15 @@ Execution steps:
 
 4. Sequential questioning loop (interactive):
     - Present EXACTLY ONE question at a time.
+    - ALWAYS print the question itself before any recommendation, suggestion, or answer options.
+    - Format the question line as: `**Question:** <question text>`
     - For multiple‑choice questions:
        - **Analyze all options** and determine the **most suitable option** based on:
           - Best practices for the project type
           - Common patterns in similar implementations
           - Risk reduction (security, performance, maintainability)
           - Alignment with any explicit project goals or constraints visible in the spec
-       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - After printing the question, present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
        - Format as: `**Recommended:** Option [X] - <reasoning>`
        - Then render all options as a Markdown table:
 
@@ -120,7 +122,7 @@ Execution steps:
 
        - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
     - For short‑answer style (no meaningful discrete options):
-       - Provide your **suggested answer** based on best practices and context.
+       - After printing the question, provide your **suggested answer** based on best practices and context.
        - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
        - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
     - After the user answers:

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -47,7 +47,7 @@ Given that feature description, do this:
       {SCRIPT} --short-name "your-short-name" "{ARGS}"
       ```
 
-   b. Do **not** precompute or force `--number` unless the user explicitly asks for a specific number and you have verified it will not collide.
+   b. Do **not** pass `--number` unless the user explicitly asks for a specific feature number. Run the script once; if the script reports that the requested number collides with an existing feature, explain this to the user and ask them for a different number or permission to proceed without forcing one.
 
    c. Read the JSON output from the script and use it as the source of truth for:
       - `BRANCH_NAME`

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -39,33 +39,24 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Create the feature branch and spec scaffold exactly once**:
 
-   a. First, fetch all remote branches to ensure we have the latest information:
+   a. Run the script and let it assign the next globally unique feature number:
 
       ```bash
-      git fetch --all --prune
+      {SCRIPT} --short-name "your-short-name" "{ARGS}"
       ```
 
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+   b. Do **not** precompute or force `--number` unless the user explicitly asks for a specific number and you have verified it will not collide.
 
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `{SCRIPT}` with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `{SCRIPT} --json --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `{SCRIPT} -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   c. Read the JSON output from the script and use it as the source of truth for:
+      - `BRANCH_NAME`
+      - `SPEC_FILE`
+      - `FEATURE_NUM`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
+   - Feature numbers are globally unique across all feature branches and spec directories, not unique per short name
+   - Do not infer that a new short name should start at `001`; the script already checks existing branches and spec folders globally
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths


### PR DESCRIPTION
## Summary

Two fixes discovered while using spec-kit in a real project.

### 1. `clarify`: Always print question text before recommendations/options

**Problem**: The clarify agent would sometimes present a recommendation or answer table before the actual question text, making the interaction confusing — users would see "Recommended: Option A" before knowing what they were being asked.

**Fix**: Added an explicit instruction to always print the question itself first, formatted as `**Question:** <question text>`, before any suggestion or options table.

### 2. `specify`: Trust the script for feature numbering instead of precomputing

**Problem**: The specify agent was instructed to precompute the next feature number by scanning remote branches, local branches, and spec directories — then pass `--number N+1` to the script. This is error-prone because:
- Feature numbers are globally unique (not per-short-name), so starting at `001` for every new short-name was wrong
- The script (`create-new-feature.sh`) already does this check correctly

**Fix**: Simplified the instructions to just run the script with `--short-name` and let it assign the globally unique number. The agent now reads the JSON output as the source of truth instead of precomputing.

## Testing

Validated both changes against a real project over multiple spec-creation and clarification sessions.