### PR TITLE
docs: add extensions reference page and integrations FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Community projects that extend, visualize, or build on Spec Kit:
 
 ## 🤖 Supported AI Coding Agent Integrations
 
-Spec Kit works with 30+ AI coding agents — both CLI tools and IDE-based assistants. See the full list with notes and usage details in the [Supported AI Coding Agent Integrations](docs/integrations.md) guide.
+Spec Kit works with 30+ AI coding agents — both CLI tools and IDE-based assistants. See the full list with notes and usage details in the [Supported AI Coding Agent Integrations](https://github.github.io/spec-kit/integrations.html) guide.
 
 Run `specify integration list` to see all available integrations in your installed version.
 
@@ -510,7 +510,7 @@ specify extension add <extension-name>
 
 For example, extensions could add Jira integration, post-implementation code review, V-Model test traceability, or project health diagnostics.
 
-See the [Extensions README](./extensions/README.md) for the full guide and how to build and publish your own. Browse the [community extensions](#-community-extensions) above for what's available.
+See the [Extensions reference](https://github.github.io/spec-kit/extensions.html) for the full command guide. Browse the [community extensions](#-community-extensions) above for what's available.
 
 ### Presets — Customize Existing Workflows
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,201 @@
+# Extensions
+
+Extensions add new capabilities to Spec Kit — domain-specific commands, external tool integrations, quality gates, and more. They introduce new commands and templates that go beyond the built-in Spec-Driven Development workflow.
+
+## Search Available Extensions
+
+```bash
+specify extension search [query]
+```
+
+| Option       | Description                          |
+| ------------ | ------------------------------------ |
+| `--tag`      | Filter by tag                        |
+| `--author`   | Filter by author                     |
+| `--verified` | Show only verified extensions        |
+
+Searches all active catalogs for extensions matching the query. Without a query, lists all available extensions.
+
+## Install an Extension
+
+```bash
+specify extension add <name>
+```
+
+| Option          | Description                                              |
+| --------------- | -------------------------------------------------------- |
+| `--dev`         | Install from a local directory (for development)         |
+| `--from <url>`  | Install from a custom URL instead of the catalog         |
+| `--priority <N>`| Resolution priority (default: 10; lower = higher precedence) |
+
+Installs an extension from the catalog, a URL, or a local directory. Extension commands are automatically registered with the currently installed AI coding agent integration.
+
+> **Note:** All extension commands require a project already initialized with `specify init`.
+
+## Remove an Extension
+
+```bash
+specify extension remove <name>
+```
+
+| Option          | Description                                    |
+| --------------- | ---------------------------------------------- |
+| `--keep-config` | Preserve configuration files during removal    |
+| `--force`       | Skip confirmation prompt                       |
+
+Removes an installed extension. Configuration files are backed up by default; use `--keep-config` to leave them in place or `--force` to skip the confirmation.
+
+## List Installed Extensions
+
+```bash
+specify extension list
+```
+
+| Option        | Description                                        |
+| ------------- | -------------------------------------------------- |
+| `--available` | Show available (uninstalled) extensions            |
+| `--all`       | Show both installed and available extensions       |
+
+Lists installed extensions with their status, version, and command counts.
+
+## Extension Info
+
+```bash
+specify extension info <name>
+```
+
+Shows detailed information about an installed or available extension, including its description, version, commands, and configuration.
+
+## Update Extensions
+
+```bash
+specify extension update [<name>]
+```
+
+Updates a specific extension, or all installed extensions if no name is given.
+
+## Enable / Disable an Extension
+
+```bash
+specify extension enable <name>
+specify extension disable <name>
+```
+
+Disable an extension without removing it. Disabled extensions are not loaded and their commands are not available. Re-enable with `enable`.
+
+## Set Extension Priority
+
+```bash
+specify extension set-priority <name> <priority>
+```
+
+Changes the resolution priority of an extension. When multiple extensions provide a command with the same name, the extension with the lowest priority number takes precedence.
+
+## Catalog Management
+
+Extension catalogs control where `search` and `add` look for extensions. Catalogs are checked in priority order (lower number = higher precedence).
+
+### List Catalogs
+
+```bash
+specify extension catalog list
+```
+
+Shows all active catalogs in the stack with their priorities and install permissions.
+
+### Add a Catalog
+
+```bash
+specify extension catalog add <url>
+```
+
+| Option                               | Description                                        |
+| ------------------------------------ | -------------------------------------------------- |
+| `--name <name>`                      | Required. Unique name for the catalog              |
+| `--priority <N>`                     | Priority (default: 10; lower = higher precedence)  |
+| `--install-allowed / --no-install-allowed` | Whether extensions can be installed from this catalog |
+| `--description <text>`               | Optional description                               |
+
+Adds a catalog to the project's `.specify/extension-catalogs.yml`.
+
+### Remove a Catalog
+
+```bash
+specify extension catalog remove <name>
+```
+
+Removes a catalog from the project configuration.
+
+### Catalog Resolution Order
+
+Catalogs are resolved in this order (first match wins):
+
+1. **Environment variable** — `SPECKIT_CATALOG_URL` overrides all catalogs
+2. **Project config** — `.specify/extension-catalogs.yml`
+3. **User config** — `~/.specify/extension-catalogs.yml`
+4. **Built-in defaults** — official catalog + community catalog
+
+Example `.specify/extension-catalogs.yml`:
+
+```yaml
+catalogs:
+  - name: "my-org-catalog"
+    url: "https://example.com/catalog.json"
+    priority: 5
+    install_allowed: true
+    description: "Our approved extensions"
+```
+
+## Extension Configuration
+
+Most extensions include configuration files in their install directory:
+
+```text
+.specify/extensions/<ext>/
+├── <ext>-config.yml           # Project config (version controlled)
+├── <ext>-config.local.yml     # Local overrides (gitignored)
+└── <ext>-config.template.yml  # Template reference
+```
+
+Configuration is merged in this order (highest priority last):
+
+1. **Extension defaults** (from `extension.yml`)
+2. **Project config** (`<ext>-config.yml`)
+3. **Local overrides** (`<ext>-config.local.yml`)
+4. **Environment variables** (`SPECKIT_<EXT>_*`)
+
+To set up configuration for a newly installed extension, copy the template:
+
+```bash
+cp .specify/extensions/<ext>/<ext>-config.template.yml \
+   .specify/extensions/<ext>/<ext>-config.yml
+```
+
+## FAQ
+
+### Why can't I find an extension with `search`?
+
+Check the spelling of the extension name. The extension may not be published yet, or it may be in a catalog you haven't added. Use `specify extension catalog list` to see which catalogs are active.
+
+### Why doesn't the extension command appear in my AI coding agent?
+
+Verify the extension is installed and enabled with `specify extension list`. If it shows as installed, restart your AI coding agent — it may need to reload for it to take effect.
+
+### How do I set up extension configuration?
+
+Copy the config template that ships with the extension:
+
+```bash
+cp .specify/extensions/<ext>/<ext>-config.template.yml \
+   .specify/extensions/<ext>/<ext>-config.yml
+```
+
+See [Extension Configuration](#extension-configuration) for details on config layers and overrides.
+
+### How do I resolve an incompatible version error?
+
+Update Spec Kit to the version required by the extension.
+
+### Who maintains extensions?
+
+Most extensions are independently created and maintained by their respective authors. The Spec Kit maintainers do not review, audit, endorse, or support extension code. Review an extension's source code before installing and use at your own discretion. For issues with a specific extension, contact its author or file an issue on the extension's repository.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -116,3 +116,25 @@ Example:
 ```bash
 specify integration install generic --integration-options="--commands-dir .myagent/cmds"
 ```
+
+## FAQ
+
+### Can I use multiple integrations at the same time?
+
+No. Only one AI coding agent integration can be installed per project. Use `specify integration switch <key>` to change to a different AI coding agent.
+
+### What happens to my changes when I uninstall or switch?
+
+Files you've modified are preserved automatically. Only unmodified files (matching their original SHA-256 hash) are removed. Use `--force` to override this.
+
+### How do I know which key to use?
+
+Run `specify integration list` to see all available integrations with their keys, or check the [Supported AI Coding Agents](#supported-ai-coding-agents) table above.
+
+### Do I need the AI coding agent installed to use an integration?
+
+CLI-based integrations (like Claude Code, Gemini CLI) require the tool to be installed. IDE-based integrations (like Windsurf, Cursor) work through the IDE itself. Some agents like GitHub Copilot support both IDE and CLI usage. `specify integration list` shows which type each integration is.
+
+### When should I use `upgrade` vs `switch`?
+
+Use `upgrade` when you've upgraded Spec Kit and want to refresh the same integration's templates. Use `switch` when you want to change to a different AI coding agent.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -17,6 +17,8 @@
   items:
     - name: Integrations
       href: integrations.md
+    - name: Extensions
+      href: extensions.md
 
 # Development workflows
 - name: Development


### PR DESCRIPTION
Adds a dedicated `docs/extensions.md` reference page covering the full `specify extension` command surface, and adds an FAQ section to `docs/integrations.md`.

## Changes

- **New `docs/extensions.md`** — command reference for all 9 `specify extension` commands and 3 `specify extension catalog` commands, plus catalog resolution order, extension configuration, and FAQ
- **`docs/integrations.md`** — added FAQ section covering single-integration limit, file preservation, key discovery, CLI vs IDE requirements, and upgrade vs switch
- **`docs/toc.yml`** — added Extensions under Reference section
- **`README.md`** — updated integration and extension links to point to published docs site (`github.github.io/spec-kit/`)

## Motivation

Follows the same pattern established in #2241 for integrations. The extensions reference page replaces the command-reference portions of the Extension User Guide, consolidating all `specify extension` CLI documentation into a single docs page that can serve as the canonical reference.