### PR TITLE
feat: Intelligent constitution generation with dynamic solution state detection and automated bootstrapping

### DIFF
--- a/presets/lean/commands/speckit.constitution.md
+++ b/presets/lean/commands/speckit.constitution.md
@@ -14,12 +14,10 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 Before generating or revising the constitution, determine whether this is a **new** or **existing** solution.
 
-1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled `[PLACEHOLDER]` tokens), treat as **existing**.
-2. If the repo has meaningful source code, architecture docs, or prior constitution versions, treat as **existing**.
-3. Otherwise, ask the user: "Is this a new solution or an existing one? Reply with one of: `new`, `existing`"
+1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled `[PLACEHOLDER]` tokens), treat as **existing** → follow Path A below.
+2. If `.specify/memory/constitution.md` does not exist, or contains only unfilled placeholder tokens, treat as **new** → follow Path B below.
 
-- If **existing** → follow Path A below.
-- If **new** → follow Path B below.
+Do not ask the user — the check is automatic.
 
 ## Path A — Existing Solution
 

--- a/presets/lean/commands/speckit.constitution.md
+++ b/presets/lean/commands/speckit.constitution.md
@@ -27,18 +27,18 @@ Do not ask the user — the check is automatic.
 
 ## Path B — New Solution Bootstrap
 
-Do **NOT** draft the constitution yet. First collect these minimum durable inputs:
+Do **NOT** draft the constitution yet. First collect these minimum durable inputs (present options and examples to reduce ambiguity):
 
-1. **solution_name** — "What is the name of the solution?"
+1. **solution_name** — "What is the name of the solution?" (e.g. `InventoryTracker`, `PayrollEngine`)
 2. **solution_purpose** — "In 2–5 sentences, what is this solution for?"
-3. **solution_type** — "What type of solution is this?"
-4. **primary_stack** — "What is the expected primary stack or platform?"
-5. **core_dependencies** — "What important external systems or dependencies does it rely on?"
-6. **security_constraints** — "What security or authentication constraints must always be followed?"
-7. **data_rules** — "What data/storage rules must always be followed?"
-8. **quality_rules** — "What quality expectations must always apply?"
-9. **boundary_rules** — "Does this solution need strict boundaries from other solutions or repos?"
-10. **out_of_scope** — "What kinds of details should NOT go into the constitution?"
+3. **solution_type** — "What type of solution is this?" Options: `Windows desktop app` · `Web app` · `REST API` · `Background service` · `Class library` · `CLI tool` · `Mobile app`
+4. **primary_stack** — "What is the expected primary stack or platform?" Options: `C# / .NET` · `Python` · `TypeScript / Node.js` · `Java / Spring` · `Go` · `Rust`. Include framework + database if known.
+5. **core_dependencies** — "What important external systems or dependencies does it rely on?" (e.g. Active Directory, Azure, Stripe). Reply `none` if self-contained.
+6. **security_constraints** — "What security or auth constraints must always be followed?" Options: `Windows Auth` · `OAuth 2.0` · `API keys` · `RBAC` · `No auth`. Reply `unknown` for safe defaults.
+7. **data_rules** — "What data/storage rules must always be followed?" Options: `SQL Server only` · `PostgreSQL` · `SQLite` · `NoSQL` · `No persistent storage`. Also: parameterized queries, no sensitive data in logs. Reply `unknown` for safe defaults.
+8. **quality_rules** — "What quality expectations must always apply?" Options: `Unit tests` · `Integration tests` · `Code review` · `CI must pass` · `Structured logging` · `Retry handling`. Reply `unknown` for safe defaults.
+9. **boundary_rules** — "Does this solution need strict boundaries from other solutions or repos?" (e.g. no shared DB, API-only communication). Reply `none` if no boundaries.
+10. **out_of_scope** — "What should NOT go into the constitution?" Options: `Feature-specific requirements` · `Screen UI behavior` · `One-off queries` · `Sprint priorities`. Reply `standard exclusions` for defaults.
 
 Then generate a lean constitution with these sections: Scope, Purpose, Solution Boundary, Architecture, Security, Data Access, Error Handling, Quality, Change Governance, and Explicit Exclusions. Write to `.specify/memory/constitution.md`.
 

--- a/presets/lean/commands/speckit.constitution.md
+++ b/presets/lean/commands/speckit.constitution.md
@@ -15,7 +15,9 @@ You **MUST** consider the user input before proceeding (if not empty).
 Before generating or revising the constitution, determine whether this is a **new** or **existing** solution.
 
 1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled square-bracket placeholder identifiers such as `[PROJECT_NAME]`), treat as **existing** → follow Path A below.
-2. If `.specify/memory/constitution.md` does not exist, or contains only unfilled square-bracket placeholder identifiers, treat as **new** → follow Path B below.
+2. If `.specify/memory/constitution.md` does not exist **but** `.specify/templates/constitution-template.md` exists, treat the solution as an **initialized existing repo with a missing working copy** → copy the template to `.specify/memory/constitution.md`, then follow Path A below.
+3. If `.specify/memory/constitution.md` exists but contains only unfilled square-bracket placeholder identifiers, treat as **new** → follow Path B below.
+4. If neither `.specify/memory/constitution.md` nor `.specify/templates/constitution-template.md` exists, treat as **new** → follow Path B below.
 
 Do not ask the user — the check is automatic.
 

--- a/presets/lean/commands/speckit.constitution.md
+++ b/presets/lean/commands/speckit.constitution.md
@@ -1,5 +1,5 @@
 ---
