### PR TITLE
fix: skip docs deployment workflow on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository == 'github/spec-kit'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,6 +57,7 @@ jobs:
 
   # Deploy job
   deploy:
+    if: github.repository == 'github/spec-kit'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Add `if: github.repository == 'github/spec-kit'` to both the build and deploy jobs in the docs workflow so they skip with success on forks.

## Problem

The "Deploy Documentation to Pages" workflow triggers on forks even when no `docs/` files changed, causing failed workflow runs for contributors.

## Solution

Both jobs now check the repository name and skip immediately on forks, showing a green checkmark instead of a failure.