### PR TITLE
docs: remove deprecated --skip-tls references from local-development guide

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -128,12 +128,14 @@ python -m src.specify_cli init --here --ai claude --ignore-agent-tools --script 
 
 Or copy only the modified CLI portion if you want a lighter sandbox.
 
-## 9. Debug Network / TLS Skips
+## 9. Debug Network / TLS Issues
 
 > **Deprecated:** The `--skip-tls` flag is a no-op and has no effect.
-> Previously it was used to bypass TLS validation during local testing.
-> If you encounter TLS errors on a corporate network, configure your
+> It was previously used to bypass TLS validation during local testing.
+> If you encounter TLS errors (e.g., on a corporate network), configure your
 > environment's certificate store or proxy instead.
+>
+> For example, set `SSL_CERT_FILE` or configure `HTTPS_PROXY` / `HTTP_PROXY`.
 
 ## 10. Rapid Edit Loop Summary
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -130,14 +130,10 @@ Or copy only the modified CLI portion if you want a lighter sandbox.
 
 ## 9. Debug Network / TLS Skips
 
-If you need to bypass TLS validation while experimenting:
+> **Note:** The `--skip-tls` flag is deprecated and no longer has any effect.
+> If you encounter TLS errors on a corporate network, configure your
+> environment's certificate store or proxy instead.
 
-```bash
-specify check --skip-tls
-specify init demo --skip-tls --ai gemini --ignore-agent-tools --script ps
-```
-
-(Use only for local experimentation.)
 
 ## 10. Rapid Edit Loop Summary
 
@@ -166,7 +162,7 @@ rm -rf .venv dist build *.egg-info
 | Scripts not executable (Linux) | Re-run init or `chmod +x scripts/*.sh` |
 | Git step skipped | You passed `--no-git` or Git not installed |
 | Wrong script type downloaded | Pass `--script sh` or `--script ps` explicitly |
-| TLS errors on corporate network | Try `--skip-tls` (not for production) |
+| TLS errors on corporate network | Configure your environment's certificate store or proxy. The `--skip-tls` flag is deprecated and has no effect. |
 
 ## 13. Next Steps
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -130,10 +130,10 @@ Or copy only the modified CLI portion if you want a lighter sandbox.
 
 ## 9. Debug Network / TLS Skips
 
-> **Note:** The `--skip-tls` flag is deprecated and no longer has any effect.
+> **Deprecated:** The `--skip-tls` flag is a no-op and has no effect.
+> Previously it was used to bypass TLS validation during local testing.
 > If you encounter TLS errors on a corporate network, configure your
 > environment's certificate store or proxy instead.
-
 
 ## 10. Rapid Edit Loop Summary
 


### PR DESCRIPTION
## Summary

The `--skip-tls` flag is deprecated and no longer has any effect on 
`specify init` or `specify check`. However, `docs/local-development.md` 
still documents it as a working option in two places:

- Section 9 shows example commands using `--skip-tls`
- Section 12 (Common Issues table) recommends `--skip-tls` for TLS errors

This PR removes the outdated references and replaces them with accurate guidance.

## Changes

- `docs/local-development.md`: Updated Section 9 and Section 12 table

## Verification

Running `specify init --help` confirms `--skip-tls` is not listed as an option.

## AI Disclosure

I used Claude Code to help identify this issue by analyzing the repository files.
The fix was manually verified and applied by me.