### PR TITLE
docs: sync AGENTS.md with AGENT_CONFIG for missing agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,7 +411,7 @@ Command content with {SCRIPT} and {{args}} placeholders.
   - Kilo Code: `.kilocode/workflows/`
   - Roo Code: `.roo/commands/`
   - IBM Bob: `.bob/commands/`
-  - Antigravity: `.agent/commands/` (default) → `.agent/skills/` with `--ai-skills` (required)
+  - Antigravity: `.agent/skills/` (`--ai-skills` required; `.agent/commands/` is deprecated)
 
 ## Argument Patterns
 


### PR DESCRIPTION
 ## Summary
  - Added missing agents (Antigravity, Mistral Vibe) to the supported agents table
  - Fixed Cursor categorization: moved from CLI-Based to IDE-Based (matches `requires_cli: False` in   
  AGENT_CONFIG)
  - Added missing agents to CLI-Based list (Codex, Auggie, iFlow)
  - Added missing agents to IDE-Based list (Kilo Code, Roo Code, Trae, Antigravity)
  - Updated Markdown Format users list and Directory Conventions sections

  ## Test plan
  - [x] Verified all changes match AGENT_CONFIG in `src/specify_cli/__init__.py`
  - [x] No code changes, documentation only