### PR TITLE
Add plan-review extension to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The following community-contributed extensions are available in [`catalog.commun
 | Extensify | Create and validate extensions and extension catalogs | `process` | Read+Write | [extensify](https://github.com/mnriem/spec-kit-extensions/tree/main/extensify) |
 | Fleet Orchestrator | Orchestrate a full feature lifecycle with human-in-the-loop gates across all SpecKit phases | `process` | Read+Write | [spec-kit-fleet](https://github.com/sharathsatish/spec-kit-fleet) |
 | Iterate | Iterate on spec documents with a two-phase define-and-apply workflow — refine specs mid-implementation and go straight back to building | `docs` | Read+Write | [spec-kit-iterate](https://github.com/imviancagrace/spec-kit-iterate) |
+| Plan Review Gate | Require spec.md and plan.md to be merged via MR/PR before allowing task generation | `process` | Read-only | [spec-kit-plan-review](https://github.com/luno/spec-kit-plan-review) |
 | Jira Integration | Create Jira Epics, Stories, and Issues from spec-kit specifications and task breakdowns with configurable hierarchy and custom field support | `integration` | Read+Write | [spec-kit-jira](https://github.com/mbachorik/spec-kit-jira) |
 | Learning Extension | Generate educational guides from implementations and enhance clarifications with mentoring context | `docs` | Read+Write | [spec-kit-learn](https://github.com/imviancagrace/spec-kit-learn) |
 | Presetify | Create and validate presets and preset catalogs | `process` | Read+Write | [presetify](https://github.com/mnriem/spec-kit-extensions/tree/main/presetify) |

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-03-19T12:08:20Z",
+  "updated_at": "2026-03-26T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -405,6 +405,36 @@
       "stars": 0,
       "created_at": "2026-03-17T00:00:00Z",
       "updated_at": "2026-03-17T00:00:00Z"
+    },
+    "plan-review": {
+      "name": "Plan Review Gate",
+      "id": "plan-review",
+      "description": "Require spec.md and plan.md to be merged via MR/PR before allowing task generation",
+      "author": "luno",
+      "version": "2.0.0",
+      "download_url": "https://github.com/luno/spec-kit-plan-review/archive/refs/tags/v2.0.0.zip",
+      "repository": "https://github.com/luno/spec-kit-plan-review",
+      "homepage": "https://github.com/luno/spec-kit-plan-review",
+      "documentation": "https://github.com/luno/spec-kit-plan-review/blob/main/README.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.1.0"
+      },
+      "provides": {
+        "commands": 1,
+        "hooks": 1
+      },
+      "tags": [
+        "review",
+        "quality",
+        "workflow",
+        "gate"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-03-26T00:00:00Z",
+      "updated_at": "2026-03-26T00:00:00Z"
     },
     "jira": {
       "name": "Jira Integration",


### PR DESCRIPTION
## Extension Submission

**Extension Name**: Plan Review Gate
**Extension ID**: plan-review
**Version**: 2.0.0
**Author**: luno
**Repository**: https://github.com/luno/spec-kit-plan-review

### Description

Mandatory `before_tasks` gate that blocks `/speckit.tasks` unless `spec.md` and `plan.md` have been merged to the default branch via MR/PR. Ensures implementation plans are reviewed before task generation begins.

Users can bypass with `--skip-review` if needed.

### Checklist
- [x] Valid extension.yml manifest
- [x] README.md with installation and usage docs
- [x] LICENSE file included
- [x] GitHub release created (v2.0.0)
- [x] All commands working
- [x] No security vulnerabilities
- [x] Added to extensions/catalog.community.json
- [x] Added to Community Extensions table in README.md