-description: Create or update the project constitution.
+description: Create or update the project constitution. Detects whether this is a new or existing solution and adapts the workflow accordingly.
 ---
 
 ## User Input
@@ -8,8 +8,40 @@ description: Create or update the project constitution.
 $ARGUMENTS
 ```
 
-## Outline
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Step 0 — Determine Solution State
+
+Before generating or revising the constitution, determine whether this is a **new** or **existing** solution.
+
+1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled `[PLACEHOLDER]` tokens), treat as **existing**.
+2. If the repo has meaningful source code, architecture docs, or prior constitution versions, treat as **existing**.
+3. Otherwise, ask the user: "Is this a new solution or an existing one? Reply with one of: `new`, `existing`"
+
+- If **existing** → follow Path A below.
+- If **new** → follow Path B below.
+
+## Path A — Existing Solution
 
 1. Create or update the project constitution and store it in `.specify/memory/constitution.md`.
    - Project name, guiding principles, non-negotiable rules
    - Derive from user input and existing repo context (README, docs)
+
+## Path B — New Solution Bootstrap
+
+Do **NOT** draft the constitution yet. First collect these minimum durable inputs:
+
+1. **solution_name** — "What is the name of the solution?"
+2. **solution_purpose** — "In 2–5 sentences, what is this solution for?"
+3. **solution_type** — "What type of solution is this?"
+4. **primary_stack** — "What is the expected primary stack or platform?"
+5. **core_dependencies** — "What important external systems or dependencies does it rely on?"
+6. **security_constraints** — "What security or authentication constraints must always be followed?"
+7. **data_rules** — "What data/storage rules must always be followed?"
+8. **quality_rules** — "What quality expectations must always apply?"
+9. **boundary_rules** — "Does this solution need strict boundaries from other solutions or repos?"
+10. **out_of_scope** — "What kinds of details should NOT go into the constitution?"
+
+Then generate a lean constitution with these sections: Scope, Purpose, Solution Boundary, Architecture, Security, Data Access, Error Handling, Quality, Change Governance, and Explicit Exclusions. Write to `.specify/memory/constitution.md`.
+
+The constitution must contain only durable, solution-wide principles — no feature specs, UI flows, or one-off implementation details.

--- a/presets/lean/commands/speckit.constitution.md
+++ b/presets/lean/commands/speckit.constitution.md
@@ -14,8 +14,8 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 Before generating or revising the constitution, determine whether this is a **new** or **existing** solution.
 
-1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled `[PLACEHOLDER]` tokens), treat as **existing** → follow Path A below.
-2. If `.specify/memory/constitution.md` does not exist, or contains only unfilled placeholder tokens, treat as **new** → follow Path B below.
+1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled square-bracket placeholder identifiers such as `[PROJECT_NAME]`), treat as **existing** → follow Path A below.
+2. If `.specify/memory/constitution.md` does not exist, or contains only unfilled square-bracket placeholder identifiers, treat as **new** → follow Path B below.
 
 Do not ask the user — the check is automatic.
 

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -44,7 +44,7 @@ You **MUST** consider the user input before proceeding (if not empty).
     Executing: `/{command}`
     EXECUTE_COMMAND: {command}
 
-    Wait for the result of the hook command before proceeding to the Outline.
+   Wait for the result of the hook command before proceeding to Step 0.
     ```
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
@@ -54,8 +54,8 @@ Before generating or revising the constitution, determine whether this is a **ne
 
 **Detection rule** (check in order):
 
-1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled `[PLACEHOLDER]` tokens), treat as **existing** → proceed to **Path A**.
-2. If `.specify/memory/constitution.md` does not exist, or contains only unfilled placeholder tokens, treat as **new** → proceed to **Path B**.
+1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled square-bracket placeholder identifiers such as `[PROJECT_NAME]`), treat as **existing** → proceed to **Path A**.
+2. If `.specify/memory/constitution.md` does not exist, or contains only unfilled square-bracket placeholder identifiers, treat as **new** → proceed to **Path B**.
 
 ---
 

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -138,18 +138,48 @@ If `solution_state = new`, do **NOT** draft the constitution yet.
 
 ### B.1 — Collect minimum durable inputs
 
-Ask exactly these questions to gather the information needed for a strong constitution. Do not ask for feature-by-feature requirements, screen flows, or pseudo-code.
+Ask exactly these questions to gather the information needed for a strong constitution. Do not ask for feature-by-feature requirements, screen flows, or pseudo-code. Present options and examples as shown below to reduce ambiguity.
 
 1. **solution_name** — "What is the name of the solution?"
+   - Example: `InventoryTracker`, `PayrollEngine`, `Contoso.Api`
+
 2. **solution_purpose** — "In 2–5 sentences, what is this solution for?"
