### PR TITLE
fix(scripts): validate --number flag against existing branches/specs

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -287,9 +287,8 @@ else
             done
         fi
 
-        # Check git branches for collision (fetch first to catch remote-only branches)
+        # Check git branches for collision
         if [ "$NUMBER_IN_USE" = false ] && [ "$HAS_GIT" = true ]; then
-            git fetch --all --prune 2>/dev/null || true
             branches=$(git branch -a 2>/dev/null || echo "")
             if [ -n "$branches" ]; then
                 while IFS= read -r branch; do

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -251,7 +251,7 @@ if [ "$USE_TIMESTAMP" = true ]; then
 else
     # Validate --number input when provided
     if [ -n "$BRANCH_NUMBER" ]; then
-        if ! echo "$BRANCH_NUMBER" | grep -q '^[0-9]\+$' || [ "$((10#$BRANCH_NUMBER))" -lt 1 ]; then
+        if ! echo "$BRANCH_NUMBER" | grep -Eq '^[0-9]+$' || [ "$((10#$BRANCH_NUMBER))" -lt 1 ]; then
             >&2 echo "Error: --number requires a positive integer, got '$BRANCH_NUMBER'"
             exit 1
         fi
@@ -287,8 +287,9 @@ else
             done
         fi
 
-        # Check git branches for collision
+        # Check git branches for collision (fetch to catch remote-only branches)
         if [ "$NUMBER_IN_USE" = false ] && [ "$HAS_GIT" = true ]; then
+            git fetch --all --prune 2>/dev/null || true
             branches=$(git branch -a 2>/dev/null || echo "")
             if [ -n "$branches" ]; then
                 while IFS= read -r branch; do

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -251,6 +251,7 @@ if [ "$USE_TIMESTAMP" = true ]; then
 else
     # Determine branch number
     if [ -z "$BRANCH_NUMBER" ]; then
+        # No manual number provided -- auto-detect
         if [ "$HAS_GIT" = true ]; then
             # Check existing branches on remotes
             BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
@@ -258,6 +259,49 @@ else
             # Fall back to local directory check
             HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
             BRANCH_NUMBER=$((HIGHEST + 1))
