### PR TITLE
feat(scripts): add --allow-existing-branch flag to create-new-feature

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -294,7 +294,10 @@ if [ "$HAS_GIT" = true ]; then
         if git branch --list "$BRANCH_NAME" | grep -q .; then
             if [ "$ALLOW_EXISTING" = true ]; then
                 # Switch to the existing branch instead of failing
-                git checkout "$BRANCH_NAME" 2>/dev/null || true
+                if ! git checkout "$BRANCH_NAME" 2>/dev/null; then
+                    >&2 echo "Error: Failed to switch to existing branch '$BRANCH_NAME'. Please resolve any local changes or conflicts and try again."
+                    exit 1
+                fi
             elif [ "$USE_TIMESTAMP" = true ]; then
                 >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Rerun to get a new timestamp or use a different --short-name."
                 exit 1

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -256,6 +256,10 @@ if ($hasGit) {
             if ($AllowExistingBranch) {
                 # Switch to the existing branch instead of failing
                 git checkout -q $branchName 2>$null | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "Error: Branch '$branchName' exists but could not be checked out. Resolve any uncommitted changes or conflicts and try again."
+                    exit 1
+                }
             } elseif ($Timestamp) {
                 Write-Error "Error: Branch '$branchName' already exists. Rerun to get a new timestamp or use a different -ShortName."
                 exit 1
@@ -276,7 +280,7 @@ $featureDir = Join-Path $specsDir $branchName
 New-Item -ItemType Directory -Path $featureDir -Force | Out-Null
 
 $specFile = Join-Path $featureDir 'spec.md'
-if (-not (Test-Path $specFile)) {
+if (-not (Test-Path -PathType Leaf $specFile)) {
     $template = Resolve-Template -TemplateName 'spec-template' -RepoRoot $repoRoot
     if ($template -and (Test-Path $template)) {
         Copy-Item $template $specFile -Force

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -403,3 +403,12 @@ class TestAllowExistingBranch:
             "No git feature",
         )
         assert result.returncode == 0, result.stderr
+
+
+class TestAllowExistingBranchPowerShell:
+    def test_powershell_supports_allow_existing_branch_flag(self):
+        """Static guard: PS script exposes and uses -AllowExistingBranch."""
+        contents = CREATE_FEATURE_PS.read_text(encoding="utf-8")
+        assert "-AllowExistingBranch" in contents
+        # Ensure the flag is referenced in script logic, not just declared
+        assert "AllowExistingBranch" in contents.replace("-AllowExistingBranch", "")


### PR DESCRIPTION
## Summary

- Add `--allow-existing-branch` / `-AllowExistingBranch` flag to both bash and PowerShell `create-new-feature` scripts
- When the target branch already exists, switch to it instead of failing
- Spec directory and template are still created if missing
- Existing `spec.md` files are NOT overwritten (prevents data loss on re-runs)
- Flag is opt-in: without it, behavior is 100% unchanged

This enables worktree-based workflows and CI/CD pipelines that create branches externally before running `speckit.specify`.

Relates to #1931. Also addresses #1680, #841, and #1921.

Companion to #1998 (`--dry-run` flag, independent).

## Changes

| File | Change |
|------|--------|
| `scripts/bash/create-new-feature.sh` | Add `--allow-existing-branch` flag, modify branch creation to switch on existing, protect spec.md from overwrite |
| `scripts/powershell/create-new-feature.ps1` | Add `-AllowExistingBranch` switch, mirror bash logic |
| `tests/test_timestamp_branches.py` | Add `TestAllowExistingBranch` class with 8 test cases |

## Test plan

- [x] All 18 existing tests pass unchanged (backwards compatibility)
- [x] 8 new tests cover: switch to existing branch, already on branch, spec dir creation, backwards compat error without flag, no overwrite of existing spec.md, normal creation when branch doesn't exist, JSON output, non-git repo
- [x] Manual smoke test: pre-create branch, run with `--allow-existing-branch`, verify switch + spec dir creation

## Backwards compatibility

- Without `--allow-existing-branch`, behavior is identical to before (error on existing branch)
- Added spec.md overwrite protection (only copies template if spec.md doesn't exist)
- No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)