-3. **solution_type** — "What type of solution is this? (examples: Windows desktop app, web app, API, background service, library)"
-4. **primary_stack** — "What is the expected primary stack or platform? (examples: C#/.NET, WPF, WinForms, ASP.NET Core, SQL Server)"
-5. **core_dependencies** — "What important external systems or dependencies does it rely on? If none, reply `none`."
-6. **security_constraints** — "What security or authentication constraints must always be followed? If unknown, reply `unknown`."
-7. **data_rules** — "What data/storage rules must always be followed? (examples: SQL Server only, parameterized queries only, no sensitive data in logs). If unknown, reply `unknown`."
-8. **quality_rules** — "What quality expectations must always apply? (examples: automated tests, structured logging, responsive UI, retry handling). If unknown, reply `unknown`."
-9. **boundary_rules** — "Does this solution need strict boundaries from other solutions or repos? If yes, describe them. If none, reply `none`."
-10. **out_of_scope** — "What kinds of details should NOT go into the constitution for this solution? (examples: feature-specific requirements, screen behavior, one-off SQL queries). If unsure, reply `standard exclusions`."
+   - Example: *"A desktop tool for warehouse staff to track incoming shipments, manage stock levels, and generate reorder reports. It replaces the current spreadsheet-based workflow."*
+
+3. **solution_type** — "What type of solution is this?"
+   - Options: `Windows desktop app` · `Web app` · `REST API` · `Background service / worker` · `Class library / SDK` · `CLI tool` · `Mobile app` · `Monorepo (multiple projects)`
+   - Pick one, or describe if none fit.
+
+4. **primary_stack** — "What is the expected primary stack or platform?"
+   - Options: `C# / .NET` · `Python` · `TypeScript / Node.js` · `Java / Spring` · `Go` · `Rust` · `Ruby / Rails`
+   - Include framework and database if known. Example: `C# / .NET 8, WPF, SQL Server` or `TypeScript, Next.js, PostgreSQL`
+
+5. **core_dependencies** — "What important external systems or dependencies does it rely on?"
+   - Examples: Active Directory, Azure Blob Storage, Stripe API, SAP, RabbitMQ, a shared internal auth service
+   - Reply `none` if the solution is self-contained.
+
+6. **security_constraints** — "What security or authentication constraints must always be followed?"
+   - Options: `Windows Auth / AD` · `OAuth 2.0 / OIDC` · `API keys` · `Certificate-based` · `Role-based access (RBAC)` · `No auth required`
+   - Also mention: secrets management, encryption-at-rest, PII handling, compliance standards (HIPAA, SOC 2, GDPR) if applicable.
+   - Reply `unknown` if not yet decided — safe defaults will be used.
+
+7. **data_rules** — "What data/storage rules must always be followed?"
+   - Options: `SQL Server only` · `PostgreSQL only` · `SQLite (local)` · `NoSQL (MongoDB, Cosmos)` · `File-based storage` · `No persistent storage`
+   - Also consider: parameterized queries only, no raw SQL in app code, no sensitive data in logs, soft-delete policy, audit trail required.
+   - Reply `unknown` if not yet decided — safe defaults will be used.
+
+8. **quality_rules** — "What quality expectations must always apply?"
+   - Options: `Unit tests required` · `Integration tests required` · `Code review required` · `CI pipeline must pass` · `Structured logging` · `Responsive UI (< 200ms)` · `Retry / resilience handling` · `Accessibility (WCAG)`
+   - Pick all that apply, or describe your own.
+   - Reply `unknown` if not yet decided — safe defaults will be used.
+
+9. **boundary_rules** — "Does this solution need strict boundaries from other solutions or repos?"
+   - Examples: *"Must not share a database with the billing system"*, *"Must communicate with the auth service only via its public API"*, *"Must be deployable independently from the monorepo"*
+   - Reply `none` if there are no cross-solution boundaries.
+
+10. **out_of_scope** — "What kinds of details should NOT go into the constitution?"
+    - Options: `Feature-specific requirements` · `Screen-by-screen UI behavior` · `One-off SQL queries` · `Sprint-level priorities` · `Individual user stories`
+    - Reply `standard exclusions` to use the defaults above.
 
 ### B.2 — Normalize answers into constitution categories
 

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -136,7 +136,7 @@ Do not create a new template; always operate on the existing `.specify/memory/co
 
 ## Path B — New Solution Bootstrap
 
-If `solution_state = new`, do **NOT** draft the constitution yet.
+If you determined in Step 0 that this is a new solution, do **NOT** draft the constitution yet.
 
 ### B.1 — Collect minimum durable inputs
 

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -55,7 +55,9 @@ Before generating or revising the constitution, determine whether this is a **ne
 **Detection rule** (check in order):
 
 1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled square-bracket placeholder identifiers such as `[PROJECT_NAME]`), treat as **existing** → proceed to **Path A**.
-2. If `.specify/memory/constitution.md` does not exist, or contains only unfilled square-bracket placeholder identifiers, treat as **new** → proceed to **Path B**.
+2. If `.specify/memory/constitution.md` does not exist **but** `.specify/templates/constitution-template.md` exists, treat the solution as an **initialized existing repo with a missing working copy** → copy the template to `.specify/memory/constitution.md`, then proceed to **Path A**.
+3. If `.specify/memory/constitution.md` exists but contains only unfilled square-bracket placeholder identifiers, treat as **new** → proceed to **Path B**.
+4. If neither `.specify/memory/constitution.md` nor `.specify/templates/constitution-template.md` exists, treat as **new** → proceed to **Path B**.
 
 ---
 
@@ -65,7 +67,7 @@ If `solution_state = existing`, follow the standard constitution update flow.
 
 You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
 
-**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+**Note**: The missing-file recovery in Path A applies only when `.specify/templates/constitution-template.md` exists, which indicates the repo was already initialized and only the working copy is missing. In that case, copy the template first.
 
 Follow this execution flow:
 

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -50,20 +50,12 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Step 0 — Determine Solution State
 
-Before generating or revising the constitution, determine whether this is a **new** or **existing** solution.
+Before generating or revising the constitution, determine whether this is a **new** or **existing** solution automatically — do not ask the user.
 
-**Detection heuristic** (check in order):
+**Detection rule** (check in order):
 
-1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled `[PLACEHOLDER]` tokens), treat as **existing**.
-2. If the repo has meaningful source code, architecture docs, or prior constitution versions, treat as **existing**.
-3. Otherwise, ask the user:
-
-> **Is this a new solution or an existing one?** Reply with one of: `new`, `existing`
-
-Rules:
-- If the user answers `existing`, proceed to **Path A — Existing Solution** below.
-- If the user answers `new`, proceed to **Path B — New Solution Bootstrap** below.
-- If the answer is ambiguous, ask one follow-up question to clarify before continuing.
+1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled `[PLACEHOLDER]` tokens), treat as **existing** → proceed to **Path A**.
+2. If `.specify/memory/constitution.md` does not exist, or contains only unfilled placeholder tokens, treat as **new** → proceed to **Path B**.
 
 ---
 

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -228,10 +228,12 @@ The constitution MUST:
 - Avoid one-off implementation details unless they are global rules.
 - Avoid pseudo-code unless it expresses a global engineering rule.
 
-The constitution MUST end with:
+The constitution MUST end with a concrete footer that uses the current date in ISO format `YYYY-MM-DD` for both date fields when creating a new solution. Do **not** leave literal placeholders such as `<TODAY>` in the generated file.
+
+Use this exact footer shape:
 
 ```
