### PR TITLE
fix: use quiet checkout to avoid exception on git checkout

### DIFF
--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -250,7 +250,7 @@ if ($branchName.Length -gt $maxBranchLength) {
 if ($hasGit) {
     $branchCreated = $false
     try {
-        git checkout -b $branchName 2>$null | Out-Null
+        git checkout -q -b $branchName 2>$null | Out-Null
         if ($LASTEXITCODE -eq 0) {
             $branchCreated = $true
         }


### PR DESCRIPTION
## Description

Fix Git checkout inside try catch raising exception causing failure of create_new_feature.ps1 script

## Testing

Replicate the issue in a standalone script. 

Test the script itself in a sample project by running it after making changes.

The issue was caused by a combination of git checkout writing output to error stream and $ErrorActionPreference set to stop, leading to powershell raising Exception on outputs to error steam (invoking 2> $null)

The fix is adding a quiet parameter ensuring no output is sent by git on successful checkout.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Consulted GPT on what causes the issue, to understand the underlying cause, test it in a standalone script, replicating it

