### PR TITLE
ci: increase stale workflow operations-per-run to 250

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -39,4 +39,4 @@ jobs:
           any-of-labels: ''
           
           # Operations per run (helps avoid rate limits)
-          operations-per-run: 100
+          operations-per-run: 250


### PR DESCRIPTION
Increases `operations-per-run` from 100 to 250 in the stale issues/PRs workflow to process more items per run.

The workflow already had `workflow_dispatch` enabled for manual triggering.