### PR TITLE
feat(extensions): add speckit-utils extension with resume, doctor, validate

### DIFF
--- a/extensions/speckit-utils/CHANGELOG.md
+++ b/extensions/speckit-utils/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 1.0.0 (2026-03-18)
+
+- Initial release
+- Added `speckit.sdd-utils.resume` command for session continuation
+- Added `speckit.sdd-utils.doctor` command for project health validation
+- Added `speckit.sdd-utils.validate` command for spec-to-task verification
+- Added optional hooks for `after_specify` and `after_plan` events

--- a/extensions/speckit-utils/LICENSE
+++ b/extensions/speckit-utils/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Van Horn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/speckit-utils/README.md
+++ b/extensions/speckit-utils/README.md
@@ -1,0 +1,57 @@
+# Spec Kit Utilities Extension
+
+Session management and validation tools for Spec Kit projects.
+
+## Commands
+
+### Resume (`/speckit.speckit-utils.resume`)
+
+Scan your project for active features and get a prompt to continue where you left off.
+
+```
+/speckit.speckit-utils.resume
+/speckit.speckit-utils.resume 001-auth
+```
+
+Detects which SDD phase each feature is in (specify, plan, tasks, implement, complete) and suggests the next command.
+
+### Doctor (`/speckit.speckit-utils.doctor`)
+
+Validate project health across five categories:
+
+- Templates: all required templates present
+- Agent config: AI agent directory and commands registered
+- Scripts: bash/powershell scripts exist and are executable
+- Constitution: project constitution exists with content
+- Features: spec/plan/tasks artifacts present for each feature
+
+```
+/speckit.speckit-utils.doctor
+```
+
+### Validate (`/speckit.speckit-utils.validate`)
+
+Verify that completed tasks produced expected files and that spec requirements trace to tasks.
+
+```
+/speckit.speckit-utils.validate
+/speckit.speckit-utils.validate 001-auth
+/speckit.speckit-utils.validate --strict
+```
+
+## Installation
+
+```bash
+specify extension add speckit-utils
+```
+
+## Hooks
+
+The extension optionally hooks into:
+
+- `after_specify`: prompts to run doctor (project health check)
+- `after_plan`: prompts to run validate (requirement traceability)
+
+## License
+
+MIT

--- a/extensions/speckit-utils/commands/doctor.md
+++ b/extensions/speckit-utils/commands/doctor.md
@@ -1,0 +1,93 @@
+---
+description: "Validate project health: templates, agent config, scripts, constitution, and feature artifacts"
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+Run a comprehensive health check on the spec-kit project, validating that all required components are present and correctly configured.
+
+### Step 1: Find the project root
+
+Locate the `.specify/` directory. If not found, error: "No spec-kit project found. Run `specify init` first."
+
+### Step 2: Check templates
+
+Verify these template files exist in `templates/` and are non-empty:
+- `spec-template.md`
+- `plan-template.md`
+- `tasks-template.md`
+- `constitution-template.md`
+- `checklist-template.md`
+
+For each template:
+- File exists and non-empty: PASS
+- File exists but empty: WARN ("template is empty")
+- File missing: FAIL ("template not found")
+
+### Step 3: Check agent configuration
+
+Read `.specify/init-options.json` to determine the configured AI agent.
+
+If no `init-options.json` exists: WARN ("no AI agent configured - run `specify init` to set up")
+
+If an agent is configured (e.g., `"ai_assistant": "claude"`):
+1. Check that the agent's directory exists (e.g., `.claude/`)
+2. Check that command files are registered (e.g., `.claude/commands/speckit.*.md`)
+3. Count registered commands
+
+- Agent dir exists with commands: PASS
+- Agent dir missing: FAIL ("agent directory not found")
+- Agent dir exists but no commands: WARN ("no command files registered")
+
+### Step 4: Check scripts
+
+Scan `scripts/bash/` and `scripts/powershell/` for script files.
+
+- No scripts directory: WARN ("no scripts directory found")
+- Scripts exist and are executable: PASS
+- Scripts exist but not executable (missing +x on .sh files): WARN ("scripts not executable - run `chmod +x scripts/bash/*.sh`")
+
+### Step 5: Check constitution
+
+Look for `constitution.md` or `memory/constitution.md` in the project root.
+
+- Exists and has content (>10 words): PASS (show word count)
+- Exists but empty: WARN ("constitution is empty")
+- Not found: WARN ("no constitution found - consider creating one to guide AI decisions")
+
+### Step 6: Check features
+
+Scan `specs/` for numbered feature directories. For each feature:
+
+Check for required artifacts: `spec.md`, `plan.md`, `tasks.md`
+
+- All three present: PASS
+- Some missing: WARN (list which are missing, e.g., "spec ✓ plan ✗ tasks ✗")
+
+### Step 7: Report
+
+Output a summary table:
+
+```
+Project Health Check
+====================
+
+Templates:     5/5 PASS
+Agent Config:  PASS (Claude Code, 8 commands registered)
+Scripts:       PASS (bash: 4 executable, powershell: 4)
+Constitution:  PASS (245 words)
+
+Features:
+  001-auth:      spec ✓  plan ✓  tasks ✓  PASS
+  002-dashboard: spec ✓  plan ✗  tasks ✗  WARN (needs /speckit.plan)
+
+Overall: 4 PASS, 1 WARN, 0 FAIL
+```
+
+If any FAIL results exist, suggest specific remediation steps.

