### PR TITLE
Update V-Model Extension Pack to v0.5.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1067,7 +1067,7 @@
       "created_at": "2026-03-14T00:00:00Z",
       "updated_at": "2026-03-14T00:00:00Z"
     },
-    "repoindex":{
+    "repoindex": {
       "name": "Repository Index",
       "id": "repoindex",
       "description": "Generate index of your repo for overview, architecture and module",
@@ -1082,7 +1082,7 @@
       "requires": {
         "speckit_version": ">=0.1.0",
         "tools": [
-         {
+          {
             "name": "no need",
             "version": ">=1.0.0",
             "required": false
@@ -1436,8 +1436,8 @@
       "id": "v-model",
       "description": "Enforces V-Model paired generation of development specs and test specs with full traceability.",
       "author": "leocamello",
-      "version": "0.4.0",
-      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.4.0.zip",
+      "version": "0.5.0",
+      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.5.0.zip",
       "repository": "https://github.com/leocamello/spec-kit-v-model",
       "homepage": "https://github.com/leocamello/spec-kit-v-model",
       "documentation": "https://github.com/leocamello/spec-kit-v-model/blob/main/README.md",
@@ -1447,7 +1447,7 @@
         "speckit_version": ">=0.1.0"
       },
       "provides": {
-        "commands": 9,
+        "commands": 14,
         "hooks": 1
       },
       "tags": [
@@ -1461,7 +1461,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-02-20T00:00:00Z",
-      "updated_at": "2026-02-22T00:00:00Z"
+      "updated_at": "2026-04-06T00:00:00Z"
     },
     "verify": {
       "name": "Verify Extension",
@@ -1526,6 +1526,5 @@
       "created_at": "2026-03-16T00:00:00Z",
       "updated_at": "2026-03-16T00:00:00Z"
     }
-    
   }
 }


### PR DESCRIPTION
## Summary

Updates the V-Model Extension Pack catalog entry from v0.4.0 to v0.5.0.

## What's New in v0.5.0

### 5 New Commands (9 → 14 total)
- **hazard-analysis** — ISO 14971/26262 FMEA with HAZ-NNN identifiers, operational state awareness, risk matrix, and mitigation traceability
- **impact-analysis** — Deterministic change impact analysis with bidirectional graph traversal (downward, upward, full)
- **peer-review** — AI-powered stateless linter with standards-based criteria (INCOSE, IEEE 1016, ISO 29119, ISO 14971, DO-178C) and CI exit codes
- **test-results** — JUnit XML + Cobertura XML ingestor that updates traceability matrix with execution status and code coverage
- **audit-report** — Point-in-time release audit report builder with waiver cross-referencing and compliance gating

### Release Enhancements
- `validate-level.sh` / `Validate-Level.ps1` — Dispatch wrapper for all 5 validators
- Agent definitions for all 14 commands (was 3)
- Sample CI workflow template (`examples/github-actions/v-model-validation.yml`)

### Test Coverage
- 364 BATS + 347 Pester + 89 structural + 42 LLM-as-judge tests
- 5 dogfooded V-Model specification sets

## Catalog Changes
| Field | Before | After |
|-------|--------|-------|
| version | 0.4.0 | 0.5.0 |
| download_url | v0.4.0.zip | v0.5.0.zip |
| commands | 9 | 14 |
| updated_at | 2026-02-22 | 2026-04-06 |

## Links
- Release: https://github.com/leocamello/spec-kit-v-model/releases/tag/v0.5.0
- Changelog: https://github.com/leocamello/spec-kit-v-model/blob/main/CHANGELOG.md
- Previous catalog PRs: #1640 (v0.1.0), #1656 (v0.2.0), #1661 (v0.3.0), #1665 (v0.4.0)