### PR TITLE
feat(extensions): authenticate GitHub-hosted catalog and download requests with GITHUB_TOKEN/GH_TOKEN

### DIFF
--- a/extensions/EXTENSION-USER-GUIDE.md
+++ b/extensions/EXTENSION-USER-GUIDE.md
@@ -421,7 +421,7 @@ In addition to extension-specific environment variables (`SPECKIT_{EXT_ID}_*`), 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `SPECKIT_CATALOG_URL`       | Override the full catalog stack with a single URL (backward compat) | Built-in default stack |
-| `GH_TOKEN` / `GITHUB_TOKEN` | GitHub API token for downloads     | None                  |
+| `GH_TOKEN` / `GITHUB_TOKEN` | GitHub token for authenticated requests to GitHub-hosted URLs (`raw.githubusercontent.com`, `github.com`, `api.github.com`). Required when your catalog JSON or extension ZIPs are hosted in a private GitHub repository. | None |
 
 #### Example: Using a custom catalog for testing
 
@@ -432,6 +432,21 @@ export SPECKIT_CATALOG_URL="http://localhost:8000/catalog.json"
 # Or use a staging catalog
 export SPECKIT_CATALOG_URL="https://example.com/staging/catalog.json"
 ```
+
+#### Example: Using a private GitHub-hosted catalog
+
+```bash
+# Authenticate with a token (gh CLI, PAT, or GITHUB_TOKEN in CI)
+export GITHUB_TOKEN=$(gh auth token)
+
+# Search a private catalog added via `specify extension catalog add`
+specify extension search jira
+
+# Install from a private catalog
+specify extension add jira-sync
+```
+
+The token is attached automatically to requests targeting GitHub domains. Non-GitHub catalog URLs are always fetched without credentials.
 
 ---
 

--- a/presets/README.md
+++ b/presets/README.md
@@ -93,9 +93,25 @@ See [scaffold/](scaffold/) for a scaffold you can copy to create your own preset
 
 ## Environment Variables
 
-| Variable | Description |
-|----------|-------------|
-| `SPECKIT_PRESET_CATALOG_URL` | Override the catalog URL (replaces all defaults) |
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SPECKIT_PRESET_CATALOG_URL` | Override the full catalog stack with a single URL (replaces all defaults) | Built-in default stack |
+| `GH_TOKEN` / `GITHUB_TOKEN` | GitHub token for authenticated requests to GitHub-hosted URLs (`raw.githubusercontent.com`, `github.com`, `api.github.com`). Required when your catalog JSON or preset ZIPs are hosted in a private GitHub repository. | None |
+
+#### Example: Using a private GitHub-hosted catalog
+
+```bash
+# Authenticate with a token (gh CLI, PAT, or GITHUB_TOKEN in CI)
+export GITHUB_TOKEN=$(gh auth token)
+
+# Search a private catalog added via `specify preset catalog add`
+specify preset search my-template
+
+# Install from a private catalog
+specify preset add my-template
+```
+
+The token is attached automatically to requests targeting GitHub domains. Non-GitHub catalog URLs are always fetched without credentials.
 
 ## Configuration Files
 

--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -41,6 +41,23 @@ def build_github_request(url: str) -> urllib.request.Request:
     return urllib.request.Request(url, headers=headers)
 
 
