### PR TITLE
fix(init): generate root CLAUDE.md for --ai claude

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -128,6 +128,11 @@ SCRIPT_TYPE_CHOICES = {"sh": "POSIX Shell (bash/zsh)", "ps": "PowerShell"}
 CLAUDE_LOCAL_PATH = Path.home() / ".claude" / "local" / "claude"
 CLAUDE_NPM_LOCAL_PATH = Path.home() / ".claude" / "local" / "node_modules" / ".bin" / "claude"
 
+# Relative path (from project root) to the authoritative constitution file.
+# Shared by init-time scaffolding and integration-specific context-file
+# generation so the two cannot drift.
+CONSTITUTION_REL_PATH = Path(".specify") / "memory" / "constitution.md"
+
 BANNER = """
 ███████╗██████╗ ███████╗ ██████╗██╗███████╗██╗   ██╗
 ██╔════╝██╔══██╗██╔════╝██╔════╝██║██╔════╝╚██╗ ██╔╝
@@ -842,7 +847,7 @@ def ensure_executable_scripts(project_path: Path, tracker: StepTracker | None = 
 
 def ensure_constitution_from_template(project_path: Path, tracker: StepTracker | None = None) -> None:
     """Copy constitution template to memory if it doesn't exist (preserves existing constitution on reinitialization)."""
-    memory_constitution = project_path / ".specify" / "memory" / "constitution.md"
+    memory_constitution = project_path / CONSTITUTION_REL_PATH
     template_constitution = project_path / ".specify" / "templates" / "constitution-template.md"
 
     # If constitution already exists in memory, preserve it
@@ -1280,6 +1285,12 @@ def init(
             tracker.complete("shared-infra", f"scripts ({selected_script}) + templates")
 
             ensure_constitution_from_template(project_path, tracker=tracker)
+
+            # Post-constitution hook: let the integration create its root
+            # context file (e.g. CLAUDE.md) now that the constitution exists.
+            context_file = resolved_integration.ensure_context_file(project_path, manifest)
+            if context_file is not None:
+                manifest.save()
 
             if not no_git:
                 tracker.start("git")

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -208,6 +208,23 @@ class IntegrationBase(ABC):
             "stderr": result.stderr,
         }
 
+    def ensure_context_file(
+        self,
+        project_root: Path,
+        manifest: "IntegrationManifest",
+    ) -> Path | None:
+        """Post-constitution-setup hook: create the agent's root context file.
+
+        Called from ``init()`` after ``ensure_constitution_from_template``
+        has run. Integrations that depend on the constitution should still
+        verify that it exists before using it, since the setup step may
+        complete without creating the file. Default: no-op. Integrations
+        that need a root file (e.g. ``CLAUDE.md``) should override this.
+        Returns the created path (to be recorded in the manifest) or
+        ``None``.
+        """
+        return None
+
     # -- Primitives — building blocks for setup() -------------------------
 
     def shared_commands_dir(self) -> Path | None:

--- a/src/specify_cli/integrations/claude/__init__.py
+++ b/src/specify_cli/integrations/claude/__init__.py
@@ -219,19 +219,26 @@ class ClaudeIntegration(SkillsIntegration):
             return None
 
         constitution_rel = CONSTITUTION_REL_PATH.as_posix()
