### PR TITLE
docs: add Brownfield Go / React dashboard demo — GitHub Copilot CLI walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ See Spec-Driven Development in action across different scenarios with these comm
 
 - **[Brownfield Java runtime extension](https://github.com/mnriem/spec-kit-java-brownfield-demo)** — Extends an existing open-source Jakarta EE runtime (Piranha, ~420,000 lines of Java, XML, JSP, HTML, and config files across 180 Maven modules) with a password-protected Server Admin Console, demonstrating spec-kit on a large multi-module Java project with no prior specs or constitution.
 
+- **[Brownfield Go / React dashboard demo](https://github.com/mnriem/spec-kit-go-brownfield-demo)** — Demonstrates spec-kit driven entirely from the **terminal using GitHub Copilot CLI**. Extends NASA's open-source Hermes ground support system (Go) with a lightweight React-based web telemetry dashboard, showing that the full constitution → specify → plan → tasks → implement workflow works from the terminal.
+
 ## 🤖 Supported AI Agents
 
 | Agent                                                                                | Support | Notes                                                                                                                                     |


### PR DESCRIPTION
Adds a new entry to the Community Walkthroughs section for the Go / React brownfield demo using GitHub Copilot CLI.

The demo extends NASA's open-source Hermes ground support system with a React-based web telemetry dashboard, showing the full spec-kit workflow (constitution → specify → plan → tasks → implement) driven entirely from the terminal.

Repo: https://github.com/mnriem/spec-kit-go-brownfield-demo

Closes #1390