+class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that drops the Authorization header when leaving GitHub.
+
+    Prevents token leakage to CDNs or other third-party hosts that GitHub
+    may redirect to (e.g. S3 for release asset downloads, objects.githubusercontent.com).
+    Auth is preserved as long as the redirect target remains within GITHUB_HOSTS.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is not None:
+            hostname = (urlparse(newurl).hostname or "").lower()
+            if hostname not in GITHUB_HOSTS:
+                new_req.headers.pop("Authorization", None)
+        return new_req
+
+
 def open_github_url(url: str, timeout: int = 10):
     """Open a URL with GitHub auth, stripping the header on cross-host redirects.
 
@@ -53,15 +70,6 @@ def open_github_url(url: str, timeout: int = 10):
 
     if not req.get_header("Authorization"):
         return urllib.request.urlopen(req, timeout=timeout)
-
-    class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
-        def redirect_request(_self, req, fp, code, msg, headers, newurl):
-            new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
-            if new_req is not None:
-                hostname = (urlparse(newurl).hostname or "").lower()
-                if hostname not in GITHUB_HOSTS:
-                    new_req.headers.pop("Authorization", None)
-            return new_req
 
     opener = urllib.request.build_opener(_StripAuthOnRedirect)
     return opener.open(req, timeout=timeout)

--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -1,0 +1,65 @@
+"""Shared GitHub-authenticated HTTP helpers.
+
+Used by both ExtensionCatalog and PresetCatalog to attach
+GITHUB_TOKEN / GH_TOKEN credentials to requests targeting
+GitHub-hosted domains, while preventing token leakage to
+third-party hosts on redirects.
+"""
+
+import os
+import urllib.request
+from urllib.parse import urlparse
+from typing import Dict
+
+# GitHub-owned hostnames that should receive the Authorization header.
+# Includes codeload.github.com because GitHub archive URL downloads
+# (e.g. /archive/refs/tags/<tag>.zip) redirect there and require auth
+# for private repositories.
+GITHUB_HOSTS = frozenset({
+    "raw.githubusercontent.com",
+    "github.com",
+    "api.github.com",
+    "codeload.github.com",
+})
+
+
+def build_github_request(url: str) -> urllib.request.Request:
+    """Build a urllib Request, adding a GitHub auth header when available.
+
+    Reads GITHUB_TOKEN or GH_TOKEN from the environment and attaches an
+    ``Authorization: token <value>`` header when the target hostname is one
+    of the known GitHub-owned domains. Non-GitHub URLs are returned as plain
+    requests so credentials are never leaked to third-party hosts.
+    """
+    headers: Dict[str, str] = {}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    hostname = (urlparse(url).hostname or "").lower()
+    if token and hostname in GITHUB_HOSTS:
+        headers["Authorization"] = f"token {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def open_github_url(url: str, timeout: int = 10):
+    """Open a URL with GitHub auth, stripping the header on cross-host redirects.
+
+    When the request carries an Authorization header, a custom redirect
+    handler drops that header if the redirect target is not a GitHub-owned
+    domain, preventing token leakage to CDNs or other third-party hosts
+    that GitHub may redirect to (e.g. S3 for release asset downloads).
+    """
+    req = build_github_request(url)
+
+    if not req.get_header("Authorization"):
+        return urllib.request.urlopen(req, timeout=timeout)
+
+    class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(_self, req, fp, code, msg, headers, newurl):
+            new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+            if new_req is not None:
+                hostname = (urlparse(newurl).hostname or "").lower()
+                if hostname not in GITHUB_HOSTS:
+                    new_req.headers.pop("Authorization", None)
+            return new_req
+
+    opener = urllib.request.build_opener(_StripAuthOnRedirect)
+    return opener.open(req, timeout=timeout)

--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -32,7 +32,9 @@ def build_github_request(url: str) -> urllib.request.Request:
     requests so credentials are never leaked to third-party hosts.
     """
     headers: Dict[str, str] = {}
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    github_token = (os.environ.get("GITHUB_TOKEN") or "").strip()
+    gh_token = (os.environ.get("GH_TOKEN") or "").strip()
+    token = github_token or gh_token or None
     hostname = (urlparse(url).hostname or "").lower()
     if token and hostname in GITHUB_HOSTS:
         headers["Authorization"] = f"token {token}"

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1411,7 +1411,7 @@ class ExtensionCatalog:
         if not parsed.netloc:
             raise ValidationError("Catalog URL must be a valid URL with a host.")
 
-    def _make_request(self, url: str) -> "urllib.request.Request":
+    def _make_request(self, url: str):
         """Build a urllib Request, adding a GitHub auth header when available.
 
         Delegates to :func:`specify_cli._github_http.build_github_request`.
@@ -1583,7 +1583,6 @@ class ExtensionCatalog:
         Raises:
             ExtensionError: If catalog cannot be fetched or has invalid format
         """
-        import urllib.request
         import urllib.error
 
         # Determine cache file paths (backward compat for default catalog)
@@ -1731,7 +1730,6 @@ class ExtensionCatalog:
         catalog_url = self.get_catalog_url()
 
         try:
-            import urllib.request
             import urllib.error
 
             with self._open_url(catalog_url, timeout=10) as response:
@@ -1845,7 +1843,6 @@ class ExtensionCatalog:
         Raises:
             ExtensionError: If extension not found or download fails
         """
-        import urllib.request
         import urllib.error
 
         # Get extension info from catalog

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1432,6 +1432,36 @@ class ExtensionCatalog:
             headers["Authorization"] = f"token {token}"
         return urllib.request.Request(url, headers=headers)
 
+    def _open_url(self, url: str, timeout: int = 10):
+        """Open a URL using _make_request, stripping auth on cross-host redirects.
+
+        When the request carries an Authorization header, a custom redirect
+        handler is used to drop that header if the redirect target is not a
+        GitHub-hosted domain, preventing token leakage to CDNs or other
+        third-party hosts that GitHub may redirect to.
+        """
+        import urllib.request
+        from urllib.parse import urlparse
+
+        req = self._make_request(url)
+
+        if not req.get_header("Authorization"):
+            return urllib.request.urlopen(req, timeout=timeout)
+
+        _github_hosts = {"raw.githubusercontent.com", "github.com", "api.github.com"}
+
+        class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
+            def redirect_request(_self, req, fp, code, msg, headers, newurl):
+                new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+                if new_req is not None:
+                    hostname = (urlparse(newurl).hostname or "").lower()
+                    if hostname not in _github_hosts:
+                        new_req.headers.pop("Authorization", None)
+                return new_req
+
+        opener = urllib.request.build_opener(_StripAuthOnRedirect)
+        return opener.open(req, timeout=timeout)
+
     def _load_catalog_config(self, config_path: Path) -> Optional[List[CatalogEntry]]:
         """Load catalog stack configuration from a YAML file.
 
@@ -1622,7 +1652,7 @@ class ExtensionCatalog:
 
         # Fetch from network
         try:
-            with urllib.request.urlopen(self._make_request(entry.url), timeout=10) as response:
+            with self._open_url(entry.url, timeout=10) as response:
                 catalog_data = json.loads(response.read())
 
             if "schema_version" not in catalog_data or "extensions" not in catalog_data:
@@ -1739,7 +1769,7 @@ class ExtensionCatalog:
             import urllib.request
             import urllib.error
 
-            with urllib.request.urlopen(self._make_request(catalog_url), timeout=10) as response:
+            with self._open_url(catalog_url, timeout=10) as response:
                 catalog_data = json.loads(response.read())
 
             # Validate catalog structure
