### PR TITLE
Add canon extension and canon-core preset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The following community-contributed presets customize how Spec Kit behaves — o
 | Preset | Purpose | Provides | Requires | URL |
 |--------|---------|----------|----------|-----|
 | AIDE In-Place Migration | Adapts the AIDE extension workflow for in-place technology migrations (X → Y pattern) — adds migration objectives, verification gates, knowledge documents, and behavioral equivalence criteria | 2 templates, 8 commands | AIDE extension | [spec-kit-presets](https://github.com/mnriem/spec-kit-presets) |
-| Canon Core | Adapts original Spec Kit workflow to work together with Canon extension | 2 templates, 8 commands | — | [spec-kit-canon](https://github.com/maximiliamus/spec-kit-canon/tree/master/preset) |
+| Canon Core | Adapts original Spec Kit workflow to work together with Canon extension | 2 templates, 8 commands | — | [spec-kit-canon](https://github.com/maximiliamus/spec-kit-canon) |
 | Pirate Speak (Full) | Transforms all Spec Kit output into pirate speak — specs become "Voyage Manifests", plans become "Battle Plans", tasks become "Crew Assignments" | 6 templates, 9 commands | — | [spec-kit-presets](https://github.com/mnriem/spec-kit-presets) |
 | VS Code Ask Questions | Enhances the clarify command to use `vscode/askQuestions` for batched interactive questioning. | 1 command | — | [spec-kit-presets](https://github.com/fdcastel/spec-kit-presets) |
 

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -113,7 +113,7 @@
       "author": "Maxim Stupakov",
       "version": "0.1.0",
       "download_url": "https://github.com/maximiliamus/spec-kit-canon/releases/download/v0.1.0/spec-kit-canon-v0.1.0.zip",
-      "repository": "https://github.com/maximiliamus/spec-kit-canon/tree/master/extension",
+      "repository": "https://github.com/maximiliamus/spec-kit-canon",
       "homepage": "https://github.com/maximiliamus/spec-kit-canon",
       "documentation": "https://github.com/maximiliamus/spec-kit-canon/blob/master/README.md",
       "changelog": "https://github.com/maximiliamus/spec-kit-canon/blob/master/CHANGELOG.md",

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -36,7 +36,7 @@
       "description": "Adapts original Spec Kit workflow to work together with Canon extension.",
       "author": "Maxim Stupakov",
       "download_url": "https://github.com/maximiliamus/spec-kit-canon/releases/download/v0.1.0/spec-kit-canon-core-v0.1.0.zip",
-      "repository": "https://github.com/maximiliamus/spec-kit-canon/tree/master/preset",
+      "repository": "https://github.com/maximiliamus/spec-kit-canon",
       "homepage": "https://github.com/maximiliamus/spec-kit-canon",
       "documentation": "https://github.com/maximiliamus/spec-kit-canon/blob/master/README.md",
       "license": "MIT",


### PR DESCRIPTION
## Extension And Preset Submission

**Extension Name**: Canon
**Extension ID**: canon
**Version**: 0.1.0
**Author**: Maxim Stupakov
**Repository**: https://github.com/maximiliamus/spec-kit-canon/tree/master/extension
**Description**: Adds canon-driven (baseline-driven) workflows: spec-first, code-first, spec-drift. Requires Canon Core preset installation.

**Preset Name**: Canon Core
**Preset ID**: canon-core
**Version**: 0.1.0
**Author**: Maxim Stupakov
**Repository**: https://github.com/maximiliamus/spec-kit-canon/tree/master/preset
**Description**: Adapts original Spec Kit workflow to work together with Canon extension.

### Description

Extension + preset add canon-driven (baseline-driven) workflows to Spec Kit: spec-first, code-first, spec-drift.

Use it when you want canon files to remain the long-lived source of truth even
when the team moves between spec-first work, post-implementation drift repair,
and low-ceremony vibecoding.

### Checklist
- [x] Valid extension.yml and preset.yml manifests
- [x] README.md with installation and usage docs
- [x] LICENSE file included
- [x] GitHub release created (v0.1.0)
- [x] All commands working
- [x] Extension added to extensions/catalog.community.json (alphabetically)
- [x] Extension Added to Community Extensions table in README.md (alphabetically)
- [x] Preset added to presets/catalog.community.json (alphabetically)
- [x] Preset added to Community Presets table in README.md (alphabetically)
- [x] CHANGELOG.md included
- [x] Extension tested by internal skill and on real project
