### PR TITLE
feat(extensions): support .extensionignore to exclude files during install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Recent changes to the Specify CLI and templates are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- feat(extensions): support `.extensionignore` to exclude files/folders during `specify extension add` (#1781)
+
 ## [0.2.0] - 2026-03-09
 
 ### Changed
@@ -62,7 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Higher-priority catalogs win on merge conflicts (same extension id in multiple catalogs)
   - 13 new tests covering catalog stack resolution, merge conflicts, URL validation, and `install_allowed` enforcement
   - Updated RFC, Extension User Guide, and Extension API Reference documentation
-- feat(extensions): support `.extensionignore` to exclude files/folders during `specify extension add` (#1781)
 
 ## [0.1.13] - 2026-03-03
 

--- a/extensions/EXTENSION-DEVELOPMENT-GUIDE.md
+++ b/extensions/EXTENSION-DEVELOPMENT-GUIDE.md
@@ -338,11 +338,18 @@ Extension authors can create a `.extensionignore` file in the extension root to 
 
 ### Format
 
-The file uses glob-style patterns, one per line:
+The file uses `.gitignore`-compatible patterns (one per line), powered by the [`pathspec`](https://pypi.org/project/pathspec/) library:
 
 - Blank lines are ignored
 - Lines starting with `#` are comments
-- Patterns are matched against both the file/folder name and its path relative to the extension root
+- `*` matches anything **except** `/` (does not cross directory boundaries)
+- `**` matches zero or more directories (e.g., `docs/**/*.draft.md`)
+- `?` matches any single character except `/`
+- A trailing `/` restricts a pattern to directories only
+- Patterns containing `/` (other than a trailing slash) are anchored to the extension root
+- Patterns without `/` match at any depth in the tree
+- `!` negates a previously excluded pattern (re-includes a file)
+- Backslashes in patterns are normalised to forward slashes for cross-platform compatibility
 - The `.extensionignore` file itself is always excluded automatically
 
 ### Example
@@ -367,12 +374,22 @@ CONTRIBUTING.md
 
 ### Pattern Matching
 
-| Pattern | Matches |
-|---------|---------|
-| `*.pyc` | Any `.pyc` file in any directory |
-| `tests/` | The `tests` directory (and all its contents) |
-| `docs/*.draft.md` | Draft markdown files inside `docs/` |
-| `.github` | The `.github` directory at any level |
+| Pattern | Matches | Does NOT match |
+|---------|---------|----------------|
+| `*.pyc` | Any `.pyc` file in any directory | — |
+| `tests/` | The `tests` directory (and all its contents) | A file named `tests` |
+| `docs/*.draft.md` | `docs/api.draft.md` (directly inside `docs/`) | `docs/sub/api.draft.md` (nested) |
+| `.env` | The `.env` file at any level | — |
+| `!README.md` | Re-includes `README.md` even if matched by an earlier pattern | — |
+| `docs/**/*.draft.md` | `docs/api.draft.md`, `docs/sub/api.draft.md` | — |
+
+### Unsupported Features
+
+The following `.gitignore` features are **not applicable** in this context:
+
+- **Multiple `.extensionignore` files**: Only a single file at the extension root is supported (`.gitignore` supports files in subdirectories)
+- **`$GIT_DIR/info/exclude` and `core.excludesFile`**: These are Git-specific and have no equivalent here
+- **Negation inside excluded directories**: Because file copying uses `shutil.copytree`, excluding a directory prevents recursion into it entirely. A negation pattern cannot re-include a file inside a directory that was itself excluded. For example, the combination `tests/` followed by `!tests/important.py` will **not** preserve `tests/important.py` — the `tests/` directory is skipped at the root level and its contents are never evaluated. To work around this, exclude the directory's contents individually instead of the directory itself (e.g., `tests/*.pyc` and `tests/.cache/` rather than `tests/`).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "truststore>=0.10.4",
     "pyyaml>=6.0",
     "packaging>=23.0",
+    "pathspec>=0.12.0",
 ]
 
 [project.scripts]

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -6,7 +6,6 @@ Extensions are modular packages that add commands and functionality to spec-kit
 without bloating the core framework.
 """
 
-import fnmatch
 import json
 import hashlib
 import os
@@ -18,6 +17,8 @@ from pathlib import Path
 from typing import Optional, Dict, List, Any, Callable, Set
 from datetime import datetime, timezone
 import re
+
+import pathspec
 
 import yaml
 from packaging import version as pkg_version
@@ -285,9 +286,17 @@ class ExtensionManager:
     def _load_extensionignore(source_dir: Path) -> Optional[Callable[[str, List[str]], Set[str]]]:
         """Load .extensionignore and return an ignore function for shutil.copytree.
 
-        The .extensionignore file uses glob-style patterns (one per line).
+        The .extensionignore file uses .gitignore-compatible patterns (one per line).
         Lines starting with '#' are comments. Blank lines are ignored.
         The .extensionignore file itself is always excluded.
+
+        Pattern semantics mirror .gitignore:
+        - '*' matches anything except '/'
+        - '**' matches zero or more directories
+        - '?' matches any single character except '/'
+        - Trailing '/' restricts a pattern to directories only
+        - Patterns with '/' (other than trailing) are anchored to the root
+        - '!' negates a previously excluded pattern
 
         Args:
             source_dir: Path to the extension source directory
@@ -300,14 +309,22 @@ class ExtensionManager:
         if not ignore_file.exists():
             return None
 
-        patterns: List[str] = []
-        for line in ignore_file.read_text().splitlines():
+        lines: List[str] = ignore_file.read_text().splitlines()
+
+        # Normalise backslashes in patterns so Windows-authored files work
+        normalised: List[str] = []
+        for line in lines:
             stripped = line.strip()
             if stripped and not stripped.startswith("#"):
-                patterns.append(stripped)
+                normalised.append(stripped.replace("\\", "/"))
+            else:
+                # Preserve blanks/comments so pathspec line numbers stay stable
+                normalised.append(line)
 
         # Always ignore the .extensionignore file itself
-        patterns.append(".extensionignore")
+        normalised.append(".extensionignore")
+
+        spec = pathspec.GitIgnoreSpec.from_lines(normalised)
 
         def _ignore(directory: str, entries: List[str]) -> Set[str]:
             ignored: Set[str] = set()
@@ -316,17 +333,15 @@ class ExtensionManager:
                 rel_path = str(rel_dir / entry) if str(rel_dir) != "." else entry
                 # Normalise to forward slashes for consistent matching
                 rel_path_fwd = rel_path.replace("\\", "/")
-                for pattern in patterns:
-                    # Strip trailing slash so "tests/" matches directory name "tests"
-                    pat = pattern.rstrip("/")
-                    # Match against the entry name itself
-                    if fnmatch.fnmatch(entry, pat):
+
+                entry_full = Path(directory) / entry
+                if entry_full.is_dir():
+                    # Append '/' so directory-only patterns (e.g. tests/) match
+                    if spec.match_file(rel_path_fwd + "/"):
                         ignored.add(entry)
-                        break
-                    # Match against the relative path from the source root
-                    if fnmatch.fnmatch(rel_path_fwd, pat):
+                else:
+                    if spec.match_file(rel_path_fwd):
                         ignored.add(entry)
-                        break
             return ignored
 
         return _ignore

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1774,3 +1774,167 @@ class TestExtensionIgnore:
         dest = proj_dir / ".specify" / "extensions" / "test-ext"
         assert (dest / "docs" / "guide.md").exists()
         assert not (dest / "docs" / "internal" / "draft.md").exists()
+
+    def test_extensionignore_dotdot_pattern_is_noop(self, temp_dir, valid_manifest_data):
+        """Patterns with '..' should not escape the extension root."""
+        ext_dir = self._make_extension(
+            temp_dir,
+            valid_manifest_data,
+            extra_files={"README.md": "# Hello"},
+            ignore_content="../sibling/\n",
+        )
+
+        proj_dir = temp_dir / "project"
+        proj_dir.mkdir()
+        (proj_dir / ".specify").mkdir()
+
+        manager = ExtensionManager(proj_dir)
+        manager.install_from_directory(ext_dir, "0.1.0", register_commands=False)
+
+        dest = proj_dir / ".specify" / "extensions" / "test-ext"
+        # Everything should still be copied — the '..' pattern matches nothing inside
+        assert (dest / "README.md").exists()
+        assert (dest / "extension.yml").exists()
+        assert (dest / "commands" / "hello.md").exists()
+
+    def test_extensionignore_absolute_path_pattern_is_noop(self, temp_dir, valid_manifest_data):
+        """Absolute path patterns should not match anything."""
+        ext_dir = self._make_extension(
+            temp_dir,
+            valid_manifest_data,
+            extra_files={"README.md": "# Hello", "passwd": "sensitive"},
+            ignore_content="/etc/passwd\n",
+        )
+
+        proj_dir = temp_dir / "project"
+        proj_dir.mkdir()
+        (proj_dir / ".specify").mkdir()
+
+        manager = ExtensionManager(proj_dir)
+        manager.install_from_directory(ext_dir, "0.1.0", register_commands=False)
+
+        dest = proj_dir / ".specify" / "extensions" / "test-ext"
+        # Nothing matches — /etc/passwd is anchored to root and there's no 'etc' dir
+        assert (dest / "README.md").exists()
+        assert (dest / "passwd").exists()
+
+    def test_extensionignore_empty_file(self, temp_dir, valid_manifest_data):
+        """An empty .extensionignore should exclude only itself."""
+        ext_dir = self._make_extension(
+            temp_dir,
+            valid_manifest_data,
+            extra_files={"README.md": "# Hello", "notes.txt": "notes"},
+            ignore_content="",
+        )
+
+        proj_dir = temp_dir / "project"
+        proj_dir.mkdir()
+        (proj_dir / ".specify").mkdir()
+
+        manager = ExtensionManager(proj_dir)
+        manager.install_from_directory(ext_dir, "0.1.0", register_commands=False)
+
+        dest = proj_dir / ".specify" / "extensions" / "test-ext"
+        assert (dest / "README.md").exists()
+        assert (dest / "notes.txt").exists()
+        assert (dest / "extension.yml").exists()
+        # .extensionignore itself is still excluded
+        assert not (dest / ".extensionignore").exists()
+
+    def test_extensionignore_windows_backslash_patterns(self, temp_dir, valid_manifest_data):
+        """Backslash patterns (Windows-style) are normalised to forward slashes."""
+        ext_dir = self._make_extension(
+            temp_dir,
+            valid_manifest_data,
+            extra_files={
+                "docs/internal/draft.md": "draft",
+                "docs/guide.md": "# Guide",
+            },
+            ignore_content="docs\\internal\\draft.md\n",
+        )
+
+        proj_dir = temp_dir / "project"
+        proj_dir.mkdir()
+        (proj_dir / ".specify").mkdir()
+
+        manager = ExtensionManager(proj_dir)
+        manager.install_from_directory(ext_dir, "0.1.0", register_commands=False)
+
+        dest = proj_dir / ".specify" / "extensions" / "test-ext"
+        assert (dest / "docs" / "guide.md").exists()
+        assert not (dest / "docs" / "internal" / "draft.md").exists()
+
+    def test_extensionignore_star_does_not_cross_directories(self, temp_dir, valid_manifest_data):
+        """'*' should NOT match across directory boundaries (gitignore semantics)."""
+        ext_dir = self._make_extension(
+            temp_dir,
+            valid_manifest_data,
+            extra_files={
+                "docs/api.draft.md": "draft",
+                "docs/sub/api.draft.md": "nested draft",
+            },
+            ignore_content="docs/*.draft.md\n",
+        )
+
+        proj_dir = temp_dir / "project"
+        proj_dir.mkdir()
+        (proj_dir / ".specify").mkdir()
+
+        manager = ExtensionManager(proj_dir)
+        manager.install_from_directory(ext_dir, "0.1.0", register_commands=False)
+
+        dest = proj_dir / ".specify" / "extensions" / "test-ext"
+        # docs/*.draft.md should only match directly inside docs/, NOT subdirs
+        assert not (dest / "docs" / "api.draft.md").exists()
+        assert (dest / "docs" / "sub" / "api.draft.md").exists()
+
+    def test_extensionignore_doublestar_crosses_directories(self, temp_dir, valid_manifest_data):
+        """'**' should match across directory boundaries."""
+        ext_dir = self._make_extension(
+            temp_dir,
+            valid_manifest_data,
+            extra_files={
+                "docs/api.draft.md": "draft",
+                "docs/sub/api.draft.md": "nested draft",
+                "docs/guide.md": "guide",
+            },
+            ignore_content="docs/**/*.draft.md\n",
+        )
+
+        proj_dir = temp_dir / "project"
+        proj_dir.mkdir()
+        (proj_dir / ".specify").mkdir()
+
+        manager = ExtensionManager(proj_dir)
+        manager.install_from_directory(ext_dir, "0.1.0", register_commands=False)
+
+        dest = proj_dir / ".specify" / "extensions" / "test-ext"
+        assert not (dest / "docs" / "api.draft.md").exists()
+        assert not (dest / "docs" / "sub" / "api.draft.md").exists()
+        assert (dest / "docs" / "guide.md").exists()
+
+    def test_extensionignore_negation_pattern(self, temp_dir, valid_manifest_data):
+        """'!' negation re-includes a previously excluded file."""
+        ext_dir = self._make_extension(
+            temp_dir,
+            valid_manifest_data,
+            extra_files={
+                "docs/guide.md": "# Guide",
+                "docs/internal.md": "internal",
+                "docs/api.md": "api",
+            },
+            ignore_content="docs/*.md\n!docs/api.md\n",
+        )
+
+        proj_dir = temp_dir / "project"
+        proj_dir.mkdir()
+        (proj_dir / ".specify").mkdir()
+
+        manager = ExtensionManager(proj_dir)
+        manager.install_from_directory(ext_dir, "0.1.0", register_commands=False)
+
+        dest = proj_dir / ".specify" / "extensions" / "test-ext"
+        # docs/*.md excludes all .md in docs, but !docs/api.md re-includes it
+        assert not (dest / "docs" / "guide.md").exists()
+        assert not (dest / "docs" / "internal.md").exists()
+        assert (dest / "docs" / "api.md").exists()


### PR DESCRIPTION
## Summary

Adds `.extensionignore` support so extension authors can exclude files and folders from being copied when users run `specify extension add`.

## Problem

Extension authors often have development-only files (tests, CI configs, documentation source, build artifacts) that shouldn't be copied into the user's project when installing an extension. There was no mechanism to exclude these files.

## Solution

Extension authors can now create a `.extensionignore` file in their extension root. The file uses `.gitignore`-compatible patterns (one per line), powered by the [`pathspec`](https://pypi.org/project/pathspec/) library:

```gitignore
# .extensionignore

# Development files
tests/
.github/
.gitignore

# Build artifacts
__pycache__/
*.pyc
```

### Features
- `.gitignore`-compatible pattern matching via `pathspec.GitIgnoreSpec`
- `*` matches anything except `/`; `**` matches zero or more directories
- `?` matches any single character except `/`
- Trailing `/` on directory patterns restricts matching to directories only
- Patterns containing `/` (other than trailing) are anchored to the extension root
- `!` negates a previously excluded pattern (re-includes a file)
- Comment lines (`#`) and blank lines are ignored
- Backslash patterns are normalised to forward slashes for cross-platform compatibility
- The `.extensionignore` file itself is always excluded from the copy

## Changes

- **src/specify_cli/extensions.py**: Added `_load_extensionignore()` static method and integrated it into `install_from_directory()` via `shutil.copytree(ignore=...)`
- **extensions/EXTENSION-DEVELOPMENT-GUIDE.md**: New documentation section covering `.extensionignore` format, example patterns, and a pattern-matching reference table
- **tests/test_extensions.py**: 13 new tests in `TestExtensionIgnore` covering all pattern matching scenarios
- **pyproject.toml**: Added `pathspec>=0.12.0` dependency
- **CHANGELOG.md**: Added `[Unreleased]` entry for this feature

## Testing

All 152 passing tests continue to pass (4 pre-existing failures in `test_cursor_frontmatter.py` are unrelated — bash/WSL not available on Windows). New tests cover:

- No `.extensionignore` → all files copied (baseline)
- Directory exclusion (`tests/`, `.github/`)
- Glob patterns (`*.pyc`) across nested directories
- Comments and blank lines ignored
- `.extensionignore` itself never copied
- Relative path pattern matching
- `..` traversal patterns are a no-op (security)
- Absolute path patterns are a no-op (security)
- Empty `.extensionignore` file
- Windows backslash patterns normalised correctly
- `*` does not cross directory boundaries
- `**` crosses directory boundaries
- `!` negation re-includes previously excluded files

## AI Disclosure

This PR was authored with GitHub Copilot assistance.