### PR TITLE
fix: add actions:write permission to stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch: # Allow manual triggering
 
 permissions:
+  actions: write
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## Problem

The stale workflow marks issues as stale after 150 days but never closes them after the 30-day close window.

## Root Cause

`actions/stale@v10` uses the GitHub Actions cache to persist state across runs. The workflow only has `issues: write` and `pull-requests: write` permissions — it's missing `actions: write`.

Without that permission, the action can **write** cache entries but **cannot delete** them (returns a 403 on cache cleanup):

```
##[warning]Error delete _state: [403] Resource not accessible by integration
```

This creates a vicious cycle: once an issue is processed and cached, the action skips it on every future run:

```
[#96] issue skipped due being processed during the previous run
[#87] issue skipped due being processed during the previous run
[#83] issue skipped due being processed during the previous run
...
```

So stale issues never reach the closing logic.

## Fix

Add `actions: write` to the workflow permissions block, allowing the stale action to properly manage its cache lifecycle.

## Post-Merge

After merging, you may want to clear the existing stale action cache so all issues get reprocessed on the next run:

```bash
gh cache list --repo github/spec-kit | grep stale
gh cache delete <cache-key> --repo github/spec-kit
```