-**Version**: 1.0.0 | **Ratified**: <TODAY> | **Last Amended**: <TODAY>
+**Version**: 1.0.0 | **Ratified**: YYYY-MM-DD | **Last Amended**: YYYY-MM-DD
 ```
 
 ### B.4 — Output behavior for new solutions

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -63,7 +63,7 @@ Before generating or revising the constitution, determine whether this is a **ne
 
 ## Path A — Existing Solution
 
-If `solution_state = existing`, follow the standard constitution update flow.
+If you determined this is an existing solution in Step 0, follow the standard constitution update flow.
 
 You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
 

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -1,5 +1,5 @@
 ---
-description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
+description: Create or update the project constitution from interactive or provided principle inputs. Detects whether this is a new or existing solution — new solutions go through a guided bootstrap to collect durable inputs first; existing solutions follow the standard update flow. Ensures all dependent templates stay in sync.
 handoffs: 
   - label: Build Specification
     agent: speckit.specify
@@ -48,7 +48,28 @@ You **MUST** consider the user input before proceeding (if not empty).
     ```
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
-## Outline
+## Step 0 — Determine Solution State
+
+Before generating or revising the constitution, determine whether this is a **new** or **existing** solution.
+
+**Detection heuristic** (check in order):
+
+1. If `.specify/memory/constitution.md` exists **and** contains concrete content (not just unfilled `[PLACEHOLDER]` tokens), treat as **existing**.
+2. If the repo has meaningful source code, architecture docs, or prior constitution versions, treat as **existing**.
+3. Otherwise, ask the user:
+
+> **Is this a new solution or an existing one?** Reply with one of: `new`, `existing`
+
+Rules:
+- If the user answers `existing`, proceed to **Path A — Existing Solution** below.
+- If the user answers `new`, proceed to **Path B — New Solution Bootstrap** below.
+- If the answer is ambiguous, ask one follow-up question to clarify before continuing.
+
+---
+
+## Path A — Existing Solution
+
+If `solution_state = existing`, follow the standard constitution update flow.
 
 You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
 
@@ -116,6 +137,96 @@ If the user supplies partial updates (e.g., only one principle revision), still 
 If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
 
 Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+---
