### PR TITLE
feat: update fleet extension to v1.1.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -350,8 +350,8 @@
       "id": "fleet",
       "description": "Orchestrate a full feature lifecycle with human-in-the-loop gates across all SpecKit phases.",
       "author": "sharathsatish",
-      "version": "1.0.0",
-      "download_url": "https://github.com/sharathsatish/spec-kit-fleet/archive/refs/tags/v1.0.0.zip",
+      "version": "1.1.0",
+      "download_url": "https://github.com/sharathsatish/spec-kit-fleet/archive/refs/tags/v1.1.0.zip",
       "repository": "https://github.com/sharathsatish/spec-kit-fleet",
       "homepage": "https://github.com/sharathsatish/spec-kit-fleet",
       "documentation": "https://github.com/sharathsatish/spec-kit-fleet/blob/main/README.md",
@@ -374,7 +374,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-03-06T00:00:00Z",
-      "updated_at": "2026-03-06T00:00:00Z"
+      "updated_at": "2026-03-31T00:00:00Z"
     },
     "iterate": {
       "name": "Iterate",


### PR DESCRIPTION
Updates the Fleet Orchestrator extension in the community catalog from v1.0.0 to v1.1.0.

### Changes
- Version bumped to 1.1.0
- Download URL updated to v1.1.0 tag
- updated_at timestamp set to 2026-03-31

### Breaking change in spec-kit-fleet v1.1.0
- Removed speckit.fleet alias - use speckit.fleet.run instead