### PR TITLE
docs: add Community Friends section with Spec Kit Assistant VS Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - [⚡ Get Started](#-get-started)
 - [📽️ Video Overview](#️-video-overview)
 - [🚶 Community Walkthroughs](#-community-walkthroughs)
-- [🛠️ Community Tools](#️-community-tools)
+- [🛠️ Community Friends](#️-community-friends)
 - [🤖 Supported AI Agents](#-supported-ai-agents)
 - [🔧 Specify CLI Reference](#-specify-cli-reference)
 - [🧩 Making Spec Kit Your Own: Extensions & Presets](#-making-spec-kit-your-own-extensions--presets)


### PR DESCRIPTION
## Description

Adds a new **🛠️ Community Friends** section to the README, positioned between the existing _Community Walkthroughs_ and _Supported AI Agents_ sections.

This section documents community-built tooling that integrates with Spec Kit — starting with the [Spec Kit Assistant](https://marketplace.visualstudio.com/items?itemName=rfsales.speckit-assistant), a VS Code extension that provides a visual orchestrator for the full SDD workflow (constitution → specification → planning → tasks → implementation) with phase status visualization, an interactive task checklist, DAG visualization, and multi-AI backend support (Claude, Gemini, GitHub Copilot, OpenAI).

**Why a new section instead of adding to Community Walkthroughs?**
Community Walkthroughs lists demo repos showing SDD in action. The Spec Kit Assistant is a published, installable IDE extension — a categorically different kind of community contribution. A dedicated section keeps both lists semantically clean and provides a scalable anchor for future community tools.

The Table of Contents is updated accordingly.

## Testing

- [x] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

> This is a documentation-only change (README.md). No CLI code, templates, or scripts were modified.

## AI Disclosure

- [x] I **did not** use AI assistance for this contribution