--- a/extensions/speckit-utils/commands/resume.md
+++ b/extensions/speckit-utils/commands/resume.md
@@ -1,0 +1,81 @@
+---
+description: "Resume an interrupted session by detecting feature state and suggesting the next command"
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+Resume an interrupted SDD session by scanning the project for active features, detecting their completion state, and generating a prompt to continue work.
+
+### Step 1: Find the project root
+
+Locate the `.specify/` directory to identify the project root. If not found, error: "No spec-kit project found. Run `specify init` first."
+
+### Step 2: Discover features
+
+Scan the `specs/` directory for feature directories (numbered directories like `001-auth`, `002-dashboard`).
+
+For each feature directory, detect state by checking for these files:
+- `spec.md` - specification exists and is non-empty
+- `plan.md` - implementation plan exists and is non-empty
+- `tasks.md` - task breakdown exists
+- `checklists/` - quality checklists exist
+
+### Step 3: Parse task completion
+
+If `tasks.md` exists, parse checkbox items:
+- `- [x]` or `- [X]` = completed
+- `- [ ]` = remaining
+
+Count total tasks, completed tasks, and extract remaining task descriptions.
+
+### Step 4: Determine phase for each feature
+
+| Condition | Phase | Next Command |
+|-----------|-------|-------------|
+| No `spec.md` or empty | `specify` | `/speckit.specify` |
+| `spec.md` exists, no `plan.md` | `plan` | `/speckit.plan` |
+| `plan.md` exists, no `tasks.md` | `tasks` | `/speckit.tasks` |
+| `tasks.md` exists, some incomplete | `implement` | `/speckit.implement` |
+| All tasks complete | `complete` | Review and finalize |
+
+### Step 5: Handle arguments
+
+If `$ARGUMENTS` specifies a feature name or number (e.g., `001-auth` or `auth`), filter to that feature only.
+
+### Step 6: Generate resume prompt
+
+For each active (non-complete) feature, output:
+
+```
+Feature: {name}
+Status: {spec ✓/✗} {plan ✓/✗} {tasks ✓/✗}
+Phase: {phase}
+Progress: {completed}/{total} tasks complete
+
+Next step: Run `/{next_command}`
+```
+
+If tasks remain, list the first 3 remaining tasks:
+
+```
+Remaining tasks:
+  1. {task description}
+  2. {task description}
+  3. {task description}
+```
+
+If all features are complete:
+
+```
+All features are complete. Review and finalize the project.
+```
+
+### Step 7: Report
+
+Output the resume prompt. If `--copy` was passed as an argument, mention that the prompt can be copied to clipboard.

--- a/extensions/speckit-utils/commands/validate.md
+++ b/extensions/speckit-utils/commands/validate.md
@@ -1,0 +1,80 @@
+---
+description: "Verify spec-to-task traceability and check that completed tasks produced expected files"
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Outline
+
+Deterministically verify that the implementation matches the specification by checking task completion, file existence, and requirement traceability.
+
+### Step 1: Select feature
+
+If `$ARGUMENTS` specifies a feature name or number, use that. Otherwise, find the most recently modified feature in `specs/`.
+
+If no features exist, error: "No features found in specs/. Run `/speckit.specify` first."
+
+### Step 2: Parse tasks
+
+Read `tasks.md` from the feature directory. Parse each checkbox line:
+- Extract task text (after `- [x]` or `- [ ]`)
+- Mark as completed or remaining
+- Extract keywords: file paths (`auth/login.py`), snake_case names (`user_auth`), CamelCase names (`UserAuth`), dotted names (`config.yaml`)
+
+If no `tasks.md` exists, error: "No tasks.md found. Run `/speckit.tasks` first."
+
+### Step 3: Verify completed task artifacts
+
+For each completed task that references file paths:
+1. Search the project directory for the referenced file
+2. If found: PASS
+3. If not found: WARN ("task says 'Create auth/login.py' but file not found")
+
+Skip verification for:
+- Incomplete tasks (not yet implemented)
+- Tasks with no file path references (e.g., "Set up CI pipeline")
+
+### Step 4: Parse spec requirements
+
+Read `spec.md` from the feature directory. Extract items from the "Functional Requirements" section (bulleted list items under that heading).
+
+If no requirements section found, skip to Step 6.
+
+### Step 5: Trace requirements to tasks
+
+For each requirement, search task descriptions for matching keywords:
+- Tokenize the requirement into significant words (skip stop words)
+- Check each task's text for overlap (2+ matching keywords = traced)
+
+Report:
+- Requirement with matching tasks: PASS ("traced to Task N")
+- Requirement with no matching tasks: WARN ("no task found for this requirement")
+
+### Step 6: Report
+
+Output a validation report:
+
+```
+Validation Report: 001-auth
+============================
+
+Task Completion: 3/5 (60%)
+  [x] Task 1: Create auth/login.py      -> auth/login.py FOUND
+  [x] Task 2: Add password hashing      -> (no file reference)
+  [x] Task 3: Write auth tests          -> tests/test_auth.py FOUND
+  [ ] Task 4: Add rate limiting         -> (not yet implemented)
+  [ ] Task 5: Update API docs           -> (not yet implemented)
+
+Requirement Traceability: 3/3
+  "Users can log in with email"          -> Task 1 (PASS)
+  "Passwords are stored securely"        -> Task 2 (PASS)
+  "Users can reset password via email"   -> (no matching task - WARN)
+
+Summary: 2 PASS, 1 WARN, 0 FAIL
+```
+
+If `$ARGUMENTS` includes `--strict`, treat any WARN as FAIL and report a non-zero exit status.

