### PR TITLE
fix(scripts): encode residual JSON control chars as \uXXXX instead of stripping

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -179,7 +179,7 @@ json_escape() {
     local i char code
     for (( i=0; i<${#s}; i++ )); do
         char="${s:$i:1}"
-        code=$(printf '%d' "'$char" 2>/dev/null || echo 256)
+        printf -v code '%d' "'$char" 2>/dev/null || code=256
         if (( code >= 1 && code <= 31 )); then
             printf '\\u%04x' "$code"
         else


### PR DESCRIPTION
## Summary

- `json_escape()` in `common.sh` was silently **deleting** control characters (U+0000–U+001F) not individually handled (`\n`, `\t`, `\r`, `\b`, `\f`) via `tr -d`, causing data loss
- Per RFC 8259, these characters must be encoded as `\uXXXX` sequences
- Replaced the `tr -d` strip with a char-by-char loop that emits proper `\uXXXX` escapes, preserving data integrity
- Multi-byte UTF-8 sequences are unaffected (first-byte values >= 0xC0 are never control characters)

### Example

Before: `"hello\x01world"` → `"helloworld"` (SOH silently deleted)
After: `"hello\x01world"` → `"hello\u0001world"` (SOH properly escaped)

## Test plan

- [ ] Verify `json_escape` correctly encodes control characters like SOH (`\x01`), STX (`\x02`), etc. as `\uXXXX`
- [ ] Verify previously handled characters (`\n`, `\t`, `\r`, `\b`, `\f`) still use their short escape forms
- [ ] Verify multi-byte UTF-8 strings (e.g. emoji, CJK) pass through unchanged
- [ ] Run `check-prerequisites.sh --json` and `create-new-feature.sh --json` to verify JSON output is valid