### PR TITLE
fix: suppress CRLF warnings in auto-commit.ps1

### DIFF
--- a/extensions/git/scripts/powershell/auto-commit.ps1
+++ b/extensions/git/scripts/powershell/auto-commit.ps1
@@ -36,10 +36,14 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
     exit 0
 }
 
-try {
-    git rev-parse --is-inside-work-tree 2>$null | Out-Null
-    if ($LASTEXITCODE -ne 0) { throw "not a repo" }
-} catch {
+# Temporarily relax ErrorActionPreference so git stderr warnings
+# (e.g. CRLF notices on Windows) do not become terminating errors.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'SilentlyContinue'
+git rev-parse --is-inside-work-tree 2>$null | Out-Null
+$isRepo = $LASTEXITCODE -eq 0
+$ErrorActionPreference = $savedEAP
+if (-not $isRepo) {
     Write-Warning "[specify] Warning: Not a Git repository; skipped auto-commit"
     exit 0
 }
@@ -117,11 +121,13 @@ if (-not $enabled) {
 }
 
 # Check if there are changes to commit
-$null = git diff --quiet HEAD 2>&1
-$d1 = $LASTEXITCODE
-$null = git diff --cached --quiet 2>&1
-$d2 = $LASTEXITCODE
-$untracked = git ls-files --others --exclude-standard 2>&1
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'SilentlyContinue'
+git diff --quiet HEAD 2>$null; $d1 = $LASTEXITCODE
+git diff --cached --quiet 2>$null; $d2 = $LASTEXITCODE
+$untracked = git ls-files --others --exclude-standard 2>$null
+$ErrorActionPreference = $savedEAP
 
 if ($d1 -eq 0 -and $d2 -eq 0 -and -not $untracked) {
     Write-Host "[specify] No changes to commit after $EventName" -ForegroundColor DarkGray
@@ -138,14 +144,19 @@ if (-not $commitMsg) {
 }
 
 # Stage and commit
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'SilentlyContinue'
 try {
     $out = git add . 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) { throw "git add failed: $out" }
     $out = git commit -q -m $commitMsg 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) { throw "git commit failed: $out" }
 } catch {
+    $ErrorActionPreference = $savedEAP
     Write-Warning "[specify] Error: $_"
     exit 1
 }
+$ErrorActionPreference = $savedEAP
 
 Write-Host "[OK] Changes committed $phase $commandName"

--- a/extensions/git/scripts/powershell/auto-commit.ps1
+++ b/extensions/git/scripts/powershell/auto-commit.ps1
@@ -117,9 +117,11 @@ if (-not $enabled) {
 }
 
 # Check if there are changes to commit
