### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
     <a href="https://github.com/github/spec-kit/stargazers"><img src="https://img.shields.io/github/stars/github/spec-kit?style=social" alt="GitHub stars"/></a>
     <a href="https://github.com/github/spec-kit/blob/main/LICENSE"><img src="https://img.shields.io/github/license/github/spec-kit" alt="License"/></a>
     <a href="https://github.github.io/spec-kit/"><img src="https://img.shields.io/badge/docs-GitHub_Pages-blue" alt="Documentation"/></a>
+    <a href="https://gitcgr.com/github/spec-kit" target="_blank" rel="noopener noreferrer">
+      <img src="https://gitcgr.com/badge/github/spec-kit.svg" alt="gitcgr" />
+    </a>
 </p>
 
 ---


### PR DESCRIPTION
Someone visualized your repository on [gitcgr.com](https://gitcgr.com/github/spec-kit)! This badge lets visitors explore your codebase as an interactive graph.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/github/spec-kit.svg)](https://gitcgr.com/github/spec-kit)

Clicking the badge takes users to an interactive visualization of your code structure — functions, classes, modules, and their relationships.