### PR TITLE
fix(specify): correct self-referencing step number in validation flow

### DIFF
--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -183,7 +183,7 @@ Given that feature description, do this:
 
    c. **Handle Validation Results**:
 
-      - **If all items pass**: Mark checklist complete and proceed to step 7
+      - **If all items pass**: Mark checklist complete and proceed to step 8
 
       - **If items fail (excluding [NEEDS CLARIFICATION])**:
         1. List the failing items and specific issues


### PR DESCRIPTION
## Description

Fix self-referencing step number in the `specify` command template's validation flow.

Step 7c ("If all items pass") incorrectly said "proceed to step 7", which points back to the current step (Specification Quality Validation), creating an infinite loop. Changed to "proceed to step 8" (Report completion).

## Testing

- [x] Verified the step numbering is correct by reviewing the full outline (steps 1–9)

## AI Disclosure

- [x] I **did not** use AI assistance for this contribution