-$diffHead = git diff --quiet HEAD 2>$null; $d1 = $LASTEXITCODE
-$diffCached = git diff --cached --quiet 2>$null; $d2 = $LASTEXITCODE
-$untracked = git ls-files --others --exclude-standard 2>$null
+$null = git diff --quiet HEAD 2>&1
+$d1 = $LASTEXITCODE
+$null = git diff --cached --quiet 2>&1
+$d2 = $LASTEXITCODE
+$untracked = git ls-files --others --exclude-standard 2>&1
 
 if ($d1 -eq 0 -and $d2 -eq 0 -and -not $untracked) {
     Write-Host "[specify] No changes to commit after $EventName" -ForegroundColor DarkGray

--- a/extensions/git/scripts/powershell/auto-commit.ps1
+++ b/extensions/git/scripts/powershell/auto-commit.ps1
@@ -39,10 +39,13 @@ if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
 # Temporarily relax ErrorActionPreference so git stderr warnings
 # (e.g. CRLF notices on Windows) do not become terminating errors.
 $savedEAP = $ErrorActionPreference
-$ErrorActionPreference = 'SilentlyContinue'
-git rev-parse --is-inside-work-tree 2>$null | Out-Null
-$isRepo = $LASTEXITCODE -eq 0
-$ErrorActionPreference = $savedEAP
+$ErrorActionPreference = 'Continue'
+try {
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    $isRepo = $LASTEXITCODE -eq 0
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
 if (-not $isRepo) {
     Write-Warning "[specify] Warning: Not a Git repository; skipped auto-commit"
     exit 0
@@ -123,11 +126,14 @@ if (-not $enabled) {
 # Check if there are changes to commit
 # Relax ErrorActionPreference so CRLF warnings on stderr do not terminate.
 $savedEAP = $ErrorActionPreference
-$ErrorActionPreference = 'SilentlyContinue'
-git diff --quiet HEAD 2>$null; $d1 = $LASTEXITCODE
-git diff --cached --quiet 2>$null; $d2 = $LASTEXITCODE
-$untracked = git ls-files --others --exclude-standard 2>$null
-$ErrorActionPreference = $savedEAP
+$ErrorActionPreference = 'Continue'
+try {
+    git diff --quiet HEAD 2>$null; $d1 = $LASTEXITCODE
+    git diff --cached --quiet 2>$null; $d2 = $LASTEXITCODE
+    $untracked = git ls-files --others --exclude-standard 2>$null
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
 
 if ($d1 -eq 0 -and $d2 -eq 0 -and -not $untracked) {
     Write-Host "[specify] No changes to commit after $EventName" -ForegroundColor DarkGray
@@ -144,19 +150,20 @@ if (-not $commitMsg) {
 }
 
 # Stage and commit
-# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate.
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate,
+# while still allowing redirected error output to be captured for diagnostics.
 $savedEAP = $ErrorActionPreference
-$ErrorActionPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Continue'
 try {
     $out = git add . 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) { throw "git add failed: $out" }
     $out = git commit -q -m $commitMsg 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0) { throw "git commit failed: $out" }
 } catch {
-    $ErrorActionPreference = $savedEAP
     Write-Warning "[specify] Error: $_"
     exit 1
+} finally {
+    $ErrorActionPreference = $savedEAP
 }
-$ErrorActionPreference = $savedEAP
 
 Write-Host "[OK] Changes committed $phase $commandName"

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -585,6 +585,136 @@ class TestAutoCommitPowerShell:
         assert "\u2713" not in result.stdout, "Must not use Unicode checkmark"
 
 
+# ── auto-commit.ps1 CRLF warning tests (issue #2253) ────────────────────────
+
+
+@pytest.mark.skipif(not HAS_PWSH, reason="pwsh not available")
+class TestAutoCommitPowerShellCRLF:
+    """Tests for CRLF warning handling in auto-commit.ps1 (issue #2253).
+
+    On Windows, git emits CRLF warnings to stderr when core.autocrlf=true
+    and files use LF line endings.  PowerShell's $ErrorActionPreference='Stop'
+    converts stderr output into terminating errors, crashing the script.
+
+    These tests use core.autocrlf=true + explicit LF-ending files.  On Windows
+    the CRLF warnings fire and exercise the fix; on other platforms the tests
+    still run (they just won't produce stderr warnings, so they pass trivially).
+    """
+
+    # -- positive tests (fix works) ----------------------------------------
+
+    def test_commit_succeeds_with_autocrlf(self, tmp_path: Path):
+        """auto-commit.ps1 creates a commit when core.autocrlf=true (CRLF
+        warnings on stderr must not crash the script)."""
+        project = _setup_project(tmp_path)
+        _write_config(project, (
+            "auto_commit:\n"
+            "  default: false\n"
+            "  after_specify:\n"
+            "    enabled: true\n"
+            '    message: "crlf commit"\n'
+        ))
+        subprocess.run(
+            ["git", "config", "core.autocrlf", "true"],
+            cwd=project, check=True,
+        )
+        # Write a file with explicit LF line endings to trigger the warning.
+        (project / "crlf-test.txt").write_bytes(b"line one\nline two\nline three\n")
+
+        result = _run_pwsh("auto-commit.ps1", project, "after_specify")
+
+        assert result.returncode == 0, (
+            f"Script crashed (likely CRLF stderr); stderr:\n{result.stderr}"
+        )
+        assert "[OK] Changes committed" in result.stdout
+
+        log = subprocess.run(
+            ["git", "log", "--oneline", "-1"],
+            cwd=project, capture_output=True, text=True,
+        )
+        assert "crlf commit" in log.stdout
+
+    def test_custom_message_not_corrupted_by_crlf(self, tmp_path: Path):
+        """Commit message is the configured value, not a CRLF warning."""
+        project = _setup_project(tmp_path)
+        _write_config(project, (
+            "auto_commit:\n"
+            "  default: false\n"
+            "  after_plan:\n"
+            "    enabled: true\n"
+            '    message: "[Project] Plan done"\n'
+        ))
+        subprocess.run(
+            ["git", "config", "core.autocrlf", "true"],
+            cwd=project, check=True,
+        )
+        (project / "plan.txt").write_bytes(b"plan\ncontent\n")
+
+        result = _run_pwsh("auto-commit.ps1", project, "after_plan")
+        assert result.returncode == 0
+
+        log = subprocess.run(
+            ["git", "log", "--format=%s", "-1"],
+            cwd=project, capture_output=True, text=True,
+        )
+        assert "[Project] Plan done" in log.stdout.strip()
+
+    def test_no_changes_still_skips_with_autocrlf(self, tmp_path: Path):
+        """Script correctly detects 'no changes' even with core.autocrlf=true."""
+        project = _setup_project(tmp_path)
+        _write_config(project, (
+            "auto_commit:\n"
+            "  default: false\n"
+            "  after_specify:\n"
+            "    enabled: true\n"
+        ))
+        subprocess.run(
+            ["git", "config", "core.autocrlf", "true"],
+            cwd=project, check=True,
+        )
+        # Stage and commit everything so the working tree is clean.
+        subprocess.run(["git", "add", "."], cwd=project, check=True,
+                        env={**os.environ, **_GIT_ENV})
+        subprocess.run(["git", "commit", "-m", "setup", "-q"], cwd=project,
+                        check=True, env={**os.environ, **_GIT_ENV})
+
+        result = _run_pwsh("auto-commit.ps1", project, "after_specify")
+        assert result.returncode == 0
+        assert "[OK]" not in result.stdout, "Should not have committed anything"
+
+    # -- negative tests (real errors still surface) ------------------------
+
+    def test_not_a_repo_still_detected_with_autocrlf(self, tmp_path: Path):
+        """Script still exits gracefully when not in a git repo, even though
+        ErrorActionPreference is relaxed around the rev-parse call."""
+        project = _setup_project(tmp_path, git=False)
+        _write_config(project, "auto_commit:\n  default: true\n")
+
+        result = _run_pwsh("auto-commit.ps1", project, "after_specify")
+        assert result.returncode == 0
+        combined = result.stdout + result.stderr
+        assert "not a git repository" in combined.lower() or "warning" in combined.lower()
+
+    def test_missing_config_still_exits_cleanly_with_autocrlf(self, tmp_path: Path):
+        """Script exits 0 when git-config.yml is absent (no over-suppression)."""
+        project = _setup_project(tmp_path)
+        subprocess.run(
+            ["git", "config", "core.autocrlf", "true"],
+            cwd=project, check=True,
+        )
+        config = project / ".specify" / "extensions" / "git" / "git-config.yml"
+        config.unlink(missing_ok=True)
+
+        result = _run_pwsh("auto-commit.ps1", project, "after_specify")
+        assert result.returncode == 0
+        # Should not have committed anything — config file missing means disabled.
+        log = subprocess.run(
+            ["git", "log", "--oneline"],
+            cwd=project, capture_output=True, text=True,
+        )
+        assert log.stdout.strip().count("\n") == 0  # only the seed commit
+
+
 # ── git-common.sh Tests ──────────────────────────────────────────────────────
 
 

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -614,12 +614,22 @@ class TestAutoCommitPowerShellCRLF:
             "    enabled: true\n"
             '    message: "crlf commit"\n'
         ))
+        # Create and commit a tracked LF-ending file first so the script's
+        # `git diff --quiet HEAD` checks inspect a tracked modification.
+        tracked = project / "crlf-test.txt"
+        tracked.write_bytes(b"line one\nline two\nline three\n")
+        subprocess.run(["git", "add", "crlf-test.txt"], cwd=project, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "seed tracked file"],
+            cwd=project, check=True, env={**os.environ, **_GIT_ENV},
+        )
         subprocess.run(
             ["git", "config", "core.autocrlf", "true"],
             cwd=project, check=True,
         )
-        # Write a file with explicit LF line endings to trigger the warning.
-        (project / "crlf-test.txt").write_bytes(b"line one\nline two\nline three\n")
+        # Modify the tracked file with explicit LF endings to trigger the
+        # CRLF warning during diff/status checks on Windows.
+        tracked.write_bytes(b"line one\nline two changed\nline three\n")
 
         result = _run_pwsh("auto-commit.ps1", project, "after_specify")
 

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -14,6 +14,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -630,6 +631,16 @@ class TestAutoCommitPowerShellCRLF:
         # Modify the tracked file with explicit LF endings to trigger the
         # CRLF warning during diff/status checks on Windows.
         tracked.write_bytes(b"line one\nline two changed\nline three\n")
+
+        # On Windows, verify the test setup actually produces a CRLF warning.
+        if sys.platform == "win32":
+            probe = subprocess.run(
+                ["git", "diff", "--quiet", "HEAD"],
+                cwd=project, capture_output=True, text=True,
+            )
+            assert "LF will be replaced by CRLF" in probe.stderr, (
+                "Expected CRLF warning from git on Windows; test setup may be wrong"
+            )
 
         result = _run_pwsh("auto-commit.ps1", project, "after_specify")
 


### PR DESCRIPTION
## Description

Fixes #2253

The `auto-commit.ps1` script fails on Windows when git emits CRLF line-ending warnings to stderr. With `$ErrorActionPreference = 'Stop'`, PowerShell converts any stderr output from native commands into terminating `ErrorRecord` exceptions — crashing the script before the `2>$null` redirection can suppress them.

### Root Cause

PowerShell raises a `NativeCommandError` when it sees *any* stderr output from a native command under `$ErrorActionPreference = 'Stop'`, terminating the script before stderr redirection takes effect. Lines using `2>$null` are ineffective because the error is raised before the redirection is processed.

### Solution

Temporarily set `$ErrorActionPreference = 'Continue'` around all native git calls that may emit stderr warnings (repo detection, change detection, and staging/commit). This prevents stderr from becoming a terminating error while still allowing `2>&1` capture for diagnostics on real failures. Each block uses `try/finally` to guarantee the preference is restored.

### Changes

- **`extensions/git/scripts/powershell/auto-commit.ps1`** — Three git call sites wrapped with `$ErrorActionPreference = 'Continue'` + `try/finally`:
  1. `git rev-parse` (repo detection)
  2. `git diff` / `git ls-files` (change detection — the original crash site)
  3. `git add` / `git commit` (staging and commit)
- **`tests/extensions/git/test_git_extension.py`** — New `TestAutoCommitPowerShellCRLF` class with 5 tests using `core.autocrlf=true` + LF-ending tracked files. On Windows runners the CRLF warnings fire and validate the fix end-to-end.

### Why This Is Safe

- Only affects `$ErrorActionPreference` scope; restored via `finally` blocks
- Uses `'Continue'` (not `'SilentlyContinue'`) so error output is still captured in `$out` for diagnostics
- Exit code semantics unchanged (`$LASTEXITCODE` is unaffected by `ErrorActionPreference`)
- Bash version is unaffected (stderr redirection works correctly there)

## Testing

- All 15 PowerShell tests pass locally (macOS with pwsh)
- New CRLF tests pass trivially on non-Windows (no warnings emitted); on the Windows runner `core.autocrlf=true` triggers actual CRLF warnings to exercise the fix
- Existing `TestAutoCommitPowerShell` tests confirm no regressions