### PR TITLE
fix(extensions): show extension ID in list output

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2576,6 +2576,7 @@ def extension_list(
             status_color = "green" if ext["enabled"] else "red"
 
             console.print(f"  [{status_color}]{status_icon}[/{status_color}] [bold]{ext['name']}[/bold] (v{ext['version']})")
+            console.print(f"     [dim]{ext['id']}[/dim]")
             console.print(f"     {ext['description']}")
             console.print(f"     Commands: {ext['command_count']} | Hooks: {ext['hook_count']} | Status: {'Enabled' if ext['enabled'] else 'Disabled'}")
             console.print()


### PR DESCRIPTION
## Summary
- Display extension ID in `specify extension list` output

## Problem
When extension names are ambiguous, users are told to use the extension ID:
```
Please rerun using the extension ID:
  specify extension <command> <extension-id>
```

But `specify extension list` didn't show the ID, forcing users to inspect `.specify/extensions/registry.json` manually.

## Solution
Add the ID on a separate line (dim style) below the extension name:

```
  ✓ Jira Integration (v1.2.0)
     speckit/jira
     Integrate Jira issues with spec-kit workflows
     Commands: 3 | Hooks: 1 | Status: Enabled
```

## Test plan
- [x] All 84 extension tests pass
- [ ] Manual verification with installed extensions

Fixes #1832

🤖 Generated with [Claude Code](https://claude.com/claude-code)