--- a/extensions/speckit-utils/config-template.yml
+++ b/extensions/speckit-utils/config-template.yml
@@ -1,0 +1,17 @@
+# SDD Utils Extension Configuration
+# Copy to sdd-utils-config.yml and customize
+
+# Resume command settings
+resume:
+  # Show all features or only active (non-complete) ones
+  show_complete: false
+
+# Doctor command settings
+doctor:
+  # Skip specific checks (e.g., ["scripts", "constitution"])
+  skip_checks: []
+
+# Validate command settings
+validate:
+  # Treat warnings as failures
+  strict: false

--- a/extensions/speckit-utils/extension.yml
+++ b/extensions/speckit-utils/extension.yml
@@ -1,0 +1,52 @@
+schema_version: "1.0"
+
+extension:
+  id: "speckit-utils"
+  name: "Spec Kit Utilities"
+  version: "1.0.0"
+  description: "Resume interrupted sessions, validate project health, and verify spec-to-task traceability"
+  author: "Matt Van Horn"
+  repository: "https://github.com/github/spec-kit"
+  license: "MIT"
+  homepage: "https://github.com/github/spec-kit/tree/main/extensions/speckit-utils"
+
+requires:
+  speckit_version: ">=0.1.0"
+
+provides:
+  commands:
+    - name: "speckit.speckit-utils.resume"
+      file: "commands/resume.md"
+      description: "Resume an interrupted session by detecting feature state and suggesting the next command"
+      aliases: ["speckit.resume"]
+
+    - name: "speckit.speckit-utils.doctor"
+      file: "commands/doctor.md"
+      description: "Validate project health: templates, agent config, scripts, constitution, and feature artifacts"
+      aliases: ["speckit.doctor"]
+
+    - name: "speckit.speckit-utils.validate"
+      file: "commands/validate.md"
+      description: "Verify spec-to-task traceability and check that completed tasks produced expected files"
+      aliases: ["speckit.validate"]
+
+hooks:
+  after_specify:
+    command: "speckit.speckit-utils.doctor"
+    optional: true
+    prompt: "Run project health check?"
+    description: "Validate project health after specification generation"
+    condition: null
+
+  after_plan:
+    command: "speckit.speckit-utils.validate"
+    optional: true
+    prompt: "Validate spec-to-task traceability?"
+    description: "Verify requirements map to planned tasks after planning"
+    condition: null
+
+tags:
+  - "productivity"
+  - "validation"
+  - "session-management"
+  - "quality"


### PR DESCRIPTION
## Summary

Packages three SDD utility commands as an extension, per feedback on PRs #1892, #1893, #1894 where @mnriem requested these be delivered as extensions rather than core commands.

## Commands

- **speckit.speckit-utils.resume** - Scan project features, detect their SDD phase (specify/plan/tasks/implement/complete), and suggest the next command to continue work
- **speckit.speckit-utils.doctor** - Validate project health across five categories: templates, agent config, scripts, constitution, and feature artifacts
- **speckit.speckit-utils.validate** - Verify spec-to-task traceability and check that completed tasks produced expected files

## Hooks

Optional hooks into:
- `after_specify` - prompts to run doctor (project health check)
- `after_plan` - prompts to run validate (requirement traceability)

## Structure

Follows the extension template pattern with `extension.yml` manifest, `commands/*.md` agent instruction files, config template, README, LICENSE, and CHANGELOG.

## Testing

Manually verified extension structure matches the template and selftest patterns. Markdown lint is excluded for extensions per the lint workflow config.

This contribution was developed with AI assistance (Claude Code).