### PR TITLE
fix(scripts): honor PowerShell agent and script filters

### DIFF
--- a/.github/workflows/scripts/create-release-packages.ps1
+++ b/.github/workflows/scripts/create-release-packages.ps1
@@ -498,13 +498,13 @@ $AllAgents = @('claude', 'gemini', 'copilot', 'cursor-agent', 'qwen', 'opencode'
 $AllScripts = @('sh', 'ps')
 
 function Normalize-List {
-    param([string]$Input)
+    param([string]$Value)
 
-    if ([string]::IsNullOrEmpty($Input)) {
+    if ([string]::IsNullOrEmpty($Value)) {
         return @()
     }
 
-    $items = $Input -split '[,\s]+' | Where-Object { $_ } | Select-Object -Unique
+    $items = $Value -split '[,\s]+' | Where-Object { $_ } | Select-Object -Unique
     return $items
 }
 
@@ -527,7 +527,7 @@ function Validate-Subset {
 
 # Determine agent list
 if (-not [string]::IsNullOrEmpty($Agents)) {
-    $AgentList = Normalize-List -Input $Agents
+    $AgentList = Normalize-List -Value $Agents
     if (-not (Validate-Subset -Type 'agent' -Allowed $AllAgents -Items $AgentList)) {
         exit 1
     }
@@ -537,7 +537,7 @@ if (-not [string]::IsNullOrEmpty($Agents)) {
 
 # Determine script list
 if (-not [string]::IsNullOrEmpty($Scripts)) {
-    $ScriptList = Normalize-List -Input $Scripts
+    $ScriptList = Normalize-List -Value $Scripts
     if (-not (Validate-Subset -Type 'script' -Allowed $AllScripts -Items $ScriptList)) {
         exit 1
     }


### PR DESCRIPTION
Fixes #1946 

## Description

Fixes a Windows offline scaffolding bug in `create-release-packages.ps1`.

The PowerShell helper `Normalize-List` used `$Input` as its parameter name, which conflicts with PowerShell's automatic `$input` variable. This caused `-Agents` and `-Scripts` filtering to be ignored, so `specify init --offline` could fail with `release script produced no output`.

This change renames the parameter and updates the call sites so the selected agent/script filters are honored correctly.

## Testing

- [x] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

Manual verification:
- Reproduced the failure with `specify init ... --offline --ai opencode --script ps` before the fix
- Verified that offline scaffolding succeeds after the fix

Note:
- I did not mark the full pytest suite as passing in my Windows environment because there are unrelated bash/path/tooling failures, including missing `zip` for the bash release-packaging path and tests that pass Windows absolute paths directly to bash.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

I used OpenCode (GPT-5.4) to help analyze the code, identify the root cause, and draft parts of the fix description (to help me communicate more clearly in English). I manually reproduced the bug, reviewed the relevant script behavior, and verified the final fix locally.