### PR TITLE
feat: add /speckit.rfc command for technical decision documents

### DIFF
--- a/scripts/bash/setup-rfc.sh
+++ b/scripts/bash/setup-rfc.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Parse command line arguments
+JSON_MODE=false
+ARGS=()
+
+for arg in "$@"; do
+    case "$arg" in
+        --json)
+            JSON_MODE=true
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--json]"
+            echo "  --json    Output results in JSON format"
+            echo "  --help    Show this help message"
+            exit 0
+            ;;
+        *)
+            ARGS+=("$arg")
+            ;;
+    esac
+done
+
+# Get script directory and load common functions
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Get all paths and variables from common functions
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
+
+# Check if we're on a proper feature branch (only for git repos)
+check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
+
+# Ensure the feature directory exists
+mkdir -p "$FEATURE_DIR"
+
+# Derive RFC path
+RFC_FILE="$FEATURE_DIR/rfc.md"
+
+# Copy RFC template if it exists
+TEMPLATE=$(resolve_template "rfc-template" "$REPO_ROOT") || true
+if [[ -n "$TEMPLATE" ]] && [[ -f "$TEMPLATE" ]]; then
+    cp "$TEMPLATE" "$RFC_FILE"
+    echo "Copied RFC template to $RFC_FILE"
+else
+    echo "Warning: RFC template not found"
+    touch "$RFC_FILE"
+fi
+
+# Output results
+if $JSON_MODE; then
+    if has_jq; then
+        jq -cn \
+            --arg feature_spec "$FEATURE_SPEC" \
+            --arg rfc_file "$RFC_FILE" \
+            --arg specs_dir "$FEATURE_DIR" \
+            --arg branch "$CURRENT_BRANCH" \
+            --arg has_git "$HAS_GIT" \
+            '{FEATURE_SPEC:$feature_spec,RFC_FILE:$rfc_file,SPECS_DIR:$specs_dir,BRANCH:$branch,HAS_GIT:$has_git}'
+    else
+        printf '{"FEATURE_SPEC":"%s","RFC_FILE":"%s","SPECS_DIR":"%s","BRANCH":"%s","HAS_GIT":"%s"}\n' \
+            "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$RFC_FILE")" "$(json_escape "$FEATURE_DIR")" "$(json_escape "$CURRENT_BRANCH")" "$(json_escape "$HAS_GIT")"
+    fi
+else
+    echo "FEATURE_SPEC: $FEATURE_SPEC"
+    echo "RFC_FILE: $RFC_FILE"
+    echo "SPECS_DIR: $FEATURE_DIR"
+    echo "BRANCH: $CURRENT_BRANCH"
+    echo "HAS_GIT: $HAS_GIT"
+fi

