### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- insert new changelog below this comment -->
 
+## [0.4.3] - 2026-03-26
+
+### Changed
+
+- Unify Kimi/Codex skill naming and migrate legacy dotted Kimi dirs (#1971)
+- fix(ps1): replace null-conditional operator for PowerShell 5.1 compatibility (#1975)
+- chore: bump version to 0.4.2 (#1973)
+
 ## [0.4.2] - 2026-03-25
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.4.2"
+version = "0.4.3"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Automated version bump to 0.4.3.

This PR was created by the Release Trigger workflow. The git tag `v0.4.3` has already been pushed and the release artifacts are being built.

Merge this PR to record the version bump and changelog update on `main`.