### PR TITLE
fix(tasks): require executable commands for governed operations in task bodies

### DIFF
--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -25,6 +25,7 @@ You **MUST** consider the user input before proceeding (if not empty).
   - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
 - For each executable hook, output the following based on its `optional` flag:
   - **Optional hook** (`optional: true`):
+
     ```text
     ## Extension Hooks
 
@@ -36,6 +37,7 @@ You **MUST** consider the user input before proceeding (if not empty).
     To execute: `/{command}`
     ```
   - **Mandatory hook** (`optional: false`):
+
     ```text
     ## Extension Hooks
 
@@ -181,6 +183,7 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
       - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
     - For each executable hook, output the following based on its `optional` flag:
       - **Optional hook** (`optional: true`):
+
         ```text
         ## Extension Hooks
 
@@ -192,6 +195,7 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
         To execute: `/{command}`
         ```
       - **Mandatory hook** (`optional: false`):
+
         ```text
         ## Extension Hooks
 

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -42,7 +42,7 @@ You **MUST** consider the user input before proceeding (if not empty).
     **Automatic Pre-Hook**: {extension}
     Executing: `/{command}`
     EXECUTE_COMMAND: {command}
-    
+
     Wait for the result of the hook command before proceeding to the Outline.
     ```
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -25,7 +25,7 @@ You **MUST** consider the user input before proceeding (if not empty).
   - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
 - For each executable hook, output the following based on its `optional` flag:
   - **Optional hook** (`optional: true`):
-    ```
+    ```text
     ## Extension Hooks
 
     **Optional Pre-Hook**: {extension}
@@ -36,7 +36,7 @@ You **MUST** consider the user input before proceeding (if not empty).
     To execute: `/{command}`
     ```
   - **Mandatory hook** (`optional: false`):
-    ```
+    ```text
     ## Extension Hooks
 
     **Automatic Pre-Hook**: {extension}
@@ -181,7 +181,7 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
       - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
     - For each executable hook, output the following based on its `optional` flag:
       - **Optional hook** (`optional: true`):
-        ```
+        ```text
         ## Extension Hooks
 
         **Optional Hook**: {extension}
