### PR TITLE
Clarify CLI reference usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Community projects that extend, visualize, or build on Spec Kit:
 ## 🔧 Specify CLI Reference
 
 The `specify` command supports the following options:
-
+The examples below assume you used the persistent installation method from the Get Started section, so the `specify` command is available directly in your PATH. If you are using the one-time usage method instead, run the equivalent commands with `uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify ...`.
 ### Commands
 
 | Command | Description                                                                                                                                                                                                                                                                              |
@@ -314,7 +314,7 @@ The `specify` command supports the following options:
 | `--branch-numbering`   | Option   | Branch numbering strategy: `sequential` (default — `001`, `002`, `003`) or `timestamp` (`YYYYMMDD-HHMMSS`). Timestamp mode is useful for distributed teams to avoid numbering conflicts                                                                                                                                                                                                  |
 
 ### Examples
-
+Examples below use the persistent installation form. If you did not install the CLI persistently, use the `uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify ...` form instead.
 ```bash
 # Basic project initialization
 specify init my-project


### PR DESCRIPTION
## Summary
This pull request clarifies the CLI reference in the README by explaining that the examples assume the persistent installation method was used, which makes the `specify` command available directly in PATH.

It also adds a note above the examples section explaining that users who did not install the CLI persistently should use the `uvx --from ... specify ...` form instead.

## Issue
Addresses confusion described in issue #318.

## Files Changed
- README.md

## Impact
These documentation updates help reduce confusion for new users and make the CLI usage instructions easier to follow.
