### PR TITLE
[stage2] fix: serialize multiline descriptions in legacy TOML renderer

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -191,8 +191,9 @@ class CommandRegistrar:
         toml_lines = []
 
         if "description" in frontmatter:
-            desc = frontmatter["description"].replace('"', '\\"')
-            toml_lines.append(f'description = "{desc}"')
+            toml_lines.append(
+                f'description = {self._render_basic_toml_string(frontmatter["description"])}'
+            )
             toml_lines.append("")
 
         toml_lines.append(f"# Source: {source_id}")
@@ -219,6 +220,18 @@ class CommandRegistrar:
             toml_lines.append(f'prompt = "{escaped_body}"')
 
         return "\n".join(toml_lines)
+
+    @staticmethod
+    def _render_basic_toml_string(value: str) -> str:
+        """Render *value* as a TOML basic string literal."""
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
+        return f'"{escaped}"'
 
     def render_skill_command(
         self,

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -210,14 +210,7 @@ class CommandRegistrar:
             toml_lines.append(body)
             toml_lines.append("'''")
         else:
-            escaped_body = (
-                body.replace("\\", "\\\\")
-                .replace('"', '\\"')
-                .replace("\n", "\\n")
-                .replace("\r", "\\r")
-                .replace("\t", "\\t")
-            )
-            toml_lines.append(f'prompt = "{escaped_body}"')
+            toml_lines.append(f"prompt = {self._render_basic_toml_string(body)}")
 
         return "\n".join(toml_lines)
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -13,6 +13,7 @@ import pytest
 import json
 import tempfile
 import shutil
+import tomllib
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -1013,6 +1014,21 @@ $ARGUMENTS
         assert 'prompt = "' in output
         assert "\\n" in output
         assert "\\\"\\\"\\\"" in output
+
+    def test_render_toml_command_preserves_multiline_description(self):
+        """Multiline descriptions should render as parseable TOML with preserved semantics."""
+        from specify_cli.agents import CommandRegistrar as AgentCommandRegistrar
+
+        registrar = AgentCommandRegistrar()
+        output = registrar.render_toml_command(
+            {"description": "first line\nsecond line\n"},
+            "body",
+            "extension:test-ext",
+        )
+
+        parsed = tomllib.loads(output)
+
+        assert parsed["description"] == "first line\nsecond line\n"
 
     def test_register_commands_for_claude(self, extension_dir, project_dir):
         """Test registering commands for Claude agent."""


### PR DESCRIPTION
## Summary

Fix the legacy TOML rendering path still used by preset and extension command registration.

This PR corrects the `CommandRegistrar.render_toml_command()` behavior for multiline `description` values so the generated TOML remains parseable and preserves the description text when loaded back through `tomllib`.

## What changed

- render TOML `description` values through safe basic-string escaping instead of embedding raw newlines in a one-line TOML string
- add regression coverage for multiline description round-tripping in `tests/test_extensions.py`
- leave prompt fallback behavior unchanged

## Validation

- `uv run --with pytest python -m pytest tests/test_extensions.py -q -k "multiline_description or embedded_triple_double_quotes or escapes_when_both_triple_quote_styles_exist"`
- `uv run --with pytest python -m pytest tests/test_extensions.py -q`

## Issue

Part of #2095.
