### PR TITLE
Add Community Friends page to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,18 +305,7 @@ See Spec-Driven Development in action across different scenarios with these comm
 
 ## 🛠️ Community Friends
 
-> [!NOTE]
-> Community projects listed here are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review their source code before installation and use at your own discretion.
-
-Community projects that extend, visualize, or build on Spec Kit:
-
-- **[cc-spex](https://github.com/rhuss/cc-spex)** - A Claude Code plugin that adds composable traits on top of Spec Kit with [Superpowers](https://github.com/obra/superpowers)-based quality gates, spec/code review, git worktree isolation, and parallel implementation via agent teams.
-
-- **[Spec Kit Assistant](https://marketplace.visualstudio.com/items?itemName=rfsales.speckit-assistant)** — A VS Code extension that provides a visual orchestrator for the full SDD workflow (constitution → specification → planning → tasks → implementation) with phase status visualization, an interactive task checklist, DAG visualization, and support for Claude, Gemini, GitHub Copilot, and OpenAI backends. Requires the `specify` CLI in your PATH.
-
-- **[SpecKit Companion](https://marketplace.visualstudio.com/items?itemName=alfredoperez.speckit-companion)** — A VS Code extension that brings a visual GUI to Spec Kit. Browse specs in a rich markdown viewer with clickable file references, create specifications with image attachments, comment and refine each step inline (GitHub-style review), track your progress through the SDD workflow with a visual phase stepper, and manage steering documents like constitutions and templates.
-
-- **[cc-spec-kit](https://github.com/speckit-community/cc-spec-kit)** — Community-maintained plugin for Claude Code and GitHub Copilot CLI that installs Spec Kit skills via the plugin marketplace.
+Community projects that extend, visualize, or build on Spec Kit. See the full list on the [Community Friends](https://github.github.io/spec-kit/community/friends.html) page.
 
 ## 🤖 Supported AI Coding Agent Integrations
 

--- a/docs/community/friends.md
+++ b/docs/community/friends.md
@@ -1,0 +1,14 @@
+# Community Friends
+
+> [!NOTE]
+> Community projects listed here are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review their source code before installation and use at your own discretion.
+
+Community projects that extend, visualize, or build on Spec Kit:
+
+- **[cc-spex](https://github.com/rhuss/cc-spex)** — A Claude Code plugin that adds composable traits on top of Spec Kit with [Superpowers](https://github.com/obra/superpowers)-based quality gates, spec/code review, git worktree isolation, and parallel implementation via agent teams.
+
+- **[Spec Kit Assistant](https://marketplace.visualstudio.com/items?itemName=rfsales.speckit-assistant)** — A VS Code extension that provides a visual orchestrator for the full SDD workflow (constitution → specification → planning → tasks → implementation) with phase status visualization, an interactive task checklist, DAG visualization, and support for Claude, Gemini, GitHub Copilot, and OpenAI backends. Requires the `specify` CLI in your PATH.
+
+- **[SpecKit Companion](https://marketplace.visualstudio.com/items?itemName=alfredoperez.speckit-companion)** — A VS Code extension that brings a visual GUI to Spec Kit. Browse specs in a rich markdown viewer with clickable file references, create specifications with image attachments, comment and refine each step inline (GitHub-style review), track your progress through the SDD workflow with a visual phase stepper, and manage steering documents like constitutions and templates.
+
+- **[cc-spec-kit](https://github.com/speckit-community/cc-spec-kit)** — Community-maintained plugin for Claude Code and GitHub Copilot CLI that installs Spec Kit skills via the plugin marketplace.

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -5,6 +5,7 @@
         "files": [
           "*.md",
           "toc.yml",
+          "community/*.md",
           "reference/*.md"
         ]
       },

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -33,3 +33,9 @@
   items:
     - name: Local Development
       href: local-development.md
+
+# Community
+- name: Community
+  items:
+    - name: Friends
+      href: community/friends.md


### PR DESCRIPTION
Moves the Community Friends section from the main README into a dedicated docs page, following the same structure as the Reference section.

### Changes

- **New:** `docs/community/friends.md` — Community Friends page with the content previously inline in the README
- **Updated:** `docs/toc.yml` — Added a Community section with a Friends entry
- **Updated:** `docs/docfx.json` — Added `community/*.md` to the content glob so DocFX picks up the new page
- **Updated:** `README.md` — Replaced the inline list and note with a single link to the new docs page

This is the first page in the `docs/community/` section, establishing the pattern for future community pages (e.g., walkthroughs, extensions, presets).