### PR TITLE
feat(extensions): scripts support, command filtering, and template discovery

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2743,7 +2743,14 @@ def preset_list_templates(
     ),
 ):
     """List all available templates from the resolution stack."""
-    from .presets import PresetResolver
+    from .presets import PresetResolver, VALID_PRESET_TEMPLATE_TYPES
+
+    if template_type not in VALID_PRESET_TEMPLATE_TYPES:
+        console.print(
+            f"[red]Error:[/red] Invalid template type '{template_type}'. "
+            f"Must be one of: {', '.join(sorted(VALID_PRESET_TEMPLATE_TYPES))}"
+        )
+        raise typer.Exit(1)
 
     project_root = Path.cwd()
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2735,6 +2735,38 @@ def preset_resolve(
         console.print("    [dim]No template with this name exists in the resolution stack[/dim]")
 
 
+@preset_app.command("list-templates")
+def preset_list_templates(
+    template_type: str = typer.Option(
+        "template", "--type", "-t",
+        help="Template type: template, command, or script",
+    ),
+):
+    """List all available templates from the resolution stack."""
+    from .presets import PresetResolver
+
+    project_root = Path.cwd()
+
+    specify_dir = project_root / ".specify"
+    if not specify_dir.exists():
+        console.print("[red]Error:[/red] Not a spec-kit project (no .specify/ directory)")
+        console.print("Run this command from a spec-kit project root")
+        raise typer.Exit(1)
+
+    resolver = PresetResolver(project_root)
+    available = resolver.list_available(template_type)
+
+    if not available:
+        console.print(f"[yellow]No {template_type}s found in the resolution stack[/yellow]")
+        return
+
+    console.print(f"\n[bold]Available {template_type}s ({len(available)}):[/bold]\n")
+    for entry in available:
+        console.print(f"  [bold]{entry['name']}[/bold]")
+        console.print(f"    [dim]Source: {entry['source']}[/dim]")
+        console.print(f"    [dim]Path: {entry['path']}[/dim]")
+
+
 @preset_app.command("info")
 def preset_info(
     pack_id: str = typer.Argument(..., help="Preset ID to get info about"),
@@ -3281,7 +3313,7 @@ def extension_list(
             console.print(f"  [{status_color}]{status_icon}[/{status_color}] [bold]{ext['name']}[/bold] (v{ext['version']})")
             console.print(f"     [dim]{ext['id']}[/dim]")
             console.print(f"     {ext['description']}")
-            console.print(f"     Commands: {ext['command_count']} | Hooks: {ext['hook_count']} | Priority: {ext['priority']} | Status: {'Enabled' if ext['enabled'] else 'Disabled'}")
+            console.print(f"     Commands: {ext['command_count']} | Scripts: {ext['script_count']} | Hooks: {ext['hook_count']} | Priority: {ext['priority']} | Status: {'Enabled' if ext['enabled'] else 'Disabled'}")
             console.print()
 
     if available or all_extensions:
@@ -3590,9 +3622,15 @@ def extension_add(
         console.print("\n[green]✓[/green] Extension installed successfully!")
         console.print(f"\n[bold]{manifest.name}[/bold] (v{manifest.version})")
         console.print(f"  {manifest.description}")
-        console.print("\n[bold cyan]Provided commands:[/bold cyan]")
-        for cmd in manifest.commands:
-            console.print(f"  • {cmd['name']} - {cmd.get('description', '')}")
+        if manifest.commands:
+            console.print("\n[bold cyan]Provided commands:[/bold cyan]")
+            for cmd in manifest.commands:
+                console.print(f"  • {cmd['name']} - {cmd.get('description', '')}")
+
+        if manifest.scripts:
+            console.print("\n[bold cyan]Provided scripts:[/bold cyan]")
+            for script in manifest.scripts:
+                console.print(f"  • {script['name']} - {script.get('description', '')}")
 
         console.print("\n[yellow]⚠[/yellow]  Configuration may be required")
         console.print(f"   Check: .specify/extensions/{manifest.id}/")
@@ -3890,6 +3928,8 @@ def _print_extension_info(ext_info: dict, manager):
         provides = ext_info['provides']
         if provides.get('commands'):
             console.print(f"  • Commands: {provides['commands']}")
+        if provides.get('scripts'):
+            console.print(f"  • Scripts: {provides['scripts']}")
         if provides.get('hooks'):
             console.print(f"  • Hooks: {provides['hooks']}")
         console.print()

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -847,6 +847,178 @@ class ExtensionManager:
             return None
 
 
+class ExtensionResolver:
+    """Resolves and discovers templates provided by installed extensions.
+
+    Handles priority-based ordering of extensions, template resolution,
+    and source attribution for extension-provided templates.
+
+    This class owns the extension tier of the template resolution stack.
+    PresetResolver delegates to it for extension lookups rather than
+    walking extension directories directly.
+    """
+
+    def __init__(self, project_root: Path):
+        self.project_root = project_root
+        self.extensions_dir = project_root / ".specify" / "extensions"
+
+    def get_all_by_priority(self) -> List[tuple]:
+        """Build unified list of registered and unregistered extensions sorted by priority.
+
+        Registered extensions use their stored priority; unregistered directories
+        get implicit priority=10. Results are sorted by (priority, ext_id) for
+        deterministic ordering.
+
+        Returns:
+            List of (priority, ext_id, metadata_or_none) tuples sorted by priority.
+        """
+        if not self.extensions_dir.exists():
+            return []
+
+        registry = ExtensionRegistry(self.extensions_dir)
+        registered_extension_ids = registry.keys()
+        all_registered = registry.list_by_priority(include_disabled=True)
+
+        all_extensions: list[tuple[int, str, dict | None]] = []
+
+        for ext_id, metadata in all_registered:
+            if not metadata.get("enabled", True):
+                continue
+            priority = normalize_priority(metadata.get("priority") if metadata else None)
+            all_extensions.append((priority, ext_id, metadata))
+
+        for ext_dir in self.extensions_dir.iterdir():
+            if not ext_dir.is_dir() or ext_dir.name.startswith("."):
+                continue
+            if ext_dir.name not in registered_extension_ids:
+                all_extensions.append((10, ext_dir.name, None))
+
+        all_extensions.sort(key=lambda x: (x[0], x[1]))
+        return all_extensions
+
+    def resolve(
+        self,
+        template_name: str,
+        template_type: str = "template",
+    ) -> Optional[Path]:
+        """Resolve a template name to its file path within extensions.
+
+        Args:
+            template_name: Template name (e.g., "spec-template")
+            template_type: Template type ("template", "command", or "script")
+
+        Returns:
+            Path to the resolved template file, or None if not found
+        """
+        subdirs, ext = self._type_config(template_type)
+
+        for _priority, ext_id, _metadata in self.get_all_by_priority():
+            ext_dir = self.extensions_dir / ext_id
+            if not ext_dir.is_dir():
+                continue
+            for subdir in subdirs:
+                if subdir:
+                    candidate = ext_dir / subdir / f"{template_name}{ext}"
+                else:
+                    candidate = ext_dir / f"{template_name}{ext}"
+                if candidate.exists():
+                    return candidate
+
+        return None
+
+    def resolve_with_source(
+        self,
+        template_name: str,
+        template_type: str = "template",
+    ) -> Optional[Dict[str, str]]:
+        """Resolve a template name and return source attribution.
+
+        Args:
+            template_name: Template name (e.g., "spec-template")
+            template_type: Template type ("template", "command", or "script")
+
+        Returns:
+            Dictionary with 'path' and 'source' keys, or None if not found
+        """
+        subdirs, ext = self._type_config(template_type)
+
+        for _priority, ext_id, ext_meta in self.get_all_by_priority():
+            ext_dir = self.extensions_dir / ext_id
+            if not ext_dir.is_dir():
+                continue
+            for subdir in subdirs:
+                if subdir:
+                    candidate = ext_dir / subdir / f"{template_name}{ext}"
+                else:
+                    candidate = ext_dir / f"{template_name}{ext}"
+                if candidate.exists():
+                    if ext_meta:
+                        version = ext_meta.get("version", "?")
+                        source = f"extension:{ext_id} v{version}"
+                    else:
+                        source = f"extension:{ext_id} (unregistered)"
+                    return {"path": str(candidate), "source": source}
+
+        return None
+
+    def list_templates(
+        self,
+        template_type: str = "template",
+    ) -> List[Dict[str, str]]:
+        """List all templates of a given type provided by extensions.
+
+        Returns templates sorted by extension priority, then alphabetically.
+
+        Args:
+            template_type: Template type ("template", "command", or "script")
+
+        Returns:
+            List of dicts with 'name', 'path', and 'source' keys.
+        """
+        subdirs, ext = self._type_config(template_type)
+        results: List[Dict[str, str]] = []
+        seen: set[str] = set()
+
+        for _priority, ext_id, ext_meta in self.get_all_by_priority():
+            ext_dir = self.extensions_dir / ext_id
+            if not ext_dir.is_dir():
+                continue
+
+            if ext_meta:
+                version = ext_meta.get("version", "?")
+                source_label = f"extension:{ext_id} v{version}"
+            else:
+                source_label = f"extension:{ext_id} (unregistered)"
+
+            for subdir in subdirs:
+                scan_dir = ext_dir / subdir if subdir else ext_dir
+                if not scan_dir.is_dir():
+                    continue
+                for f in sorted(scan_dir.iterdir()):
+                    if f.is_file() and f.suffix == ext:
+                        name = f.stem
+                        if name not in seen:
+                            seen.add(name)
+                            results.append({
+                                "name": name,
+                                "path": str(f),
+                                "source": source_label,
+                            })
+
+        return results
+
+    @staticmethod
+    def _type_config(template_type: str) -> tuple:
+        """Return (subdirs, file_extension) for a template type."""
+        if template_type == "template":
+            return ["templates", ""], ".md"
+        elif template_type == "command":
+            return ["commands"], ".md"
+        elif template_type == "script":
+            return ["scripts"], ".sh"
+        return [""], ".md"
+
+
 def version_satisfies(current: str, required: str) -> bool:
     """Check if current version satisfies required version specifier.
 

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -121,6 +121,8 @@ class ExtensionManifest:
         for field in ["id", "name", "version", "description"]:
             if field not in ext:
                 raise ValidationError(f"Missing extension.{field}")
+            if not isinstance(ext[field], str):
+                raise ValidationError(f"extension.{field} must be a string")
 
         # Validate extension ID format
         if not re.match(r'^[a-z0-9-]+$', ext["id"]):
@@ -141,6 +143,8 @@ class ExtensionManifest:
             raise ValidationError("'requires' must be a mapping")
         if "speckit_version" not in requires:
             raise ValidationError("Missing requires.speckit_version")
+        if not isinstance(requires["speckit_version"], str):
+            raise ValidationError("requires.speckit_version must be a string")
 
         # Validate provides section
         provides = self.data["provides"]
@@ -1002,6 +1006,7 @@ class ExtensionResolver:
             List of dicts with 'name', 'path', and 'source' keys.
         """
         subdirs, exts = self._type_config(template_type)
+        name_re = self._name_re_for_type(template_type)
         results: List[Dict[str, str]] = []
         seen: set[str] = set()
 
@@ -1020,18 +1025,36 @@ class ExtensionResolver:
                 scan_dir = ext_dir / subdir if subdir else ext_dir
                 if not scan_dir.is_dir():
                     continue
-                for f in sorted(scan_dir.iterdir()):
-                    if f.is_file() and f.suffix in exts:
-                        name = f.stem
+
+                if template_type == "script":
+                    # Prefer .sh over .ps1 when both exist (matches resolve order)
+                    candidates: Dict[str, Path] = {}
+                    for f in sorted(scan_dir.iterdir()):
+                        if f.is_file() and f.suffix in exts and name_re.match(f.stem):
+                            existing = candidates.get(f.stem)
+                            if existing is None or exts.index(f.suffix) < exts.index(existing.suffix):
+                                candidates[f.stem] = f
+                    for name, f in sorted(candidates.items()):
                         if name not in seen:
                             seen.add(name)
-                            results.append({
-                                "name": name,
-                                "path": str(f),
-                                "source": source_label,
-                            })
+                            results.append({"name": name, "path": str(f), "source": source_label})
+                else:
+                    for f in sorted(scan_dir.iterdir()):
+                        if f.is_file() and f.suffix in exts:
+                            name = f.stem
+                            if name not in seen and name_re.match(name):
+                                seen.add(name)
+                                results.append({"name": name, "path": str(f), "source": source_label})
 
         return results
+
+    @staticmethod
+    def _name_re_for_type(template_type: str) -> re.Pattern:
+        """Return compiled regex for valid names of the given template type."""
+        if template_type == "command":
+            return re.compile(r'^speckit\.[a-z0-9.-]+$')
+        # template and script both use lowercase-alphanumeric-hyphen
+        return re.compile(r'^[a-z0-9-]+$')
 
     @staticmethod
     def _type_config(template_type: str) -> tuple:

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -171,10 +171,16 @@ class ExtensionManifest:
                     "must be lowercase alphanumeric with hyphens only"
                 )
 
-            # Validate file path safety: must be relative, no parent traversal
+            # Validate file path safety: must be relative, no anchored/drive
+            # paths, and no parent traversal components
             file_path = script["file"]
-            normalized = os.path.normpath(file_path)
-            if os.path.isabs(normalized) or normalized.startswith(".."):
+            p = Path(file_path)
+            if p.is_absolute() or p.anchor:
+                raise ValidationError(
+                    f"Invalid script file path '{file_path}': "
+                    "must be a relative path within the extension directory"
+                )
+            if ".." in p.parts:
                 raise ValidationError(
                     f"Invalid script file path '{file_path}': "
                     "must be a relative path within the extension directory"
@@ -622,11 +628,12 @@ class ExtensionManager:
         ignore_fn = self._load_extensionignore(source_dir)
         shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
 
-        # Set execute permissions on extension scripts
-        for script in manifest.scripts:
-            script_path = dest_dir / script["file"]
-            if script_path.exists() and script_path.suffix == ".sh":
-                script_path.chmod(script_path.stat().st_mode | 0o755)
+        # Set execute permissions on extension scripts (POSIX only)
+        if os.name == "posix":
+            for script in manifest.scripts:
+                script_path = dest_dir / script["file"]
+                if script_path.exists() and script_path.suffix == ".sh":
+                    script_path.chmod(script_path.stat().st_mode | 0o111)
 
         # Register commands with AI agents
         registered_commands = {}
@@ -1092,7 +1099,9 @@ class CommandRegistrar:
         Extension-specific commands are only kept if the target extension
         directory exists under .specify/extensions/.
 
-        If the extensions directory does not exist, no filtering is applied.
+        If the extensions directory does not exist, it is treated as empty
+        and all extension-scoped commands are filtered out (matching the
+        preset filtering behavior at presets.py:518-529).
 
         Note: This method is not applied during extension self-registration
         (all commands in an extension's own manifest are always registered).
@@ -1100,8 +1109,6 @@ class CommandRegistrar:
         commands for extensions that may not be installed.
         """
         extensions_dir = project_root / ".specify" / "extensions"
-        if not extensions_dir.is_dir():
-            return commands
         filtered = []
         for cmd in commands:
             parts = cmd["name"].split(".")

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -140,11 +140,15 @@ class ExtensionManifest:
 
         # Validate provides section
         provides = self.data["provides"]
-        if "commands" not in provides or not provides["commands"]:
-            raise ValidationError("Extension must provide at least one command")
+        has_commands = "commands" in provides and provides["commands"]
+        has_scripts = "scripts" in provides and provides["scripts"]
+        if not has_commands and not has_scripts:
+            raise ValidationError(
+                "Extension must provide at least one command or script"
+            )
 
         # Validate commands
-        for cmd in provides["commands"]:
+        for cmd in provides.get("commands", []):
             if "name" not in cmd or "file" not in cmd:
                 raise ValidationError("Command missing 'name' or 'file'")
 
@@ -153,6 +157,27 @@ class ExtensionManifest:
                 raise ValidationError(
                     f"Invalid command name '{cmd['name']}': "
                     "must follow pattern 'speckit.{extension}.{command}'"
+                )
+
+        # Validate scripts
+        for script in provides.get("scripts", []):
+            if "name" not in script or "file" not in script:
+                raise ValidationError("Script missing 'name' or 'file'")
+
+            # Validate script name format
+            if not re.match(r'^[a-z0-9-]+$', script["name"]):
+                raise ValidationError(
+                    f"Invalid script name '{script['name']}': "
+                    "must be lowercase alphanumeric with hyphens only"
+                )
+
+            # Validate file path safety: must be relative, no parent traversal
+            file_path = script["file"]
+            normalized = os.path.normpath(file_path)
+            if os.path.isabs(normalized) or normalized.startswith(".."):
+                raise ValidationError(
+                    f"Invalid script file path '{file_path}': "
+                    "must be a relative path within the extension directory"
                 )
 
     @property
@@ -183,7 +208,12 @@ class ExtensionManifest:
     @property
     def commands(self) -> List[Dict[str, Any]]:
         """Get list of provided commands."""
-        return self.data["provides"]["commands"]
+        return self.data["provides"].get("commands", [])
+
+    @property
+    def scripts(self) -> List[Dict[str, Any]]:
+        """Get list of provided scripts."""
+        return self.data["provides"].get("scripts", [])
 
     @property
     def hooks(self) -> Dict[str, Any]:
@@ -592,6 +622,12 @@ class ExtensionManager:
         ignore_fn = self._load_extensionignore(source_dir)
         shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
 
+        # Set execute permissions on extension scripts
+        for script in manifest.scripts:
+            script_path = dest_dir / script["file"]
+            if script_path.exists() and script_path.suffix == ".sh":
+                script_path.chmod(script_path.stat().st_mode | 0o755)
+
         # Register commands with AI agents
         registered_commands = {}
         if register_commands:
@@ -770,6 +806,7 @@ class ExtensionManager:
                     "priority": normalize_priority(metadata.get("priority")),
                     "installed_at": metadata.get("installed_at"),
                     "command_count": len(manifest.commands),
+                    "script_count": len(manifest.scripts),
                     "hook_count": len(manifest.hooks)
                 })
             except ValidationError:
@@ -783,6 +820,7 @@ class ExtensionManager:
                     "priority": normalize_priority(metadata.get("priority")),
                     "installed_at": metadata.get("installed_at"),
                     "command_count": 0,
+                    "script_count": 0,
                     "hook_count": 0
                 })
 
@@ -869,6 +907,38 @@ class CommandRegistrar:
         base = self._registrar.render_toml_command(frontmatter, body, ext_id)
         context_lines = f"# Extension: {ext_id}\n# Config: .specify/extensions/{ext_id}/\n"
         return base.rstrip("\n") + "\n" + context_lines
+
+    @staticmethod
+    def _filter_commands_for_installed_extensions(
+        commands: List[Dict[str, Any]],
+        project_root: Path,
+    ) -> List[Dict[str, Any]]:
+        """Filter out commands targeting extensions that are not installed.
+
+        Command names follow the pattern: speckit.<ext-id>.<cmd-name>
+        Core commands (e.g. speckit.specify) have only two parts — always kept.
+        Extension-specific commands are only kept if the target extension
+        directory exists under .specify/extensions/.
+
+        If the extensions directory does not exist, no filtering is applied.
+
+        Note: This method is not applied during extension self-registration
+        (all commands in an extension's own manifest are always registered).
+        It is designed for cross-boundary filtering, e.g. when presets provide
+        commands for extensions that may not be installed.
+        """
+        extensions_dir = project_root / ".specify" / "extensions"
+        if not extensions_dir.is_dir():
+            return commands
+        filtered = []
+        for cmd in commands:
+            parts = cmd["name"].split(".")
+            if len(parts) >= 3 and parts[0] == "speckit":
+                ext_id = parts[1]
+                if not (extensions_dir / ext_id).is_dir():
+                    continue
+            filtered.append(cmd)
+        return filtered
 
     def register_commands_for_agent(
         self,

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -140,15 +140,19 @@ class ExtensionManifest:
 
         # Validate provides section
         provides = self.data["provides"]
-        has_commands = "commands" in provides and provides["commands"]
-        has_scripts = "scripts" in provides and provides["scripts"]
-        if not has_commands and not has_scripts:
+        commands = provides.get("commands") or []
+        scripts = provides.get("scripts") or []
+        if not isinstance(commands, list):
+            raise ValidationError("provides.commands must be a list")
+        if not isinstance(scripts, list):
+            raise ValidationError("provides.scripts must be a list")
+        if not commands and not scripts:
             raise ValidationError(
                 "Extension must provide at least one command or script"
             )
 
         # Validate commands
-        for cmd in provides.get("commands", []):
+        for cmd in commands:
             if "name" not in cmd or "file" not in cmd:
                 raise ValidationError("Command missing 'name' or 'file'")
 
@@ -160,7 +164,7 @@ class ExtensionManifest:
                 )
 
         # Validate scripts
-        for script in provides.get("scripts", []):
+        for script in scripts:
             if "name" not in script or "file" not in script:
                 raise ValidationError("Script missing 'name' or 'file'")
 
@@ -214,12 +218,12 @@ class ExtensionManifest:
     @property
     def commands(self) -> List[Dict[str, Any]]:
         """Get list of provided commands."""
-        return self.data["provides"].get("commands", [])
+        return self.data["provides"].get("commands") or []
 
     @property
     def scripts(self) -> List[Dict[str, Any]]:
         """Get list of provided scripts."""
-        return self.data["provides"].get("scripts", [])
+        return self.data["provides"].get("scripts") or []
 
     @property
     def hooks(self) -> Dict[str, Any]:
@@ -920,19 +924,18 @@ class ExtensionResolver:
         Returns:
             Path to the resolved template file, or None if not found
         """
-        subdirs, ext = self._type_config(template_type)
+        subdirs, exts = self._type_config(template_type)
 
         for _priority, ext_id, _metadata in self.get_all_by_priority():
             ext_dir = self.extensions_dir / ext_id
             if not ext_dir.is_dir():
                 continue
             for subdir in subdirs:
-                if subdir:
-                    candidate = ext_dir / subdir / f"{template_name}{ext}"
-                else:
-                    candidate = ext_dir / f"{template_name}{ext}"
-                if candidate.exists():
-                    return candidate
+                base = ext_dir / subdir if subdir else ext_dir
+                for file_ext in exts:
+                    candidate = base / f"{template_name}{file_ext}"
+                    if candidate.exists():
+                        return candidate
 
         return None
 
@@ -950,24 +953,23 @@ class ExtensionResolver:
         Returns:
             Dictionary with 'path' and 'source' keys, or None if not found
         """
-        subdirs, ext = self._type_config(template_type)
+        subdirs, exts = self._type_config(template_type)
 
         for _priority, ext_id, ext_meta in self.get_all_by_priority():
             ext_dir = self.extensions_dir / ext_id
             if not ext_dir.is_dir():
                 continue
             for subdir in subdirs:
-                if subdir:
-                    candidate = ext_dir / subdir / f"{template_name}{ext}"
-                else:
-                    candidate = ext_dir / f"{template_name}{ext}"
-                if candidate.exists():
-                    if ext_meta:
-                        version = ext_meta.get("version", "?")
-                        source = f"extension:{ext_id} v{version}"
-                    else:
-                        source = f"extension:{ext_id} (unregistered)"
-                    return {"path": str(candidate), "source": source}
+                base = ext_dir / subdir if subdir else ext_dir
+                for file_ext in exts:
+                    candidate = base / f"{template_name}{file_ext}"
+                    if candidate.exists():
+                        if ext_meta:
+                            version = ext_meta.get("version", "?")
+                            source = f"extension:{ext_id} v{version}"
+                        else:
+                            source = f"extension:{ext_id} (unregistered)"
+                        return {"path": str(candidate), "source": source}
 
         return None
 
@@ -985,7 +987,7 @@ class ExtensionResolver:
         Returns:
             List of dicts with 'name', 'path', and 'source' keys.
         """
-        subdirs, ext = self._type_config(template_type)
+        subdirs, exts = self._type_config(template_type)
         results: List[Dict[str, str]] = []
         seen: set[str] = set()
 
@@ -1005,7 +1007,7 @@ class ExtensionResolver:
                 if not scan_dir.is_dir():
                     continue
                 for f in sorted(scan_dir.iterdir()):
-                    if f.is_file() and f.suffix == ext:
+                    if f.is_file() and f.suffix in exts:
                         name = f.stem
                         if name not in seen:
                             seen.add(name)
@@ -1019,14 +1021,18 @@ class ExtensionResolver:
 
     @staticmethod
     def _type_config(template_type: str) -> tuple:
-        """Return (subdirs, file_extension) for a template type."""
+        """Return (subdirs, file_extensions) for a template type.
+
+        Returns:
+            Tuple of (subdirs list, list of file extensions to match).
+        """
         if template_type == "template":
-            return ["templates", ""], ".md"
+            return ["templates", ""], [".md"]
         elif template_type == "command":
-            return ["commands"], ".md"
+            return ["commands"], [".md"]
         elif template_type == "script":
-            return ["scripts"], ".sh"
-        return [""], ".md"
+            return ["scripts"], [".sh", ".ps1"]
+        return [""], [".md"]
 
 
 def version_satisfies(current: str, required: str) -> bool:

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -116,6 +116,8 @@ class ExtensionManifest:
 
         # Validate extension metadata
         ext = self.data["extension"]
+        if not isinstance(ext, dict):
+            raise ValidationError("'extension' must be a mapping")
         for field in ["id", "name", "version", "description"]:
             if field not in ext:
                 raise ValidationError(f"Missing extension.{field}")
@@ -135,11 +137,15 @@ class ExtensionManifest:
 
         # Validate requires section
         requires = self.data["requires"]
+        if not isinstance(requires, dict):
+            raise ValidationError("'requires' must be a mapping")
         if "speckit_version" not in requires:
             raise ValidationError("Missing requires.speckit_version")
 
         # Validate provides section
         provides = self.data["provides"]
+        if not isinstance(provides, dict):
+            raise ValidationError("'provides' must be a mapping")
         commands = provides.get("commands") or []
         scripts = provides.get("scripts") or []
         if not isinstance(commands, list):
@@ -165,8 +171,12 @@ class ExtensionManifest:
 
         # Validate scripts
         for script in scripts:
+            if not isinstance(script, dict):
+                raise ValidationError("Each script entry must be a mapping")
             if "name" not in script or "file" not in script:
                 raise ValidationError("Script missing 'name' or 'file'")
+            if not isinstance(script["name"], str) or not isinstance(script["file"], str):
+                raise ValidationError("Script 'name' and 'file' must be strings")
 
             # Validate script name format
             if not re.match(r'^[a-z0-9-]+$', script["name"]):

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -628,12 +628,15 @@ class ExtensionManager:
         ignore_fn = self._load_extensionignore(source_dir)
         shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
 
-        # Set execute permissions on extension scripts (POSIX only)
+        # Set execute permissions on extension scripts (POSIX only, best-effort)
         if os.name == "posix":
             for script in manifest.scripts:
                 script_path = dest_dir / script["file"]
                 if script_path.exists() and script_path.suffix == ".sh":
-                    script_path.chmod(script_path.stat().st_mode | 0o111)
+                    try:
+                        script_path.chmod(script_path.stat().st_mode | 0o111)
+                    except OSError:
+                        pass
 
         # Register commands with AI agents
         registered_commands = {}

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -159,8 +159,12 @@ class ExtensionManifest:
 
         # Validate commands
         for cmd in commands:
+            if not isinstance(cmd, dict):
+                raise ValidationError("Each command entry must be a mapping")
             if "name" not in cmd or "file" not in cmd:
                 raise ValidationError("Command missing 'name' or 'file'")
+            if not isinstance(cmd["name"], str) or not isinstance(cmd["file"], str):
+                raise ValidationError("Command 'name' and 'file' must be strings")
 
             # Validate command name format
             if not re.match(r'^speckit\.[a-z0-9-]+\.[a-z0-9-]+$', cmd["name"]):
@@ -1042,7 +1046,10 @@ class ExtensionResolver:
             return ["commands"], [".md"]
         elif template_type == "script":
             return ["scripts"], [".sh", ".ps1"]
-        return [""], [".md"]
+        raise ValueError(
+            f"Invalid template type '{template_type}': "
+            "must be one of 'template', 'command', 'script'"
+        )
 
 
 def version_satisfies(current: str, required: str) -> bool:

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -24,7 +24,7 @@ import yaml
 from packaging import version as pkg_version
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
 
-from .extensions import ExtensionRegistry, ExtensionResolver, normalize_priority
+from .extensions import ExtensionResolver, normalize_priority
 
 
 @dataclass

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1681,7 +1681,16 @@ class PresetResolver:
 
         Returns:
             List of dicts with 'name', 'path', and 'source' keys, sorted by name.
+
+        Raises:
+            ValueError: If template_type is not one of "template", "command", "script"
         """
+        if template_type not in VALID_PRESET_TEMPLATE_TYPES:
+            raise ValueError(
+                f"Invalid template type '{template_type}': "
+                f"must be one of {sorted(VALID_PRESET_TEMPLATE_TYPES)}"
+            )
+
         seen: set[str] = set()
         results: List[Dict[str, str]] = []
 
@@ -1691,10 +1700,8 @@ class PresetResolver:
             subdirs = ["templates", ""]
         elif template_type == "command":
             subdirs = ["commands"]
-        elif template_type == "script":
+        else:  # script
             subdirs = ["scripts"]
-        else:
-            subdirs = [""]
 
         def _collect(directory: Path, source: str):
             """Collect template files from a directory."""

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1704,38 +1704,54 @@ class PresetResolver:
         else:  # script
             subdirs = ["scripts"]
 
-        def _name_matches_type(name: str) -> bool:
-            """Check if a file name matches the expected pattern for the template type.
+        _template_name_re = re.compile(r'^[a-z0-9-]+$')
+        _command_name_re = re.compile(r'^speckit\.[a-z0-9.-]+$')
 
-            Commands use dot notation (e.g. speckit.specify), templates use
-            hyphens only (e.g. spec-template). This prevents the shared
-            overrides directory from leaking commands into template listings
-            or vice versa. Scripts live in their own subdirectory so no
-            filtering is needed.
+        def _name_matches_type(name: str) -> bool:
+            """Check if a file name matches the expected naming rules for the template type.
+
+            Commands must start with speckit. and use dot notation.
+            Templates/scripts must be lowercase alphanumeric with hyphens only.
+            This prevents README.md, CHANGELOG.md, etc. from appearing as
+            templates, and keeps the shared overrides directory clean.
             """
             if template_type == "command":
-                return "." in name
+                return _command_name_re.match(name) is not None
             if template_type == "template":
-                return "." not in name
-            return True
+                return "." not in name and _template_name_re.match(name) is not None
+            # script
+            return _template_name_re.match(name) is not None
 
         def _collect(directory: Path, source: str):
             """Collect template files from a directory."""
             if not directory.is_dir():
                 return
-            for f in sorted(directory.iterdir()):
-                if f.is_file() and f.suffix in exts:
-                    name = f.stem
-                    if name in seen:
-                        continue
-                    if not _name_matches_type(name):
-                        continue
-                    seen.add(name)
-                    results.append({
-                        "name": name,
-                        "path": str(f),
-                        "source": source,
-                    })
+            if template_type == "script":
+                # For scripts, both .sh and .ps1 may exist for the same stem.
+                # Pick the one matching resolution order (exts list order).
+                candidates: dict[str, Path] = {}
+                for f in sorted(directory.iterdir()):
+                    if f.is_file() and f.suffix in exts:
+                        name = f.stem
+                        if not _name_matches_type(name):
+                            continue
+                        existing = candidates.get(name)
+                        if existing is None or exts.index(f.suffix) < exts.index(existing.suffix):
+                            candidates[name] = f
+                for name, f in sorted(candidates.items()):
+                    if name not in seen:
+                        seen.add(name)
+                        results.append({"name": name, "path": str(f), "source": source})
+            else:
+                for f in sorted(directory.iterdir()):
+                    if f.is_file() and f.suffix in exts:
+                        name = f.stem
+                        if name in seen:
+                            continue
+                        if not _name_matches_type(name):
+                            continue
+                        seen.add(name)
+                        results.append({"name": name, "path": str(f), "source": source})
 
         # Priority 1: Project-local overrides
         if template_type == "script":

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1703,6 +1703,21 @@ class PresetResolver:
         else:  # script
             subdirs = ["scripts"]
 
+        def _name_matches_type(name: str) -> bool:
+            """Check if a file name matches the expected pattern for the template type.
+
+            Commands use dot notation (e.g. speckit.specify), templates use
+            hyphens only (e.g. spec-template). This prevents the shared
+            overrides directory from leaking commands into template listings
+            or vice versa. Scripts live in their own subdirectory so no
+            filtering is needed.
+            """
+            if template_type == "command":
+                return "." in name
+            if template_type == "template":
+                return "." not in name
+            return True
+
         def _collect(directory: Path, source: str):
             """Collect template files from a directory."""
             if not directory.is_dir():
@@ -1710,13 +1725,16 @@ class PresetResolver:
             for f in sorted(directory.iterdir()):
                 if f.is_file() and f.suffix == ext:
                     name = f.stem
-                    if name not in seen:
-                        seen.add(name)
-                        results.append({
-                            "name": name,
-                            "path": str(f),
-                            "source": source,
-                        })
+                    if name in seen:
+                        continue
+                    if not _name_matches_type(name):
+                        continue
+                    seen.add(name)
+                    results.append({
+                        "name": name,
+                        "path": str(f),
+                        "source": source,
+                    })
 
         # Priority 1: Project-local overrides
         if template_type == "script":

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1557,18 +1557,17 @@ class PresetResolver:
         else:
             subdirs = [""]
 
-        # Determine file extension based on template type
-        ext = ".md"
-        if template_type == "script":
-            ext = ".sh"  # scripts use .sh; callers can also check .ps1
+        # Determine file extensions based on template type
+        exts = [".sh", ".ps1"] if template_type == "script" else [".md"]
 
         # Priority 1: Project-local overrides
-        if template_type == "script":
-            override = self.overrides_dir / "scripts" / f"{template_name}{ext}"
-        else:
-            override = self.overrides_dir / f"{template_name}{ext}"
-        if override.exists():
-            return override
+        for file_ext in exts:
+            if template_type == "script":
+                override = self.overrides_dir / "scripts" / f"{template_name}{file_ext}"
+            else:
+                override = self.overrides_dir / f"{template_name}{file_ext}"
+            if override.exists():
+                return override
 
         # Priority 2: Installed presets (sorted by priority — lower number wins)
         if self.presets_dir.exists():
@@ -1576,12 +1575,13 @@ class PresetResolver:
             for pack_id, _metadata in registry.list_by_priority():
                 pack_dir = self.presets_dir / pack_id
                 for subdir in subdirs:
-                    if subdir:
-                        candidate = pack_dir / subdir / f"{template_name}{ext}"
-                    else:
-                        candidate = pack_dir / f"{template_name}{ext}"
-                    if candidate.exists():
-                        return candidate
+                    for file_ext in exts:
+                        if subdir:
+                            candidate = pack_dir / subdir / f"{template_name}{file_ext}"
+                        else:
+                            candidate = pack_dir / f"{template_name}{file_ext}"
+                        if candidate.exists():
+                            return candidate
 
         # Priority 3: Extension-provided templates (delegated to ExtensionResolver)
         ext_result = self._ext_resolver.resolve(template_name, template_type)
@@ -1598,9 +1598,10 @@ class PresetResolver:
             if core.exists():
                 return core
         elif template_type == "script":
-            core = self.templates_dir / "scripts" / f"{template_name}{ext}"
-            if core.exists():
-                return core
+            for file_ext in exts:
+                core = self.templates_dir / "scripts" / f"{template_name}{file_ext}"
+                if core.exists():
+                    return core
 
         return None
 

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1694,8 +1694,8 @@ class PresetResolver:
         seen: set[str] = set()
         results: List[Dict[str, str]] = []
 
-        # Determine file extension and subdirectory mapping
-        ext = ".sh" if template_type == "script" else ".md"
+        # Determine file extensions and subdirectory mapping
+        exts = [".sh", ".ps1"] if template_type == "script" else [".md"]
         if template_type == "template":
             subdirs = ["templates", ""]
         elif template_type == "command":
@@ -1723,7 +1723,7 @@ class PresetResolver:
             if not directory.is_dir():
                 return
             for f in sorted(directory.iterdir()):
-                if f.is_file() and f.suffix == ext:
+                if f.is_file() and f.suffix in exts:
                     name = f.stem
                     if name in seen:
                         continue

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -24,7 +24,7 @@ import yaml
 from packaging import version as pkg_version
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
 
-from .extensions import ExtensionRegistry, normalize_priority
+from .extensions import ExtensionRegistry, ExtensionResolver, normalize_priority
 
 
 @dataclass
@@ -1529,48 +1529,7 @@ class PresetResolver:
         self.presets_dir = project_root / ".specify" / "presets"
         self.overrides_dir = self.templates_dir / "overrides"
         self.extensions_dir = project_root / ".specify" / "extensions"
-
-    def _get_all_extensions_by_priority(self) -> list[tuple[int, str, dict | None]]:
-        """Build unified list of registered and unregistered extensions sorted by priority.
-
-        Registered extensions use their stored priority; unregistered directories
-        get implicit priority=10. Results are sorted by (priority, ext_id) for
-        deterministic ordering.
-
-        Returns:
-            List of (priority, ext_id, metadata_or_none) tuples sorted by priority.
-        """
-        if not self.extensions_dir.exists():
-            return []
-
-        registry = ExtensionRegistry(self.extensions_dir)
-        # Use keys() to track ALL extensions (including corrupted entries) without deep copy
-        # This prevents corrupted entries from being picked up as "unregistered" dirs
-        registered_extension_ids = registry.keys()
-
-        # Get all registered extensions including disabled; we filter disabled manually below
-        all_registered = registry.list_by_priority(include_disabled=True)
-
-        all_extensions: list[tuple[int, str, dict | None]] = []
-
-        # Only include enabled extensions in the result
-        for ext_id, metadata in all_registered:
-            # Skip disabled extensions
-            if not metadata.get("enabled", True):
-                continue
-            priority = normalize_priority(metadata.get("priority") if metadata else None)
-            all_extensions.append((priority, ext_id, metadata))
-
-        # Add unregistered directories with implicit priority=10
-        for ext_dir in self.extensions_dir.iterdir():
-            if not ext_dir.is_dir() or ext_dir.name.startswith("."):
-                continue
-            if ext_dir.name not in registered_extension_ids:
-                all_extensions.append((10, ext_dir.name, None))
-
-        # Sort by (priority, ext_id) for deterministic ordering
-        all_extensions.sort(key=lambda x: (x[0], x[1]))
-        return all_extensions
+        self._ext_resolver = ExtensionResolver(project_root)
 
     def resolve(
         self,
@@ -1624,18 +1583,10 @@ class PresetResolver:
                     if candidate.exists():
                         return candidate
 
-        # Priority 3: Extension-provided templates (sorted by priority — lower number wins)
-        for _priority, ext_id, _metadata in self._get_all_extensions_by_priority():
-            ext_dir = self.extensions_dir / ext_id
-            if not ext_dir.is_dir():
-                continue
-            for subdir in subdirs:
-                if subdir:
-                    candidate = ext_dir / subdir / f"{template_name}{ext}"
-                else:
-                    candidate = ext_dir / f"{template_name}{ext}"
-                if candidate.exists():
-                    return candidate
+        # Priority 3: Extension-provided templates (delegated to ExtensionResolver)
+        ext_result = self._ext_resolver.resolve(template_name, template_type)
+        if ext_result is not None:
+            return ext_result
 
         # Priority 4: Core templates
         if template_type == "template":
@@ -1693,7 +1644,7 @@ class PresetResolver:
                 except ValueError:
                     continue
 
-        for _priority, ext_id, ext_meta in self._get_all_extensions_by_priority():
+        for _priority, ext_id, ext_meta in self._ext_resolver.get_all_by_priority():
             ext_dir = self.extensions_dir / ext_id
             if not ext_dir.is_dir():
                 continue
@@ -1779,21 +1730,11 @@ class PresetResolver:
                     else:
                         _collect(pack_dir, source_label)
 
-        # Priority 3: Extension-provided templates (sorted by priority)
-        for _priority, ext_id, ext_meta in self._get_all_extensions_by_priority():
-            ext_dir = self.extensions_dir / ext_id
-            if not ext_dir.is_dir():
-                continue
-            if ext_meta:
-                version = ext_meta.get("version", "?")
-                source_label = f"extension:{ext_id} v{version}"
-            else:
-                source_label = f"extension:{ext_id} (unregistered)"
-            for subdir in subdirs:
-                if subdir:
-                    _collect(ext_dir / subdir, source_label)
-                else:
-                    _collect(ext_dir, source_label)
+        # Priority 3: Extension-provided templates (delegated to ExtensionResolver)
+        for entry in self._ext_resolver.list_templates(template_type):
+            if entry["name"] not in seen:
+                seen.add(entry["name"])
+                results.append(entry)
 
         # Priority 4: Core templates
         if template_type == "template":

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1714,3 +1714,94 @@ class PresetResolver:
                 continue
 
         return {"path": resolved_str, "source": "core"}
+
+    def list_available(
+        self,
+        template_type: str = "template",
+    ) -> List[Dict[str, str]]:
+        """List all available templates of a given type with source attribution.
+
+        Walks the full priority stack and collects all discoverable templates.
+        For templates that exist in multiple sources, only the winning (highest
+        priority) source is included.
+
+        Args:
+            template_type: Template type ("template", "command", or "script")
+
+        Returns:
+            List of dicts with 'name', 'path', and 'source' keys, sorted by name.
+        """
+        seen: set[str] = set()
+        results: List[Dict[str, str]] = []
+
+        # Determine file extension and subdirectory mapping
+        ext = ".sh" if template_type == "script" else ".md"
+        if template_type == "template":
+            subdirs = ["templates", ""]
+        elif template_type == "command":
+            subdirs = ["commands"]
+        elif template_type == "script":
+            subdirs = ["scripts"]
+        else:
+            subdirs = [""]
+
+        def _collect(directory: Path, source: str):
+            """Collect template files from a directory."""
+            if not directory.is_dir():
+                return
+            for f in sorted(directory.iterdir()):
+                if f.is_file() and f.suffix == ext:
+                    name = f.stem
+                    if name not in seen:
+                        seen.add(name)
+                        results.append({
+                            "name": name,
+                            "path": str(f),
+                            "source": source,
+                        })
+
+        # Priority 1: Project-local overrides
+        if template_type == "script":
+            _collect(self.overrides_dir / "scripts", "project override")
+        else:
+            _collect(self.overrides_dir, "project override")
+
+        # Priority 2: Installed presets (sorted by priority)
+        if self.presets_dir.exists():
+            registry = PresetRegistry(self.presets_dir)
+            for pack_id, metadata in registry.list_by_priority():
+                pack_dir = self.presets_dir / pack_id
+                version = metadata.get("version", "?") if metadata else "?"
+                source_label = f"{pack_id} v{version}"
+                for subdir in subdirs:
+                    if subdir:
+                        _collect(pack_dir / subdir, source_label)
+                    else:
+                        _collect(pack_dir, source_label)
+
+        # Priority 3: Extension-provided templates (sorted by priority)
+        for _priority, ext_id, ext_meta in self._get_all_extensions_by_priority():
+            ext_dir = self.extensions_dir / ext_id
+            if not ext_dir.is_dir():
+                continue
+            if ext_meta:
+                version = ext_meta.get("version", "?")
+                source_label = f"extension:{ext_id} v{version}"
+            else:
+                source_label = f"extension:{ext_id} (unregistered)"
+            for subdir in subdirs:
+                if subdir:
+                    _collect(ext_dir / subdir, source_label)
+                else:
+                    _collect(ext_dir, source_label)
+
+        # Priority 4: Core templates
+        if template_type == "template":
+            _collect(self.templates_dir, "core")
+        elif template_type == "command":
+            _collect(self.templates_dir / "commands", "core")
+        elif template_type == "script":
+            _collect(self.templates_dir / "scripts", "core")
+
+        results.sort(key=lambda x: x["name"])
+        return results

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -240,8 +240,8 @@ class TestExtensionManifest:
         with pytest.raises(ValidationError, match="Invalid command name"):
             ExtensionManifest(manifest_path)
 
-    def test_no_commands(self, temp_dir, valid_manifest_data):
-        """Test manifest with no commands provided."""
+    def test_no_commands_or_scripts(self, temp_dir, valid_manifest_data):
+        """Test manifest with no commands or scripts provided."""
         import yaml
 
         valid_manifest_data["provides"]["commands"] = []
@@ -250,7 +250,7 @@ class TestExtensionManifest:
         with open(manifest_path, 'w') as f:
             yaml.dump(valid_manifest_data, f)
 
-        with pytest.raises(ValidationError, match="must provide at least one command"):
+        with pytest.raises(ValidationError, match="must provide at least one command or script"):
             ExtensionManifest(manifest_path)
 
     def test_manifest_hash(self, extension_dir):
@@ -3231,3 +3231,278 @@ class TestExtensionPriorityBackwardsCompatibility:
         assert result[0][0] == "ext-with-priority"
         assert result[1][0] == "legacy-ext"
         assert result[2][0] == "ext-low-priority"
+
+
+# ===== Scripts Support Tests (#1847) =====
+
+class TestScriptsSupport:
+    """Test extension scripts support (parity with presets)."""
+
+    def test_manifest_with_scripts_only(self, temp_dir):
+        """Extension with scripts but no commands is valid."""
+        import yaml
+
+        manifest_data = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "scripts-only",
+                "name": "Scripts Only Extension",
+                "version": "1.0.0",
+                "description": "An extension with only scripts",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "scripts": [
+                    {
+                        "name": "setup",
+                        "file": "scripts/setup.sh",
+                        "description": "Setup script",
+                    }
+                ]
+            },
+        }
+
+        manifest_path = temp_dir / "extension.yml"
+        with open(manifest_path, "w") as f:
+            yaml.dump(manifest_data, f)
+
+        manifest = ExtensionManifest(manifest_path)
+        assert len(manifest.scripts) == 1
+        assert manifest.scripts[0]["name"] == "setup"
+        assert len(manifest.commands) == 0
+
+    def test_manifest_with_commands_and_scripts(self, temp_dir, valid_manifest_data):
+        """Extension with both commands and scripts is valid."""
+        import yaml
+
+        valid_manifest_data["provides"]["scripts"] = [
+            {"name": "deploy", "file": "scripts/deploy.sh", "description": "Deploy"}
+        ]
+
+        manifest_path = temp_dir / "extension.yml"
+        with open(manifest_path, "w") as f:
+            yaml.dump(valid_manifest_data, f)
+
+        manifest = ExtensionManifest(manifest_path)
+        assert len(manifest.commands) == 1
+        assert len(manifest.scripts) == 1
+
+    def test_manifest_script_name_validation(self, temp_dir):
+        """Invalid script names are rejected."""
+        import yaml
+
+        manifest_data = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "bad-scripts",
+                "name": "Bad Scripts",
+                "version": "1.0.0",
+                "description": "Extension with bad script name",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "scripts": [
+                    {"name": "Invalid_Name", "file": "scripts/bad.sh"}
+                ]
+            },
+        }
+
+        manifest_path = temp_dir / "extension.yml"
+        with open(manifest_path, "w") as f:
+            yaml.dump(manifest_data, f)
+
+        with pytest.raises(ValidationError, match="Invalid script name"):
+            ExtensionManifest(manifest_path)
+
+    def test_manifest_script_path_traversal(self, temp_dir):
+        """Script with path traversal is rejected."""
+        import yaml
+
+        manifest_data = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "bad-path",
+                "name": "Bad Path",
+                "version": "1.0.0",
+                "description": "Extension with path traversal",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "scripts": [
+                    {"name": "evil", "file": "../../etc/passwd"}
+                ]
+            },
+        }
+
+        manifest_path = temp_dir / "extension.yml"
+        with open(manifest_path, "w") as f:
+            yaml.dump(manifest_data, f)
+
+        with pytest.raises(ValidationError, match="Invalid script file path"):
+            ExtensionManifest(manifest_path)
+
+    def test_manifest_script_missing_name(self, temp_dir):
+        """Script missing name field is rejected."""
+        import yaml
+
+        manifest_data = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "no-name",
+                "name": "No Name",
+                "version": "1.0.0",
+                "description": "Missing script name",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "scripts": [{"file": "scripts/setup.sh"}]
+            },
+        }
+
+        manifest_path = temp_dir / "extension.yml"
+        with open(manifest_path, "w") as f:
+            yaml.dump(manifest_data, f)
+
+        with pytest.raises(ValidationError, match="Script missing 'name' or 'file'"):
+            ExtensionManifest(manifest_path)
+
+    def test_scripts_property_default(self, extension_dir):
+        """Scripts property returns empty list when no scripts defined."""
+        manifest = ExtensionManifest(extension_dir / "extension.yml")
+        assert manifest.scripts == []
+
+    def test_list_installed_includes_script_count(self, temp_dir):
+        """list_installed output includes script_count."""
+        import yaml
+
+        project_dir = temp_dir / "project"
+        project_dir.mkdir()
+        specify_dir = project_dir / ".specify"
+        specify_dir.mkdir()
+        extensions_dir = specify_dir / "extensions"
+        extensions_dir.mkdir()
+
+        # Create extension with scripts
+        ext_dir = extensions_dir / "scripted-ext"
+        ext_dir.mkdir()
+        scripts_dir = ext_dir / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "setup.sh").write_text("#!/bin/bash\necho setup")
+
+        manifest_data = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "scripted-ext",
+                "name": "Scripted",
+                "version": "1.0.0",
+                "description": "Has scripts",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "scripts": [
+                    {"name": "setup", "file": "scripts/setup.sh"}
+                ]
+            },
+        }
+        with open(ext_dir / "extension.yml", "w") as f:
+            yaml.dump(manifest_data, f)
+
+        registry = ExtensionRegistry(extensions_dir)
+        registry.add("scripted-ext", {"version": "1.0.0", "enabled": True})
+
+        manager = ExtensionManager(project_dir)
+        installed = manager.list_installed()
+
+        assert len(installed) == 1
+        assert installed[0]["script_count"] == 1
+        assert installed[0]["command_count"] == 0
+
+
+# ===== Command Filtering Tests (#1848) =====
+
+class TestCommandFiltering:
+    """Test extension-specific command filtering in CommandRegistrar."""
+
+    def test_extension_command_skipped_when_target_missing(self, temp_dir):
+        """Commands targeting non-installed extensions are filtered out."""
+        project_root = temp_dir / "project"
+        project_root.mkdir()
+        specify_dir = project_root / ".specify"
+        specify_dir.mkdir()
+        extensions_dir = specify_dir / "extensions"
+        extensions_dir.mkdir()
+
+        commands = [
+            {"name": "speckit.other-ext.cmd", "file": "commands/cmd.md"},
+        ]
+
+        filtered = CommandRegistrar._filter_commands_for_installed_extensions(
+            commands, project_root
+        )
+        assert filtered == []
+
+    def test_extension_command_kept_when_target_installed(self, temp_dir):
+        """Commands targeting installed extensions pass the filter."""
+        project_root = temp_dir / "project"
+        project_root.mkdir()
+        specify_dir = project_root / ".specify"
+        specify_dir.mkdir()
+        extensions_dir = specify_dir / "extensions"
+        extensions_dir.mkdir()
+        # Create the target extension directory
+        (extensions_dir / "other-ext").mkdir()
+
+        commands = [
+            {"name": "speckit.other-ext.cmd", "file": "commands/cmd.md"},
+        ]
+
+        filtered = CommandRegistrar._filter_commands_for_installed_extensions(
+            commands, project_root
+        )
+        assert len(filtered) == 1
+        assert filtered[0]["name"] == "speckit.other-ext.cmd"
+
+    def test_core_commands_always_kept(self, temp_dir):
+        """Core commands (2-part names) are never filtered out."""
+        project_root = temp_dir / "project"
+        project_root.mkdir()
+        specify_dir = project_root / ".specify"
+        specify_dir.mkdir()
+        extensions_dir = specify_dir / "extensions"
+        extensions_dir.mkdir()
+
+        commands = [
+            {"name": "speckit.specify", "file": "commands/specify.md"},
+            {"name": "speckit.tasks", "file": "commands/tasks.md"},
+        ]
+
+        filtered = CommandRegistrar._filter_commands_for_installed_extensions(
+            commands, project_root
+        )
+        assert len(filtered) == 2
+
+    def test_mixed_commands_filtered_correctly(self, temp_dir):
+        """Mix of core and extension commands is filtered correctly."""
+        project_root = temp_dir / "project"
+        project_root.mkdir()
+        specify_dir = project_root / ".specify"
+        specify_dir.mkdir()
+        extensions_dir = specify_dir / "extensions"
+        extensions_dir.mkdir()
+        # Only ext-a is installed
+        (extensions_dir / "ext-a").mkdir()
+
+        commands = [
+            {"name": "speckit.specify", "file": "commands/specify.md"},
+            {"name": "speckit.ext-a.run", "file": "commands/run.md"},
+            {"name": "speckit.ext-b.deploy", "file": "commands/deploy.md"},
+        ]
+
+        filtered = CommandRegistrar._filter_commands_for_installed_extensions(
+            commands, project_root
+        )
+        assert len(filtered) == 2
+        names = [c["name"] for c in filtered]
+        assert "speckit.specify" in names
+        assert "speckit.ext-a.run" in names
+        assert "speckit.ext-b.deploy" not in names

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -21,6 +21,7 @@ from specify_cli.extensions import (
     ExtensionManifest,
     ExtensionRegistry,
     ExtensionManager,
+    ExtensionResolver,
     CommandRegistrar,
     ExtensionCatalog,
     ExtensionError,
@@ -3506,3 +3507,150 @@ class TestCommandFiltering:
         assert "speckit.specify" in names
         assert "speckit.ext-a.run" in names
         assert "speckit.ext-b.deploy" not in names
+
+
+# ===== ExtensionResolver Tests (#1846) =====
+
+class TestExtensionResolver:
+    """Test ExtensionResolver template resolution and discovery."""
+
+    def test_resolve_extension_template(self, temp_dir):
+        """Resolves a template from an installed extension."""
+        project_dir = temp_dir / "project"
+        specify_dir = project_dir / ".specify"
+        ext_dir = specify_dir / "extensions" / "my-ext" / "templates"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "custom.md").write_text("# Custom")
+
+        registry = ExtensionRegistry(specify_dir / "extensions")
+        registry.add("my-ext", {"version": "1.0.0", "enabled": True, "priority": 5})
+
+        resolver = ExtensionResolver(project_dir)
+        result = resolver.resolve("custom", "template")
+
+        assert result is not None
+        assert result.name == "custom.md"
+
+    def test_resolve_returns_none_when_not_found(self, temp_dir):
+        """Returns None when no extension has the template."""
+        project_dir = temp_dir / "project"
+        (project_dir / ".specify" / "extensions").mkdir(parents=True)
+
+        resolver = ExtensionResolver(project_dir)
+        assert resolver.resolve("nonexistent") is None
+
+    def test_resolve_with_source_attribution(self, temp_dir):
+        """resolve_with_source returns correct source label."""
+        project_dir = temp_dir / "project"
+        ext_dir = project_dir / ".specify" / "extensions" / "docguard" / "commands"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "speckit.docguard.check.md").write_text("# Check")
+
+        registry = ExtensionRegistry(project_dir / ".specify" / "extensions")
+        registry.add("docguard", {"version": "2.1.0", "enabled": True})
+
+        resolver = ExtensionResolver(project_dir)
+        result = resolver.resolve_with_source("speckit.docguard.check", "command")
+
+        assert result is not None
+        assert result["source"] == "extension:docguard v2.1.0"
+
+    def test_resolve_with_source_unregistered(self, temp_dir):
+        """Unregistered extension directories get '(unregistered)' label."""
+        project_dir = temp_dir / "project"
+        ext_dir = project_dir / ".specify" / "extensions" / "loose-ext" / "templates"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "loose.md").write_text("# Loose")
+
+        # Don't register — just have the directory
+        resolver = ExtensionResolver(project_dir)
+        result = resolver.resolve_with_source("loose", "template")
+
+        assert result is not None
+        assert "unregistered" in result["source"]
+
+    def test_list_templates_from_extensions(self, temp_dir):
+        """list_templates discovers templates across extensions."""
+        project_dir = temp_dir / "project"
+        extensions_dir = project_dir / ".specify" / "extensions"
+
+        # Extension A (priority 1)
+        (extensions_dir / "ext-a" / "commands").mkdir(parents=True)
+        (extensions_dir / "ext-a" / "commands" / "speckit.ext-a.run.md").write_text("# Run")
+
+        # Extension B (priority 5)
+        (extensions_dir / "ext-b" / "commands").mkdir(parents=True)
+        (extensions_dir / "ext-b" / "commands" / "speckit.ext-b.deploy.md").write_text("# Deploy")
+
+        registry = ExtensionRegistry(extensions_dir)
+        registry.add("ext-a", {"version": "1.0.0", "enabled": True, "priority": 1})
+        registry.add("ext-b", {"version": "2.0.0", "enabled": True, "priority": 5})
+
+        resolver = ExtensionResolver(project_dir)
+        results = resolver.list_templates("command")
+
+        assert len(results) == 2
+        names = [r["name"] for r in results]
+        assert "speckit.ext-a.run" in names
+        assert "speckit.ext-b.deploy" in names
+
+    def test_list_templates_priority_deduplication(self, temp_dir):
+        """Higher-priority extension wins when same template name exists."""
+        project_dir = temp_dir / "project"
+        extensions_dir = project_dir / ".specify" / "extensions"
+
+        # Both extensions provide "shared.md"
+        (extensions_dir / "ext-high" / "templates").mkdir(parents=True)
+        (extensions_dir / "ext-high" / "templates" / "shared.md").write_text("# High")
+        (extensions_dir / "ext-low" / "templates").mkdir(parents=True)
+        (extensions_dir / "ext-low" / "templates" / "shared.md").write_text("# Low")
+
+        registry = ExtensionRegistry(extensions_dir)
+        registry.add("ext-high", {"version": "1.0.0", "enabled": True, "priority": 1})
+        registry.add("ext-low", {"version": "1.0.0", "enabled": True, "priority": 10})
+
+        resolver = ExtensionResolver(project_dir)
+        results = resolver.list_templates("template")
+
+        shared = [r for r in results if r["name"] == "shared"]
+        assert len(shared) == 1
+        assert "ext-high" in shared[0]["source"]
+
+    def test_list_templates_empty(self, temp_dir):
+        """Returns empty list when no extensions directory exists."""
+        project_dir = temp_dir / "project"
+        (project_dir / ".specify").mkdir(parents=True)
+
+        resolver = ExtensionResolver(project_dir)
+        assert resolver.list_templates("template") == []
+
+    def test_disabled_extension_excluded(self, temp_dir):
+        """Disabled extensions are not resolved."""
+        project_dir = temp_dir / "project"
+        ext_dir = project_dir / ".specify" / "extensions" / "disabled-ext" / "templates"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "hidden.md").write_text("# Hidden")
+
+        registry = ExtensionRegistry(project_dir / ".specify" / "extensions")
+        registry.add("disabled-ext", {"version": "1.0.0", "enabled": False})
+
+        resolver = ExtensionResolver(project_dir)
+        assert resolver.resolve("hidden", "template") is None
+        assert resolver.list_templates("template") == []
+
+    def test_list_scripts(self, temp_dir):
+        """list_templates discovers script files from extensions."""
+        project_dir = temp_dir / "project"
+        ext_dir = project_dir / ".specify" / "extensions" / "script-ext" / "scripts"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "deploy.sh").write_text("#!/bin/bash")
+
+        registry = ExtensionRegistry(project_dir / ".specify" / "extensions")
+        registry.add("script-ext", {"version": "1.0.0", "enabled": True})
+
+        resolver = ExtensionResolver(project_dir)
+        results = resolver.list_templates("script")
+
+        assert len(results) == 1
+        assert results[0]["name"] == "deploy"
+        assert "script-ext" in results[0]["source"]

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -2391,3 +2391,134 @@ class TestPresetEnableDisable:
 
         assert result.exit_code == 1
         assert "corrupted state" in result.output.lower()
