### PR TITLE
fix(scripts): suppress git fetch stdout leak in multi-remote environments

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -138,7 +138,7 @@ check_existing_branches() {
     local specs_dir="$1"
 
     # Fetch all remotes to get latest branch info (suppress errors if no remotes)
-    git fetch --all --prune 2>/dev/null || true
+    git fetch --all --prune >/dev/null 2>&1 || true
 
     # Get highest number from ALL branches (not just matching short name)
     local highest_branch=$(get_highest_from_branches)


### PR DESCRIPTION
## Description

  In multi-remote environments, `git fetch --all` outputs messages like `Fetching origin` to stdout. Since
   `check_existing_branches()` only redirected stderr (`2>/dev/null`), the stdout output was captured by
  `$(check_existing_branches ...)` command substitution, contaminating the branch number return value and
  causing arithmetic errors like `$((10#Fetching...))`.

  Fix: redirect both stdout and stderr to `/dev/null` (`>/dev/null 2>&1`).

  ### Reproduction

  1. Clone a repository and add a second remote (e.g. a fork)
  2. Run `create-new-feature.sh`
  3. `git fetch --all` outputs `Fetching origin\nFetching fork` to stdout
  4. The output is captured into the variable that should contain only a branch number
  5. Script fails with a bash arithmetic error

  ### Actual error output

  **Before fix** (`2>/dev/null` — stderr only):

  ```
  $ result="$(git fetch --all --prune 2>/dev/null; echo "10")"
  $ echo "$result"
  Fetching origin
  Fetching fork
  10

  $ BRANCH_NUMBER="$result"
  $ echo "$((10#$BRANCH_NUMBER))"
  (eval):1: bad math expression: operator expected at `Fetching o...'
  ```

  **After fix** (`>/dev/null 2>&1` — stdout + stderr):

  ```
  $ result="$(git fetch --all --prune >/dev/null 2>&1; echo "10")"
  $ echo "$result"
  10

  $ BRANCH_NUMBER="$result"
  $ echo "$((10#$BRANCH_NUMBER))"
  10
  ```

  ## Testing

  - [x] Confirmed the bug in a multi-remote environment (repository with both `origin` and a fork remote)
  - [x] Verified `git fetch --all --prune >/dev/null 2>&1` suppresses stdout in multi-remote setup
  - [x] Ran `create-new-feature.sh` after the fix and confirmed branch numbering works correctly

  ## AI Disclosure

  - [ ] I **did not** use AI assistance for this contribution
  - [x] I **did** use AI assistance (describe below)

  The bug was discovered automatically when running Spec Kit's `specify` command via GitHub Copilot
  (Claude Opus 4.6) in a downstream project with multiple git remotes. The fix was also generated by the
  same agent.