+
+## Path B — New Solution Bootstrap
+
+If `solution_state = new`, do **NOT** draft the constitution yet.
+
+### B.1 — Collect minimum durable inputs
+
+Ask exactly these questions to gather the information needed for a strong constitution. Do not ask for feature-by-feature requirements, screen flows, or pseudo-code.
+
+1. **solution_name** — "What is the name of the solution?"
+2. **solution_purpose** — "In 2–5 sentences, what is this solution for?"
+3. **solution_type** — "What type of solution is this? (examples: Windows desktop app, web app, API, background service, library)"
+4. **primary_stack** — "What is the expected primary stack or platform? (examples: C#/.NET, WPF, WinForms, ASP.NET Core, SQL Server)"
+5. **core_dependencies** — "What important external systems or dependencies does it rely on? If none, reply `none`."
+6. **security_constraints** — "What security or authentication constraints must always be followed? If unknown, reply `unknown`."
+7. **data_rules** — "What data/storage rules must always be followed? (examples: SQL Server only, parameterized queries only, no sensitive data in logs). If unknown, reply `unknown`."
+8. **quality_rules** — "What quality expectations must always apply? (examples: automated tests, structured logging, responsive UI, retry handling). If unknown, reply `unknown`."
+9. **boundary_rules** — "Does this solution need strict boundaries from other solutions or repos? If yes, describe them. If none, reply `none`."
+10. **out_of_scope** — "What kinds of details should NOT go into the constitution for this solution? (examples: feature-specific requirements, screen behavior, one-off SQL queries). If unsure, reply `standard exclusions`."
+
+### B.2 — Normalize answers into constitution categories
+
+Map collected answers into durable constitution sections:
+
+| Constitution category | Source inputs |
+|---|---|
+| **Scope** | solution_name, solution_purpose, boundary_rules |
+| **Technical context** | solution_type, primary_stack, core_dependencies |
+| **Security and data handling** | security_constraints, data_rules |
+| **Quality and engineering standards** | quality_rules |
+| **Exclusions** | out_of_scope |
+
+Where the user answered `unknown`:
+- Use safe, minimal defaults.
+- Keep them generic and durable.
+- Mark assumptions clearly with `<!-- ASSUMPTION: ... -->` in the generated constitution.
+
+### B.3 — Generate the constitution
+
+Generate a lean constitution written to `.specify/memory/constitution.md` with only durable, solution-wide principles. The constitution MUST include these sections:
+
+1. **Scope** — Solution name, boundary, and what is in/out of scope.
+2. **Purpose** — What the solution exists to do (2–5 sentences).
+3. **Solution Boundary** — Strict separation from other solutions/repos if applicable.
+4. **Architecture / Separation of Concerns** — High-level layering and dependency rules.
+5. **Security and Credential Handling** — Authentication, authorization, secrets management rules.
+6. **Data Access and Storage Rules** — Database access patterns, sensitive-data handling.
+7. **Error Handling and Observability** — Logging, monitoring, error propagation rules.
+8. **Quality and Testing Expectations** — Testing strategy, coverage expectations, CI gates.
+9. **Simplicity and Change Governance** — YAGNI, amendment process, versioning policy.
+10. **Explicit Exclusions** — What does NOT belong in the constitution (feature specs, UI flows, one-off queries).
+
+The constitution MUST also include a **Documentation Boundaries** rule:
+
+> - The **constitution** defines durable engineering principles and global constraints.
+> - **Specifications** define functional requirements and expected behavior.
+> - **Implementation plans** define technical design and architecture choices for a specific effort.
+> - **Tasks** define actionable work derived from the plan.
+
+The constitution MUST:
+- Apply to the whole solution, not individual features.
+- Avoid detailed functional requirements or feature-specific behavior.
+- Avoid one-off implementation details unless they are global rules.
+- Avoid pseudo-code unless it expresses a global engineering rule.
+
+The constitution MUST end with:
+
+```
+**Version**: 1.0.0 | **Ratified**: <TODAY> | **Last Amended**: <TODAY>
+```
+
+### B.4 — Output behavior for new solutions
+
+1. Summarize the captured inputs briefly.
+2. Generate the constitution using those inputs.
+3. Write it to `.specify/memory/constitution.md`.
+4. Output a final summary with the version, a suggested commit message, and any assumptions marked for follow-up.
+
+### B.5 — Safety rails
+
+Never do the following in a new-solution constitution:
+- Copy raw functional requirements into it.
+- Include UI screen-by-screen behavior.
+- Include feature-specific acceptance criteria.
+- Include exact one-off queries, workflows, or pseudo-code unless they represent global rules.
+- Over-specify technical details that are better suited for a plan.
+
+When in doubt: keep the constitution smaller, move feature behavior to the spec, move implementation specifics to the plan.
 
 ## Post-Execution Checks
 

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -33,7 +33,7 @@ class TestMainConstitutionCommandStructure:
         content = self._content()
         assert "Detection rule" in content
         assert ".specify/memory/constitution.md" in content
-        assert "unfilled" in content or "[PLACEHOLDER]" in content
+        assert "unfilled" in content or "[PROJECT_NAME]" in content
 
     def test_detection_is_automatic_no_user_prompt(self):
         """Detection must be fully automatic — the command must not ask the user."""

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -35,6 +35,13 @@ class TestMainConstitutionCommandStructure:
         assert ".specify/memory/constitution.md" in content
         assert "unfilled" in content or "[PLACEHOLDER]" in content
 
+    def test_detection_distinguishes_initialized_repo_from_truly_new(self):
+        """Missing working copies in initialized repos must route to Path A, not Path B."""
+        content = self._content()
+        assert ".specify/templates/constitution-template.md" in content
+        assert "initialized existing repo with a missing working copy" in content
+        assert "copy the template to `.specify/memory/constitution.md`, then proceed to **Path A**" in content
+
     def test_detection_is_automatic_no_user_prompt(self):
         """Detection must be fully automatic — the command must not ask the user."""
         content = self._content()
@@ -231,6 +238,13 @@ class TestLeanPresetConstitutionCommand:
         content = self._content()
         assert ".specify/memory/constitution.md" in content
         assert "unfilled" in content or "[PLACEHOLDER]" in content
+
+    def test_lean_detection_distinguishes_initialized_repo_from_truly_new(self):
+        """Lean preset must route initialized repos with a missing working copy to Path A."""
+        content = self._content()
+        assert ".specify/templates/constitution-template.md" in content
+        assert "initialized existing repo with a missing working copy" in content
+        assert "copy the template to `.specify/memory/constitution.md`, then follow Path A below" in content
 
     def test_path_a_exists_in_lean(self):
         """Lean preset must have a Path A for existing solutions."""

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -197,10 +197,12 @@ class TestMainConstitutionCommandStructure:
 
     def test_no_standalone_prompt_file(self):
         """The standalone bootstrap prompt file must be removed — logic now lives in the command."""
