### PR TITLE
Update conduct extension to v1.0.1

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-01T00:00:00Z",
+  "updated_at": "2026-04-03T12:35:01Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -172,8 +172,8 @@
       "id": "conduct",
       "description": "Executes a single spec-kit phase via sub-agent delegation to reduce context pollution.",
       "author": "twbrandon7",
-      "version": "1.0.0",
-      "download_url": "https://github.com/twbrandon7/spec-kit-conduct-ext/archive/refs/tags/v1.0.0.zip",
+      "version": "1.0.1",
+      "download_url": "https://github.com/twbrandon7/spec-kit-conduct-ext/archive/refs/tags/v1.0.1.zip",
       "repository": "https://github.com/twbrandon7/spec-kit-conduct-ext",
       "homepage": "https://github.com/twbrandon7/spec-kit-conduct-ext",
       "documentation": "https://github.com/twbrandon7/spec-kit-conduct-ext/blob/main/README.md",
@@ -195,7 +195,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-03-19T12:08:20Z",
-      "updated_at": "2026-03-19T12:08:20Z"
+      "updated_at": "2026-04-03T12:35:01Z"
     },
     "critique": {
       "name": "Spec Critique Extension",


### PR DESCRIPTION
## Description

Update conduct extension to v1.0.1

### Changelog of the extension

#### Added
- `.extensionignore` to selectively ignore specific files and directories during the extension installation process.
- Integration test coverage for extension installation, validating script loading and command registration.

#### Changed
- Integrated and configured `uv` as the default package and dependency manager.

#### Fixed
- Refined the `conduct` agent prompt to strictly enforce one-step delegation per sub-agent, preventing single sub-agents from erroneously executing entire multi-step tasks.
- Corrected the required Spec Kit version constraint.

## Testing

<!-- How did you test your changes? -->

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

The update of the catalog file was done by GitHub Copilot.

<!-- If you used AI, briefly describe how (e.g., "Code generated by Copilot", "Consulted ChatGPT for approach"): -->

