### PR TITLE
docs(readme): consolidate Community Friends sections and fix ToC anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@
 - [📋 Detailed Process](#-detailed-process)
 - [🔍 Troubleshooting](#-troubleshooting)
 - [💬 Support](#-support)
-- [🤝 Community Friends](#-community-friends)
 - [🙏 Acknowledgements](#-acknowledgements)
 - [📄 License](#-license)
 


### PR DESCRIPTION
## Summary

Consolidates the duplicate "Community Friends" sections in the README and fixes broken Table of Contents anchors.

### Changes

- **Merge duplicate section**: The `🤝 Community Friends` section (table format, near bottom) is merged into the existing `🛠️ Community Friends` section (bullet list, earlier in the doc)
- **Add cc-sdd entry**: Moved the [cc-sdd](https://github.com/rhuss/cc-sdd) entry into the consolidated section alongside Spec Kit Assistant
- **Update intro text**: Changed from "Community-built tools that integrate with Spec Kit to enhance the SDD workflow" to "Community projects that extend, visualize, or build on Spec Kit"
- **Fix ToC anchors**: Removed Unicode variation selector (`️`) from the `#️-video-overview` and `#️-community-friends` fragment links — the variation selector was causing anchor mismatches on some renderers

### Before

Two separate "Community Friends" sections:
1. `🛠️ Community Friends` (line ~178) — bullet list with Spec Kit Assistant
2. `🤝 Community Friends` (line ~789) — table with cc-sdd

### After

Single `🛠️ Community Friends` section with both entries in a consistent bullet-list format.