### PR TITLE
fix: support feature branch numbers with 4+ digits

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -124,9 +124,10 @@ check_feature_branch() {
         return 0
     fi
 
-    # Accept sequential prefix (3+ digits) but exclude malformed timestamps (7-digit date + 6-digit time)
+    # Accept sequential prefix (3+ digits) but exclude malformed timestamps
+    # Malformed: 7-or-8 digit date + 6-digit time with no trailing slug (e.g. "2026031-143022" or "20260319-143022")
     local is_sequential=false
-    if [[ "$branch" =~ ^[0-9]{3,}- ]] && [[ ! "$branch" =~ ^[0-9]{7}-[0-9]{6}- ]]; then
+    if [[ "$branch" =~ ^[0-9]{3,}- ]] && [[ ! "$branch" =~ ^[0-9]{7}-[0-9]{6}- ]] && [[ ! "$branch" =~ ^[0-9]{7,8}-[0-9]{6}$ ]]; then
         is_sequential=true
     fi
     if [[ "$is_sequential" != "true" ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -139,8 +139,10 @@ function Test-FeatureBranch {
         return $true
     }
     
-    # Accept sequential prefix (3+ digits) but exclude malformed timestamps (7-digit date + 6-digit time)
-    $isSequential = ($Branch -match '^[0-9]{3,}-') -and ($Branch -notmatch '^[0-9]{7}-[0-9]{6}-')
+    # Accept sequential prefix (3+ digits) but exclude malformed timestamps
+    # Malformed: 7-or-8 digit date + 6-digit time with no trailing slug (e.g. "2026031-143022" or "20260319-143022")
+    $hasMalformedTimestamp = ($Branch -match '^[0-9]{7}-[0-9]{6}-') -or ($Branch -match '^(?:\d{7}|\d{8})-\d{6}$')
+    $isSequential = ($Branch -match '^[0-9]{3,}-') -and (-not $hasMalformedTimestamp)
     if (-not $isSequential -and $Branch -notmatch '^\d{8}-\d{6}-') {
         Write-Output "ERROR: Not on a feature branch. Current branch: $Branch"
         Write-Output "Feature branches should be named like: 001-feature-name, 1234-feature-name, or 20260319-143022-feature-name"

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -196,6 +196,16 @@ class TestCheckFeatureBranch:
         result = source_and_call('check_feature_branch "2026031-143022-feat" "true"')
         assert result.returncode != 0
 
+    def test_rejects_timestamp_without_slug(self):
+        """check_feature_branch rejects timestamp-like branch missing trailing slug."""
+        result = source_and_call('check_feature_branch "20260319-143022" "true"')
+        assert result.returncode != 0
+
+    def test_rejects_7digit_timestamp_without_slug(self):
+        """check_feature_branch rejects 7-digit date + 6-digit time without slug."""
+        result = source_and_call('check_feature_branch "2026031-143022" "true"')
+        assert result.returncode != 0
+
 
 # ── find_feature_dir_by_prefix Tests ─────────────────────────────────────────
 


### PR DESCRIPTION
## Description

The sequential feature number regex in `common.sh` and `common.ps1` was hardcoded to exactly 3 digits (`{3}`), causing branches like `1234-feature-name` to be rejected once a project exceeds 999 features.

This PR changes the pattern to `{3,}` (3 or more digits) so that 4+ digit prefixes are recognized correctly. A guard is also added in `check_feature_branch` / `Test-FeatureBranch` to prevent malformed timestamps (e.g. `2026031-143022-feat`) from being falsely accepted as sequential prefixes.

Closes #344

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

All 27 `test_timestamp_branches.py` tests pass, including the existing test that rejects partial timestamps.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Code changes generated and reviewed with Claude Code (Claude Opus 4.6).
