### PR TITLE
fix(ps1): replace null-conditional operator for PowerShell 5.1 compatibility

### DIFF
--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -8,7 +8,8 @@ function Find-SpecifyRoot {
 
     # Normalize to absolute path to prevent issues with relative paths
     # Use -LiteralPath to handle paths with wildcard characters ([, ], *, ?)
-    $current = (Resolve-Path -LiteralPath $StartDir -ErrorAction SilentlyContinue)?.Path
+    $resolved = Resolve-Path -LiteralPath $StartDir -ErrorAction SilentlyContinue
+    $current = if ($resolved) { $resolved.Path } else { $null }
     if (-not $current) { return $null }
 
     while ($true) {


### PR DESCRIPTION
## Summary

Replaces the `?.` (null-conditional member access) operator in `scripts/powershell/common.ps1` with a PowerShell 5.1-compatible pattern.

## Problem

The `?.` operator requires PowerShell 7.1+, but Windows ships with PowerShell 5.1 by default. When AI agents (e.g., Cursor) invoke `.ps1` scripts on Windows, they typically use the system-associated handler (Windows PowerShell 5.1), causing:

```
Unexpected token '?.Path' in expression or statement.
```

This breaks **all** spec-kit script execution on Windows for users without PowerShell 7+ installed, since `common.ps1` is sourced by every other script.

## Fix

Single-line change in `scripts/powershell/common.ps1` line 11:

```powershell
# Before (requires PS 7.1+)
$current = (Resolve-Path -LiteralPath $StartDir -ErrorAction SilentlyContinue)?.Path

# After (works on PS 5.1+)
$resolved = Resolve-Path -LiteralPath $StartDir -ErrorAction SilentlyContinue
$current = if ($resolved) { $resolved.Path } else { $null }
```

The replacement preserves identical null-safety behavior.

## Audit

Performed a comprehensive scan of all 6 `.ps1` files for PowerShell 7+ syntax features (`?.`, `??`, `??=`, `&&`/`||` pipeline chains, ternary operators, `-Parallel`, 7.0+ cmdlets). This was the **only** instance. The CI script (`create-release-packages.ps1`) intentionally requires 7.0 via `#requires` but only runs in GitHub Actions.

Fixes #1972