### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [0.4.0] - 2026-03-23
-
-### Changes
-
-- fix(cli): add allow_unicode=True and encoding="utf-8" to YAML I/O (#1936)
-- fix(codex): native skills fallback refresh + legacy prompt suppression (#1930)
-
 ## [0.4.1] - 2026-03-24
 
 ### Changes
@@ -15,7 +8,14 @@
 - fix(scripts): prioritize .specify over git for repo root detection (#1933)
 - docs: add AIDE extension demo to community projects (#1943)
 - fix(templates): add missing Assumptions section to spec template (#1939)
-- chore: bump version to 0.4.0 (#1937)
+- chore: bump version to 0.4.1 (#1937)
+
+## [0.4.0] - 2026-03-23
+
+### Changes
+
+- fix(cli): add allow_unicode=True and encoding="utf-8" to YAML I/O (#1936)
+- fix(codex): native skills fallback refresh + legacy prompt suppression (#1930)
 
 - feat(cli): embed core pack in wheel for offline/air-gapped deployment (#1803)
 - ci: increase stale workflow operations-per-run to 250 (#1922)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 - fix(cli): add allow_unicode=True and encoding="utf-8" to YAML I/O (#1936)
 - fix(codex): native skills fallback refresh + legacy prompt suppression (#1930)
+
+## [0.4.1] - 2026-03-24
+
+### Changes
+
+- Add checkpoint extension (#1947)
+- fix(scripts): prioritize .specify over git for repo root detection (#1933)
+- docs: add AIDE extension demo to community projects (#1943)
+- fix(templates): add missing Assumptions section to spec template (#1939)
+- chore: bump version to 0.4.0 (#1937)
+
 - feat(cli): embed core pack in wheel for offline/air-gapped deployment (#1803)
 - ci: increase stale workflow operations-per-run to 250 (#1922)
 - docs: update publishing guide with Category and Effect columns (#1913)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Automated version bump to 0.4.1.

This PR was created by the Release Trigger workflow. The git tag `v0.4.1` has already been pushed and the release artifacts are being built.

Merge this PR to record the version bump and changelog update on `main`.