@@ -1882,7 +1912,7 @@ class ExtensionCatalog:
 
         # Download the ZIP file
         try:
-            with urllib.request.urlopen(self._make_request(download_url), timeout=60) as response:
+            with self._open_url(download_url, timeout=60) as response:
                 zip_data = response.read()
 
             zip_path.write_bytes(zip_data)

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1414,53 +1414,18 @@ class ExtensionCatalog:
     def _make_request(self, url: str) -> "urllib.request.Request":
         """Build a urllib Request, adding a GitHub auth header when available.
 
-        Reads GITHUB_TOKEN or GH_TOKEN from the environment and attaches an
-        ``Authorization: token <value>`` header for requests to GitHub-hosted
-        domains (``raw.githubusercontent.com``, ``github.com``,
-        ``api.github.com``).  Non-GitHub URLs are returned as plain requests
-        so credentials are never leaked to third-party hosts.
+        Delegates to :func:`specify_cli._github_http.build_github_request`.
         """
-        import os
-        import urllib.request
-        from urllib.parse import urlparse
-
-        headers: Dict[str, str] = {}
-        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-        hostname = (urlparse(url).hostname or "").lower()
-        github_hosts = {"raw.githubusercontent.com", "github.com", "api.github.com"}
-        if token and hostname in github_hosts:
-            headers["Authorization"] = f"token {token}"
-        return urllib.request.Request(url, headers=headers)
+        from specify_cli._github_http import build_github_request
+        return build_github_request(url)
 
     def _open_url(self, url: str, timeout: int = 10):
-        """Open a URL using _make_request, stripping auth on cross-host redirects.
+        """Open a URL with GitHub auth, stripping the header on cross-host redirects.
 
-        When the request carries an Authorization header, a custom redirect
-        handler is used to drop that header if the redirect target is not a
-        GitHub-hosted domain, preventing token leakage to CDNs or other
-        third-party hosts that GitHub may redirect to.
+        Delegates to :func:`specify_cli._github_http.open_github_url`.
         """
-        import urllib.request
-        from urllib.parse import urlparse
-
-        req = self._make_request(url)
-
-        if not req.get_header("Authorization"):
-            return urllib.request.urlopen(req, timeout=timeout)
-
-        _github_hosts = {"raw.githubusercontent.com", "github.com", "api.github.com"}
-
-        class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
-            def redirect_request(_self, req, fp, code, msg, headers, newurl):
-                new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
-                if new_req is not None:
-                    hostname = (urlparse(newurl).hostname or "").lower()
-                    if hostname not in _github_hosts:
-                        new_req.headers.pop("Authorization", None)
-                return new_req
-
-        opener = urllib.request.build_opener(_StripAuthOnRedirect)
-        return opener.open(req, timeout=timeout)
+        from specify_cli._github_http import open_github_url
+        return open_github_url(url, timeout)
 
     def _load_catalog_config(self, config_path: Path) -> Optional[List[CatalogEntry]]:
         """Load catalog stack configuration from a YAML file.

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1422,13 +1422,13 @@ class ExtensionCatalog:
         """
         import os
         import urllib.request
+        from urllib.parse import urlparse
 
         headers: Dict[str, str] = {}
         token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-        if token and any(
-            host in url
-            for host in ("raw.githubusercontent.com", "github.com", "api.github.com")
-        ):
+        hostname = (urlparse(url).hostname or "").lower()
+        github_hosts = {"raw.githubusercontent.com", "github.com", "api.github.com"}
+        if token and hostname in github_hosts:
             headers["Authorization"] = f"token {token}"
         return urllib.request.Request(url, headers=headers)
 

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1411,6 +1411,27 @@ class ExtensionCatalog:
         if not parsed.netloc:
             raise ValidationError("Catalog URL must be a valid URL with a host.")
 
+    def _make_request(self, url: str) -> "urllib.request.Request":
+        """Build a urllib Request, adding a GitHub auth header when available.
+
+        Reads GITHUB_TOKEN or GH_TOKEN from the environment and attaches an
+        ``Authorization: token <value>`` header for requests to GitHub-hosted
+        domains (``raw.githubusercontent.com``, ``github.com``,
+        ``api.github.com``).  Non-GitHub URLs are returned as plain requests
+        so credentials are never leaked to third-party hosts.
+        """
+        import os
+        import urllib.request
+
+        headers: Dict[str, str] = {}
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        if token and any(
+            host in url
+            for host in ("raw.githubusercontent.com", "github.com", "api.github.com")
+        ):
+            headers["Authorization"] = f"token {token}"
+        return urllib.request.Request(url, headers=headers)
+
     def _load_catalog_config(self, config_path: Path) -> Optional[List[CatalogEntry]]:
         """Load catalog stack configuration from a YAML file.
 
@@ -1601,7 +1622,7 @@ class ExtensionCatalog:
 
         # Fetch from network
         try:
-            with urllib.request.urlopen(entry.url, timeout=10) as response:
+            with urllib.request.urlopen(self._make_request(entry.url), timeout=10) as response:
                 catalog_data = json.loads(response.read())
 
             if "schema_version" not in catalog_data or "extensions" not in catalog_data:
@@ -1718,7 +1739,7 @@ class ExtensionCatalog:
             import urllib.request
             import urllib.error
 
