### PR TITLE
fix(templates): add missing Assumptions section to spec template

### DIFF
--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -113,3 +113,16 @@
 - **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
 - **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
 - **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]


### PR DESCRIPTION
## Description

The `specify` command references an "Assumptions section" in the spec template and instructs the agent to "document assumptions in Assumptions section" and "Record reasonable defaults in the Assumptions section." The quality checklist also validates "Dependencies and assumptions identified." However, the actual `spec-template.md` did not contain an Assumptions section. This caused a mismatch: the agent would try to populate a section that didn't exist in the template.

This PR adds the missing `## Assumptions` section to `spec-template.md` with placeholder bullets covering:
- Target users/environment assumptions
- Scope boundary assumptions
- Data/infrastructure assumptions
- Dependencies on existing systems/services

## Testing

- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

The Assumptions section layout and placeholder bullets were drafted with the help of AI (GitHub Copilot).

