### PR TITLE
Add Worktrees extension to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The following community-contributed extensions are available in [`catalog.commun
 | Verify Tasks Extension | Detect phantom completions: tasks marked [X] in tasks.md with no real implementation | `code` | Read-only | [spec-kit-verify-tasks](https://github.com/datastone-inc/spec-kit-verify-tasks) |
 | What-if Analysis | Preview the downstream impact (complexity, effort, tasks, risks) of requirement changes before committing to them | `visibility` | Read-only | [spec-kit-whatif](https://github.com/DevAbdullah90/spec-kit-whatif) |
 | Worktree Isolation | Spawn isolated git worktrees for parallel feature development without checkout switching | `process` | Read+Write | [spec-kit-worktree](https://github.com/Quratulain-bilal/spec-kit-worktree) |
+| Worktrees | Default-on worktree isolation for parallel agents — sibling or nested layout | `process` | Read+Write | [spec-kit-worktree-parallel](https://github.com/dango85/spec-kit-worktree-parallel) |
 
 To submit your own extension, see the [Extension Publishing Guide](extensions/EXTENSION-PUBLISHING-GUIDE.md).
 

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1977,6 +1977,38 @@
       "stars": 0,
       "created_at": "2026-04-09T00:00:00Z",
       "updated_at": "2026-04-09T00:00:00Z"
+    },
+    "worktrees": {
+      "name": "Worktrees",
+      "id": "worktrees",
+      "description": "Default-on worktree isolation for parallel agents — sibling or nested layout",
+      "author": "dango85",
+      "version": "1.0.0",
+      "download_url": "https://github.com/dango85/spec-kit-worktree-parallel/archive/refs/tags/v1.0.0.zip",
+      "repository": "https://github.com/dango85/spec-kit-worktree-parallel",
+      "homepage": "https://github.com/dango85/spec-kit-worktree-parallel",
+      "documentation": "https://github.com/dango85/spec-kit-worktree-parallel/blob/main/README.md",
+      "changelog": "https://github.com/dango85/spec-kit-worktree-parallel/blob/main/CHANGELOG.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.4.0"
+      },
+      "provides": {
+        "commands": 3,
+        "hooks": 1
+      },
+      "tags": [
+        "worktree",
+        "git",
+        "parallel",
+        "isolation",
+        "agents"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-04-13T00:00:00Z",
+      "updated_at": "2026-04-13T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Extension Submission

**Extension Name**: Worktrees
**Extension ID**: worktrees
**Version**: 1.0.0
**Author**: dango85
**Repository**: https://github.com/dango85/spec-kit-worktree-parallel

### Description

Default-on git worktree isolation for parallel agents and features. Supports two layout modes: **sibling** (`../<repo>--<branch>`, default) and **nested** (`.worktrees/<branch>/`). Includes a deterministic bash script with `--json` output for CI/scripted workflows.

Commands: `/speckit.worktrees.create`, `/speckit.worktrees.list`, `/speckit.worktrees.clean`
Hook: `after_specify` — auto-creates worktree after feature specification

### Checklist

- [x] Valid extension.yml manifest
- [x] README.md with installation and usage docs
- [x] LICENSE file included
- [x] GitHub release created (v1.0.0)
- [x] Extension tested on real project
- [x] All commands working
- [x] No security vulnerabilities
- [x] Added to extensions/catalog.community.json
- [x] Added to Community Extensions table in README.md

### Testing

Tested on:
- macOS 15.4 with spec-kit >= 0.4.0
- Project: Agentico POC — multi-agent creative platform

### Related Issues

- #61 — Spawn worktree when creating new branch (36+ upvotes)
- #1476 — Native worktree support for parallel agents
- #1940 — Git operations extracted to extension (closed)

### Additional Notes

Differs from the existing `worktree` community extension (Quratulain-bilal) in three ways:
1. **Default-on** — worktree auto-created after `/speckit.specify`; opt out with `--in-place`
2. **Sibling-dir layout** — each feature gets its own IDE window at `../<repo>--<branch>`
3. **Bash script** — deterministic `create-worktree.sh` with `--json`, `--dry-run`, env var overrides

Made with [Cursor](https://cursor.com)