### PR TITLE
feat(extensions): add Archive and Reconcile extensions to community catalog

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -72,7 +72,7 @@ The following community-contributed extensions are available in [`catalog.commun
 
 | Extension | Purpose | URL |
 |-----------|---------|-----|
-| Archive Extension | Archive merged features into main project memory. | [@stn1slv](https://github.com/stn1slv/spec-kit-archive) |
+| Archive Extension | Archive merged features into main project memory. | [spec-kit-archive](https://github.com/stn1slv/spec-kit-archive) |
 | Azure DevOps Integration | Sync user stories and tasks to Azure DevOps work items using OAuth authentication | [spec-kit-azure-devops](https://github.com/pragya247/spec-kit-azure-devops) |
 | Cleanup Extension | Post-implementation quality gate that reviews changes, fixes small issues (scout rule), creates tasks for medium issues, and generates analysis for large issues | [spec-kit-cleanup](https://github.com/dsrednicki/spec-kit-cleanup) |
 | DocGuard — CDD Enforcement | Canonical-Driven Development enforcement. Generates, validates, scores, and traces project documentation against 92 automated checks with config-aware traceability, quality labels, and AI-ready fix prompts. Zero dependencies. | [spec-kit-docguard](https://github.com/raccioly/docguard) |
@@ -80,7 +80,7 @@ The following community-contributed extensions are available in [`catalog.commun
 | Jira Integration | Create Jira Epics, Stories, and Issues from spec-kit specifications and task breakdowns with configurable hierarchy and custom field support | [spec-kit-jira](https://github.com/mbachorik/spec-kit-jira) |
 | Project Health Check | Diagnose a Spec Kit project and report health issues across structure, agents, features, scripts, extensions, and git | [spec-kit-doctor](https://github.com/KhawarHabibKhan/spec-kit-doctor) |
 | Ralph Loop | Autonomous implementation loop using AI agent CLI | [spec-kit-ralph](https://github.com/Rubiss/spec-kit-ralph) |
-| Reconcile Extension | Reconcile implementation drift by surgically updating feature artifacts. | [@stn1slv](https://github.com/stn1slv/spec-kit-reconcile) |
+| Reconcile Extension | Reconcile implementation drift by surgically updating feature artifacts. | [spec-kit-reconcile](https://github.com/stn1slv/spec-kit-reconcile) |
 | Retrospective Extension | Post-implementation retrospective with spec adherence scoring, drift analysis, and human-gated spec updates | [spec-kit-retrospective](https://github.com/emi-dm/spec-kit-retrospective) |
 | Review Extension | Post-implementation comprehensive code review with specialized agents for code quality, comments, tests, error handling, type design, and simplification | [spec-kit-review](https://github.com/ismaelJimenez/spec-kit-review) |
 | Spec Sync | Detect and resolve drift between specs and implementation. AI-assisted resolution with human approval | [spec-kit-sync](https://github.com/bgervin/spec-kit-sync) |

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -13,7 +13,7 @@
       "repository": "https://github.com/stn1slv/spec-kit-archive",
       "homepage": "https://github.com/stn1slv/spec-kit-archive",
       "documentation": "https://github.com/stn1slv/spec-kit-archive/blob/main/README.md",
-      "changelog": "",
+      "changelog": "https://github.com/stn1slv/spec-kit-archive/blob/main/CHANGELOG.md",
       "license": "MIT",
       "requires": {
         "speckit_version": ">=0.1.0"
@@ -291,7 +291,7 @@
       "repository": "https://github.com/stn1slv/spec-kit-reconcile",
       "homepage": "https://github.com/stn1slv/spec-kit-reconcile",
       "documentation": "https://github.com/stn1slv/spec-kit-reconcile/blob/main/README.md",
-      "changelog": "",
+      "changelog": "https://github.com/stn1slv/spec-kit-reconcile/blob/main/CHANGELOG.md",
       "license": "MIT",
       "requires": {
         "speckit_version": ">=0.1.0"


### PR DESCRIPTION
## Description

Adds two community extensions to the community catalog that implement the **Double-Loop Parity** pattern — keeping feature artifacts and project memory in sync throughout the development lifecycle.

**Archive Extension** (Outer Loop): Post-merge archival that consolidates finalized feature specs, plans, and technical debt into the project's canonical memory (`.specify/memory/`).

**Reconcile Extension** (Inner Loop): Post-implementation gap closer that takes a natural-language gap report and surgically updates the feature's own `spec.md`, `plan.md`, and `tasks.md`.

Addresses the artifact drift problems discussed in #1063, #1100, and #1818.

**Repositories:**
- Archive: https://github.com/stn1slv/spec-kit-archive
- Reconcile: https://github.com/stn1slv/spec-kit-reconcile

**Changes:**
- `extensions/catalog.community.json`: Added both extensions with `verified: false`, `downloads: 0`, `stars: 0`. Alphabetical ordering preserved.
- `extensions/README.md`: Added both extensions to the community table in alphabetical order.

## Testing

- [x] Validated JSON syntax and schema against existing catalog entries
- [x] Verified alphabetical ordering in both JSON and README table
- [x] Confirmed no existing catalog entries were modified
- [x] Tested both extensions with a sample project

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Extension command definitions (`archive.md`, `reconcile.md`) were iteratively developed with AI assistance (Claude Code) — primarily for cross-checking against Spec-Kit extension conventions, validating  catalog schema compliance, and reviewing adherence to publishing rules.