-        standalone = REPO_ROOT / ".github" / "Prompts" / "smart-constitution-bootstrap-prompt.md"
-        assert not standalone.exists(), (
-            "Standalone smart-constitution-bootstrap-prompt.md should be deleted; "
-            "the logic now lives in templates/commands/constitution.md"
+        standalone_lowercase = REPO_ROOT / ".github" / "prompts" / "smart-constitution-bootstrap-prompt.md"
+        standalone_uppercase = REPO_ROOT / ".github" / "Prompts" / "smart-constitution-bootstrap-prompt.md"
+        assert not standalone_lowercase.exists() and not standalone_uppercase.exists(), (
+            "Standalone smart-constitution-bootstrap-prompt.md should be deleted from "
+            ".github/prompts/ or .github/Prompts/; the logic now lives in "
+            "templates/commands/constitution.md"
         )
 
 

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -1,0 +1,236 @@
+"""Static content tests for the Smart Constitution Bootstrap changes.
+
+Verifies that `templates/commands/constitution.md` and
+`presets/lean/commands/speckit.constitution.md` contain the correct
+new vs existing solution detection logic, bootstrap questions, and
+safety rails introduced by the Smart Constitution Bootstrap feature.
+
+These are pure static-analysis tests — they read the markdown files and
+assert key strings are present, following the pattern established in
+`test_cursor_frontmatter.py`.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+MAIN_TEMPLATE = REPO_ROOT / "templates" / "commands" / "constitution.md"
+LEAN_PRESET_COMMAND = REPO_ROOT / "presets" / "lean" / "commands" / "speckit.constitution.md"
+
+
+class TestMainConstitutionCommandStructure:
+    """Verify the main constitution command template has the bootstrap detection flow."""
+
+    def _content(self) -> str:
+        return MAIN_TEMPLATE.read_text(encoding="utf-8")
+
+    def test_step_0_detection_section_exists(self):
+        """Step 0 must exist to trigger solution-state detection before any constitution work."""
+        assert "## Step 0" in self._content()
+
+    def test_detection_rule_checks_constitution_file(self):
+        """Detection rule must check whether the constitution file exists with filled content."""
+        content = self._content()
+        assert "Detection rule" in content
+        assert ".specify/memory/constitution.md" in content
+        assert "unfilled" in content or "[PLACEHOLDER]" in content
+
+    def test_detection_is_automatic_no_user_prompt(self):
+        """Detection must be fully automatic — the command must not ask the user."""
+        content = self._content()
+        # Explicit instruction not to ask the user
+        assert "do not ask the user" in content.lower()
+        # The old interactive prompt reply syntax must not appear
+        assert "`new`, `existing`" not in content
+
+    def test_path_a_existing_solution_section_exists(self):
+        """Path A (existing solution) section must be present."""
+        assert "Path A" in self._content()
+
+    def test_path_b_new_solution_section_exists(self):
+        """Path B (new solution bootstrap) section must be present."""
+        assert "Path B" in self._content()
+
+    def test_path_a_preserves_existing_update_flow(self):
+        """Path A must still contain the full existing-solution constitution update logic."""
+        content = self._content()
+        # Core steps from the original existing-solution flow
+        assert "CONSTITUTION_VERSION" in content
+        assert "RATIFICATION_DATE" in content
+        assert "LAST_AMENDED_DATE" in content
+        assert "Sync Impact Report" in content
+        assert "semantic versioning" in content
+
+    def test_path_b_collects_ten_bootstrap_questions(self):
+        """Path B must ask all 10 required minimum-durable-input questions."""
+        content = self._content()
+        questions = [
+            "solution_name",
+            "solution_purpose",
+            "solution_type",
+            "primary_stack",
+            "core_dependencies",
+            "security_constraints",
+            "data_rules",
+            "quality_rules",
+            "boundary_rules",
+            "out_of_scope",
+        ]
+        for q in questions:
+            assert q in content, f"Bootstrap question '{q}' missing from Path B"
+
+    def test_path_b_normalizes_answers_into_categories(self):
+        """Path B must normalize answers into constitution-friendly categories."""
+        content = self._content()
+        assert "Scope" in content
+        assert "Technical context" in content
+        assert "Security and data handling" in content
+        assert "Quality and engineering standards" in content
+        assert "Exclusions" in content
+
+    def test_path_b_generates_ten_constitution_sections(self):
+        """Path B must produce a constitution with all required sections."""
+        content = self._content()
+        required_sections = [
+            "Scope",
+            "Purpose",
+            "Solution Boundary",
+            "Architecture",
+            "Security",
+            "Data Access",
+            "Error Handling",
+            "Quality",
+            "Change Governance",
+            "Explicit Exclusions",
+        ]
+        for section in required_sections:
+            assert section in content, f"Required constitution section '{section}' missing from Path B"
+
+    def test_path_b_includes_documentation_boundaries_rule(self):
+        """Path B constitution must include the Documentation Boundaries rule."""
+        content = self._content()
+        assert "Documentation Boundaries" in content
+        assert "constitution" in content.lower()
+        assert "Specifications" in content
+        assert "Implementation plans" in content or "Implementation plan" in content
+        assert "Tasks" in content
+
+    def test_path_b_outputs_version_1_0_0_for_new_solutions(self):
+        """New solutions must start at version 1.0.0."""
+        assert "1.0.0" in self._content()
+
+    def test_path_b_safety_rails_forbid_functional_requirements(self):
+        """Safety rails must explicitly forbid functional requirements in the constitution."""
+        content = self._content()
+        assert "Safety rails" in content or "safety rails" in content
+        # Key prohibitions
+        assert "functional requirement" in content.lower() or "raw functional requirements" in content.lower()
+        assert "feature-specific" in content.lower()
+        assert "pseudo-code" in content.lower() or "pseudocode" in content.lower()
+
+    def test_path_b_handles_unknown_answers_gracefully(self):
+        """Path B must document behavior when user answers 'unknown'."""
+        content = self._content()
+        assert "`unknown`" in content
+        # Must not invent specifics
+        assert "safe, minimal defaults" in content or "generic and durable" in content
+
+    def test_no_ambiguous_answer_handling(self):
+        """Detection is automatic — there is no ambiguous-answer follow-up prompt."""
+        assert "ambiguous" not in self._content()
+
+    def test_path_b_writes_to_memory_constitution(self):
+        """Path B must write the generated constitution to the correct path."""
+        content = self._content()
+        assert ".specify/memory/constitution.md" in content
+
+    def test_description_frontmatter_reflects_bootstrap_behavior(self):
+        """The frontmatter description must mention new vs existing detection."""
+        content = self._content()
+        # The description should be in the first few lines
+        lines = content.split("\n")
+        frontmatter_block = "\n".join(lines[:10])
+        assert "new" in frontmatter_block.lower() and "existing" in frontmatter_block.lower()
+
+    def test_extension_hooks_are_preserved(self):
+        """Pre/post extension hook checks must still be present (regression guard)."""
+        content = self._content()
+        assert "before_constitution" in content
+        assert "after_constitution" in content
+
+    def test_no_standalone_prompt_file(self):
+        """The standalone bootstrap prompt file must be removed — logic now lives in the command."""
+        standalone = REPO_ROOT / ".github" / "Prompts" / "smart-constitution-bootstrap-prompt.md"
+        assert not standalone.exists(), (
+            "Standalone smart-constitution-bootstrap-prompt.md should be deleted; "
+            "the logic now lives in templates/commands/constitution.md"
+        )
+
+
+class TestLeanPresetConstitutionCommand:
+    """Verify the lean preset command has the same detection structure."""
+
+    def _content(self) -> str:
+        return LEAN_PRESET_COMMAND.read_text(encoding="utf-8")
+
+    def test_lean_preset_command_exists(self):
+        """The lean preset constitution command file must exist."""
+        assert LEAN_PRESET_COMMAND.exists()
+
+    def test_step_0_detection_exists_in_lean(self):
+        """Lean preset must also have Step 0 detection logic."""
+        assert "Step 0" in self._content()
+
+    def test_lean_detection_is_automatic_no_user_prompt(self):
+        """Lean preset detection must be fully automatic — no user prompt."""
+        content = self._content()
+        assert "do not ask the user" in content.lower()
+        assert "`new`, `existing`" not in content
+
+    def test_lean_detection_rule_checks_constitution_file(self):
+        """Lean preset detection must be based solely on constitution file existence."""
+        content = self._content()
+        assert ".specify/memory/constitution.md" in content
+        assert "unfilled" in content or "[PLACEHOLDER]" in content
+
+    def test_path_a_exists_in_lean(self):
+        """Lean preset must have a Path A for existing solutions."""
+        assert "Path A" in self._content()
+
+    def test_path_b_exists_in_lean(self):
+        """Lean preset must have a Path B for new solutions."""
+        assert "Path B" in self._content()
+
+    def test_lean_bootstrap_questions_present(self):
+        """Lean preset Path B must include the core bootstrap questions."""
+        content = self._content()
+        for question_key in [
+            "solution_name",
+            "solution_purpose",
+            "primary_stack",
+            "security_constraints",
+            "data_rules",
+        ]:
+            assert question_key in content, f"Bootstrap question '{question_key}' missing from lean preset"
+
+    def test_lean_path_b_constitution_sections(self):
+        """Lean preset Path B must list the required constitution sections."""
+        content = self._content()
+        for section in ["Scope", "Purpose", "Security", "Quality"]:
+            assert section in content, f"Section '{section}' missing from lean preset Path B"
+
+    def test_lean_path_b_no_feature_specs(self):
+        """Lean preset must state that the constitution must not contain feature specs."""
+        content = self._content()
+        assert "feature spec" in content.lower() or "feature-specific" in content.lower()
+
+    def test_lean_description_updated(self):
+        """Lean preset description must reflect the new detection behavior."""
+        content = self._content()
+        lines = content.split("\n")
+        frontmatter_block = "\n".join(lines[:10])
+        assert "new" in frontmatter_block.lower() or "existing" in frontmatter_block.lower()
+
+    def test_lean_writes_to_memory_constitution(self):
+        """Lean preset Path B must write to `.specify/memory/constitution.md`."""
+        assert ".specify/memory/constitution.md" in self._content()

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -79,6 +79,41 @@ class TestMainConstitutionCommandStructure:
         for q in questions:
             assert q in content, f"Bootstrap question '{q}' missing from Path B"
 
+    def test_path_b_questions_include_options_or_examples(self):
+        """Bootstrap questions must include options or examples to reduce ambiguity."""
+        content = self._content()
+        # solution_type must offer structured options
+        assert "Windows desktop app" in content
+        assert "Web app" in content
+        assert "REST API" in content
+        assert "CLI tool" in content
+        # primary_stack must offer technology options
+        assert "C# / .NET" in content
+        assert "Python" in content
+        assert "TypeScript / Node.js" in content
+        # security_constraints must offer auth options
+        assert "OAuth 2.0" in content
+        assert "RBAC" in content
+        # data_rules must offer storage options
+        assert "SQL Server only" in content
+        assert "parameterized queries" in content
+        # quality_rules must offer quality options
+        assert "Unit tests" in content
+        assert "Structured logging" in content
+        # out_of_scope must offer exclusion options
+        assert "Feature-specific requirements" in content
+        assert "standard exclusions" in content
+
+    def test_path_b_questions_show_concrete_examples(self):
+        """Bootstrap questions must show concrete examples where applicable."""
+        content = self._content()
+        # solution_name should have name examples
+        assert "InventoryTracker" in content or "PayrollEngine" in content
+        # core_dependencies should have service examples
+        assert "Active Directory" in content
+        # boundary_rules should have boundary examples
+        assert "shared" in content.lower() or "public API" in content
+
     def test_path_b_normalizes_answers_into_categories(self):
         """Path B must normalize answers into constitution-friendly categories."""
         content = self._content()
@@ -212,6 +247,22 @@ class TestLeanPresetConstitutionCommand:
             "data_rules",
         ]:
             assert question_key in content, f"Bootstrap question '{question_key}' missing from lean preset"
+
+    def test_lean_bootstrap_questions_include_options(self):
+        """Lean preset bootstrap questions must include options to reduce ambiguity."""
+        content = self._content()
+        # solution_type must offer options
+        assert "Windows desktop app" in content
+        assert "REST API" in content
+        # primary_stack must offer technology options
+        assert "C# / .NET" in content
+        assert "Python" in content
+        # security_constraints must offer auth options
+        assert "OAuth 2.0" in content
+        # data_rules must offer storage options
+        assert "SQL Server" in content
+        # quality_rules must offer quality options
+        assert "Unit tests" in content
 
     def test_lean_path_b_constitution_sections(self):
         """Lean preset Path B must list the required constitution sections."""

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -172,7 +172,9 @@ class TestMainConstitutionCommandStructure:
 
     def test_no_ambiguous_answer_handling(self):
         """Detection is automatic — there is no ambiguous-answer follow-up prompt."""
-        assert "ambiguous" not in self._content()
+        content = self._content().lower()
+        assert "if the answer is ambiguous" not in content
+        assert "ask a single follow-up" not in content
 
     def test_path_b_writes_to_memory_constitution(self):
         """Path B must write the generated constitution to the correct path."""

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -234,10 +234,10 @@ class TestLeanPresetConstitutionCommand:
         assert "`new`, `existing`" not in content
 
     def test_lean_detection_rule_checks_constitution_file(self):
-        """Lean preset detection must be based solely on constitution file existence."""
+        """Lean preset detection must check constitution file existence and whether content is still placeholders."""
         content = self._content()
         assert ".specify/memory/constitution.md" in content
-        assert "unfilled" in content or "[PLACEHOLDER]" in content
+        assert "unfilled" in content or "[PROJECT_NAME]" in content
 
     def test_lean_detection_distinguishes_initialized_repo_from_truly_new(self):
         """Lean preset must route initialized repos with a missing working copy to Path A."""

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -161,6 +161,13 @@ class TestMainConstitutionCommandStructure:
         """New solutions must start at version 1.0.0."""
         assert "1.0.0" in self._content()
 
+    def test_path_b_requires_concrete_iso_dates_in_footer(self):
+        """Path B must require concrete ISO dates instead of leaving placeholders in the footer."""
+        content = self._content()
+        assert "current date in ISO format `YYYY-MM-DD`" in content
+        assert "Do **not** leave literal placeholders such as `<TODAY>`" in content
+        assert "**Ratified**: YYYY-MM-DD | **Last Amended**: YYYY-MM-DD" in content
+
     def test_path_b_safety_rails_forbid_functional_requirements(self):
         """Safety rails must explicitly forbid functional requirements in the constitution."""
         content = self._content()

--- a/tests/test_constitution_command.py
+++ b/tests/test_constitution_command.py
@@ -284,7 +284,7 @@ class TestLeanPresetConstitutionCommand:
         content = self._content()
         lines = content.split("\n")
         frontmatter_block = "\n".join(lines[:10])
-        assert "new" in frontmatter_block.lower() or "existing" in frontmatter_block.lower()
+        assert "new" in frontmatter_block.lower() and "existing" in frontmatter_block.lower()
 
     def test_lean_writes_to_memory_constitution(self):
         """Lean preset Path B must write to `.specify/memory/constitution.md`."""


### PR DESCRIPTION
## Summary

This PR updates the `/speckit.constitution` workflow so it can handle both existing solutions and first-time bootstrap scenarios from the command itself.

The main command template and the lean preset now automatically determine whether a solution already has a real constitution, route to the correct path, and provide a clearer bootstrap flow for new solutions with structured questions, options, and examples.

## Key Enhancements

- **Automatic Solution State Detection**
  - Detects `new` vs `existing` solution state by inspecting `.specify/memory/constitution.md`.
  - Avoids prompting the user for that classification when the repository state already answers it.

- **Guided New-Solution Bootstrap**
  - Adds a dedicated bootstrap path for repositories that do not yet have a concrete constitution.
  - Collects the minimum durable project-wide inputs needed to generate a lean initial constitution.
  - Uses clearer prompts with options, examples, and fallback guidance such as `unknown`, `none`, and `standard exclusions`.

- **Preserved Existing-Solution Workflow**
  - Keeps the existing constitution update path intact for established solutions.
  - Preserves versioning guidance, placeholder replacement rules, sync impact reporting, and extension hooks.

- **Regression Coverage**
  - Adds static regression tests for the main constitution command and lean preset command.
  - Removes the standalone bootstrap prompt file now that the behavior lives in the command templates.

## Testing

- [x] Ran targeted regression tests for this change: `./.venv/Scripts/pytest.exe tests/test_constitution_command.py` (`32 passed`)
- [x] Ran the full test suite from this environment with Git Bash ahead of the Windows `bash.exe` alias in `PATH`
- [ ] Full suite is fully green in this Windows environment

Full suite result from this environment:

- `1443 passed, 9 failed`
- The failures are not in the updated constitution command tests
- Remaining failures are in existing Windows-specific path/branch-length areas and one unrelated manifest assertion / command registration assertion:
  - `tests/integrations/test_manifest.py`
  - `tests/test_extensions.py`
  - `tests/test_timestamp_branches.py`

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

AI assistance was used to:

- help draft and refine the updated constitution command text
- suggest improvements to the new-solution bootstrap questions, including clearer options and examples
- help outline and refine the static regression tests in tests/test_constitution_command.py
- help draft and revise this pull request description
 
All code, prompt changes, and test updates were reviewed and finalized by me before submission.
