### PR TITLE
chore: use PEP 440 .dev0 versions on main after releases

### DIFF
--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -139,6 +139,18 @@ jobs:
           git push origin "${{ steps.version.outputs.tag }}"
           echo "Branch ${{ env.branch }} and tag ${{ steps.version.outputs.tag }} pushed"
 
+      - name: Bump to dev version
+        id: dev_version
+        run: |
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${{ steps.version.outputs.version }}"
+          NEXT_DEV="$MAJOR.$MINOR.$((PATCH + 1)).dev0"
+          echo "dev_version=$NEXT_DEV" >> $GITHUB_OUTPUT
+          sed -i "s/version = \".*\"/version = \"$NEXT_DEV\"/" pyproject.toml
+          git add pyproject.toml
+          git commit -m "chore: begin $NEXT_DEV development"
+          git push origin "${{ env.branch }}"
+          echo "Bumped to dev version $NEXT_DEV"
+
       - name: Open pull request
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
@@ -146,16 +158,17 @@ jobs:
           gh pr create \
             --base main \
             --head "${{ env.branch }}" \
-            --title "chore: bump version to ${{ steps.version.outputs.version }}" \
-            --body "Automated version bump to ${{ steps.version.outputs.version }}.
+            --title "chore: release ${{ steps.version.outputs.version }}, begin ${{ steps.dev_version.outputs.dev_version }} development" \
+            --body "Automated release of ${{ steps.version.outputs.version }}.
 
           This PR was created by the Release Trigger workflow. The git tag \`${{ steps.version.outputs.tag }}\` has already been pushed and the release artifacts are being built.
 
-          Merge this PR to record the version bump and changelog update on \`main\`."
+          Merging this PR will set \`main\` to \`${{ steps.dev_version.outputs.dev_version }}\` so that development installs are clearly marked as pre-release."
 
       - name: Summary
         run: |
           echo "✅ Version bumped to ${{ steps.version.outputs.version }}"
           echo "✅ Tag ${{ steps.version.outputs.tag }} created and pushed"
+          echo "✅ Dev version set to ${{ steps.dev_version.outputs.dev_version }}"
           echo "✅ PR opened to merge version bump into main"
           echo "🚀 Release workflow is building artifacts from the tag"

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -147,9 +147,13 @@ jobs:
           echo "dev_version=$NEXT_DEV" >> $GITHUB_OUTPUT
           sed -i "s/version = \".*\"/version = \"$NEXT_DEV\"/" pyproject.toml
           git add pyproject.toml
-          git commit -m "chore: begin $NEXT_DEV development"
-          git push origin "${{ env.branch }}"
-          echo "Bumped to dev version $NEXT_DEV"
+          if git diff --cached --quiet; then
+            echo "No dev version changes to commit"
+          else
+            git commit -m "chore: begin $NEXT_DEV development"
+            git push origin "${{ env.branch }}"
+            echo "Bumped to dev version $NEXT_DEV"
+          fi
 
       - name: Open pull request
         env:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/github/spec-kit/actions/workflows/release.yml"><img src="https://github.com/github/spec-kit/actions/workflows/release.yml/badge.svg" alt="Release"/></a>
+    <a href="https://github.com/github/spec-kit/releases/latest"><img src="https://img.shields.io/github/v/release/github/spec-kit" alt="Latest Release"/></a>
     <a href="https://github.com/github/spec-kit/stargazers"><img src="https://img.shields.io/github/stars/github/spec-kit?style=social" alt="GitHub stars"/></a>
     <a href="https://github.com/github/spec-kit/blob/main/LICENSE"><img src="https://img.shields.io/github/license/github/spec-kit" alt="License"/></a>
     <a href="https://github.github.io/spec-kit/"><img src="https://img.shields.io/badge/docs-GitHub_Pages-blue" alt="Documentation"/></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.4.3"
+version = "0.4.4.dev0"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
After a release, `main` showed the same version as the published release (e.g. `0.4.3`), which confused users installing from `main` via `uv` — they couldn't tell they had a development build.

## Changes

- **Release-trigger workflow**: adds a second commit on the release branch bumping `pyproject.toml` to `X.Y.(Z+1).dev0` before the PR is opened. The git tag still points at the release commit. PR title and summary updated to reflect the dev version.
- **pyproject.toml**: set current version to `0.4.4.dev0` so `main` is immediately correct.
- **README.md**: replaced broken release workflow badge with a shields.io release version badge that dynamically shows the latest release tag.

## Result

- `uv tool install specify-cli --from git+https://github.com/github/spec-kit.git` → `0.4.4.dev0` (clearly a dev build)
- `uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@v0.4.3` → `0.4.3` (stable release)