### PR TITLE
fix(scripts): add explicit positional binding to PowerShell create-new-feature params

### DIFF
--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -4,9 +4,10 @@
 param(
     [switch]$Json,
     [string]$ShortName,
+    [Parameter()]
     [int]$Number = 0,
     [switch]$Help,
-    [Parameter(ValueFromRemainingArguments = $true)]
+    [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
     [string[]]$FeatureDescription
 )
 $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary

Fixes PowerShell positional parameter binding in `create-new-feature.ps1` that caused `ParameterBindingArgumentTransformationException` when AI agents passed the feature description as a positional argument.

## Why this matters

When an AI agent calls `create-new-feature.ps1 'Add user authentication'` with positional arguments, PowerShell's implicit binding assigns the string to `$Number` (Int32) before reaching `$FeatureDescription`, causing the script to fail on first attempt ([#1879](https://github.com/github/spec-kit/issues/1879)). The bash equivalent (`create-new-feature.sh`) already handles this correctly via explicit `--number` flag parsing.

## Changes

- Added `[Parameter(Position = 0, ValueFromRemainingArguments = $true)]` to `$FeatureDescription` so it binds first positionally
- Added `[Parameter()]` (no Position) to `$Number` so it only binds by name (`-Number N`)

This matches the invocation pattern documented in `specify.md` line 45: `-Json -ShortName "user-auth" "Add user authentication"`

## Testing

- All 382 existing tests pass (`uv run pytest`)
- `ruff check src/` passes
- Verified the param block change matches PowerShell positional binding semantics

## AI Disclosure

This PR was authored with AI assistance (Claude Code). The fix was identified from the error description in #1879 and verified against PowerShell parameter binding documentation.

Fixes #1879