@@ -192,7 +192,7 @@ Note: This command assumes a complete task breakdown exists in tasks.md. If task
         To execute: `/{command}`
         ```
       - **Mandatory hook** (`optional: false`):
-        ```
+        ```text
         ## Extension Hooks
 
         **Automatic Hook**: {extension}

--- a/templates/commands/implement.md
+++ b/templates/commands/implement.md
@@ -142,10 +142,11 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 6. Execute implementation following the task plan:
    - **Phase-by-phase execution**: Complete each phase before moving to the next
-   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together
    - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
    - **File-based coordination**: Tasks affecting the same files must run sequentially
    - **Validation checkpoints**: Verify each phase completion before proceeding
+   - **Task-level re-read**: Before executing each individual task, re-read that task's entry from tasks.md to get its complete body. This ensures any embedded commands (e.g., governed operations with exact flags and env vars) are in active context even if the initial tasks.md load was compressed out during a long session.
 
 7. Implementation execution rules:
    - **Setup first**: Initialize project structure, dependencies, configuration

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -172,7 +172,7 @@ Every task MUST strictly follow this format:
 - ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
 - ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
 - ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
-- ✅ CORRECT (governed): ``- [ ] T008 Push packages to NuGet feed: `dotnet nuget push "*.nupkg" --api-key $NUGET_API_KEY --source $NUGET_FEED_URL````
+- ✅ CORRECT (governed): ``- [ ] T008 dist/*.nupkg Push packages to NuGet feed: `dotnet nuget push "*.nupkg" --api-key $NUGET_API_KEY --source $NUGET_FEED_URL````
 - ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
 - ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
 - ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
@@ -183,10 +183,10 @@ Every task MUST strictly follow this format:
 
 A **governed operation** is any operation the project constitution defines with specific command syntax, required flags, or environment variable references (for example: a package publish step, a deployment command, a signed git tag).
 
-When a task covers a governed operation, its description MUST include the exact executable command from the constitution, parameterized with environment variable names rather than literal credential values. Do not paraphrase the command.
+When a task covers a governed operation, it MUST still include the required file path from the standard task format, and its description MUST include the exact executable command from the constitution, parameterized with environment variable names rather than literal credential values. Do not paraphrase the command.
 
 ```text
-- [ ] [TaskID] [P?] [Story?] Description: `<exact-command --flag $ENV_VAR>`
+- [ ] [TaskID] [P?] [Story?] path/to/file.ext Description: `<exact-command --flag $ENV_VAR>`
 ```
 
 **Why this matters**: Tasks are surfaced in agent context every session. The constitution may be compacted out of active context by the time a task is executed — especially across session boundaries or late in long sessions. Embedding the exact command in the task body ensures the agent executes the correct syntax without re-reading the constitution.

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -172,7 +172,7 @@ Every task MUST strictly follow this format:
 - ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
 - ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
 - ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
-- ✅ CORRECT (governed): `- [ ] T008 Push packages to NuGet feed: \`dotnet nuget push "*.nupkg" --api-key $NUGET_API_KEY --source $NUGET_FEED_URL\``
+- ✅ CORRECT (governed): ``- [ ] T008 Push packages to NuGet feed: `dotnet nuget push "*.nupkg" --api-key $NUGET_API_KEY --source $NUGET_FEED_URL````
 - ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
 - ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
 - ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -25,6 +25,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 ## Pre-Execution Checks
 
 **Check for extension hooks (before tasks generation)**:
+
 - Check if `.specify/extensions.yml` exists in the project root.
 - If it exists, read it and look for entries under the `hooks.before_tasks` key
 - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
@@ -34,7 +35,8 @@ You **MUST** consider the user input before proceeding (if not empty).
   - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
 - For each executable hook, output the following based on its `optional` flag:
   - **Optional hook** (`optional: true`):
-    ```
+
+    ```text
     ## Extension Hooks
 
     **Optional Pre-Hook**: {extension}
@@ -44,16 +46,19 @@ You **MUST** consider the user input before proceeding (if not empty).
     Prompt: {prompt}
     To execute: `/{command}`
     ```
+
   - **Mandatory hook** (`optional: false`):
-    ```
+
+    ```text
     ## Extension Hooks
 
     **Automatic Pre-Hook**: {extension}
     Executing: `/{command}`
     EXECUTE_COMMAND: {command}
-    
+
     Wait for the result of the hook command before proceeding to the Outline.
     ```
+
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
 ## Outline
@@ -106,7 +111,8 @@ You **MUST** consider the user input before proceeding (if not empty).
      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
    - For each executable hook, output the following based on its `optional` flag:
      - **Optional hook** (`optional: true`):
-       ```
+
+       ```text
        ## Extension Hooks
 
        **Optional Hook**: {extension}
@@ -116,14 +122,17 @@ You **MUST** consider the user input before proceeding (if not empty).
        Prompt: {prompt}
        To execute: `/{command}`
        ```
+
      - **Mandatory hook** (`optional: false`):
-       ```
+
+       ```text
        ## Extension Hooks
 
        **Automatic Hook**: {extension}
        Executing: `/{command}`
        EXECUTE_COMMAND: {command}
        ```
+
    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
 Context for task generation: {ARGS}

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -163,10 +163,31 @@ Every task MUST strictly follow this format:
 - ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
 - ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
 - ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ✅ CORRECT (governed): `- [ ] T008 Push packages to NuGet feed: \`dotnet nuget push "*.nupkg" --api-key $NUGET_API_KEY --source $NUGET_FEED_URL\``
 - ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
 - ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
 - ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
 - ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+- ❌ WRONG (governed): `- [ ] T008 Push packages to NuGet feed` (prose only — omits executable command for a governed operation)
+
+### Governed Operations (REQUIRED)
+
+A **governed operation** is any operation the project constitution defines with specific command syntax, required flags, or environment variable references (for example: a package publish step, a deployment command, a signed git tag).
+
+When a task covers a governed operation, its description MUST include the exact executable command from the constitution, parameterized with environment variable names rather than literal credential values. Do not paraphrase the command.
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description: `<exact-command --flag $ENV_VAR>`
+```
+
+**Why this matters**: Tasks are surfaced in agent context every session. The constitution may be compacted out of active context by the time a task is executed — especially across session boundaries or late in long sessions. Embedding the exact command in the task body ensures the agent executes the correct syntax without re-reading the constitution.
+
+**How to identify governed operations while generating tasks**:
+
+- The constitution is in active context during `/speckit.tasks` execution — read it before generating tasks
+- Any operation the constitution names with a specific tool, required flags, or env var references is governed
+- If the constitution says "do not use X, use Y" (e.g., use the feed URL env var, not the config source name), the task body must use Y
+- If a governed operation has multiple steps (e.g., pack then push), each step is its own task with its own command
 
 ### Task Organization
 

--- a/templates/commands/taskstoissues.md
+++ b/templates/commands/taskstoissues.md
@@ -17,6 +17,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 ## Pre-Execution Checks
 
 **Check for extension hooks (before tasks-to-issues conversion)**:
+
 - Check if `.specify/extensions.yml` exists in the project root.
 - If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
 - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
@@ -26,7 +27,8 @@ You **MUST** consider the user input before proceeding (if not empty).
   - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
 - For each executable hook, output the following based on its `optional` flag:
   - **Optional hook** (`optional: true`):
-    ```
+
+    ```text
     ## Extension Hooks
 
     **Optional Pre-Hook**: {extension}
@@ -36,8 +38,10 @@ You **MUST** consider the user input before proceeding (if not empty).
     Prompt: {prompt}
     To execute: `/{command}`
     ```
+
   - **Mandatory hook** (`optional: false`):
-    ```
+
+    ```text
     ## Extension Hooks
 
     **Automatic Pre-Hook**: {extension}
@@ -46,6 +50,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
     Wait for the result of the hook command before proceeding to the Outline.
     ```
+
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
 ## Outline
@@ -69,7 +74,8 @@ git config --get remote.origin.url
 ## Post-Execution Checks
 
 **Check for extension hooks (after tasks-to-issues conversion)**:
-Check if `.specify/extensions.yml` exists in the project root.
+
+- Check if `.specify/extensions.yml` exists in the project root.
 - If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
 - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
 - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.

--- a/templates/commands/taskstoissues.md
+++ b/templates/commands/taskstoissues.md
@@ -78,7 +78,8 @@ Check if `.specify/extensions.yml` exists in the project root.
   - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
 - For each executable hook, output the following based on its `optional` flag:
   - **Optional hook** (`optional: true`):
-    ```
+
+    ```text
     ## Extension Hooks
 
     **Optional Hook**: {extension}
@@ -88,12 +89,15 @@ Check if `.specify/extensions.yml` exists in the project root.
     Prompt: {prompt}
     To execute: `/{command}`
     ```
+
   - **Mandatory hook** (`optional: false`):
-    ```
+
+    ```text
     ## Extension Hooks
 
     **Automatic Hook**: {extension}
     Executing: `/{command}`
     EXECUTE_COMMAND: {command}
     ```
+
 - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -17,6 +17,7 @@ description: "Task list template for feature implementation"
 - **[P]**: Can run in parallel (different files, no dependencies)
 - **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
 - Include exact file paths in descriptions
+- For **governed operations** (commands the constitution defines with specific syntax): append the exact command — e.g., `Push packages: \`dotnet nuget push "*.nupkg" --api-key $KEY --source $URL\``
 
 ## Path Conventions
 

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -17,7 +17,6 @@ description: "Task list template for feature implementation"
 - **[P]**: Can run in parallel (different files, no dependencies)
 - **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
 - Include exact file paths in descriptions
-- For **governed operations** (commands the constitution defines with specific syntax): append the exact command — e.g., `Push packages: \`dotnet nuget push "*.nupkg" --api-key $KEY --source $URL\``
 
 ## Path Conventions
 

--- a/tests/hooks/TESTING.md
+++ b/tests/hooks/TESTING.md
@@ -7,7 +7,7 @@ This directory contains a mock project to verify that LLM agents correctly ident
 1. Open a chat with an LLM (like GitHub Copilot) in this project.
 2. Ask it to generate tasks for the current directory:
    > "Please follow `/speckit.tasks` for the `./tests/hooks` directory."
-3. **Expected Behavior**: 
+3. **Expected Behavior**:
    - Before doing any generation, the LLM should notice the `AUTOMATIC Pre-Hook` in `.specify/extensions.yml` under `before_tasks`.
    - It should state it is executing `EXECUTE_COMMAND: pre_tasks_test`.
    - It should then proceed to read the `.md` docs and produce a `tasks.md`.

--- a/workflows/ARCHITECTURE.md
+++ b/workflows/ARCHITECTURE.md
@@ -186,7 +186,7 @@ When `specify workflow add <id>` installs from catalog, it downloads the workflo
 
 ## Module Structure
 
-```
+```text
 src/specify_cli/
 ├── workflows/
 │   ├── __init__.py          # STEP_REGISTRY + _register_builtin_steps()

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -327,7 +327,7 @@ specify workflow catalog remove <index>
 
 ## Repository Layout
 
-```
+```text
 workflows/
 ├── ARCHITECTURE.md                         # Internal architecture documentation
 ├── PUBLISHING.md                           # Guide for submitting workflows to the catalog


### PR DESCRIPTION
Fixes #2219

## Description
Tasks generated by `/speckit.tasks` describe governed operations in prose.
When the constitution is compacted out of context, the agent guesses the
command, gets flags wrong, and the operation fails (e.g. 403 on NuGet push).

## Root Cause
Task Generation Rules had no requirement to embed the exact command for
operations the constitution defines with specific syntax, flags, or env vars.
Tasks are always in agent context — prose descriptions throw that away.

## Solution
Require that any task covering a governed operation includes the exact
executable command, parameterized with env var names, directly in the task body.

## Changes
- `templates/commands/tasks.md` — new `### Governed Operations (REQUIRED)` rule + examples; fix inline-code nesting in governed example (double-backtick outer span)
- `templates/commands/implement.md` — adds task-level re-read instruction; fixes four bare fenced code blocks (MD040 info strings)
- `templates/commands/taskstoissues.md`, `tests/hooks/TESTING.md`,
  `workflows/ARCHITECTURE.md`, `workflows/README.md` — pre-existing MD031/MD032/MD040 lint fixes

## Why This Is Safe
Pure documentation change — no Python code, no CLI arguments, no new files.
Adds an instruction to an existing rule section; all existing task formats remain valid.

## Testing
- [ ] Run `/speckit.tasks` on a project with a governed push/deploy in the constitution — verify generated task body contains the exact command
- [ ] `ruff check src/` passes
- [ ] `markdownlint` on changed files: 0 errors