### PR TITLE
Update cc-sdd reference to cc-spex

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ See Spec-Driven Development in action across different scenarios with these comm
 
 Community projects that extend, visualize, or build on Spec Kit:
 
-- **[cc-sdd](https://github.com/rhuss/cc-sdd)** - A Claude Code plugin that adds composable traits on top of Spec Kit with [Superpowers](https://github.com/obra/superpowers)-based quality gates, spec/code review, git worktree isolation, and parallel implementation via agent teams.
+- **[cc-spex](https://github.com/rhuss/cc-spex)** - A Claude Code plugin that adds composable traits on top of Spec Kit with [Superpowers](https://github.com/obra/superpowers)-based quality gates, spec/code review, git worktree isolation, and parallel implementation via agent teams.
 
 - **[Spec Kit Assistant](https://marketplace.visualstudio.com/items?itemName=rfsales.speckit-assistant)** — A VS Code extension that provides a visual orchestrator for the full SDD workflow (constitution → specification → planning → tasks → implementation) with phase status visualization, an interactive task checklist, DAG visualization, and support for Claude, Gemini, GitHub Copilot, and OpenAI backends. Requires the `specify` CLI in your PATH.
 


### PR DESCRIPTION
## Summary

- Update the Community Friends link from `cc-sdd` to `cc-spex` to reflect the project rename

## Context

I renamed my project from [cc-sdd](https://github.com/rhuss/cc-spex) to **cc-spex** in v3.0.0. I discovered yesterday, completely by accident, that there is an unrelated project at [gotalab/cc-sdd](https://github.com/gotalab/cc-sdd). I was not aware of it when I originally chose the name, and never expected a collision. To avoid any confusion, I renamed the project and plugin from `sdd` to `spex`. GitHub auto-redirects the old URL, but updating the reference here keeps things clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)