### PR TITLE
docs: add community extensions website link to README and extensions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Want to see Spec Kit in action? Watch our [video overview](https://www.youtube.c
 
 ## 🧩 Community Extensions
 
+🔍 **Browse and search community extensions on the [Community Extensions website](https://speckit-community.github.io/extensions/).**
+
 The following community-contributed extensions are available in [`catalog.community.json`](extensions/catalog.community.json):
 
 **Categories:**

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -68,6 +68,8 @@ specify extension add --from https://github.com/org/spec-kit-ext/archive/refs/ta
 
 ## Available Community Extensions
 
+🔍 **Browse and search community extensions on the [Community Extensions website](https://speckit-community.github.io/extensions/).**
+
 See the [Community Extensions](../README.md#-community-extensions) section in the main README for the full list of available community-contributed extensions.
 
 For the raw catalog data, see [`catalog.community.json`](catalog.community.json).


### PR DESCRIPTION
## Description

Add a link to the Community Extensions website (https://speckit-community.github.io/extensions/) with repo at https://github.com/speckit-community/extensions so users can browse and search extensions more conveniently.

- Added website link to the Community Extensions section in `README.md`
- Added website link to the Available Community Extensions section in `extensions/README.md`

## Testing

- [x] Verified Markdown renders correctly in GitHub

## AI Disclosure

- [x] I **did not** use AI assistance for this contribution

