### PR TITLE
docs: Add Extensions & Presets section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ block-beta
     style core fill:transparent,stroke:#e6a817
 ```
 
-**Templates** are resolved at **runtime** — Spec Kit walks the stack top-down and uses the first match. Project-local overrides (`.specify/templates/overrides/`) let you make one-off adjustments for a single project without creating a full preset. **Commands** are applied at **install time** — when you run `specify extension add` or `specify preset add`, command files are copied into agent directories (e.g., `.claude/commands/`), replacing whatever was there before; the last-installed version is the one the agent sees. Commands are cleaned up on removal. If no overrides or customizations exist, Spec Kit uses its core defaults.
+**Templates** are resolved at **runtime** — Spec Kit walks the stack top-down and uses the first match. Project-local overrides (`.specify/templates/overrides/`) let you make one-off adjustments for a single project without creating a full preset. **Commands** are applied at **install time** — when you run `specify extension add` or `specify preset add`, command files are written into agent directories (e.g., `.claude/commands/`). If multiple presets or extensions provide the same command, the highest-priority version wins. On removal, the next-highest-priority version is restored automatically. If no overrides or customizations exist, Spec Kit uses its core defaults.
 
 ### Extensions — Add New Capabilities
 

--- a/presets/README.md
+++ b/presets/README.md
@@ -13,7 +13,7 @@ When Spec Kit needs a template (e.g. `spec-template`), it walks a resolution sta
 
 If no preset is installed, core templates are used — exactly the same behavior as before presets existed.
 
-Template resolution happens **at runtime** — nothing is copied; Spec Kit walks the stack on every lookup.
+Template resolution happens **at runtime** — although preset files are copied into `.specify/presets/<id>/` during installation, Spec Kit walks the resolution stack on every template lookup rather than merging templates into a single location.
 
 For detailed resolution and command registration flows, see [ARCHITECTURE.md](ARCHITECTURE.md).
 


### PR DESCRIPTION
Adds a new "Making Spec Kit Your Own: Extensions & Presets" section to the README covering:

- **Layering diagram** (Mermaid) showing the resolution order: project-local overrides → presets → extensions → core
- **Extensions** — when to use them (new capabilities beyond core SDD commands), with examples
- **Presets** — when to use them (customizing existing workflows, methodology alignment, regulatory standards), with examples including the pirate-speak demo
- **When-to-use-which** comparison table
- Links to the respective READMEs for full details