### PR TITLE
fix(extensions): show extension ID in list output

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2576,6 +2576,7 @@ def extension_list(
             status_color = "green" if ext["enabled"] else "red"
 
             console.print(f"  [{status_color}]{status_icon}[/{status_color}] [bold]{ext['name']}[/bold] (v{ext['version']})")
+            console.print(f"     [dim]{ext['id']}[/dim]")
             console.print(f"     {ext['description']}")
             console.print(f"     Commands: {ext['command_count']} | Hooks: {ext['hook_count']} | Status: {'Enabled' if ext['enabled'] else 'Disabled'}")
             console.print()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2337,3 +2337,29 @@ class TestExtensionUpdateCLI:
 
         for cmd_file in command_files:
             assert cmd_file.exists(), f"Expected command file to be restored after rollback: {cmd_file}"
+
+
+class TestExtensionListCLI:
+    """Test extension list CLI output format."""
+
+    def test_list_shows_extension_id(self, extension_dir, project_dir):
+        """extension list should display the extension ID."""
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        runner = CliRunner()
+
+        # Install the extension using the manager
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        with patch.object(Path, "cwd", return_value=project_dir):
+            result = runner.invoke(app, ["extension", "list"])
+
+        assert result.exit_code == 0, result.output
+        # Verify the extension ID is shown in the output
+        assert "test-ext" in result.output
+        # Verify name and version are also shown
+        assert "Test Extension" in result.output
+        assert "1.0.0" in result.output


### PR DESCRIPTION
## Summary
- Display extension ID in `specify extension list` output

## Problem
When extension names are ambiguous, users are told to use the extension ID:
```
Please rerun using the extension ID:
  specify extension <command> <extension-id>
```

But `specify extension list` didn't show the ID, forcing users to inspect `.specify/extensions/registry.json` manually.

## Solution
Add the ID on a separate line (dim style) below the extension name:

```
  ✓ Jira Integration (v1.2.0)
     speckit/jira
     Integrate Jira issues with spec-kit workflows
     Commands: 3 | Hooks: 1 | Status: Enabled
```

## Test plan
- [x] Run full test suite (301 tests pass)
- [x] Ruff linter passes
- [x] Added `TestExtensionListCLI::test_list_shows_extension_id` test

Fixes #1832

🤖 Generated with [Claude Code](https://claude.ai/claude-code)