### PR TITLE
feat: register architect-preview in community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The following community-contributed extensions are available in [`catalog.commun
 | Extension | Purpose | Category | Effect | URL |
 |-----------|---------|----------|--------|-----|
 | AI-Driven Engineering (AIDE) | A structured 7-step workflow for building new projects from scratch with AI assistants — from vision through implementation | `process` | Read+Write | [aide](https://github.com/mnriem/spec-kit-extensions/tree/main/aide) |
+| Architect Impact Previewer | Predicts architectural impact, complexity, and risks of proposed changes before implementation. | `visibility` | Read-only | [spec-kit-architect-preview](https://github.com/UmmeHabiba1312/spec-kit-architect-preview) |
 | Archive Extension | Archive merged features into main project memory. | `docs` | Read+Write | [spec-kit-archive](https://github.com/stn1slv/spec-kit-archive) |
 | Azure DevOps Integration | Sync user stories and tasks to Azure DevOps work items using OAuth authentication | `integration` | Read+Write | [spec-kit-azure-devops](https://github.com/pragya247/spec-kit-azure-devops) |
 | Branch Convention | Configurable branch and folder naming conventions for /specify with presets and custom patterns | `process` | Read+Write | [spec-kit-branch-convention](https://github.com/Quratulain-bilal/spec-kit-branch-convention) |

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-13T23:01:30Z",
+  "updated_at": "2026-04-14T21:30:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -35,6 +35,38 @@
       "stars": 0,
       "created_at": "2026-03-18T00:00:00Z",
       "updated_at": "2026-03-18T00:00:00Z"
+    },
+    "architect-preview": {
+      "name": "Architect Impact Previewer",
+      "id": "architect-preview",
+      "description": "Predicts architectural impact, complexity, and risks of proposed changes before implementation.",
+      "author": "Umme Habiba",
+      "version": "1.0.0",
+      "download_url": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/archive/refs/tags/v1.0.0.zip",
+      "repository": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
+      "homepage": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
+      "documentation": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/blob/main/README.md",
+      "changelog": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/blob/main/CHANGELOG.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.1.0"
+      },
+      "provides": {
+        "commands": 1,
+        "hooks": 0
+      },
+      "tags": [
+        "architecture",
+        "analysis",
+        "risk-assessment",
+        "planning",
+        "preview"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-04-14T00:00:00Z",
+      "updated_at": "2026-04-14T00:00:00Z"
     },
     "archive": {
       "name": "Archive Extension",
@@ -2053,38 +2085,6 @@
       "stars": 0,
       "created_at": "2026-04-13T00:00:00Z",
       "updated_at": "2026-04-13T00:00:00Z"
-    },
-    "architect-preview": {
-      "name": "Architect Impact Previewer",
-      "id": "architect-preview",
-      "description": "Predicts architectural impact, complexity, and risks of proposed changes before implementation.",
-      "author": "Umme Habiba",
-      "version": "1.0.0",
-      "download_url": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/archive/refs/tags/v1.0.0.zip",
-      "repository": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
-      "homepage": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
-      "documentation": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/blob/main/README.md",
-      "changelog": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/blob/main/CHANGELOG.md",
-      "license": "MIT",
-      "requires": {
-        "speckit_version": ">=0.1.0"
-      },
-      "provides": {
-        "commands": 1,
-        "hooks": 0
-      },
-      "tags": [
-        "architecture",
-        "analysis",
-        "risk-assessment",
-        "planning",
-        "preview"
-      ],
-      "verified": false,
-      "downloads": 0,
-      "stars": 0,
-      "created_at": "2026-04-14T00:00:00Z",
-      "updated_at": "2026-04-14T00:00:00Z"
     }
   }
 }

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -2053,6 +2053,38 @@
       "stars": 0,
       "created_at": "2026-04-13T00:00:00Z",
       "updated_at": "2026-04-13T00:00:00Z"
+    },
+    "architect-preview": {
+      "name": "Architect Impact Previewer",
+      "id": "architect-preview",
+      "description": "Predicts architectural impact, complexity, and risks of proposed changes before implementation.",
+      "author": "Umme Habiba",
+      "version": "1.0.0",
+      "download_url": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/archive/refs/tags/v1.0.0.zip",
+      "repository": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
+      "homepage": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
+      "documentation": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/blob/main/README.md",
+      "changelog": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/blob/main/CHANGELOG.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.1.0"
+      },
+      "provides": {
+        "commands": 1,
+        "hooks": 0
+      },
+      "tags": [
+        "architecture",
+        "analysis",
+        "risk-assessment",
+        "planning",
+        "preview"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-04-14T00:00:00Z",
+      "updated_at": "2026-04-14T00:00:00Z"
     }
   }
 }

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -244,7 +244,7 @@
       "name": "Architect Impact Previewer",
       "id": "architect-preview",
       "version": "1.0.0",
-      "description": "Predicts architectural impact, complexity, and risks of proposed changes.",
+      "description": "Predicts architectural impact, complexity and risks of proposed changes.",
       "author": "Umme Habiba",
       "repository": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
       "homepage": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -239,6 +239,33 @@
         "clarify",
         "interactive"
       ]
+    },
+    "architect-preview": {
+      "name": "Architect Impact Previewer",
+      "id": "architect-preview",
+      "version": "1.0.0",
+      "description": "Predicts architectural impact, complexity, and risks of proposed changes.",
+      "author": "Umme Habiba",
+      "repository": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
+      "homepage": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
+      "documentation": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/blob/main/README.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.4.0"
+      },
+      "provides": {
+        "templates": 1,
+        "commands": 1,
+        "scripts": 1
+      },
+      "tags": [
+        "architecture",
+        "impact-analysis",
+        "risk-assessment",
+        "preview"
+      ],
+      "created_at": "2026-04-14T00:00:00Z",
+      "updated_at": "2026-04-14T00:00:00Z"
     }
   }
 }

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -239,33 +239,6 @@
         "clarify",
         "interactive"
       ]
-    },
-    "architect-preview": {
-      "name": "Architect Impact Previewer",
-      "id": "architect-preview",
-      "version": "1.0.0",
-      "description": "Predicts architectural impact, complexity and risks of proposed changes.",
-      "author": "Umme Habiba",
-      "repository": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
-      "homepage": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview",
-      "documentation": "https://github.com/UmmeHabiba1312/spec-kit-architect-preview/blob/main/README.md",
-      "license": "MIT",
-      "requires": {
-        "speckit_version": ">=0.4.0"
-      },
-      "provides": {
-        "templates": 1,
-        "commands": 1,
-        "scripts": 1
-      },
-      "tags": [
-        "architecture",
-        "impact-analysis",
-        "risk-assessment",
-        "preview"
-      ],
-      "created_at": "2026-04-14T00:00:00Z",
-      "updated_at": "2026-04-14T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
Description:
Following the maintainers' feedback in my previous PR, I have refactored the Architect Impact Previewer into a pure community extension model.

As requested, I have moved the logic to a standalone repository to ensure the core Spec-Kit remains clean and modular. This PR adds the necessary metadata to the community catalog so users can easily discover and install the preset.

Standalone Repository: https://github.com/UmmeHabiba1312/spec-kit-architect-preview

Key Features:

Predicts architectural complexity (1-10)

Identifies risks and affected specifications

Zero modifications to core files

Testing:
[x] Validated JSON syntax for catalog.community.json.

[x] Verified repository structure and file paths in the standalone repo.

Fixes https://github.com/github/spec-kit/issues/2176