--- a/scripts/powershell/setup-rfc.ps1
+++ b/scripts/powershell/setup-rfc.ps1
@@ -1,0 +1,63 @@
+#!/usr/bin/env pwsh
+# Setup RFC document for a feature
+
+[CmdletBinding()]
+param(
+    [switch]$Json,
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Show help if requested
+if ($Help) {
+    Write-Output "Usage: ./setup-rfc.ps1 [-Json] [-Help]"
+    Write-Output "  -Json     Output results in JSON format"
+    Write-Output "  -Help     Show this help message"
+    exit 0
+}
+
+# Load common functions
+. "$PSScriptRoot/common.ps1"
+
+# Get all paths and variables from common functions
+$paths = Get-FeaturePathsEnv
+
+# Check if we're on a proper feature branch (only for git repos)
+if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) {
+    exit 1
+}
+
+# Ensure the feature directory exists
+New-Item -ItemType Directory -Path $paths.FEATURE_DIR -Force | Out-Null
+
+# Derive RFC path
+$rfcFile = Join-Path $paths.FEATURE_DIR "rfc.md"
+
+# Copy RFC template if it exists, otherwise note it or create empty file
+$template = Resolve-Template -TemplateName 'rfc-template' -RepoRoot $paths.REPO_ROOT
+if ($template -and (Test-Path $template)) {
+    Copy-Item $template $rfcFile -Force
+    Write-Output "Copied RFC template to $rfcFile"
+} else {
+    Write-Warning "RFC template not found"
+    New-Item -ItemType File -Path $rfcFile -Force | Out-Null
+}
+
+# Output results
+if ($Json) {
+    $result = [PSCustomObject]@{
+        FEATURE_SPEC = $paths.FEATURE_SPEC
+        RFC_FILE = $rfcFile
+        SPECS_DIR = $paths.FEATURE_DIR
+        BRANCH = $paths.CURRENT_BRANCH
+        HAS_GIT = $paths.HAS_GIT
+    }
+    $result | ConvertTo-Json -Compress
+} else {
+    Write-Output "FEATURE_SPEC: $($paths.FEATURE_SPEC)"
+    Write-Output "RFC_FILE: $rfcFile"
+    Write-Output "SPECS_DIR: $($paths.FEATURE_DIR)"
+    Write-Output "BRANCH: $($paths.CURRENT_BRANCH)"
+    Write-Output "HAS_GIT: $($paths.HAS_GIT)"
+}

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -28,7 +28,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
-2. **Load context**: Read FEATURE_SPEC and `/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+2. **Load context**: Read FEATURE_SPEC and `/memory/constitution.md`. Load IMPL_PLAN template (already copied). Also check for `rfc.md` in SPECS_DIR — if it exists, read it and use its architecture, technology choices, and trade-offs as constraints for the plan.
 
 3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
    - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")

--- a/templates/commands/rfc.md
+++ b/templates/commands/rfc.md
@@ -1,0 +1,155 @@
+---
+description: Create a technical RFC (Request for Comments) from an existing feature spec, proposing HOW to build it.
+handoffs:
+  - label: Build Technical Plan
+    agent: speckit.plan
+    prompt: Create a plan for the spec and RFC. I am building with...
+    send: true
+  - label: Clarify Spec Requirements
+    agent: speckit.clarify
+    prompt: Clarify specification requirements
+    send: true
+scripts:
+  sh: scripts/bash/setup-rfc.sh --json
+  ps: scripts/powershell/setup-rfc.ps1 -Json
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+The text the user typed after `/speckit.rfc` in the triggering message provides additional context or constraints for the RFC (e.g., preferred technology, architectural direction). Use it to guide decisions but derive the RFC content from the spec.
+
+Given the feature spec, do this:
+
+1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_SPEC, RFC_FILE, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC. If spec.md does not exist, ERROR: "No spec found. Run /speckit.specify first."
+
+3. **Load RFC template**: Read `templates/rfc-template.md` to understand required sections.
+
+4. **Extract from spec**:
+   - Functional requirements (FR-xxx) — these define WHAT the system must do
+   - Success criteria (SC-xxx) — these become business metrics
+   - User scenarios — these inform rollout and architecture decisions
+   - Edge cases — these inform known limitations and trade-offs
+   - Key entities — these inform data/architecture design
+
+5. **Generate RFC content** following the execution flow:
+
+   1. Parse user input for technology preferences or constraints
+      If user specified tech stack or direction: use as primary constraint
+      If empty: infer from project context (existing code, dependencies)
+   2. Write Decision Summary (2-3 sentences: problem, chosen approach, key trade-off)
+   3. Write Background (technical landscape, current system state — NOT business context)
+   4. Write Problem (why current system can't meet spec requirements — NOT the business need)
+   5. Write Proposal with Architecture diagram
+   6. Write Alternatives Considered (MANDATORY — minimum 2 alternatives with verdicts)
+   7. Write Rollout Strategy (ONLY if change affects production systems)
+   8. Write Metrics — split into Business (from spec SC-xxx) and Technical
+   9. Write Known Limitations (bullet list)
+   10. Write Dependencies (ONLY if cross-team or external)
+   11. Write Security & Compliance (ONLY if auth, PII, external APIs, or trust boundary changes)
+   12. Write Outstanding Questions (MAX 5, each must be BLOCKING, tagged with owner)
+
+6. **Write the RFC** to RFC_FILE using the template structure.
+
+7. **RFC Quality Validation**: After writing, validate against the discipline guidelines:
+
+   a. **Run validation check** against each rule:
+
+      | Rule | Check |
+      |------|-------|
+      | Decision document | Does every section help a reviewer make or validate a decision? |
+      | No business rehash | Does Background/Problem avoid restating what's in the spec? |
+      | No teaching | Does it avoid explaining standard concepts the audience already knows? |
+      | Alternatives have verdicts | Does every alternative state why it was chosen or rejected? |
+      | Diagrams over prose | Are component interactions shown as diagrams, not paragraphs? |
+      | Blocking questions only | Are all Outstanding Questions genuinely blocking? |
+      | Single decision scope | Does the RFC cover ONE architectural decision (or tightly coupled set)? |
+      | Length discipline | Background 1-2 paragraphs, Problem 1-3 paragraphs, Questions max 5? |
+
+   b. **Handle validation results**:
+      - If all pass: proceed to step 8
+      - If any fail: fix the RFC content and re-validate (max 2 iterations)
+      - After 2 iterations: document remaining issues and warn user
+
+8. **Report completion** with branch name, RFC file path, spec reference, and readiness for `/speckit.plan`.
+
+## RFC Writing Guidelines
+
+These rules are NON-NEGOTIABLE. Apply them during generation, not just validation.
+
+1. **RFCs are DECISION documents, not design documents.**
+   The plan handles implementation detail. The RFC captures WHAT technical
+   approach was chosen, WHY it was chosen over alternatives, and WHAT the
+   trade-offs are. If a section doesn't help a reviewer make or validate
+   a decision, cut it.
+
+2. **Don't re-explain the business problem.**
+   The spec already covers WHAT and WHY. The RFC's Problem section explains
+   why the CURRENT SYSTEM can't meet that need — not why the business needs
+   the feature.
+
+3. **Don't teach your reviewers.**
+   Assume technical competence. Don't define industry terms, explain standard
+   patterns, or cite Wikipedia. Link to references if context is truly needed.
+
+4. **Every alternative must have a verdict.**
+   "Alternatives Considered" is not a literature review. Each option needs:
+   what it is, why it could work, why it was rejected (or chosen).
+   If you can't articulate why an alternative was rejected, you haven't
+   made a decision yet.
+
+5. **Diagrams over paragraphs.**
+   A system diagram replaces 500 words of prose. If you're describing
+   data flow or component interaction in sentences, draw it instead.
+
+6. **Outstanding Questions must be blocking.**
+   If a question doesn't block the decision or implementation, it doesn't
+   belong here. Nice-to-know questions go in discussion threads, not the RFC.
+
+7. **Scope the RFC to ONE decision.**
+   If your RFC covers multiple independent architectural decisions,
+   split it into separate RFCs. Exception: tightly coupled decisions
+   that can't be evaluated independently.
+
+8. **Length discipline.**
+   - Decision Summary: 2-3 sentences
+   - Background: 1-2 paragraphs (link to prior work, don't summarize it)
+   - Problem: 1-3 paragraphs
+   - Proposal: as long as needed, but prefer diagrams + bullets over prose
+   - Alternatives: table format preferred
+   - Known Limitations: bullet list
+   - Outstanding Questions: max 5 (if more, the RFC isn't ready)
+
+### Section Requirements
+
+- **Mandatory sections**: Decision Summary, Background, Problem, Proposal (with Architecture), Alternatives Considered, Metrics & Definition of Success, Known Limitations
+- **Optional sections**: Rollout Strategy, Dependencies, Security & Compliance, Outstanding Questions
+- When an optional section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### How Sections Connect to the Spec
+
+| RFC Section | Draws From Spec | Purpose |
+|-------------|-----------------|---------|
+| Background | Context + current system state | Technical landscape |
+| Problem | Requirements (FR-xxx) | Why current system fails |
+| Proposal | Success criteria + requirements | Technical approach |
+| Alternatives | -- (new in RFC) | Decision justification |
+| Metrics (Business) | Success criteria (SC-xxx) | How RFC achieves spec goals |
+| Metrics (Technical) | -- (new in RFC) | Implementation-specific measures |
+| Known Limitations | Edge cases | Deliberate scope boundaries |
+
+### What Feeds Into the Plan
+
+The `/speckit.plan` command consumes both the spec AND the RFC:
+- Spec provides: requirements, success criteria, user scenarios
+- RFC provides: architecture, technology choices, trade-offs, constraints
+- Plan produces: phased implementation steps, research tasks, data model, contracts

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -1,6 +1,10 @@
 ---
 description: Create or update the feature specification from a natural language feature description.
-handoffs: 
+handoffs:
+  - label: Create Technical RFC
+    agent: speckit.rfc
+    prompt: Create an RFC for the spec
+    send: true
   - label: Build Technical Plan
     agent: speckit.plan
     prompt: Create a plan for the spec. I am building with...

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -39,6 +39,8 @@
 
 ```text
 specs/[###-feature]/
+├── spec.md              # Feature specification (/speckit.specify command output)
+├── rfc.md               # Technical RFC (/speckit.rfc command output — optional)
 ├── plan.md              # This file (/speckit.plan command output)
 ├── research.md          # Phase 0 output (/speckit.plan command)
 ├── data-model.md        # Phase 1 output (/speckit.plan command)

--- a/templates/rfc-template.md
+++ b/templates/rfc-template.md
@@ -1,0 +1,138 @@
+# RFC: [TITLE]
+
+**RFC ID**: [TEAM-NNN]
+**Status**: Draft
+**Author**: [Name]
+**Reviewers**: [Names]
+**Created**: [DATE]
+**Updated**: [DATE]
+**Spec Reference**: [Link to spec.md]
+**Branch**: `[###-feature-name]`
+
+## Decision Summary
+
+<!--
+  2-3 sentences MAX. A reviewer short on time reads ONLY this.
+  State the problem in one line, the chosen approach, and the key trade-off.
+-->
+
+[We need X because Y. We chose approach A over B because Z.
+The main trade-off is ...]
+
+## Background
+
+<!--
+  TECHNICAL landscape only: current architecture, prior work, existing systems.
+  The spec already covers business context — do not repeat it here.
+  1-2 paragraphs. Link to prior work, don't summarize it.
+-->
+
+[Technical context, current state of the system, prior work or related efforts]
+
+## Problem
+
+<!--
+  Why the CURRENT SYSTEM cannot meet the spec's requirements.
+  This is NOT the business problem (that's in the spec).
+  1-3 paragraphs. Reference spec requirements (FR-xxx) where relevant.
+-->
+
+[Technical problem and why the current system cannot satisfy the spec]
+
+## Proposal
+
+<!--
+  The core of the RFC. WHAT technical approach was chosen and WHY.
+  Prefer diagrams over prose. Prefer bullets over paragraphs.
+  Focus on decisions and trade-offs, not exhaustive implementation detail —
+  the plan handles that.
+-->
+
+[Proposed technical solution]
+
+### Architecture
+
+<!--
+  System design, component interaction, data flow.
+  A diagram replaces 500 words of prose — draw it.
+-->
+
+```text
+[Architecture diagram]
+```
+
+### Alternatives Considered
+
+<!--
+  MANDATORY. Every alternative must have a verdict.
+  If you can't articulate why an alternative was rejected,
+  you haven't made a decision yet.
+-->
+
+| Alternative | Pros | Cons | Verdict |
+|-------------|------|------|---------|
+| [Option A — chosen] | ... | ... | **Selected** because ... |
+| [Option B] | ... | ... | Rejected because ... |
+| [Option C] | ... | ... | Rejected because ... |
+
+## Rollout Strategy
+
+<!--
+  OPTIONAL — Include when the change affects production systems.
+  How will this be deployed? Feature flags? Phased rollout?
+  Migration path from current state?
+-->
+
+[Rollout plan, migration steps, feature flags, backward compatibility]
+
+## Metrics & Definition of Success
+
+<!--
+  Business metrics come from the spec's success criteria (SC-xxx).
+  Technical metrics are specific to this implementation.
+-->
+
+### Business Metrics
+
+- [Metric from spec success criteria and how this RFC achieves it]
+
+### Technical Metrics
+
+- [Technical performance, reliability, or operational metrics]
+
+## Known Limitations
+
+<!--
+  Bullet list. Compromises, trade-offs, and scope boundaries.
+  What does this solution deliberately NOT do?
+-->
+
+- [Limitation 1]
+- [Limitation 2]
+
+## Dependencies
+
+<!--
+  OPTIONAL — Include when there are cross-team or external dependencies.
+-->
+
+- [Dependency 1]: [What is needed and from whom]
+
+## Security & Compliance
+
+<!--
+  OPTIONAL — Include when the change involves authentication, PII,
+  external APIs, or changes to trust boundaries.
+-->
+
+[Security implications, PII/GDPR considerations, auth changes]
+
+## Outstanding Questions
+
+<!--
+  MAX 5. Every question must be BLOCKING — if it doesn't block
+  the decision or implementation, it doesn't belong here.
+  Tag questions with owners.
+-->
+
+1. [Question] — *Owner: [Name/Team]*


### PR DESCRIPTION
Add RFC creation as a core command in the spec-driven workflow. The RFC sits between spec and plan: spec (WHAT/WHY) -> RFC (HOW/decision) -> plan (HOW/steps).

New files:
- templates/rfc-template.md: RFC template with Decision Summary, Alternatives Considered, etc.
- templates/commands/rfc.md: Command with 8 writing discipline guidelines
- scripts/bash/setup-rfc.sh: Setup script for RFC scaffolding
- scripts/powershell/setup-rfc.ps1: PowerShell equivalent

Modified:
- specify command: added RFC handoff option
- plan command: reads rfc.md when present for architectural constraints
- plan template: updated project structure to show rfc.md

## Description

<!-- What does this PR do? Why is it needed? -->

## Testing

<!-- How did you test your changes? -->

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [ ] I **did not** use AI assistance for this contribution
- [ ] I **did** use AI assistance (describe below)

<!-- If you used AI, briefly describe how (e.g., "Code generated by Copilot", "Consulted ChatGPT for approach"): -->

