### PR TITLE
feat(scripts): add --dry-run flag to create-new-feature

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -141,7 +141,7 @@ get_highest_from_remote_refs() {
 
     for remote in $(git remote 2>/dev/null); do
         local remote_highest
-        remote_highest=$(git ls-remote --heads "$remote" 2>/dev/null | sed 's|.*refs/heads/||' | _extract_highest_number)
+        remote_highest=$(GIT_TERMINAL_PROMPT=0 git ls-remote --heads "$remote" 2>/dev/null | sed 's|.*refs/heads/||' | _extract_highest_number)
         if [ "$remote_highest" -gt "$highest" ]; then
             highest=$remote_highest
         fi

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -107,7 +107,9 @@ function Get-HighestNumberFromRemoteRefs {
         $remotes = git remote 2>$null
         if ($remotes) {
             foreach ($remote in $remotes) {
+                $env:GIT_TERMINAL_PROMPT = '0'
                 $refs = git ls-remote --heads $remote 2>$null
+                $env:GIT_TERMINAL_PROMPT = $null
                 if ($LASTEXITCODE -eq 0 -and $refs) {
                     $refNames = $refs | ForEach-Object {
                         if ($_ -match 'refs/heads/(.+)$') { $matches[1] }

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -606,6 +606,7 @@ class TestDryRun:
             capture_output=True,
             text=True,
         )
+        assert branches.returncode == 0, f"'git branch --list' failed: {branches.stderr}"
         assert branches.stdout.strip() == ""
 
     def test_dry_run_with_number(self, git_repo: Path):


### PR DESCRIPTION
## Summary

- Add `--dry-run` / `-DryRun` flag to both bash and PowerShell `create-new-feature` scripts
- Computes next branch name, spec file path, and feature number without creating branches, directories, or files
- Queries remote branches via `git ls-remote --heads` (read-only) for accurate numbering without mutating local state. This contrasts with the normal (non-dry-run) path which runs `git fetch --all --prune` to update local remote-tracking refs.
- JSON output includes `DRY_RUN` field when flag is active; omitted otherwise (backwards compatible)
- Enables external tools (e.g., worktree-based workflows) to query the next available name before running the full specify workflow

Closes #1931. Also addresses aspects of #1680, #841, and #1921.

## Changes

| File | Change |
|------|--------|
| `scripts/bash/create-new-feature.sh` | Add `--dry-run` flag, gate branch/dir creation, add `DRY_RUN` to JSON, add `_extract_highest_number` shared helper, add `get_highest_from_remote_refs` using `git ls-remote`, add `skip_fetch` param to `check_existing_branches` |
| `scripts/powershell/create-new-feature.ps1` | Add `-DryRun` switch, mirror bash logic, add `Get-HighestNumberFromNames` shared helper, add `Get-HighestNumberFromRemoteRefs`, add `-SkipFetch` param to `Get-NextBranchNumber` |
| `tests/test_timestamp_branches.py` | Add `TestDryRun` class (12 tests including remote branch awareness), add `TestPowerShellDryRun` class (5 tests, skipped without pwsh) |

## Remote branch handling

| Mode | How remotes are queried | Side effects |
|------|------------------------|-------------|
| Normal (no `--dry-run`) | `git fetch --all --prune` then `git branch -a` | Updates local remote-tracking refs |
| `--dry-run` | `git ls-remote --heads` per remote, plus `git branch -a` | None (read-only query, no local ref updates) |

Both modes produce the same numbering result given the same remote state. The difference is that dry-run never modifies `.git/refs/remotes/`.

## Test plan

- [x] All 18 existing tests pass unchanged (backwards compatibility)
- [x] 12 new bash dry-run tests cover: sequential numbering, no branch created, no spec dir created, empty repo, short name, dry-run-then-real-run name match, remote branch awareness, JSON field presence/absence, timestamp mode, number flag, non-git repo
- [x] 5 PowerShell dry-run tests (skipped without pwsh): name output, no branch, no spec dir, JSON field presence/absence
- [x] Manual smoke test: `--dry-run --json` outputs correct name with zero side effects

## Backwards compatibility

- Without `--dry-run`, behavior is 100% unchanged
- JSON output shape unchanged when `--dry-run` is not used (no new fields)
- No new dependencies
- Refactored shared number extraction helpers reduce code duplication without changing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)