-            with urllib.request.urlopen(catalog_url, timeout=10) as response:
+            with urllib.request.urlopen(self._make_request(catalog_url), timeout=10) as response:
                 catalog_data = json.loads(response.read())
 
             # Validate catalog structure
@@ -1861,7 +1882,7 @@ class ExtensionCatalog:
 
         # Download the ZIP file
         try:
-            with urllib.request.urlopen(download_url, timeout=60) as response:
+            with urllib.request.urlopen(self._make_request(download_url), timeout=60) as response:
                 zip_data = response.read()
 
             zip_path.write_bytes(zip_data)

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1178,7 +1178,7 @@ class PresetCatalog:
                 "Catalog URL must be a valid URL with a host."
             )
 
-    def _make_request(self, url: str) -> "urllib.request.Request":
+    def _make_request(self, url: str):
         """Build a urllib Request, adding a GitHub auth header when available.
 
         Delegates to :func:`specify_cli._github_http.build_github_request`.
@@ -1376,9 +1376,6 @@ class PresetCatalog:
                 pass
 
         try:
-            import urllib.request
-            import urllib.error
-
             with self._open_url(entry.url, timeout=10) as response:
                 catalog_data = json.loads(response.read())
 
@@ -1472,9 +1469,6 @@ class PresetCatalog:
                 pass
 
         try:
-            import urllib.request
-            import urllib.error
-
             with self._open_url(catalog_url, timeout=10) as response:
                 catalog_data = json.loads(response.read())
 
@@ -1594,7 +1588,6 @@ class PresetCatalog:
         Raises:
             PresetError: If pack not found or download fails
         """
-        import urllib.request
         import urllib.error
 
         pack_info = self.get_pack_info(pack_id)

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1181,52 +1181,18 @@ class PresetCatalog:
     def _make_request(self, url: str) -> "urllib.request.Request":
         """Build a urllib Request, adding a GitHub auth header when available.
 
-        Reads GITHUB_TOKEN or GH_TOKEN from the environment and attaches an
-        ``Authorization: token <value>`` header for requests to GitHub-hosted
-        domains (``raw.githubusercontent.com``, ``github.com``,
-        ``api.github.com``).  Non-GitHub URLs are returned as plain requests
-        so credentials are never leaked to third-party hosts.
+        Delegates to :func:`specify_cli._github_http.build_github_request`.
         """
-        import urllib.request
-        from urllib.parse import urlparse
-
-        headers: Dict[str, str] = {}
-        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-        hostname = (urlparse(url).hostname or "").lower()
-        github_hosts = {"raw.githubusercontent.com", "github.com", "api.github.com"}
-        if token and hostname in github_hosts:
-            headers["Authorization"] = f"token {token}"
-        return urllib.request.Request(url, headers=headers)
+        from specify_cli._github_http import build_github_request
+        return build_github_request(url)
 
     def _open_url(self, url: str, timeout: int = 10):
-        """Open a URL using _make_request, stripping auth on cross-host redirects.
+        """Open a URL with GitHub auth, stripping the header on cross-host redirects.
 
-        When the request carries an Authorization header, a custom redirect
-        handler is used to drop that header if the redirect target is not a
-        GitHub-hosted domain, preventing token leakage to CDNs or other
-        third-party hosts that GitHub may redirect to.
+        Delegates to :func:`specify_cli._github_http.open_github_url`.
         """
-        import urllib.request
-        from urllib.parse import urlparse
-
-        req = self._make_request(url)
-
-        if not req.get_header("Authorization"):
-            return urllib.request.urlopen(req, timeout=timeout)
-
-        _github_hosts = {"raw.githubusercontent.com", "github.com", "api.github.com"}
-
-        class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
-            def redirect_request(_self, req, fp, code, msg, headers, newurl):
-                new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
-                if new_req is not None:
-                    hostname = (urlparse(newurl).hostname or "").lower()
-                    if hostname not in _github_hosts:
-                        new_req.headers.pop("Authorization", None)
-                return new_req
-
-        opener = urllib.request.build_opener(_StripAuthOnRedirect)
-        return opener.open(req, timeout=timeout)
+        from specify_cli._github_http import open_github_url
+        return open_github_url(url, timeout)
 
     def _load_catalog_config(self, config_path: Path) -> Optional[List[PresetCatalogEntry]]:
         """Load catalog stack configuration from a YAML file.

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -1178,6 +1178,56 @@ class PresetCatalog:
                 "Catalog URL must be a valid URL with a host."
             )
 