+
+
+# ===== Template Listing / Discovery Tests (#1846) =====
+
+class TestListAvailable:
+    """Test PresetResolver.list_available template discovery."""
+
+    def test_list_available_core_templates(self, project_dir):
+        """Discovers core templates."""
+        templates_dir = project_dir / ".specify" / "templates"
+        templates_dir.mkdir(parents=True, exist_ok=True)
+        (templates_dir / "spec-template.md").write_text("# Spec")
+        (templates_dir / "other-template.md").write_text("# Other")
+
+        resolver = PresetResolver(project_dir)
+        available = resolver.list_available("template")
+
+        names = [e["name"] for e in available]
+        assert "spec-template" in names
+        assert "other-template" in names
+        assert all(e["source"] == "core" for e in available)
+
+    def test_list_available_core_commands(self, project_dir):
+        """Discovers core commands."""
+        commands_dir = project_dir / ".specify" / "templates" / "commands"
+        commands_dir.mkdir(parents=True, exist_ok=True)
+        (commands_dir / "speckit.specify.md").write_text("# Specify")
+
+        resolver = PresetResolver(project_dir)
+        available = resolver.list_available("command")
+
+        assert len(available) == 1
+        assert available[0]["name"] == "speckit.specify"
+        assert available[0]["source"] == "core"
+
+    def test_list_available_core_scripts(self, project_dir):
+        """Discovers core scripts."""
+        scripts_dir = project_dir / ".specify" / "templates" / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        (scripts_dir / "setup.sh").write_text("#!/bin/bash")
+
+        resolver = PresetResolver(project_dir)
+        available = resolver.list_available("script")
+
+        assert len(available) == 1
+        assert available[0]["name"] == "setup"
+        assert available[0]["source"] == "core"
+
+    def test_list_available_extension_templates(self, project_dir):
+        """Discovers templates from extensions."""
+        ext_dir = project_dir / ".specify" / "extensions" / "my-ext"
+        templates_dir = ext_dir / "templates"
+        templates_dir.mkdir(parents=True)
+        (templates_dir / "ext-template.md").write_text("# Ext")
+
+        # Register in the extension registry
+        extensions_dir = project_dir / ".specify" / "extensions"
+        registry = ExtensionRegistry(extensions_dir)
+        registry.add("my-ext", {"version": "2.0.0", "enabled": True, "priority": 5})
+
+        resolver = PresetResolver(project_dir)
+        available = resolver.list_available("template")
+
+        ext_entries = [e for e in available if e["name"] == "ext-template"]
+        assert len(ext_entries) == 1
+        assert "extension:my-ext" in ext_entries[0]["source"]
+        assert "v2.0.0" in ext_entries[0]["source"]
+
+    def test_list_available_higher_priority_wins(self, project_dir):
+        """When same template name exists in multiple sources, higher priority wins."""
+        # Core template
+        templates_dir = project_dir / ".specify" / "templates"
+        templates_dir.mkdir(parents=True, exist_ok=True)
+        (templates_dir / "shared.md").write_text("# Core version")
+
+        # Extension template with same name (higher priority)
+        ext_dir = project_dir / ".specify" / "extensions" / "override-ext"
+        ext_templates_dir = ext_dir / "templates"
+        ext_templates_dir.mkdir(parents=True)
+        (ext_templates_dir / "shared.md").write_text("# Extension version")
+
+        extensions_dir = project_dir / ".specify" / "extensions"
+        registry = ExtensionRegistry(extensions_dir)
+        registry.add("override-ext", {"version": "1.0.0", "enabled": True, "priority": 5})
+
+        resolver = PresetResolver(project_dir)
+        available = resolver.list_available("template")
+
+        # Only one entry for "shared" — extension wins over core
+        shared_entries = [e for e in available if e["name"] == "shared"]
+        assert len(shared_entries) == 1
+        assert "extension:override-ext" in shared_entries[0]["source"]
+
+    def test_list_available_override_wins_over_all(self, project_dir):
+        """Project overrides take highest priority."""
+        # Core template
+        templates_dir = project_dir / ".specify" / "templates"
+        templates_dir.mkdir(parents=True, exist_ok=True)
+        (templates_dir / "target.md").write_text("# Core")
+
+        # Override
+        overrides_dir = templates_dir / "overrides"
+        overrides_dir.mkdir(parents=True, exist_ok=True)
+        (overrides_dir / "target.md").write_text("# Override")
+
+        resolver = PresetResolver(project_dir)
+        available = resolver.list_available("template")
+
+        target_entries = [e for e in available if e["name"] == "target"]
+        assert len(target_entries) == 1
+        assert target_entries[0]["source"] == "project override"
+
+    def test_list_available_sorted_by_name(self, project_dir):
+        """Results are sorted alphabetically by name."""
+        templates_dir = project_dir / ".specify" / "templates"
+        templates_dir.mkdir(parents=True, exist_ok=True)
+        (templates_dir / "zebra.md").write_text("# Z")
+        (templates_dir / "alpha.md").write_text("# A")
+        (templates_dir / "middle.md").write_text("# M")
+
+        resolver = PresetResolver(project_dir)
+        available = resolver.list_available("template")
+
+        names = [e["name"] for e in available]
+        assert names == sorted(names)
+
+    def test_list_available_empty(self, project_dir):
+        """Returns empty list when no templates of the given type exist."""
+        resolver = PresetResolver(project_dir)
+        available = resolver.list_available("script")
+        assert available == []


