### PR TITLE
feat: register jira preset in community catalog

### DIFF
--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -141,7 +141,34 @@
       ],
       "created_at": "2026-04-09T08:00:00Z",
       "updated_at": "2026-04-19T08:00:00Z"
-    },    
+    },
+    "jira": {
+      "name": "Jira Issue Tracking",
+      "id": "jira",
+      "version": "1.0.0",
+      "description": "Overrides speckit.taskstoissues to create Jira epics, stories, and tasks instead of GitHub Issues via Atlassian MCP tools.",
+      "author": "luno",
+      "repository": "https://github.com/luno/spec-kit-preset-jira",
+      "download_url": "https://github.com/luno/spec-kit-preset-jira/archive/refs/tags/v1.0.0.zip",
+      "homepage": "https://github.com/luno/spec-kit-preset-jira",
+      "documentation": "https://github.com/luno/spec-kit-preset-jira/blob/main/README.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.1.0"
+      },
+      "provides": {
+        "templates": 0,
+        "commands": 1
+      },
+      "tags": [
+        "jira",
+        "atlassian",
+        "issue-tracking",
+        "preset"
+      ],
+      "created_at": "2026-04-15T00:00:00Z",
+      "updated_at": "2026-04-15T00:00:00Z"
+    },
     "multi-repo-branching": {
       "name": "Multi-Repo Branching",
       "id": "multi-repo-branching",
@@ -242,33 +269,6 @@
         "clarify",
         "interactive"
       ]
-    },
-    "jira": {
-      "name": "Jira Issue Tracking",
-      "id": "jira",
-      "version": "1.0.0",
-      "description": "Overrides speckit.taskstoissues to create Jira epics, stories, and tasks instead of GitHub Issues via Atlassian MCP tools.",
-      "author": "luno",
-      "repository": "https://github.com/luno/spec-kit-preset-jira",
-      "download_url": "https://github.com/luno/spec-kit-preset-jira/archive/refs/heads/main.zip",
-      "homepage": "https://github.com/luno/spec-kit-preset-jira",
-      "documentation": "https://github.com/luno/spec-kit-preset-jira/blob/main/README.md",
-      "license": "MIT",
-      "requires": {
-        "speckit_version": ">=0.1.0"
-      },
-      "provides": {
-        "templates": 0,
-        "commands": 1
-      },
-      "tags": [
-        "jira",
-        "atlassian",
-        "issue-tracking",
-        "preset"
-      ],
-      "created_at": "2026-04-15T00:00:00Z",
-      "updated_at": "2026-04-15T00:00:00Z"
     }
   }
 }

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-13T00:00:00Z",
+  "updated_at": "2026-04-15T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/presets/catalog.community.json",
   "presets": {
     "aide-in-place": {
@@ -242,6 +242,33 @@
         "clarify",
         "interactive"
       ]
+    },
+    "jira": {
+      "name": "Jira Issue Tracking",
+      "id": "jira",
+      "version": "1.0.0",
+      "description": "Overrides speckit.taskstoissues to create Jira epics, stories, and tasks instead of GitHub Issues via Atlassian MCP tools.",
+      "author": "luno",
+      "repository": "https://github.com/luno/spec-kit-preset-jira",
+      "download_url": "https://github.com/luno/spec-kit-preset-jira/archive/refs/heads/main.zip",
+      "homepage": "https://github.com/luno/spec-kit-preset-jira",
+      "documentation": "https://github.com/luno/spec-kit-preset-jira/blob/main/README.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.1.0"
+      },
+      "provides": {
+        "templates": 0,
+        "commands": 1
+      },
+      "tags": [
+        "jira",
+        "atlassian",
+        "issue-tracking",
+        "preset"
+      ],
+      "created_at": "2026-04-15T00:00:00Z",
+      "updated_at": "2026-04-15T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds [luno/spec-kit-preset-jira](https://github.com/luno/spec-kit-preset-jira) to the community preset catalog.

This preset overrides the core `speckit.taskstoissues` command to create Jira epics, stories, and tasks via Atlassian MCP tools instead of GitHub Issues.

## Relationship with the Jira extension

This preset complements the existing [spec-kit-jira](https://github.com/mbachorik/spec-kit-jira) extension:

| | Preset (this) | Extension (existing) |
|---|---|---|
| **Purpose** | Overrides core `speckit.taskstoissues` to target Jira | Adds supplementary Jira commands |
| **Commands** | `speckit.taskstoissues` (override) | `speckit.jira.discover-fields`, `speckit.jira.sync-status` |
| **Issue creation** | Via the natural `/speckit.taskstoissues` workflow | Via parallel `/speckit.jira.specstoissues` (redundant if preset is installed) |

Teams using both should disable the extension's `after_tasks` hook to avoid double issue creation.

## Why a preset?

The core `taskstoissues` command is hardcoded to GitHub Issues. Extensions cannot override core commands due to the `speckit.{ext-id}.{command}` naming requirement. A preset sits higher in the resolution stack and can replace the core command directly, keeping the natural `/speckit.taskstoissues` workflow intact for Jira teams.

See #2223 for the full discussion.

## Checklist

- [x] Entry added to `presets/catalog.community.json`
- [x] Repository is public and accessible
- [x] `preset.yml` follows the schema
- [x] MIT licensed