+    def _make_request(self, url: str) -> "urllib.request.Request":
+        """Build a urllib Request, adding a GitHub auth header when available.
+
+        Reads GITHUB_TOKEN or GH_TOKEN from the environment and attaches an
+        ``Authorization: token <value>`` header for requests to GitHub-hosted
+        domains (``raw.githubusercontent.com``, ``github.com``,
+        ``api.github.com``).  Non-GitHub URLs are returned as plain requests
+        so credentials are never leaked to third-party hosts.
+        """
+        import urllib.request
+        from urllib.parse import urlparse
+
+        headers: Dict[str, str] = {}
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        hostname = (urlparse(url).hostname or "").lower()
+        github_hosts = {"raw.githubusercontent.com", "github.com", "api.github.com"}
+        if token and hostname in github_hosts:
+            headers["Authorization"] = f"token {token}"
+        return urllib.request.Request(url, headers=headers)
+
+    def _open_url(self, url: str, timeout: int = 10):
+        """Open a URL using _make_request, stripping auth on cross-host redirects.
+
+        When the request carries an Authorization header, a custom redirect
+        handler is used to drop that header if the redirect target is not a
+        GitHub-hosted domain, preventing token leakage to CDNs or other
+        third-party hosts that GitHub may redirect to.
+        """
+        import urllib.request
+        from urllib.parse import urlparse
+
+        req = self._make_request(url)
+
+        if not req.get_header("Authorization"):
+            return urllib.request.urlopen(req, timeout=timeout)
+
+        _github_hosts = {"raw.githubusercontent.com", "github.com", "api.github.com"}
+
+        class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
+            def redirect_request(_self, req, fp, code, msg, headers, newurl):
+                new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+                if new_req is not None:
+                    hostname = (urlparse(newurl).hostname or "").lower()
+                    if hostname not in _github_hosts:
+                        new_req.headers.pop("Authorization", None)
+                return new_req
+
+        opener = urllib.request.build_opener(_StripAuthOnRedirect)
+        return opener.open(req, timeout=timeout)
+
     def _load_catalog_config(self, config_path: Path) -> Optional[List[PresetCatalogEntry]]:
         """Load catalog stack configuration from a YAML file.
 
@@ -1363,7 +1413,7 @@ class PresetCatalog:
             import urllib.request
             import urllib.error
 
-            with urllib.request.urlopen(entry.url, timeout=10) as response:
+            with self._open_url(entry.url, timeout=10) as response:
                 catalog_data = json.loads(response.read())
 
             if (
@@ -1459,7 +1509,7 @@ class PresetCatalog:
             import urllib.request
             import urllib.error
 
-            with urllib.request.urlopen(catalog_url, timeout=10) as response:
+            with self._open_url(catalog_url, timeout=10) as response:
                 catalog_data = json.loads(response.read())
 
             if (
@@ -1620,7 +1670,7 @@ class PresetCatalog:
         zip_path = target_dir / zip_filename
 
         try:
-            with urllib.request.urlopen(download_url, timeout=60) as response:
+            with self._open_url(download_url, timeout=60) as response:
                 zip_data = response.read()
 
             zip_path.write_bytes(zip_data)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2142,6 +2142,132 @@ class TestExtensionCatalog:
         assert not catalog.cache_file.exists()
         assert not catalog.cache_metadata_file.exists()
 
+    # --- _make_request / GitHub auth ---
+
+    def _make_catalog(self, temp_dir):
+        project_dir = temp_dir / "project"
+        project_dir.mkdir()
+        (project_dir / ".specify").mkdir()
+        return ExtensionCatalog(project_dir)
+
+    def test_make_request_no_token_no_auth_header(self, temp_dir, monkeypatch):
+        """Without a token, requests carry no Authorization header."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_github_token_added_for_raw_githubusercontent(self, temp_dir, monkeypatch):
+        """GITHUB_TOKEN is attached for raw.githubusercontent.com URLs."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
+        assert req.get_header("Authorization") == "token ghp_testtoken"
+
+    def test_make_request_gh_token_fallback(self, temp_dir, monkeypatch):
+        """GH_TOKEN is used when GITHUB_TOKEN is absent."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GH_TOKEN", "ghp_ghtoken")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://github.com/org/repo/releases/download/v1/ext.zip")
+        assert req.get_header("Authorization") == "token ghp_ghtoken"
+
+    def test_make_request_github_token_takes_precedence_over_gh_token(self, temp_dir, monkeypatch):
+        """GITHUB_TOKEN takes precedence over GH_TOKEN when both are set."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_primary")
+        monkeypatch.setenv("GH_TOKEN", "ghp_secondary")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://api.github.com/repos/org/repo")
+        assert req.get_header("Authorization") == "token ghp_primary"
+
+    def test_make_request_token_not_added_for_non_github_url(self, temp_dir, monkeypatch):
+        """Auth header is never attached to non-GitHub URLs to prevent credential leakage."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://internal.example.com/catalog.json")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_token_added_for_api_github_com(self, temp_dir, monkeypatch):
+        """GITHUB_TOKEN is attached for api.github.com URLs."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://api.github.com/repos/org/repo/releases/assets/1")
+        assert req.get_header("Authorization") == "token ghp_testtoken"
+
+    def test_fetch_single_catalog_sends_auth_header(self, temp_dir, monkeypatch):
+        """_fetch_single_catalog passes Authorization header to urlopen for GitHub URLs."""
+        from unittest.mock import patch, MagicMock
+        import io
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = self._make_catalog(temp_dir)
+
+        catalog_data = {"schema_version": "1.0", "extensions": {}}
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(catalog_data).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["req"] = req
+            return mock_response
+
+        entry = CatalogEntry(
+            url="https://raw.githubusercontent.com/org/repo/main/catalog.json",
+            name="private",
+            priority=1,
+            install_allowed=True,
+        )
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            catalog._fetch_single_catalog(entry, force_refresh=True)
+
+        assert "Authorization" in captured["req"].headers
+        assert captured["req"].headers["Authorization"] == "token ghp_testtoken"
+
+    def test_download_extension_sends_auth_header(self, temp_dir, monkeypatch):
+        """download_extension passes Authorization header to urlopen for GitHub URLs."""
+        from unittest.mock import patch, MagicMock
+        import zipfile, io
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = self._make_catalog(temp_dir)
+
+        # Build a minimal valid ZIP in memory
+        zip_buf = io.BytesIO()
+        with zipfile.ZipFile(zip_buf, "w") as zf:
+            zf.writestr("extension.yml", "id: test-ext\nname: Test\nversion: 1.0.0\n")
+        zip_bytes = zip_buf.getvalue()
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = zip_bytes
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["req"] = req
+            return mock_response
+
+        ext_info = {
+            "id": "test-ext",
+            "name": "Test Extension",
+            "version": "1.0.0",
+            "download_url": "https://github.com/org/repo/releases/download/v1/test-ext.zip",
+        }
+
+        with patch.object(catalog, "get_extension_info", return_value=ext_info), \
+             patch("urllib.request.urlopen", fake_urlopen):
+            catalog.download_extension("test-ext", target_dir=temp_dir)
+
+        assert "Authorization" in captured["req"].headers
+        assert captured["req"].headers["Authorization"] == "token ghp_testtoken"
+
 
 # ===== CatalogEntry Tests =====
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2158,6 +2158,22 @@ class TestExtensionCatalog:
         req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
         assert "Authorization" not in req.headers
 
+    def test_make_request_whitespace_only_github_token_ignored(self, temp_dir, monkeypatch):
+        """A whitespace-only GITHUB_TOKEN is treated as unset."""
+        monkeypatch.setenv("GITHUB_TOKEN", "   ")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_whitespace_github_token_falls_back_to_gh_token(self, temp_dir, monkeypatch):
+        """When GITHUB_TOKEN is whitespace-only, GH_TOKEN is used as fallback."""
+        monkeypatch.setenv("GITHUB_TOKEN", "   ")
+        monkeypatch.setenv("GH_TOKEN", "ghp_fallback")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
+        assert req.get_header("Authorization") == "token ghp_fallback"
+
     def test_make_request_github_token_added_for_raw_githubusercontent(self, temp_dir, monkeypatch):
         """GITHUB_TOKEN is attached for raw.githubusercontent.com URLs."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2217,6 +2217,13 @@ class TestExtensionCatalog:
         req = catalog._make_request("https://api.github.com/repos/org/repo/releases/assets/1")
         assert req.get_header("Authorization") == "token ghp_testtoken"
 
