### PR TITLE
Update ralph extension to v1.0.1 in community catalog

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-10T17:00:00Z",
+  "updated_at": "2026-04-12T19:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -1225,8 +1225,8 @@
       "id": "ralph",
       "description": "Autonomous implementation loop using AI agent CLI.",
       "author": "Rubiss",
-      "version": "1.0.0",
-      "download_url": "https://github.com/Rubiss/spec-kit-ralph/archive/refs/tags/v1.0.0.zip",
+      "version": "1.0.1",
+      "download_url": "https://github.com/Rubiss/spec-kit-ralph/archive/refs/tags/v1.0.1.zip",
       "repository": "https://github.com/Rubiss/spec-kit-ralph",
       "homepage": "https://github.com/Rubiss/spec-kit-ralph",
       "documentation": "https://github.com/Rubiss/spec-kit-ralph/blob/main/README.md",
@@ -1259,7 +1259,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-03-09T00:00:00Z",
-      "updated_at": "2026-03-09T00:00:00Z"
+      "updated_at": "2026-04-12T19:00:00Z"
     },
     "reconcile": {
       "name": "Reconcile Extension",


### PR DESCRIPTION
## Extension Version Update

**Extension Name**: Ralph Loop
**Extension ID**: ralph
**Version**: 1.0.0 → 1.0.1
**Author**: Rubiss
**Repository**: https://github.com/Rubiss/spec-kit-ralph

### Changes in v1.0.1

**Fixed**
- Bash `get_incomplete_task_count` double-output bug (`grep -c` fallback wrote `"0"` twice)
- Removed hardcoded `model: Claude Haiku 4.5 (copilot)` from `run.md` frontmatter

**Added**
- Regression test suite (25 bash + 26 PowerShell tests)
- CI workflow (bash on ubuntu, PowerShell on windows)
- Two-workflow release pipeline (dispatch → PR → tag + GitHub Release)

**Release**: https://github.com/Rubiss/spec-kit-ralph/releases/tag/v1.0.1

### Checklist
- [x] Valid extension.yml manifest
- [x] README.md with installation and usage docs
- [x] LICENSE file included
- [x] GitHub release created (v1.0.1)
- [x] Extension tested with CI (51 regression tests passing)
- [x] All commands working
- [x] Updated `extensions/catalog.community.json` with new version and download URL
