### PR TITLE
fix: add reference/*.md to docfx content glob

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -4,7 +4,8 @@
       {
         "files": [
           "*.md",
-          "toc.yml"
+          "toc.yml",
+          "reference/*.md"
         ]
       },
       {


### PR DESCRIPTION
Adds `reference/*.md` to the docfx content glob so the reference subdirectory pages are included in the build.

Without this, the reference pages (core, integrations, extensions, presets, workflows, overview) return 404 on the published docs site.