### PR TITLE
Docs/add copilot & claude plugin installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify init --here
 
 If your environment blocks access to PyPI or GitHub, see the [Enterprise / Air-Gapped Installation](./docs/installation.md#enterprise--air-gapped-installation) guide for step-by-step instructions on using `pip download` to create portable, OS-specific wheel bundles on a connected machine.
 
+#### Option 4: Claude Code / Copilot Plugin
+
+Install Spec Kit directly as a plugin:
+
+```bash
+# Claude Code
+claude plugin marketplace add speckit-community/cc-spec-kit
+claude plugin install speckit@speckit-community
+
+# GitHub Copilot CLI
+copilot plugin marketplace add speckit-community/cc-spec-kit
+copilot plugin install speckit@speckit-community
+```
+
+Then initialize your project with `/speckit:init` and use the standard workflow (`/speckit-specify`, `/speckit-plan`, `/speckit-tasks`, `/speckit-implement`). Projects initialized with the plugin are fully compatible with the `specify` CLI.
+
 ### 2. Establish project principles
 
 Launch your AI assistant in the project directory. Most agents expose spec-kit as `/speckit.*` slash commands; Codex CLI in skills mode uses `$speckit-*` instead.

--- a/templates/commands/taskstoissues.md
+++ b/templates/commands/taskstoissues.md
@@ -51,17 +51,17 @@ You **MUST** consider the user input before proceeding (if not empty).
 ## Outline
 
 1. Run `{SCRIPT}` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
-1. From the executed script, extract the path to **tasks**.
-1. Get the Git remote by running:
+2. From the executed script, extract the path to **tasks**.
+3. Get the Git remote by running:
 
-```bash
-git config --get remote.origin.url
-```
+   ```bash
+   git config --get remote.origin.url
+   ```
 
-> [!CAUTION]
-> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+   > [!CAUTION]
+   > ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
 
-1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+4. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
 
 > [!CAUTION]
 > UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL


### PR DESCRIPTION
## Description

Add a new "Option 4: Claude Code / Copilot Plugin" section to the README installation guide, documenting how to install Spec Kit directly as a plugin via the Claude Code and GitHub Copilot CLI marketplace commands, along with the standard workflow slash commands.

## Testing

- [x] Verified the new section renders correctly in Markdown

## AI Disclosure

- [x] I **did not** use AI assistance for this contribution
