### PR TITLE
fix(scripts): Show git checkout error output on branch creation failure

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -327,13 +327,17 @@ SPEC_FILE="$FEATURE_DIR/spec.md"
 
 if [ "$DRY_RUN" != true ]; then
     if [ "$HAS_GIT" = true ]; then
-        if ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
+        checkout_stderr=""
+        if ! { checkout_stderr=$(git checkout -b "$BRANCH_NAME" 2>&1 1>&3); } 3>&1; then
             # Check if branch already exists
             if git branch --list "$BRANCH_NAME" | grep -q .; then
                 if [ "$ALLOW_EXISTING" = true ]; then
                     # Switch to the existing branch instead of failing
-                    if ! git checkout "$BRANCH_NAME" 2>/dev/null; then
+                    if ! { checkout_stderr=$(git checkout "$BRANCH_NAME" 2>&1 1>&3); } 3>&1; then
                         >&2 echo "Error: Failed to switch to existing branch '$BRANCH_NAME'. Please resolve any local changes or conflicts and try again."
+                        if [ -n "$checkout_stderr" ]; then
+                            >&2 echo "$checkout_stderr"
+                        fi
                         exit 1
                     fi
                 elif [ "$USE_TIMESTAMP" = true ]; then
@@ -345,6 +349,9 @@ if [ "$DRY_RUN" != true ]; then
                 fi
             else
                 >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'. Please check your git configuration and try again."
+                if [ -n "$checkout_stderr" ]; then
+                    >&2 echo "$checkout_stderr"
+                fi
                 exit 1
             fi
         fi

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -293,8 +293,9 @@ $specFile = Join-Path $featureDir 'spec.md'
 if (-not $DryRun) {
     if ($hasGit) {
         $branchCreated = $false
+        $checkoutStderr = ''
         try {
-            git checkout -q -b $branchName 2>$null | Out-Null
+            $checkoutStderr = git checkout -q -b $branchName 2>&1 | Out-String
             if ($LASTEXITCODE -eq 0) {
                 $branchCreated = $true
             }
@@ -308,9 +309,12 @@ if (-not $DryRun) {
             if ($existingBranch) {
                 if ($AllowExistingBranch) {
                     # Switch to the existing branch instead of failing
-                    git checkout -q $branchName 2>$null | Out-Null
+                    $checkoutStderr = git checkout -q $branchName 2>&1 | Out-String
                     if ($LASTEXITCODE -ne 0) {
                         Write-Error "Error: Branch '$branchName' exists but could not be checked out. Resolve any uncommitted changes or conflicts and try again."
+                        if (-not [string]::IsNullOrWhiteSpace($checkoutStderr)) {
+                            [Console]::Error.WriteLine($checkoutStderr.TrimEnd())
+                        }
                         exit 1
                     }
                 } elseif ($Timestamp) {
@@ -322,6 +326,9 @@ if (-not $DryRun) {
                 }
             } else {
                 Write-Error "Error: Failed to create git branch '$branchName'. Please check your git configuration and try again."
+                if (-not [string]::IsNullOrWhiteSpace($checkoutStderr)) {
+                    [Console]::Error.WriteLine($checkoutStderr.TrimEnd())
+                }
                 exit 1
             }
         }


### PR DESCRIPTION
## Summary

Improves error reporting in `create-new-feature.sh` by displaying actual git error messages instead of silently discarding them.

## Problem

When `git checkout -b` or `git checkout` failed, stderr was discarded with `2>/dev/null`. This left users without diagnostic information to troubleshoot issues like:
- Uncommitted changes blocking checkout
- Merge conflicts
- Permission problems
- Detached HEAD states

## Solution

- Capture stderr from git checkout commands using file descriptor redirection
- Display the captured error message when operations fail
- Preserve existing error handling logic and exit codes

## Testing

Tested by attempting branch operations with:
- Dirty working tree (shows "Please commit your changes or stash them")
- Existing branch without `--allow-existing-branch` flag