### PR TITLE
fix: clean up command templates (specify, analyze)

### DIFF
--- a/templates/commands/analyze.md
+++ b/templates/commands/analyze.md
@@ -182,4 +182,6 @@ Ask the user: "Would you like me to suggest concrete remediation edits for the t
 - **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
 - **Report zero issues gracefully** (emit success report with coverage statistics)
 
-Context for analysis: {ARGS}
+## Context
+
+{ARGS}


### PR DESCRIPTION
## Summary

- **specify.md**: Fix self-referential step number — step 6c says "proceed to step 6" but should say "proceed to step 7" (Report completion)
- **specify.md**: Remove empty `## General Guidelines` heading that has no content before `## Quick Guidelines`
- **analyze.md**: Deduplicate `{ARGS}` — the `## Context` section at the bottom repeats the same arguments already present in the `## User Input` section at the top

## Test plan

- [ ] Verify `specify.md` step 6c correctly references step 7
- [ ] Verify no empty headings remain in `specify.md`
- [ ] Verify `analyze.md` still passes `{ARGS}` context correctly via the `## User Input` section