### PR TITLE
fix(taskstoissues): correct outline step numbering and list continuation

### DIFF
--- a/templates/commands/taskstoissues.md
+++ b/templates/commands/taskstoissues.md
@@ -51,17 +51,17 @@ You **MUST** consider the user input before proceeding (if not empty).
 ## Outline
 
 1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
-1. From the executed script, extract the path to **tasks**.
-1. Get the Git remote by running:
+2. From the executed script, extract the path to **tasks**.
+3. Get the Git remote by running:
 
-```bash
-git config --get remote.origin.url
-```
+   ```bash
+   git config --get remote.origin.url
+   ```
 
-> [!CAUTION]
-> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+   > [!CAUTION]
+   > ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
 
-1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+4. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
 
 > [!CAUTION]
 > UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL


### PR DESCRIPTION
## Description

Fix outline step numbering in the taskstoissues command template.

All four steps used 1. (relying on Markdown auto-numbering), but the fenced code block and blockquote between steps 3 and 4 broke list continuation, resetting the counter back to 1. Changed to explicit numbering (1–4) and indented the code block and blockquote under step 3 to maintain proper list flow.

## AI Disclosure

- [x] I **did not** use AI assistance for this contribution

