### PR TITLE
Clarify conflicting persistence instructions in /speckit.clarify

### DIFF
--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -161,7 +161,7 @@ Execution steps:
        - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
        - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
        - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
-       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+       - Once satisfactory, record it in working memory and immediately hand it to the integration step below; persist it to disk there after each integration before continuing to the next queued question.
     - Stop asking further questions when:
        - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
        - User signals completion ("done", "good", "no more"), OR


### PR DESCRIPTION
## Description

Clarify that accepted answers are first recorded in working memory and then passed to the integration step below for per-integration persistence.

This preserves the intended incremental-save flow while removing the conflict between step 4's earlier "do not yet write to disk" wording and step 5's instruction to save after each integration.

This PR is intentionally scoped to a single wording change in `templates/commands/clarify.md`.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync --extra test` and `uv run python -m pytest tests/integrations/test_integration_codex.py tests/integrations/test_integration_generic.py tests/integrations/test_integration_copilot.py -q`
- [x] Tested with a sample project (if applicable)

Sample project check:
- `uv run specify init /tmp/spec-kit-clarify-8TOc7j/project --ai codex --offline --ignore-agent-tools`
- Confirmed the generated `.agents/skills/speckit-clarify/SKILL.md` includes the updated persistence wording

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

I used AI assistance to review the conflicting wording, compare the repository's contribution and testing guidance, draft the wording update, and prepare the PR text. I reviewed the final change and test results manually.