### PR DESCRIPTION
## Summary

Brings the extension system to parity with presets across three areas:

- **#1847 — Scripts support**: Extensions now accept `provides.scripts` alongside commands in the manifest. Includes name format validation (`^[a-z0-9-]+$`), path safety checks (no traversal), executable permissions on `.sh` files during install, and CLI display in `extension list`, `extension add`, and `extension info`.

- **#1848 — Command filtering**: Adds `_filter_commands_for_installed_extensions()` to `CommandRegistrar` — filters extension-specific commands (`speckit.<ext-id>.<cmd>`) against installed extension directories. Mirrors the preset filtering logic at `presets.py:518-529`. Available as a utility for cross-boundary filtering (e.g. when presets provide commands for extensions that may not be installed). Not applied during extension self-registration since all commands in an extension's own manifest are always valid.

- **#1846 — Template resolution & discovery**: Introduces `ExtensionResolver` — a dedicated class in `extensions.py` that owns extension template resolution, source attribution, and discovery. `PresetResolver` now delegates its tier-3 (extension) lookups to `ExtensionResolver` instead of walking extension directories directly. New `specify preset list-templates --type <type>` CLI command for template discovery across the full 4-tier stack.

### Why ExtensionResolver instead of using PresetResolver?

The `PresetResolver` already had extension logic baked in (tier 3 of its resolution stack), but this meant extensions had to go through the preset system to discover their own templates — mixing concerns. `ExtensionResolver` gives extensions their own resolution/discovery API:

- `resolve(name, type)` — find a template from extensions
- `resolve_with_source(name, type)` — with source attribution
- `list_templates(type)` — discover all templates provided by extensions

`PresetResolver` remains the unified resolver across all 4 tiers (overrides → presets → extensions → core) but now delegates to `ExtensionResolver` for the extension tier rather than owning that logic directly. Each system owns its own domain.

Closes #1846, closes #1847, closes #1848

## Test plan

- [x] 843 tests pass (1 pre-existing failure in `test_search_with_cached_data` unrelated to this PR)
- [ ] Verify `specify extension add` with a scripts-only extension
- [ ] Verify `specify preset list-templates` outputs templates with correct source attribution
- [ ] Verify command filtering works when a preset provides commands for an uninstalled extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)