+        fi
+    elif [ "$ALLOW_EXISTING" = false ]; then
+        # Manual number provided -- validate it is not already in use
+        # (skip when --allow-existing-branch, as the caller intentionally targets an existing branch)
+        MANUAL_NUM=$((10#$BRANCH_NUMBER))
+        MANUAL_NUM_PADDED=$(printf "%03d" "$MANUAL_NUM")
+        NUMBER_IN_USE=false
+
+        # Check specs directory for collision
+        if [ -d "$SPECS_DIR" ]; then
+            for dir in "$SPECS_DIR"/*/; do
+                [ -d "$dir" ] || continue
+                dirname=$(basename "$dir")
+                if echo "$dirname" | grep -q "^${MANUAL_NUM_PADDED}-"; then
+                    NUMBER_IN_USE=true
+                    break
+                fi
+            done
+        fi
+
+        # Check git branches for collision (fetch first to catch remote-only branches)
+        if [ "$NUMBER_IN_USE" = false ] && [ "$HAS_GIT" = true ]; then
+            git fetch --all --prune 2>/dev/null || true
+            branches=$(git branch -a 2>/dev/null || echo "")
+            if [ -n "$branches" ]; then
+                while IFS= read -r branch; do
+                    clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
+                    if echo "$clean_branch" | grep -q "^${MANUAL_NUM_PADDED}-"; then
+                        NUMBER_IN_USE=true
+                        break
+                    fi
+                done <<< "$branches"
+            fi
+        fi
+
+        if [ "$NUMBER_IN_USE" = true ]; then
+            >&2 echo "Warning: --number $BRANCH_NUMBER conflicts with existing branch/spec (${MANUAL_NUM_PADDED}-*). Auto-detecting next available number."
+            if [ "$HAS_GIT" = true ]; then
+                BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+            else
+                HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+                BRANCH_NUMBER=$((HIGHEST + 1))
+            fi
         fi
     fi
 

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -263,6 +263,10 @@ else
     elif [ "$ALLOW_EXISTING" = false ]; then
         # Manual number provided -- validate it is not already in use
         # (skip when --allow-existing-branch, as the caller intentionally targets an existing branch)
+        if ! echo "$BRANCH_NUMBER" | grep -q '^[0-9]\+$'; then
+            >&2 echo "Error: --number requires a positive integer, got '$BRANCH_NUMBER'"
+            exit 1
+        fi
         MANUAL_NUM=$((10#$BRANCH_NUMBER))
         MANUAL_NUM_PADDED=$(printf "%03d" "$MANUAL_NUM")
         NUMBER_IN_USE=false

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -249,6 +249,14 @@ if [ "$USE_TIMESTAMP" = true ]; then
     FEATURE_NUM=$(date +%Y%m%d-%H%M%S)
     BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
 else
+    # Validate --number input when provided
+    if [ -n "$BRANCH_NUMBER" ]; then
+        if ! echo "$BRANCH_NUMBER" | grep -q '^[0-9]\+$' || [ "$((10#$BRANCH_NUMBER))" -lt 1 ]; then
+            >&2 echo "Error: --number requires a positive integer, got '$BRANCH_NUMBER'"
+            exit 1
+        fi
+    fi
+
     # Determine branch number
     if [ -z "$BRANCH_NUMBER" ]; then
         # No manual number provided -- auto-detect
@@ -263,10 +271,6 @@ else
     elif [ "$ALLOW_EXISTING" = false ]; then
         # Manual number provided -- validate it is not already in use
         # (skip when --allow-existing-branch, as the caller intentionally targets an existing branch)
-        if ! echo "$BRANCH_NUMBER" | grep -q '^[0-9]\+$'; then
-            >&2 echo "Error: --number requires a positive integer, got '$BRANCH_NUMBER'"
-            exit 1
-        fi
         MANUAL_NUM=$((10#$BRANCH_NUMBER))
         MANUAL_NUM_PADDED=$(printf "%03d" "$MANUAL_NUM")
         NUMBER_IN_USE=false

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -201,8 +201,8 @@ if ($Timestamp) {
     $featureNum = Get-Date -Format 'yyyyMMdd-HHmmss'
     $branchName = "$featureNum-$branchSuffix"
 } else {
-    # Validate -Number input when provided
-    if ($Number -lt 0) {
+    # Validate -Number input when explicitly provided
+    if ($PSBoundParameters.ContainsKey('Number') -and $Number -lt 1) {
         Write-Error "-Number requires a positive integer, got $Number"
         exit 1
     }

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -203,12 +203,56 @@ if ($Timestamp) {
 } else {
     # Determine branch number
     if ($Number -eq 0) {
+        # No manual number provided -- auto-detect
         if ($hasGit) {
             # Check existing branches on remotes
             $Number = Get-NextBranchNumber -SpecsDir $specsDir
         } else {
             # Fall back to local directory check
             $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
+        }
+    } elseif (-not $AllowExistingBranch) {
+        # Manual number provided -- validate it is not already in use
+        # (skip when -AllowExistingBranch, as the caller intentionally targets an existing branch)
+        $manualNumPadded = '{0:000}' -f $Number
+        $numberInUse = $false
+
+        # Check specs directory for collision
+        if (Test-Path $specsDir) {
+            foreach ($dir in (Get-ChildItem -Path $specsDir -Directory)) {
+                if ($dir.Name -match "^$manualNumPadded-") {
+                    $numberInUse = $true
+                    break
+                }
+            }
+        }
+
+        # Check git branches for collision (fetch first to catch remote-only branches)
+        if (-not $numberInUse -and $hasGit) {
+            try {
+                git fetch --all --prune 2>$null | Out-Null
+                $branches = git branch -a 2>$null
+                if ($LASTEXITCODE -eq 0 -and $branches) {
+                    foreach ($branch in $branches) {
+                        $cleanBranch = $branch.Trim() -replace '^\*?\s*', '' -replace '^remotes/[^/]+/', ''
+                        if ($cleanBranch -match "^$manualNumPadded-") {
+                            $numberInUse = $true
+                            break
+                        }
+                    }
+                }
+            } catch {
+                Write-Verbose "Could not check Git branches: $_"
+            }
+        }
+
+        if ($numberInUse) {
+            Write-Warning "-Number $Number conflicts with existing branch/spec ($manualNumPadded-*). Auto-detecting next available number."
+            if ($hasGit) {
+                $Number = Get-NextBranchNumber -SpecsDir $specsDir
+            } else {
+                $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
+            }
         }
     }
 

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -233,9 +233,10 @@ if ($Timestamp) {
             }
         }
 
-        # Check git branches for collision
+        # Check git branches for collision (fetch to catch remote-only branches)
         if (-not $numberInUse -and $hasGit) {
             try {
+                git fetch --all --prune 2>$null | Out-Null
                 $branches = git branch -a 2>$null
                 if ($LASTEXITCODE -eq 0 -and $branches) {
                     foreach ($branch in $branches) {

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -214,6 +214,10 @@ if ($Timestamp) {
     } elseif (-not $AllowExistingBranch) {
         # Manual number provided -- validate it is not already in use
         # (skip when -AllowExistingBranch, as the caller intentionally targets an existing branch)
+        if ($Number -lt 1) {
+            Write-Error "-Number requires a positive integer, got $Number"
+            exit 1
+        }
         $manualNumPadded = '{0:000}' -f $Number
         $numberInUse = $false
 

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -201,6 +201,12 @@ if ($Timestamp) {
     $featureNum = Get-Date -Format 'yyyyMMdd-HHmmss'
     $branchName = "$featureNum-$branchSuffix"
 } else {
+    # Validate -Number input when provided
+    if ($Number -lt 0) {
+        Write-Error "-Number requires a positive integer, got $Number"
+        exit 1
+    }
+
     # Determine branch number
     if ($Number -eq 0) {
         # No manual number provided -- auto-detect
@@ -214,10 +220,6 @@ if ($Timestamp) {
     } elseif (-not $AllowExistingBranch) {
         # Manual number provided -- validate it is not already in use
         # (skip when -AllowExistingBranch, as the caller intentionally targets an existing branch)
-        if ($Number -lt 1) {
-            Write-Error "-Number requires a positive integer, got $Number"
-            exit 1
-        }
         $manualNumPadded = '{0:000}' -f $Number
         $numberInUse = $false
 

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -233,10 +233,9 @@ if ($Timestamp) {
             }
         }
 
-        # Check git branches for collision (fetch first to catch remote-only branches)
+        # Check git branches for collision
         if (-not $numberInUse -and $hasGit) {
             try {
-                git fetch --all --prune 2>$null | Out-Null
                 $branches = git branch -a 2>$null
                 if ($LASTEXITCODE -eq 0 -and $branches) {
                     foreach ($branch in $branches) {

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -466,7 +466,7 @@ class TestAllowExistingBranchPowerShell:
         # Must check specs directory for collision
         assert "manualNumPadded" in contents
         # Must check git branches for collision
-        assert "git branch -a" in contents
+        assert "git fetch --all --prune" in contents
         # Must warn and auto-detect on conflict
         assert "conflicts with existing branch/spec" in contents
         # Must skip validation when -AllowExistingBranch is set; allow flexible whitespace

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -413,3 +413,15 @@ class TestAllowExistingBranchPowerShell:
         assert "-AllowExistingBranch" in contents
         # Ensure the flag is referenced in script logic, not just declared
         assert "AllowExistingBranch" in contents.replace("-AllowExistingBranch", "")
+
+    def test_powershell_has_number_collision_validation(self):
+        """Static guard: PS script validates manual -Number against existing branches/specs."""
+        contents = CREATE_FEATURE_PS.read_text(encoding="utf-8")
+        # Must check specs directory for collision
+        assert "manualNumPadded" in contents
+        # Must check git branches for collision
+        assert "git fetch --all --prune" in contents
+        # Must warn and auto-detect on conflict
+        assert "conflicts with existing branch/spec" in contents
+        # Must skip validation when -AllowExistingBranch is set
+        assert "elseif (-not $AllowExistingBranch)" in contents

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -466,7 +466,7 @@ class TestAllowExistingBranchPowerShell:
         # Must check specs directory for collision
         assert "manualNumPadded" in contents
         # Must check git branches for collision
-        assert "git fetch --all --prune" in contents
+        assert "git branch -a" in contents
         # Must warn and auto-detect on conflict
         assert "conflicts with existing branch/spec" in contents
         # Must skip validation when -AllowExistingBranch is set; allow flexible whitespace

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -423,5 +423,7 @@ class TestAllowExistingBranchPowerShell:
         assert "git fetch --all --prune" in contents
         # Must warn and auto-detect on conflict
         assert "conflicts with existing branch/spec" in contents
-        # Must skip validation when -AllowExistingBranch is set
-        assert "elseif (-not $AllowExistingBranch)" in contents
+        # Must skip validation when -AllowExistingBranch is set; allow flexible whitespace
+        assert re.search(r"elseif\s*\(\s*-not\s+\$AllowExistingBranch\s*\)", contents), (
+            "Expected an elseif guard that negates $AllowExistingBranch"
+        )

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -453,10 +453,11 @@ class TestAllowExistingBranchPowerShell:
         # Ensure the flag is referenced in script logic, not just declared
         assert "AllowExistingBranch" in contents.replace("-AllowExistingBranch", "")
 
-    def test_powershell_rejects_negative_number(self):
-        """Static guard: PS script validates -Number is not negative."""
+    def test_powershell_rejects_invalid_number(self):
+        """Static guard: PS script validates -Number using PSBoundParameters and rejects < 1."""
         contents = CREATE_FEATURE_PS.read_text(encoding="utf-8")
-        assert "Number -lt 0" in contents or re.search(r"\$Number\s+-lt\s+0", contents)
+        assert "PSBoundParameters.ContainsKey" in contents
+        assert "Number -lt 1" in contents or re.search(r"\$Number\s+-lt\s+1", contents)
         assert "positive integer" in contents
 
     def test_powershell_has_number_collision_validation(self):

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -406,6 +406,45 @@ class TestAllowExistingBranch:
         assert result.returncode == 0, result.stderr
 
 
+class TestNumberInputValidation:
+    """Tests for --number input validation and spec-directory collision detection."""
+
+    def test_rejects_zero(self, git_repo: Path):
+        result = run_script(git_repo, "--short-name", "zero", "--number", "0", "Zero test")
+        assert result.returncode != 0
+        assert "positive integer" in result.stderr
+
+    def test_rejects_non_numeric(self, git_repo: Path):
+        result = run_script(git_repo, "--short-name", "abc", "--number", "abc", "Non-numeric test")
+        assert result.returncode != 0
+        assert "positive integer" in result.stderr
+
+    def test_rejects_negative(self, git_repo: Path):
+        result = run_script(git_repo, "--short-name", "neg", "--number", "-5", "Negative test")
+        assert result.returncode != 0
+        assert "positive integer" in result.stderr
+
+    def test_collision_detected_via_specs_directory(self, git_repo: Path):
+        """Collision detected from specs dir even when no matching branch exists."""
+        spec_dir = git_repo / "specs" / "003-existing-spec"
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "spec.md").write_text("# Existing\n")
+        result = run_script(
+            git_repo, "--short-name", "new-feature", "--number", "3", "Spec collision test",
+        )
+        assert result.returncode == 0
+        assert "conflicts with existing branch/spec" in result.stderr
+        assert "003-new-feature" not in result.stdout
+
+    def test_unused_number_accepted(self, git_repo: Path):
+        """A manual --number that doesn't collide is accepted as-is."""
+        result = run_script(
+            git_repo, "--short-name", "free", "--number", "50", "Free number test",
+        )
+        assert result.returncode == 0, result.stderr
+        assert "050-free" in result.stdout
+
+
 class TestAllowExistingBranchPowerShell:
     def test_powershell_supports_allow_existing_branch_flag(self):
         """Static guard: PS script exposes and uses -AllowExistingBranch."""
@@ -413,6 +452,12 @@ class TestAllowExistingBranchPowerShell:
         assert "-AllowExistingBranch" in contents
         # Ensure the flag is referenced in script logic, not just declared
         assert "AllowExistingBranch" in contents.replace("-AllowExistingBranch", "")
+
+    def test_powershell_rejects_negative_number(self):
+        """Static guard: PS script validates -Number is not negative."""
+        contents = CREATE_FEATURE_PS.read_text(encoding="utf-8")
+        assert "Number -lt 0" in contents or re.search(r"\$Number\s+-lt\s+0", contents)
+        assert "positive integer" in contents
 
     def test_powershell_has_number_collision_validation(self):
         """Static guard: PS script validates manual -Number against existing branches/specs."""

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -326,8 +326,8 @@ class TestAllowExistingBranch:
         assert (git_repo / "specs" / "006-spec-dir").is_dir()
         assert (git_repo / "specs" / "006-spec-dir" / "spec.md").exists()
 
-    def test_without_flag_still_errors(self, git_repo: Path):
-        """T009: Verify backwards compatibility (error without flag)."""
+    def test_without_flag_auto_detects_on_collision(self, git_repo: Path):
+        """T009: Without --allow-existing-branch, a conflicting --number auto-detects next available."""
         subprocess.run(
             ["git", "checkout", "-b", "007-no-flag"],
             cwd=git_repo, check=True, capture_output=True,
@@ -339,8 +339,9 @@ class TestAllowExistingBranch:
         result = run_script(
             git_repo, "--short-name", "no-flag", "--number", "7", "No flag feature",
         )
-        assert result.returncode != 0, "should fail without --allow-existing-branch"
-        assert "already exists" in result.stderr
+        assert result.returncode == 0, result.stderr
+        assert "conflicts with existing branch/spec" in result.stderr
+        assert "008-no-flag" in result.stdout
 
     def test_allow_existing_no_overwrite_spec(self, git_repo: Path):
         """T010: Pre-create spec.md with content, verify it is preserved."""


### PR DESCRIPTION
## Summary

Fixes the intermittent branch numbering reset reported in #1744 (see [comment](https://github.com/github/spec-kit/issues/1744#issuecomment-4073538688) by @echarrod).

PR #1757 fixed the `specify.md` prompt to tell the AI not to pass `--number`, but AI assistants **intermittently ignore** that instruction, causing new features to get `001` instead of the next available number.

This PR adds **script-level validation** as defense in depth:

- When `--number` is passed, the script checks specs directories and git branches (after fetch) for collisions
- If the number is already in use, it warns on stderr and auto-detects the next available number
- Skips validation when `--allow-existing-branch` is set (intentional reuse)
- Applied symmetrically to both Bash and PowerShell scripts

## Test plan

- [x] All 942 existing tests pass
- [x] Updated `test_without_flag_still_errors` → `test_without_flag_auto_detects_on_collision` to reflect new behavior
- [x] Verified collision detection against specs directories
- [x] Verified collision detection against git branches (local + remote)
- [x] Verified `--allow-existing-branch` bypasses validation correctly
- [x] Bash syntax validated

🤖 Generated with [Claude Code](https://claude.com/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>