+        inv = self.build_command_invocation
+        command_lines = [
+            (inv("constitution"), "establish or amend project principles"),
+            (inv("specify"), "generate spec"),
+            (inv("clarify"), f"ask structured de-risking questions (before `{inv('plan')}`)"),
+            (inv("plan"), "generate plan"),
+            (inv("tasks"), "generate task list"),
+            (inv("analyze"), f"cross-artifact consistency report (after `{inv('tasks')}`)"),
+            (inv("checklist"), "generate quality checklists"),
+            (inv("implement"), "execute plan"),
+        ]
+        commands_section = "".join(
+            f"- `{command}` — {description}\n" for command, description in command_lines
+        )
         content = (
             "## Claude's Role\n"
             f"Read `{constitution_rel}` first. It is the authoritative source of truth for this project. "
             "Everything in it is non-negotiable.\n\n"
             "## SpecKit Commands\n"
-            "- `/speckit.constitution` — establish or amend project principles\n"
-            "- `/speckit.specify` — generate spec\n"
-            "- `/speckit.clarify` — ask structured de-risking questions (before `/speckit.plan`)\n"
-            "- `/speckit.plan` — generate plan\n"
-            "- `/speckit.tasks` — generate task list\n"
-            "- `/speckit.analyze` — cross-artifact consistency report (after `/speckit.tasks`)\n"
-            "- `/speckit.checklist` — generate quality checklists\n"
-            "- `/speckit.implement` — execute plan\n\n"
+            f"{commands_section}\n"
             "## On Ambiguity\n"
             "If a spec is missing, incomplete, or conflicts with the constitution — stop and ask. "
             "Do not infer. Do not proceed.\n\n"

--- a/src/specify_cli/integrations/claude/__init__.py
+++ b/src/specify_cli/integrations/claude/__init__.py
@@ -195,6 +195,49 @@ class ClaudeIntegration(SkillsIntegration):
         updated = self._inject_hook_command_note(updated)
         return updated
 
+    def ensure_context_file(
+        self,
+        project_root: Path,
+        manifest: IntegrationManifest,
+    ) -> Path | None:
+        """Create a minimal root ``CLAUDE.md`` if missing.
+
+        Typically called from ``init()`` after
+        ``ensure_constitution_from_template``. This file acts as a bridge
+        to the constitution at ``CONSTITUTION_REL_PATH`` and is only
+        created if that constitution file exists. Returns the created
+        path or ``None`` (existing file, or prerequisites not met).
+        """
+        from specify_cli import CONSTITUTION_REL_PATH
+
+        if self.context_file is None:
+            return None
+
+        constitution = project_root / CONSTITUTION_REL_PATH
+        context_file = project_root / self.context_file
+        if context_file.exists() or not constitution.exists():
+            return None
+
+        constitution_rel = CONSTITUTION_REL_PATH.as_posix()
+        content = (
+            "## Claude's Role\n"
+            f"Read `{constitution_rel}` first. It is the authoritative source of truth for this project. "
+            "Everything in it is non-negotiable.\n\n"
+            "## SpecKit Commands\n"
+            "- `/speckit.constitution` — establish or amend project principles\n"
+            "- `/speckit.specify` — generate spec\n"
+            "- `/speckit.clarify` — ask structured de-risking questions (before `/speckit.plan`)\n"
+            "- `/speckit.plan` — generate plan\n"
+            "- `/speckit.tasks` — generate task list\n"
+            "- `/speckit.analyze` — cross-artifact consistency report (after `/speckit.tasks`)\n"
+            "- `/speckit.checklist` — generate quality checklists\n"
+            "- `/speckit.implement` — execute plan\n\n"
+            "## On Ambiguity\n"
+            "If a spec is missing, incomplete, or conflicts with the constitution — stop and ask. "
+            "Do not infer. Do not proceed.\n\n"
+        )
+        return self.write_file_and_record(content, context_file, project_root, manifest)
+
     def setup(
         self,
         project_root: Path,

--- a/tests/integrations/test_integration_claude.py
+++ b/tests/integrations/test_integration_claude.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import yaml
 
+from specify_cli import CONSTITUTION_REL_PATH
 from specify_cli.integrations import INTEGRATION_REGISTRY, get_integration
 from specify_cli.integrations.base import IntegrationBase
 from specify_cli.integrations.claude import ARGUMENT_HINTS
@@ -284,6 +285,115 @@ class TestClaudeIntegration:
 
         metadata = manager.registry.get("claude-skill-command")
         assert "speckit-research" in metadata.get("registered_skills", [])
+
+
+EXPECTED_CLAUDE_MD_COMMANDS = (
+    "/speckit.constitution",
+    "/speckit.specify",
+    "/speckit.clarify",
+    "/speckit.plan",
+    "/speckit.tasks",
+    "/speckit.analyze",
+    "/speckit.checklist",
+    "/speckit.implement",
+)
+EXPECTED_CLAUDE_MD_SECTIONS = (
+    "## Claude's Role",
+    "## SpecKit Commands",
+    "## On Ambiguity",
+)
+
+
+class TestClaudeMdCreation:
+    """Verify that CLAUDE.md is created after the constitution is in place."""
+
+    def test_ensure_context_file_creates_claude_md_when_constitution_exists(self, tmp_path):
+        integration = get_integration("claude")
+        constitution = tmp_path / CONSTITUTION_REL_PATH
+        constitution.parent.mkdir(parents=True, exist_ok=True)
+        constitution.write_text("# Constitution\n", encoding="utf-8")
+
+        manifest = IntegrationManifest("claude", tmp_path)
+        created = integration.ensure_context_file(tmp_path, manifest)
+
+        claude_md = tmp_path / "CLAUDE.md"
+        assert claude_md.exists()
+        assert created == claude_md
+        content = claude_md.read_text(encoding="utf-8")
+        assert CONSTITUTION_REL_PATH.as_posix() in content
+        for section in EXPECTED_CLAUDE_MD_SECTIONS:
+            assert section in content, f"missing section header: {section}"
+        for command in EXPECTED_CLAUDE_MD_COMMANDS:
+            assert f"`{command}`" in content, f"missing command: {command}"
+
+    def test_ensure_context_file_skips_when_constitution_missing(self, tmp_path):
+        integration = get_integration("claude")
+        manifest = IntegrationManifest("claude", tmp_path)
+        result = integration.ensure_context_file(tmp_path, manifest)
+
+        assert result is None
+        assert not (tmp_path / "CLAUDE.md").exists()
+
+    def test_ensure_context_file_preserves_existing_claude_md(self, tmp_path):
+        integration = get_integration("claude")
+        constitution = tmp_path / CONSTITUTION_REL_PATH
+        constitution.parent.mkdir(parents=True, exist_ok=True)
+        constitution.write_text("# Constitution\n", encoding="utf-8")
+
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("# Custom content\n", encoding="utf-8")
+
+        manifest = IntegrationManifest("claude", tmp_path)
+        result = integration.ensure_context_file(tmp_path, manifest)
+
+        assert result is None
+        assert claude_md.read_text(encoding="utf-8") == "# Custom content\n"
+
+    def test_setup_does_not_create_claude_md_without_constitution(self, tmp_path):
+        """``setup()`` alone must not create CLAUDE.md — that's the context-file hook's job,
+        and it only runs after the constitution exists."""
+        integration = get_integration("claude")
+        manifest = IntegrationManifest("claude", tmp_path)
+        integration.setup(tmp_path, manifest, script_type="sh")
+        assert not (tmp_path / "CLAUDE.md").exists()
+
+    def test_init_cli_creates_claude_md_on_fresh_project(self, tmp_path):
+        """End-to-end: a fresh ``specify init --ai claude`` must produce
+        BOTH the constitution AND CLAUDE.md, proving the init-flow ordering
+        is correct (context file created after constitution)."""
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        project = tmp_path / "claude-md-test"
+        project.mkdir()
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(project)
+            runner = CliRunner()
+            result = runner.invoke(
+                app,
+                ["init", "--here", "--ai", "claude", "--script", "sh", "--no-git", "--ignore-agent-tools"],
+                catch_exceptions=False,
+            )
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0, result.output
+
+        # Constitution must have been created by the init flow (not pre-seeded)
+        constitution = project / CONSTITUTION_REL_PATH
+        assert constitution.exists(), "init did not create the constitution"
+
+        # CLAUDE.md must exist and point at the constitution
+        claude_md = project / "CLAUDE.md"
+        assert claude_md.exists(), "init did not create CLAUDE.md"
+        content = claude_md.read_text(encoding="utf-8")
+        assert CONSTITUTION_REL_PATH.as_posix() in content
+        for section in EXPECTED_CLAUDE_MD_SECTIONS:
+            assert section in content, f"missing section header: {section}"
+        for command in EXPECTED_CLAUDE_MD_COMMANDS:
+            assert f"`{command}`" in content, f"missing command: {command}"
 
 
 class TestClaudeArgumentHints:

--- a/tests/integrations/test_integration_claude.py
+++ b/tests/integrations/test_integration_claude.py
@@ -287,15 +287,13 @@ class TestClaudeIntegration:
         assert "speckit-research" in metadata.get("registered_skills", [])
 
 
-EXPECTED_CLAUDE_MD_COMMANDS = (
-    "/speckit.constitution",
-    "/speckit.specify",
-    "/speckit.clarify",
-    "/speckit.plan",
-    "/speckit.tasks",
-    "/speckit.analyze",
-    "/speckit.checklist",
-    "/speckit.implement",
+_CLAUDE = get_integration("claude")
+EXPECTED_CLAUDE_MD_COMMANDS = tuple(
+    _CLAUDE.build_command_invocation(stem)
+    for stem in (
+        "constitution", "specify", "clarify", "plan",
+        "tasks", "analyze", "checklist", "implement",
+    )
 )
 EXPECTED_CLAUDE_MD_SECTIONS = (
     "## Claude's Role",


### PR DESCRIPTION
Ensure `specify init --ai claude` creates a minimal root `CLAUDE.md` pointing to `.specify/memory/constitution.md`

Made-with: Cursor

## Description

Fixes #1983 

## Testing

Ran the tests on my machine.

- [] Tested locally with `uv run specify --help`
- [X] Ran existing tests with `uv sync && uv run pytest`

Here is the output:

```
(specify-cli) arungupta@Mac spec-kit % python -m pytest tests/test_ai_skills.py
========================================================== test session starts ==========================================================
platform darwin -- Python 3.13.5, pytest-9.0.2, pluggy-1.6.0 -- /Users/arungupta/workspaces/spec-kit/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/arungupta/workspaces/spec-kit
configfile: pyproject.toml
plugins: cov-7.1.0, anyio-4.13.0
collected 98 items                                                                                                                      

tests/test_ai_skills.py::TestGetSkillsDir::test_claude_skills_dir PASSED                                                          [  1%]
tests/test_ai_skills.py::TestGetSkillsDir::test_gemini_skills_dir PASSED                                                          [  2%]
tests/test_ai_skills.py::TestGetSkillsDir::test_tabnine_skills_dir PASSED                                                         [  3%]
tests/test_ai_skills.py::TestGetSkillsDir::test_copilot_skills_dir PASSED                                                         [  4%]
tests/test_ai_skills.py::TestGetSkillsDir::test_codex_skills_dir_from_agent_config PASSED                                         [  5%]
tests/test_ai_skills.py::TestGetSkillsDir::test_cursor_agent_skills_dir PASSED                                                    [  6%]
tests/test_ai_skills.py::TestGetSkillsDir::test_kiro_cli_skills_dir PASSED                                                        [  7%]
tests/test_ai_skills.py::TestGetSkillsDir::test_pi_skills_dir PASSED                                                              [  8%]
tests/test_ai_skills.py::TestGetSkillsDir::test_unknown_agent_uses_default PASSED                                                 [  9%]
tests/test_ai_skills.py::TestGetSkillsDir::test_all_configured_agents_resolve PASSED                                              [ 10%]
tests/test_ai_skills.py::TestKimiLegacySkillMigration::test_migrates_legacy_dotted_skill_directory PASSED                         [ 11%]
tests/test_ai_skills.py::TestKimiLegacySkillMigration::test_removes_legacy_dir_when_hyphenated_target_exists_with_same_content PASSED [ 12%]
tests/test_ai_skills.py::TestKimiLegacySkillMigration::test_keeps_legacy_dir_when_hyphenated_target_differs PASSED                [ 13%]
tests/test_ai_skills.py::TestKimiLegacySkillMigration::test_keeps_legacy_dir_when_matching_target_but_extra_files_exist PASSED    [ 14%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_installed_with_correct_structure PASSED                                 [ 15%]
tests/test_ai_skills.py::TestInstallAiSkills::test_generated_skill_has_parseable_yaml PASSED                                      [ 16%]
tests/test_ai_skills.py::TestInstallAiSkills::test_empty_yaml_frontmatter PASSED                                                  [ 17%]
tests/test_ai_skills.py::TestInstallAiSkills::test_enhanced_descriptions_used_when_available PASSED                               [ 18%]
tests/test_ai_skills.py::TestInstallAiSkills::test_template_without_frontmatter PASSED                                            [ 19%]
tests/test_ai_skills.py::TestInstallAiSkills::test_missing_templates_directory PASSED                                             [ 20%]
tests/test_ai_skills.py::TestInstallAiSkills::test_empty_templates_directory PASSED                                               [ 21%]
tests/test_ai_skills.py::TestInstallAiSkills::test_malformed_yaml_frontmatter PASSED                                              [ 22%]
tests/test_ai_skills.py::TestInstallAiSkills::test_additive_does_not_overwrite_other_files PASSED                                 [ 23%]
tests/test_ai_skills.py::TestInstallAiSkills::test_return_value PASSED                                                            [ 24%]
tests/test_ai_skills.py::TestInstallAiSkills::test_return_false_when_no_templates PASSED                                          [ 25%]
tests/test_ai_skills.py::TestInstallAiSkills::test_non_md_commands_dir_falls_back PASSED                                          [ 26%]
tests/test_ai_skills.py::TestInstallAiSkills::test_qwen_md_commands_dir_installs_skills PASSED                                    [ 27%]
tests/test_ai_skills.py::TestInstallAiSkills::test_pi_prompt_dir_installs_skills PASSED                                           [ 28%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[copilot] PASSED                                  [ 29%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[claude] PASSED                                   [ 30%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[gemini] PASSED                                   [ 31%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[cursor-agent] PASSED                             [ 32%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[qwen] PASSED                                     [ 33%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[opencode] PASSED                                 [ 34%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[codex] PASSED                                    [ 35%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[windsurf] PASSED                                 [ 36%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[junie] PASSED                                    [ 37%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[kilocode] PASSED                                 [ 38%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[auggie] PASSED                                   [ 39%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[codebuddy] PASSED                                [ 40%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[qodercli] PASSED                                 [ 41%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[roo] PASSED                                      [ 42%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[kiro-cli] PASSED                                 [ 43%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[amp] PASSED                                      [ 44%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[shai] PASSED                                     [ 45%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[tabnine] PASSED                                  [ 46%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[agy] PASSED                                      [ 47%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[bob] PASSED                                      [ 48%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[vibe] PASSED                                     [ 50%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[kimi] PASSED                                     [ 51%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[trae] PASSED                                     [ 52%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[pi] PASSED                                       [ 53%]
tests/test_ai_skills.py::TestInstallAiSkills::test_skills_install_for_all_agents[iflow] PASSED                                    [ 54%]
tests/test_ai_skills.py::TestInstallAiSkills::test_copilot_ignores_non_speckit_agents PASSED                                      [ 55%]
tests/test_ai_skills.py::TestInstallAiSkills::test_non_speckit_commands_ignored_for_all_agents[claude-review.md] PASSED           [ 56%]
tests/test_ai_skills.py::TestInstallAiSkills::test_non_speckit_commands_ignored_for_all_agents[cursor-agent-deploy.md] PASSED     [ 57%]
tests/test_ai_skills.py::TestInstallAiSkills::test_non_speckit_commands_ignored_for_all_agents[qwen-my-workflow.md] PASSED        [ 58%]
tests/test_ai_skills.py::TestInstallAiSkills::test_copilot_fallback_when_only_non_speckit_agents PASSED                           [ 59%]
tests/test_ai_skills.py::TestInstallAiSkills::test_fallback_when_only_non_speckit_commands[claude] PASSED                         [ 60%]
tests/test_ai_skills.py::TestInstallAiSkills::test_fallback_when_only_non_speckit_commands[cursor-agent] PASSED                   [ 61%]
tests/test_ai_skills.py::TestInstallAiSkills::test_fallback_when_only_non_speckit_commands[qwen] PASSED                           [ 62%]
tests/test_ai_skills.py::TestCommandCoexistence::test_existing_commands_preserved_claude PASSED                                   [ 63%]
tests/test_ai_skills.py::TestCommandCoexistence::test_existing_commands_preserved_gemini PASSED                                   [ 64%]
tests/test_ai_skills.py::TestCommandCoexistence::test_existing_commands_preserved_qwen PASSED                                     [ 65%]
tests/test_ai_skills.py::TestCommandCoexistence::test_commands_dir_not_removed PASSED                                             [ 66%]
tests/test_ai_skills.py::TestCommandCoexistence::test_no_commands_dir_no_error PASSED                                             [ 67%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_init_claude_creates_root_CLAUDE_md PASSED                                [ 68%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_new_project_commands_removed_after_skills_succeed PASSED                 [ 69%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_new_project_nonstandard_commands_subdir_removed_after_skills_succeed PASSED [ 70%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_codex_native_skills_preserved_without_conversion PASSED                  [ 71%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_codex_native_skills_missing_falls_back_then_fails_cleanly PASSED         [ 72%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_codex_native_skills_ignores_non_speckit_skill_dirs PASSED                [ 73%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_kimi_legacy_migration_runs_without_ai_skills_flag PASSED                 [ 74%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_codex_ai_skills_here_mode_preserves_existing_codex_dir PASSED            [ 75%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_codex_ai_skills_fresh_dir_does_not_create_codex_dir PASSED               [ 76%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_download_and_extract_template_blocks_zip_path_traversal[False] PASSED    [ 77%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_download_and_extract_template_blocks_zip_path_traversal[True] PASSED     [ 78%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_commands_preserved_when_skills_fail PASSED                               [ 79%]
tests/test_ai_skills.py::TestNewProjectCommandSkip::test_here_mode_commands_preserved PASSED                                      [ 80%]
tests/test_ai_skills.py::TestSkipIfExists::test_existing_skill_not_overwritten PASSED                                             [ 81%]
tests/test_ai_skills.py::TestSkipIfExists::test_fresh_install_writes_all_skills PASSED                                            [ 82%]
tests/test_ai_skills.py::TestSkipIfExists::test_existing_skill_overwritten_when_enabled PASSED                                    [ 83%]
tests/test_ai_skills.py::TestSkillDescriptions::test_all_known_commands_have_descriptions PASSED                                  [ 84%]
tests/test_ai_skills.py::TestCliValidation::test_ai_skills_without_ai_fails PASSED                                                [ 85%]
tests/test_ai_skills.py::TestCliValidation::test_ai_skills_without_ai_shows_usage PASSED                                          [ 86%]
tests/test_ai_skills.py::TestCliValidation::test_agy_without_ai_skills_fails PASSED                                               [ 87%]
tests/test_ai_skills.py::TestCliValidation::test_codex_without_ai_skills_fails PASSED                                             [ 88%]
tests/test_ai_skills.py::TestCliValidation::test_interactive_agy_without_ai_skills_prompts_skills PASSED                          [ 89%]
tests/test_ai_skills.py::TestCliValidation::test_interactive_codex_without_ai_skills_enables_skills PASSED                        [ 90%]
tests/test_ai_skills.py::TestCliValidation::test_kimi_next_steps_show_skill_invocation PASSED                                     [ 91%]
tests/test_ai_skills.py::TestCliValidation::test_ai_skills_flag_appears_in_help PASSED                                            [ 92%]
tests/test_ai_skills.py::TestCliValidation::test_kiro_alias_normalized_to_kiro_cli PASSED                                         [ 93%]
tests/test_ai_skills.py::TestCliValidation::test_q_removed_from_agent_config PASSED                                               [ 94%]
tests/test_ai_skills.py::TestParameterOrderingIssue::test_ai_flag_consuming_here_flag PASSED                                      [ 95%]
tests/test_ai_skills.py::TestParameterOrderingIssue::test_ai_flag_consuming_ai_skills_flag PASSED                                 [ 96%]
tests/test_ai_skills.py::TestParameterOrderingIssue::test_error_message_provides_hint PASSED                                      [ 97%]
tests/test_ai_skills.py::TestParameterOrderingIssue::test_error_message_lists_available_agents PASSED                             [ 98%]
tests/test_ai_skills.py::TestParameterOrderingIssue::test_ai_commands_dir_consuming_flag PASSED                                   [100%]

========================================================== 98 passed in 0.64s ===========================================================
```

- [X] Tested with a sample project (if applicable)

Here is the output

```
(specify-cli) arungupta@Mac spec-kit % specify init /tmp/speckit-test2 --ai claude
                                          ███████╗██████╗ ███████╗ ██████╗██╗███████╗██╗   ██╗                                           
                                          ██╔════╝██╔══██╗██╔════╝██╔════╝██║██╔════╝╚██╗ ██╔╝                                           
                                          ███████╗██████╔╝█████╗  ██║     ██║█████╗   ╚████╔╝                                            
                                          ╚════██║██╔═══╝ ██╔══╝  ██║     ██║██╔══╝    ╚██╔╝                                             
                                          ███████║██║     ███████╗╚██████╗██║██║        ██║                                              
                                          ╚══════╝╚═╝     ╚══════╝ ╚═════╝╚═╝╚═╝        ╚═╝                                              
                                                                                                                                         
                                            GitHub Spec Kit - Spec-Driven Development Toolkit                                            

╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                       │
│  Specify Project Setup                                                                                                                │
│                                                                                                                                       │
│  Project         speckit-test2                                                                                                        │
│  Working Path    /Users/arungupta/workspaces/spec-kit                                                                                 │
│  Target Path     /private/tmp/speckit-test2                                                                                           │
│                                                                                                                                       │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

Selected AI assistant: claude
Selected script type: sh
Initialize Specify Project
├── ● Check required tools (ok)
├── ● Select AI assistant (claude)
├── ● Select script type (sh)
├── ● Fetch latest release (release v0.4.3 (64,591 bytes))
├── ● Download template (spec-kit-template-claude-sh-v0.4.3.zip)
├── ● Extract template
├── ● Archive contents (26 entries)
├── ● Extraction summary (2 top-level items)
├── ● Ensure scripts executable (5 updated)
├── ● Constitution setup (copied from template)
├── ● Claude Code role file (created)
├── ● Cleanup
├── ● Initialize git repository (initialized)
└── ● Finalize (project ready)

Project ready.

╭──────────────────────────────────────────────────────── Agent Folder Security ────────────────────────────────────────────────────────╮
│                                                                                                                                       │
│  Some agents may store credentials, auth tokens, or other identifying and private artifacts in the agent folder within your project.  │
│  Consider adding .claude/ (or parts of it) to .gitignore to prevent accidental credential leakage.                                    │
│                                                                                                                                       │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

╭───────────────────────────────────────────────────────────── Next Steps ──────────────────────────────────────────────────────────────╮
│                                                                                                                                       │
│  1. Go to the project folder: cd /tmp/speckit-test2                                                                                   │
│  2. Start using slash commands with your AI agent:                                                                                    │
│     2.1 /speckit.constitution - Establish project principles                                                                          │
│     2.2 /speckit.specify - Create baseline specification                                                                              │
│     2.3 /speckit.plan - Create implementation plan                                                                                    │
│     2.4 /speckit.tasks - Generate actionable tasks                                                                                    │
│     2.5 /speckit.implement - Execute implementation                                                                                   │
│                                                                                                                                       │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

╭──────────────────────────────────────────────────────── Enhancement Commands ─────────────────────────────────────────────────────────╮
│                                                                                                                                       │
│  Optional commands that you can use for your specs (improve quality & confidence)                                                     │
│                                                                                                                                       │
│  ○ /speckit.clarify (optional) - Ask structured questions to de-risk ambiguous areas before planning (run before /speckit.plan if     │
│  used)                                                                                                                                │
│  ○ /speckit.analyze (optional) - Cross-artifact consistency & alignment report (after /speckit.tasks, before /speckit.implement)      │
│  ○ /speckit.checklist (optional) - Generate quality checklists to validate requirements completeness, clarity, and consistency        │
│  (after /speckit.plan)                                                                                                                │
│                                                                                                                                       │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
(specify-cli) arungupta@Mac spec-kit %
```

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [ ] I **did not** use AI assistance for this contribution
- [X] I **did** use AI assistance (describe below)

I used Cursor to understand the codebase and generate the code for this particular fix. I read through the code 3x to ensure it's aligned with the rest of the codebase. I own the responsibility for this fix.


