### PR TITLE
Add Community Friends section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ Projects that extend, visualize, or build on Spec Kit:
 
 | Project | Description |
 |---------|-------------|
-| [cc-sdd](https://github.com/rhuss/cc-sdd) | Claude Code plugin that adds composable traits on top of Spec Kit: quality gates, spec/code review, git worktree isolation, and parallel implementation via agent teams. |
+| [cc-sdd](https://github.com/rhuss/cc-sdd) | Claude Code plugin that adds composable traits on top of Spec Kit: [Superpowers](https://github.com/obra/superpowers)-based quality gates, spec/code review, git worktree isolation, and parallel implementation via agent teams. |
 
 ## 🙏 Acknowledgements
 


### PR DESCRIPTION
## Summary

- Adds a new "Community Friends" section to the README for projects that extend or build on Spec Kit
- Starts with [cc-sdd](https://github.com/rhuss/cc-superpowers-sdd), a Claude Code plugin that layers composable traits on top of Spec Kit's core workflow
- Includes TOC entry for the new section

Suggested by @mnriem in [discussion #1889](https://github.com/github/spec-kit/discussions/1889#discussioncomment-13355718).

Assisted-By: 🤖 Claude Code