### PR TITLE
Add community content disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Want to see Spec Kit in action? Watch our [video overview](https://www.youtube.c
 ## 🧩 Community Extensions
 
 > [!NOTE]
-> Community extensions are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. The Community Extensions website is also a third-party resource. Review extension source code before installation and use at your own discretion.
+> Community extensions are independently created and maintained by their respective authors. GitHub and the Spec Kit maintainers may review pull requests that add entries to the community catalog for formatting, catalog structure, or policy compliance, but they do **not review, audit, endorse, or support the extension code itself**. The Community Extensions website is also a third-party resource. Review extension source code before installation and use at your own discretion.
 
 🔍 **Browse and search community extensions on the [Community Extensions website](https://speckit-community.github.io/extensions/).**
 
@@ -229,7 +229,7 @@ To submit your own extension, see the [Extension Publishing Guide](extensions/EX
 ## 🎨 Community Presets
 
 > [!NOTE]
-> Community presets are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review preset source code before installation and use at your own discretion.
+> Community presets are independently created and maintained by their respective authors. GitHub and the Spec Kit maintainers may review pull requests that add entries to the community catalog for formatting, catalog structure, or policy compliance, but they do **not review, audit, endorse, or support the preset code itself**. Review preset source code before installation and use at your own discretion.
 
 The following community-contributed presets customize how Spec Kit behaves — overriding templates, commands, and terminology without changing any tooling. Presets are available in [`catalog.community.json`](presets/catalog.community.json):
 
@@ -243,7 +243,7 @@ To build and publish your own preset, see the [Presets Publishing Guide](presets
 ## 🚶 Community Walkthroughs
 
 > [!NOTE]
-> Community walkthroughs are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**.
+> Community walkthroughs are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review their content before following along and use at your own discretion.
 
 See Spec-Driven Development in action across different scenarios with these community-contributed walkthroughs:
 
@@ -264,7 +264,7 @@ See Spec-Driven Development in action across different scenarios with these comm
 ## 🛠️ Community Friends
 
 > [!NOTE]
-> Community projects listed here are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**.
+> Community projects listed here are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review their source code before installation and use at your own discretion.
 
 Community projects that extend, visualize, or build on Spec Kit:
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -25,7 +25,7 @@ specify extension search  # Now uses your organization's catalog instead of the 
 ### Community Reference Catalog (`catalog.community.json`)
 
 > [!NOTE]
-> Community extensions are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review extension source code before installation and use at your own discretion.
+> Community extensions are independently created and maintained by their respective authors. GitHub and the Spec Kit maintainers may review pull requests that add entries to the community catalog for formatting, catalog structure, or policy compliance, but they do **not review, audit, endorse, or support the extension code itself**. Review extension source code before installation and use at your own discretion.
 
 - **Purpose**: Browse available community-contributed extensions
 - **Status**: Active - contains extensions submitted by the community
@@ -72,7 +72,7 @@ specify extension add <extension-name> --from https://github.com/org/spec-kit-ex
 ## Available Community Extensions
 
 > [!NOTE]
-> Community extensions are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. The Community Extensions website is also a third-party resource. Review extension source code before installation and use at your own discretion.
+> Community extensions are independently created and maintained by their respective authors. GitHub and the Spec Kit maintainers may review pull requests that add entries to the community catalog for formatting, catalog structure, or policy compliance, but they do **not review, audit, endorse, or support the extension code itself**. The Community Extensions website is also a third-party resource. Review extension source code before installation and use at your own discretion.
 
 🔍 **Browse and search community extensions on the [Community Extensions website](https://speckit-community.github.io/extensions/).**
 

--- a/presets/README.md
+++ b/presets/README.md
@@ -68,7 +68,7 @@ Presets **override**, they don't merge. If two presets both provide `spec-templa
 Presets are discovered through catalogs. By default, Spec Kit uses the official and community catalogs:
 
 > [!NOTE]
-> Community presets are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review preset source code before installation and use at your own discretion.
+> Community presets are independently created and maintained by their respective authors. GitHub and the Spec Kit maintainers may review pull requests that add entries to the community catalog for formatting, catalog structure, or policy compliance, but they do **not review, audit, endorse, or support the preset code itself**. Review preset source code before installation and use at your own discretion.
 
 ```bash
 # List active catalogs


### PR DESCRIPTION
## Summary

Add `[!NOTE]` disclaimers clarifying that community-contributed content (extensions, presets, walkthroughs, and related projects) is independently created and maintained by their respective authors and is **not reviewed, nor endorsed, nor supported by GitHub**.

## Changes

Disclaimers added to:

- **README.md**
  - 🧩 Community Extensions — includes note that the Community Extensions website is also a third-party resource
  - 🎨 Community Presets
  - 🚶 Community Walkthroughs
  - 🛠️ Community Friends

- **extensions/README.md**
  - Community Reference Catalog (`catalog.community.json`) section
  - Available Community Extensions section — includes note about the Community Extensions website

- **presets/README.md**
  - Catalog Management section (where community catalogs are referenced)

## Why

The README links to third-party community extensions, a community extensions website, presets, walkthroughs, and projects without making it clear that these are not reviewed, endorsed, or supported by GitHub. This PR adds consistent disclaimers across all community-facing sections.