### PR TITLE
docs: update publishing guide with Category and Effect columns

### DIFF
--- a/extensions/EXTENSION-PUBLISHING-GUIDE.md
+++ b/extensions/EXTENSION-PUBLISHING-GUIDE.md
@@ -209,8 +209,21 @@ Edit `extensions/catalog.community.json` and add your extension:
 Add your extension to the Available Extensions table in `extensions/README.md`:
 
 ```markdown
-| Your Extension Name | Brief description of what it does | [repo-name](https://github.com/your-org/spec-kit-your-extension) |
+| Your Extension Name | Brief description of what it does | `category` | Effect | [repo-name](https://github.com/your-org/spec-kit-your-extension) |
 ```
+
+**Category** — pick the one that best fits your extension:
+
+- `docs` — reads, validates, or generates spec artifacts
+- `code` — reviews, validates, or modifies source code
+- `process` — orchestrates workflow across phases
+- `integration` — syncs with external platforms
+- `visibility` — reports on project health or progress
+
+**Effect** — choose one:
+
+- `Read-only` — produces reports without modifying files
+- `Read+Write` — modifies files, creates artifacts, or updates specs
 
 Insert your extension in alphabetical order in the table.
 


### PR DESCRIPTION
## Description

Follow-up to #1897. The README table now has Category and Effect columns, but the publishing guide template still showed the old 3-column format. This updates the example row and adds descriptions of each Category and Effect value so extension authors know what to include.

## Testing

N/A — documentation-only change.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Used Cursor (Claude) to apply the same column update from #1897 to the publishing guide. All content reviewed by the author.

Made with [Cursor](https://cursor.com)