+    def test_make_request_token_added_for_codeload_github_com(self, temp_dir, monkeypatch):
+        """GITHUB_TOKEN is attached for codeload.github.com URLs (GitHub archive redirects)."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://codeload.github.com/org/repo/zip/refs/tags/v1.0.0")
+        assert req.get_header("Authorization") == "token ghp_testtoken"
+
     def test_fetch_single_catalog_sends_auth_header(self, temp_dir, monkeypatch):
         """_fetch_single_catalog passes Authorization header via opener for GitHub URLs."""
         from unittest.mock import patch, MagicMock
@@ -2252,7 +2259,7 @@ class TestExtensionCatalog:
         assert captured["req"].get_header("Authorization") == "token ghp_testtoken"
 
     def test_download_extension_sends_auth_header(self, temp_dir, monkeypatch):
-        """download_extension passes Authorization header to urlopen for GitHub URLs."""
+        """download_extension passes Authorization header via opener for GitHub URLs."""
         from unittest.mock import patch, MagicMock
         import zipfile, io
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2189,6 +2189,27 @@ class TestExtensionCatalog:
         req = catalog._make_request("https://internal.example.com/catalog.json")
         assert "Authorization" not in req.headers
 
+    def test_make_request_token_not_added_for_github_lookalike_host(self, temp_dir, monkeypatch):
+        """Auth header is not attached to hosts that include github.com as a suffix."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://github.com.evil.com/org/repo/releases/download/v1/ext.zip")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_token_not_added_for_github_in_path(self, temp_dir, monkeypatch):
+        """Auth header is not attached when github.com appears only in the URL path."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://evil.example.com/github.com/org/repo/releases/download/v1/ext.zip")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_token_not_added_for_github_in_query(self, temp_dir, monkeypatch):
+        """Auth header is not attached when github.com appears only in the query string."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = self._make_catalog(temp_dir)
+        req = catalog._make_request("https://evil.example.com/download?source=https://github.com/org/repo/v1/ext.zip")
+        assert "Authorization" not in req.headers
+
     def test_make_request_token_added_for_api_github_com(self, temp_dir, monkeypatch):
         """GITHUB_TOKEN is attached for api.github.com URLs."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2218,9 +2218,8 @@ class TestExtensionCatalog:
         assert req.get_header("Authorization") == "token ghp_testtoken"
 
     def test_fetch_single_catalog_sends_auth_header(self, temp_dir, monkeypatch):
-        """_fetch_single_catalog passes Authorization header to urlopen for GitHub URLs."""
+        """_fetch_single_catalog passes Authorization header via opener for GitHub URLs."""
         from unittest.mock import patch, MagicMock
-        import io
 
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
         catalog = self._make_catalog(temp_dir)
@@ -2232,10 +2231,13 @@ class TestExtensionCatalog:
         mock_response.__exit__ = MagicMock(return_value=False)
 
         captured = {}
+        mock_opener = MagicMock()
 
-        def fake_urlopen(req, timeout=None):
+        def fake_open(req, timeout=None):
             captured["req"] = req
             return mock_response
+
+        mock_opener.open.side_effect = fake_open
 
         entry = CatalogEntry(
             url="https://raw.githubusercontent.com/org/repo/main/catalog.json",
@@ -2244,11 +2246,10 @@ class TestExtensionCatalog:
             install_allowed=True,
         )
 
-        with patch("urllib.request.urlopen", fake_urlopen):
+        with patch("urllib.request.build_opener", return_value=mock_opener):
             catalog._fetch_single_catalog(entry, force_refresh=True)
 
-        assert "Authorization" in captured["req"].headers
-        assert captured["req"].headers["Authorization"] == "token ghp_testtoken"
+        assert captured["req"].get_header("Authorization") == "token ghp_testtoken"
 
     def test_download_extension_sends_auth_header(self, temp_dir, monkeypatch):
         """download_extension passes Authorization header to urlopen for GitHub URLs."""
@@ -2271,9 +2272,13 @@ class TestExtensionCatalog:
 
         captured = {}
 
-        def fake_urlopen(req, timeout=None):
+        mock_opener = MagicMock()
+
+        def fake_open(req, timeout=None):
             captured["req"] = req
             return mock_response
+
+        mock_opener.open.side_effect = fake_open
 
         ext_info = {
             "id": "test-ext",
@@ -2283,11 +2288,11 @@ class TestExtensionCatalog:
         }
 
         with patch.object(catalog, "get_extension_info", return_value=ext_info), \
-             patch("urllib.request.urlopen", fake_urlopen):
+             patch("urllib.request.build_opener", return_value=mock_opener):
             catalog.download_extension("test-ext", target_dir=temp_dir)
 
-        assert "Authorization" in captured["req"].headers
-        assert captured["req"].headers["Authorization"] == "token ghp_testtoken"
+        assert captured["req"].get_header("Authorization") == "token ghp_testtoken"
+
 
 
 # ===== CatalogEntry Tests =====

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1310,6 +1310,13 @@ class TestPresetCatalog:
         req = catalog._make_request("https://api.github.com/repos/org/repo")
         assert req.get_header("Authorization") == "token ghp_primary"
 
+    def test_make_request_token_added_for_codeload_github_com(self, project_dir, monkeypatch):
+        """GITHUB_TOKEN is attached for codeload.github.com URLs (GitHub archive redirects)."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://codeload.github.com/org/repo/zip/refs/tags/v1.0.0")
+        assert req.get_header("Authorization") == "token ghp_testtoken"
+
     def test_make_request_token_not_added_for_non_github_url(self, project_dir, monkeypatch):
         """Auth header is never attached to non-GitHub URLs to prevent credential leakage."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1276,6 +1276,142 @@ class TestPresetCatalog:
         catalog = PresetCatalog(project_dir)
         assert catalog.get_catalog_url() == "https://custom.example.com/catalog.json"
 
+    # --- _make_request / GitHub auth ---
+
+    def test_make_request_no_token_no_auth_header(self, project_dir, monkeypatch):
+        """Without a token, requests carry no Authorization header."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_github_token_added_for_github_url(self, project_dir, monkeypatch):
+        """GITHUB_TOKEN is attached for raw.githubusercontent.com URLs."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
+        assert req.get_header("Authorization") == "token ghp_testtoken"
+
+    def test_make_request_gh_token_fallback(self, project_dir, monkeypatch):
+        """GH_TOKEN is used when GITHUB_TOKEN is absent."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GH_TOKEN", "ghp_ghtoken")
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://github.com/org/repo/releases/download/v1/pack.zip")
+        assert req.get_header("Authorization") == "token ghp_ghtoken"
+
+    def test_make_request_github_token_takes_precedence(self, project_dir, monkeypatch):
+        """GITHUB_TOKEN takes precedence over GH_TOKEN when both are set."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_primary")
+        monkeypatch.setenv("GH_TOKEN", "ghp_secondary")
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://api.github.com/repos/org/repo")
+        assert req.get_header("Authorization") == "token ghp_primary"
+
+    def test_make_request_token_not_added_for_non_github_url(self, project_dir, monkeypatch):
+        """Auth header is never attached to non-GitHub URLs to prevent credential leakage."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://internal.example.com/catalog.json")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_token_not_added_for_github_lookalike_host(self, project_dir, monkeypatch):
+        """Auth header is not attached to hosts that include github.com as a suffix."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://github.com.evil.com/org/repo/releases/download/v1/pack.zip")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_token_not_added_for_github_in_path(self, project_dir, monkeypatch):
+        """Auth header is not attached when github.com appears only in the URL path."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://evil.example.com/github.com/org/repo/releases/download/v1/pack.zip")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_token_not_added_for_github_in_query(self, project_dir, monkeypatch):
+        """Auth header is not attached when github.com appears only in the query string."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://evil.example.com/download?source=https://github.com/org/repo/v1/pack.zip")
+        assert "Authorization" not in req.headers
+
+    def test_fetch_single_catalog_sends_auth_header(self, project_dir, monkeypatch):
+        """_fetch_single_catalog passes Authorization header via opener for GitHub URLs."""
+        from unittest.mock import patch, MagicMock
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = PresetCatalog(project_dir)
+
+        catalog_data = {"schema_version": "1.0", "presets": {}}
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps(catalog_data).encode()
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        captured = {}
+        mock_opener = MagicMock()
+
+        def fake_open(req, timeout=None):
+            captured["req"] = req
+            return mock_response
+
+        mock_opener.open.side_effect = fake_open
+
+        entry = PresetCatalogEntry(
+            url="https://raw.githubusercontent.com/org/repo/main/presets/catalog.json",
+            name="private",
+            priority=1,
+            install_allowed=True,
+        )
+
+        with patch("urllib.request.build_opener", return_value=mock_opener):
+            catalog._fetch_single_catalog(entry, force_refresh=True)
+
+        assert captured["req"].get_header("Authorization") == "token ghp_testtoken"
+
+    def test_download_pack_sends_auth_header(self, project_dir, monkeypatch):
+        """download_pack passes Authorization header via opener for GitHub URLs."""
+        from unittest.mock import patch, MagicMock
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        catalog = PresetCatalog(project_dir)
+
+        zip_buf = __import__("io").BytesIO()
+        with zipfile.ZipFile(zip_buf, "w") as zf:
+            zf.writestr("preset.yml", "id: test-pack\nname: Test\nversion: 1.0.0\n")
+        zip_bytes = zip_buf.getvalue()
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = zip_bytes
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        captured = {}
+        mock_opener = MagicMock()
+
+        def fake_open(req, timeout=None):
+            captured["req"] = req
+            return mock_response
+
+        mock_opener.open.side_effect = fake_open
+
+        pack_info = {
+            "id": "test-pack",
+            "name": "Test Pack",
+            "version": "1.0.0",
+            "download_url": "https://github.com/org/repo/releases/download/v1/test-pack.zip",
+            "_install_allowed": True,
+        }
+
+        with patch.object(catalog, "get_pack_info", return_value=pack_info), \
+             patch("urllib.request.build_opener", return_value=mock_opener):
+            catalog.download_pack("test-pack", target_dir=project_dir)
+
+        assert captured["req"].get_header("Authorization") == "token ghp_testtoken"
+
 
 # ===== Integration Tests =====
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1286,6 +1286,22 @@ class TestPresetCatalog:
         req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
         assert "Authorization" not in req.headers
 
+    def test_make_request_whitespace_only_github_token_ignored(self, project_dir, monkeypatch):
+        """A whitespace-only GITHUB_TOKEN is treated as unset."""
+        monkeypatch.setenv("GITHUB_TOKEN", "   ")
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
+        assert "Authorization" not in req.headers
+
+    def test_make_request_whitespace_github_token_falls_back_to_gh_token(self, project_dir, monkeypatch):
+        """When GITHUB_TOKEN is whitespace-only, GH_TOKEN is used as fallback."""
+        monkeypatch.setenv("GITHUB_TOKEN", "   ")
+        monkeypatch.setenv("GH_TOKEN", "ghp_fallback")
+        catalog = PresetCatalog(project_dir)
+        req = catalog._make_request("https://raw.githubusercontent.com/org/repo/main/catalog.json")
+        assert req.get_header("Authorization") == "token ghp_fallback"
+
     def test_make_request_github_token_added_for_github_url(self, project_dir, monkeypatch):
         """GITHUB_TOKEN is attached for raw.githubusercontent.com URLs."""
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")


### PR DESCRIPTION
## Description

Fixes #2037. Closes the authentication gap introduced when multi-catalog support landed in #1707.

Before this change, all network requests in `ExtensionCatalog` used bare `urllib.request.urlopen(url)` with no headers. Any catalog or extension ZIP hosted in a private GitHub repository would silently fail with HTTP 404, regardless of whether `GITHUB_TOKEN` or `GH_TOKEN` was set in the environment.

This PR adds a `_make_request(url)` helper on `ExtensionCatalog` that attaches an `Authorization: token <value>` header when:
 - `GITHUB_TOKEN` or `GH_TOKEN` is present in the environment, **and**
 - the target URL is a GitHub-hosted domain (`raw.githubusercontent.com`,
    `github.com`, or `api.github.com`)

Non-GitHub URLs are always fetched without credentials to prevent token leakage to third-party hosts.

The three affected call sites are:
 - `_fetch_single_catalog` — fetches catalog JSON from a configured catalog URL
 - `fetch_catalog` — legacy single-catalog path used when `SPECKIT_CATALOG_URL` is set
 - `download_extension` — downloads extension ZIP from a release asset URL

No behavior change for users without a token set — the code path is identical to before.

Documentation in `EXTENSION-USER-GUIDE.md` has been updated: the existing `GH_TOKEN`/`GITHUB_TOKEN` table entry (which described the token as "for downloads" only) now accurately reflects that it covers catalog fetches as well, and a private-catalog usage example has been added.

## Testing

 - [x] Ran `uv run specify --help` — CLI loads correctly, all commands present
 - [x] Ran full test suite: **1131 passed, 5 skipped, 2 failed**
   - Both failures are pre-existing on `main` before this change:
    - `TestManifestPathTraversal::test_record_file_rejects_absolute_path`
    - `TestCommandRegistrar::test_codex_skill_registration_uses_fallback_script_variant_without_init_options`
 - [x] 8 new tests added to `TestExtensionCatalog` in `tests/test_extensions.py`:
   - 6 unit tests for `_make_request`: no-token path, `GITHUB_TOKEN`, `GH_TOKEN` fallback, precedence when both are set, non-GitHub URL never gets header (security), `api.github.com` domain
   - 2 integration tests that mock `urlopen` and assert the captured `Request` object carries the auth header — one for `_fetch_single_catalog`, one for `download_extension`

## AI Disclosure

 - [x] I **did** use AI assistance (describe below)
 This PR was implemented with AI assistance via Claude Code.