### PR TITLE
docs: add AIDE extension demo to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ See Spec-Driven Development in action across different scenarios with these comm
 
 - **[Greenfield Spring Boot MVC with a custom preset](https://github.com/mnriem/spec-kit-pirate-speak-preset-demo)** — Builds a Spring Boot MVC application from scratch using a custom pirate-speak preset, demonstrating how presets can reshape the entire spec-kit experience: specifications become "Voyage Manifests," plans become "Battle Plans," and tasks become "Crew Assignments" — all generated in full pirate vernacular without changing any tooling.
 
+- **[Greenfield Spring Boot + React with a custom extension](https://github.com/mnriem/spec-kit-aide-extension-demo)** — Walks through the **AIDE extension**, a community extension that adds an alternative spec-driven workflow to spec-kit with high-level specs (vision) and low-level specs (work items) organized in a 7-step iterative lifecycle: vision → roadmap → progress tracking → work queue → work items → execution → feedback loops. Uses a family trading platform (Spring Boot 4, React 19, PostgreSQL, Docker Compose) as the scenario to illustrate how the extension mechanism lets you plug in a different style of spec-driven development without changing any core tooling — truly utilizing the "Kit" in Spec Kit.
+
 ## 🤖 Supported AI Agents
 
 | Agent                                                                                | Support | Notes                                                                                                                                     |


### PR DESCRIPTION
## Summary

Add the [AIDE extension demo](https://github.com/mnriem/spec-kit-aide-extension-demo) to the community projects section in the README.

## What's added

A new entry in the **Community Projects** section showcasing a Spring Boot + React project that uses a custom extension with an alternative spec-driven workflow featuring a 7-step iterative lifecycle:

> vision → roadmap → progress tracking → work queue → work items → execution → feedback loops

This demonstrates how the extension mechanism lets you plug in a different style of spec-driven development without changing any core tooling.