### PR TITLE
fix: fall back to older releases when latest has no template assets

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -30,6 +30,7 @@ import tempfile
 import shutil
 import shlex
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -431,58 +432,209 @@ def init_git_repo(project_path: Path, quiet: bool = False) -> bool:
         os.chdir(original_cwd)
 
 
-def download_template_from_github(ai_assistant: str, download_dir: Path, *, script_type: str = "sh", verbose: bool = True, show_progress: bool = True, client: httpx.Client = None, debug: bool = False, github_token: str = None) -> Tuple[Path, dict]:
+def _get_cache_dir() -> Path:
+    """Return (and create) the local template cache directory."""
+    cache_dir = Path.home() / ".cache" / "specify" / "templates"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def _find_cached_template(pattern: str) -> "Path | None":
+    """Return a cached zip matching *pattern*, or None."""
+    cache_dir = _get_cache_dir()
+    matches = list(cache_dir.glob(f"*{pattern}*.zip"))
+    return matches[0] if matches else None
+
+
+def _cache_template(zip_path: Path, metadata: dict) -> None:
+    """Copy *zip_path* into the cache dir and update cache-meta.json."""
+    cache_dir = _get_cache_dir()
+    dest = cache_dir / zip_path.name
+    try:
+        shutil.copy2(zip_path, dest)
+        meta_path = cache_dir / "cache-meta.json"
+        existing: dict = {}
+        if meta_path.exists():
+            try:
+                existing = json.loads(meta_path.read_text())
+            except Exception:
+                pass
+        existing[zip_path.name] = {
+            **metadata,
+            "cached_at": datetime.now(timezone.utc).isoformat(),
+        }
+        meta_path.write_text(json.dumps(existing, indent=2))
+    except Exception:
+        pass  # Caching is best-effort; never block the main flow
+
+
+def download_template_from_github(
+    ai_assistant: str,
+    download_dir: Path,
+    *,
+    script_type: str = "sh",
+    verbose: bool = True,
+    show_progress: bool = True,
+    client: httpx.Client = None,
+    debug: bool = False,
+    github_token: str = None,
+) -> Tuple[Path, dict]:
+    """Download the template zip for *ai_assistant* / *script_type*.
+
+    Strategy (in order):
+    1. Return a fresh cached copy if available and < 7 days old
+       (or always if SPECIFY_OFFLINE=1).
+    2. Try ``/releases/latest``; if it has no matching asset, walk up to 10
+       older releases looking for one that does.
+    3. On network or asset failure, fall back to a stale cached copy with a
+       warning rather than hard-failing.
+    4. Only raise Exit(1) when no release AND no cache can supply the asset.
+    """
     repo_owner = "github"
     repo_name = "spec-kit"
+    pattern = f"spec-kit-template-{ai_assistant}-{script_type}"
+    offline = os.getenv("SPECIFY_OFFLINE", "").strip() == "1"
+
     if client is None:
         client = httpx.Client(verify=ssl_context)
-    
-    if verbose:
-        console.print("[cyan]Fetching latest release information...[/cyan]")
-    api_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest"
-    
+
+    # --- 1. Cache-first path ---
+    cached = _find_cached_template(pattern)
+    if cached:
+        cache_dir = _get_cache_dir()
+        meta_path = cache_dir / "cache-meta.json"
+        cached_at = None
+        try:
+            meta = json.loads(meta_path.read_text()).get(cached.name, {})
+            cached_at_str = meta.get("cached_at", "")
+            if cached_at_str:
+                cached_at = datetime.fromisoformat(cached_at_str)
+        except Exception:
+            pass
+
+        age_ok = cached_at is not None and (
+            datetime.now(timezone.utc) - cached_at
+        ).days < 7
+
+        if offline or age_ok:
+            if offline:
+                console.print("[dim]SPECIFY_OFFLINE=1 — using cached template[/dim]")
+            else:
+                console.print(f"[dim]Using cached template ({cached.name})[/dim]")
+            dest = download_dir / cached.name
+            shutil.copy2(cached, dest)
+            try:
+                file_meta = json.loads(meta_path.read_text()).get(cached.name, {})
+            except Exception:
+                file_meta = {"filename": cached.name, "size": cached.stat().st_size,
+                             "release": "cached", "asset_url": ""}
+            return dest, file_meta
+
+    if offline:
+        console.print("[red]SPECIFY_OFFLINE=1 but no cached template found.[/red]")
+        console.print("[dim]Run without --offline first to download and cache a template.[/dim]")
+        raise typer.Exit(1)
+
+    # --- 2. Network path: try latest, then walk older releases ---
+    releases_to_check: list[dict] = []
+    checked_versions: list[str] = []
+
     try:
-        response = client.get(
-            api_url,
-            timeout=30,
-            follow_redirects=True,
+        if verbose:
+            console.print("[cyan]Fetching latest release information...[/cyan]")
+        latest_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest"
+        resp = client.get(
+            latest_url, timeout=30, follow_redirects=True,
             headers=_github_auth_headers(github_token),
         )
-        status = response.status_code
-        if status != 200:
-            msg = f"GitHub API returned {status} for {api_url}"
-            if debug:
-                msg += f"\nResponse headers: {response.headers}\nBody (truncated 500): {response.text[:500]}"
-            raise RuntimeError(msg)
-        try:
-            release_data = response.json()
-        except ValueError as je:
-            raise RuntimeError(f"Failed to parse release JSON: {je}\nRaw (truncated 400): {response.text[:400]}")
+        if resp.status_code == 200:
+            releases_to_check.append(resp.json())
     except Exception as e:
-        console.print(f"[red]Error fetching release information[/red]")
-        console.print(Panel(str(e), title="Fetch Error", border_style="red"))
-        raise typer.Exit(1)
-    
-    # Find the template asset for the specified AI assistant
-    assets = release_data.get("assets", [])
-    pattern = f"spec-kit-template-{ai_assistant}-{script_type}"
-    matching_assets = [
-        asset for asset in assets
-        if pattern in asset["name"] and asset["name"].endswith(".zip")
-    ]
+        if debug:
+            console.print(f"[dim]Warning fetching latest: {e}[/dim]")
 
-    asset = matching_assets[0] if matching_assets else None
+    # Check whether latest had assets; if not, fetch the paginated list.
+    latest_has_assets = bool(
+        releases_to_check
+        and [
+            a for a in releases_to_check[0].get("assets", [])
+            if pattern in a["name"] and a["name"].endswith(".zip")
+        ]
+    )
+    if not latest_has_assets:
+        try:
+            page_url = (
+                f"https://api.github.com/repos/{repo_owner}/{repo_name}"
+                "/releases?per_page=10"
+            )
+            resp = client.get(
+                page_url, timeout=30, follow_redirects=True,
+                headers=_github_auth_headers(github_token),
+            )
+            if resp.status_code == 200:
+                # Prepend latest (already fetched) then append older ones
+                older = [
+                    r for r in resp.json()
+                    if not releases_to_check
+                    or r.get("tag_name") != releases_to_check[0].get("tag_name")
+                ]
+                releases_to_check.extend(older)
+        except Exception as e:
+            if debug:
+                console.print(f"[dim]Warning fetching release list: {e}[/dim]")
 
+    # Walk releases looking for a matching asset
+    asset = None
+    release_data = None
+    for rel in releases_to_check:
+        tag = rel.get("tag_name", "?")
+        checked_versions.append(tag)
+        assets = rel.get("assets", [])
+        matching = [
+            a for a in assets
+            if pattern in a["name"] and a["name"].endswith(".zip")
+        ]
+        if matching:
+            asset = matching[0]
+            release_data = rel
+            break
+
+    # --- 3. Stale-cache fallback if no asset found online ---
     if asset is None:
-        console.print(f"[red]No matching release asset found[/red] for [bold]{ai_assistant}[/bold] (expected pattern: [bold]{pattern}[/bold])")
-        asset_names = [a.get('name', '?') for a in assets]
-        console.print(Panel("\n".join(asset_names) or "(no assets)", title="Available Assets", border_style="yellow"))
+        if cached:
+            console.print(
+                f"[yellow]Warning:[/yellow] No release with template assets found "
+                f"(checked: {', '.join(checked_versions[:5])}). "
+                "Using stale cached template."
+            )
+            dest = download_dir / cached.name
+            shutil.copy2(cached, dest)
+            return dest, {"filename": cached.name, "size": cached.stat().st_size,
+                          "release": "cached (stale)", "asset_url": ""}
+
+        # --- 4. Hard fail ---
+        console.print(
+            f"[red]No matching release asset found[/red] for "
+            f"[bold]{ai_assistant}[/bold] "
+            f"(expected pattern: [bold]{pattern}[/bold])"
+        )
+        checked_str = ", ".join(checked_versions[:3]) or "none"
+        console.print(
+            Panel(
+                f"Checked releases: {checked_str}\n\n"
+                "All checked releases have no template assets.\n\n"
+                "Workaround: run once with network access to cache a template,\n"
+                "then use SPECIFY_OFFLINE=1 for subsequent offline runs.",
+                title="No Assets Available",
+                border_style="red",
+            )
+        )
         raise typer.Exit(1)
 
     download_url = asset["browser_download_url"]
     filename = asset["name"]
     file_size = asset["size"]
-    
+
     if verbose:
         console.print(f"[cyan]Found template:[/cyan] {filename}")
         console.print(f"[cyan]Size:[/cyan] {file_size:,} bytes")
@@ -490,8 +642,8 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, scri
 
     zip_path = download_dir / filename
     if verbose:
-        console.print(f"[cyan]Downloading template...[/cyan]")
-    
+        console.print("[cyan]Downloading template...[/cyan]")
+
     try:
         with client.stream(
             "GET",
@@ -502,44 +654,46 @@ def download_template_from_github(ai_assistant: str, download_dir: Path, *, scri
         ) as response:
             if response.status_code != 200:
                 body_sample = response.text[:400]
-                raise RuntimeError(f"Download failed with {response.status_code}\nHeaders: {response.headers}\nBody (truncated): {body_sample}")
-            total_size = int(response.headers.get('content-length', 0))
-            with open(zip_path, 'wb') as f:
-                if total_size == 0:
+                raise RuntimeError(
+                    f"Download failed with {response.status_code}\n"
+                    f"Headers: {response.headers}\nBody (truncated): {body_sample}"
+                )
+            total_size = int(response.headers.get("content-length", 0))
+            with open(zip_path, "wb") as f:
+                if total_size == 0 or not show_progress:
                     for chunk in response.iter_bytes(chunk_size=8192):
                         f.write(chunk)
                 else:
-                    if show_progress:
-                        with Progress(
-                            SpinnerColumn(),
-                            TextColumn("[progress.description]{task.description}"),
-                            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-                            console=console,
-                        ) as progress:
-                            task = progress.add_task("Downloading...", total=total_size)
-                            downloaded = 0
-                            for chunk in response.iter_bytes(chunk_size=8192):
-                                f.write(chunk)
-                                downloaded += len(chunk)
-                                progress.update(task, completed=downloaded)
-                    else:
+                    with Progress(
+                        SpinnerColumn(),
+                        TextColumn("[progress.description]{task.description}"),
+                        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+                        console=console,
+                    ) as progress:
+                        dl_task = progress.add_task("Downloading...", total=total_size)
+                        downloaded = 0
                         for chunk in response.iter_bytes(chunk_size=8192):
                             f.write(chunk)
+                            downloaded += len(chunk)
+                            progress.update(dl_task, completed=downloaded)
     except Exception as e:
-        console.print(f"[red]Error downloading template[/red]")
-        detail = str(e)
+        console.print("[red]Error downloading template[/red]")
         if zip_path.exists():
             zip_path.unlink()
-        console.print(Panel(detail, title="Download Error", border_style="red"))
+        console.print(Panel(str(e), title="Download Error", border_style="red"))
         raise typer.Exit(1)
+
     if verbose:
         console.print(f"Downloaded: {filename}")
+
     metadata = {
         "filename": filename,
         "size": file_size,
         "release": release_data["tag_name"],
-        "asset_url": download_url
+        "asset_url": download_url,
     }
+    # Cache for future offline/fallback use (best-effort)
+    _cache_template(zip_path, metadata)
     return zip_path, metadata
 
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -440,9 +440,13 @@ def _get_cache_dir() -> Path:
 
 
 def _find_cached_template(pattern: str) -> "Path | None":
-    """Return a cached zip matching *pattern*, or None."""
+    """Return the most-recently-modified cached zip matching *pattern*, or None."""
     cache_dir = _get_cache_dir()
-    matches = list(cache_dir.glob(f"*{pattern}*.zip"))
+    matches = sorted(
+        cache_dir.glob(f"*{pattern}*.zip"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
     return matches[0] if matches else None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Ensure tests import from the fork's src/ directory, not the installed package."""
+import sys
+from pathlib import Path
+
+# Insert the fork's src/ at the front so `import specify_cli` resolves here
+src_dir = str(Path(__file__).parent.parent / "src")
+if src_dir not in sys.path:
+    sys.path.insert(0, src_dir)

--- a/tests/test_download_fallback.py
+++ b/tests/test_download_fallback.py
@@ -89,7 +89,7 @@ def test_falls_back_to_older_release_when_latest_has_no_assets(tmp_path):
 
     assert meta["release"] == "v0.4.4"
     assert PATTERN in meta["filename"]
-    assert zip_path.exists() or True  # file may be in tmp_path
+    assert zip_path.exists(), f"Expected zip at {zip_path}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_download_fallback.py
+++ b/tests/test_download_fallback.py
@@ -1,0 +1,273 @@
+"""
+Tests for download_template_from_github release-fallback + cache behavior.
+
+Covers the regression where GitHub releases v0.4.5–v0.6.2 shipped with
+zero template assets, causing specify init to hard-fail with exit code 1.
+
+The fix iterates older releases when the latest has no matching assets, and
+caches successful downloads so that future runs (and offline/air-gapped
+environments) do not need a network call at all.
+"""
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PATTERN = "spec-kit-template-claude-sh"
+
+
+def _make_release(tag: str, *, has_asset: bool) -> dict:
+    """Build a minimal GitHub release dict."""
+    assets = []
+    if has_asset:
+        assets.append(
+            {
+                "name": f"{PATTERN}-{tag}.zip",
+                "browser_download_url": f"https://example.com/{tag}.zip",
+                "size": 1000,
+            }
+        )
+    return {"tag_name": tag, "assets": assets}
+
+
+def _make_response(data: dict | list, *, status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = data
+    resp.headers = {"content-length": "0"}
+    resp.iter_bytes = MagicMock(return_value=iter([b"fake-zip-content"]))
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Test: latest has no assets → falls back to older release that does
+# ---------------------------------------------------------------------------
+
+def test_falls_back_to_older_release_when_latest_has_no_assets(tmp_path):
+    """
+    Scenario: /releases/latest returns v0.6.2 with zero assets.
+    /releases?per_page=10 returns v0.6.2 (no assets) and v0.4.4 (has asset).
+    Expected: template downloaded from v0.4.4 without raising Exit(1).
+    """
+    from specify_cli import download_template_from_github, _get_cache_dir
+
+    latest_release = _make_release("v0.6.2", has_asset=False)
+    paginated_releases = [
+        _make_release("v0.6.2", has_asset=False),
+        _make_release("v0.4.4", has_asset=True),
+    ]
+
+    download_resp = _make_response({})
+    download_resp.status_code = 200
+    download_resp.headers = {"content-length": "16"}
+
+    mock_client = MagicMock()
+    mock_client.get.side_effect = [
+        _make_response(latest_release),      # /releases/latest
+        _make_response(paginated_releases),  # /releases?per_page=10
+    ]
+    mock_client.stream.return_value = download_resp
+
+    with patch.dict("os.environ", {"SPECIFY_OFFLINE": ""}):
+        zip_path, meta = download_template_from_github(
+            "claude",
+            tmp_path,
+            script_type="sh",
+            verbose=False,
+            show_progress=False,
+            client=mock_client,
+        )
+
+    assert meta["release"] == "v0.4.4"
+    assert PATTERN in meta["filename"]
+    assert zip_path.exists() or True  # file may be in tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test: no releases have assets → stale cache used instead of hard fail
+# ---------------------------------------------------------------------------
+
+def test_uses_stale_cache_when_all_releases_have_no_assets(tmp_path):
+    """
+    Scenario: all releases have no assets but a cached zip exists.
+    Expected: stale cached zip is returned with a warning, no Exit(1).
+    """
+    import specify_cli as cli_module
+    from specify_cli import download_template_from_github
+
+    # Seed the cache with a fake zip
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    cached_zip = cache_dir / f"{PATTERN}-v0.4.4.zip"
+    cached_zip.write_bytes(b"cached-zip-content")
+    meta_path = cache_dir / "cache-meta.json"
+    meta_path.write_text(json.dumps({
+        cached_zip.name: {
+            "filename": cached_zip.name,
+            "size": 18,
+            "release": "v0.4.4",
+            "asset_url": "https://example.com/v0.4.4.zip",
+            "cached_at": "2020-01-01T00:00:00+00:00",  # very stale
+        }
+    }))
+
+    mock_client = MagicMock()
+    mock_client.get.side_effect = [
+        _make_response(_make_release("v0.6.2", has_asset=False)),  # latest
+        _make_response([
+            _make_release("v0.6.2", has_asset=False),
+            _make_release("v0.5.0", has_asset=False),
+        ]),                                                          # paginated
+    ]
+
+    with (
+        patch("specify_cli._get_cache_dir", return_value=cache_dir),
+        patch.dict("os.environ", {"SPECIFY_OFFLINE": ""}),
+    ):
+        zip_path, meta = download_template_from_github(
+            "claude",
+            tmp_path,
+            script_type="sh",
+            verbose=False,
+            show_progress=False,
+            client=mock_client,
+        )
+
+    # The stale-cache path copies the zip content; release may be "cached (stale)"
+    # or read from cache-meta.json — either is acceptable.
+    assert zip_path.read_bytes() == b"cached-zip-content"
+
+
+# ---------------------------------------------------------------------------
+# Test: SPECIFY_OFFLINE=1 uses fresh cache without network
+# ---------------------------------------------------------------------------
+
+def test_offline_mode_uses_cache_without_network(tmp_path):
+    """SPECIFY_OFFLINE=1 should return a cached template without any HTTP call."""
+    import specify_cli as cli_module
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    cached_zip = cache_dir / f"{PATTERN}-v0.4.4.zip"
+    cached_zip.write_bytes(b"offline-zip-content")
+    meta_path = cache_dir / "cache-meta.json"
+    from datetime import datetime, timezone
+    meta_path.write_text(json.dumps({
+        cached_zip.name: {
+            "filename": cached_zip.name,
+            "size": 19,
+            "release": "v0.4.4",
+            "asset_url": "",
+            "cached_at": datetime.now(timezone.utc).isoformat(),  # fresh
+        }
+    }))
+
+    mock_client = MagicMock()
+
+    with (
+        patch("specify_cli._get_cache_dir", return_value=cache_dir),
+        patch.dict("os.environ", {"SPECIFY_OFFLINE": "1"}),
+    ):
+        from specify_cli import download_template_from_github
+        zip_path, meta = download_template_from_github(
+            "claude",
+            tmp_path,
+            script_type="sh",
+            verbose=False,
+            show_progress=False,
+            client=mock_client,
+        )
+
+    # No HTTP calls should have been made
+    mock_client.get.assert_not_called()
+    mock_client.stream.assert_not_called()
+    assert zip_path.read_bytes() == b"offline-zip-content"
+
+
+# ---------------------------------------------------------------------------
+# Test: SPECIFY_OFFLINE=1 with no cache → hard fail with clear message
+# ---------------------------------------------------------------------------
+
+def test_offline_mode_without_cache_raises_exit(tmp_path):
+    """SPECIFY_OFFLINE=1 with an empty cache should raise typer.Exit(1).
+
+    typer.Exit wraps click.exceptions.Exit, which is NOT a subclass of
+    SystemExit, so we catch both and check the exit code.
+    """
+    import click
+
+    cache_dir = tmp_path / "empty_cache"
+    cache_dir.mkdir()
+
+    mock_client = MagicMock()
+
+    with (
+        patch("specify_cli._get_cache_dir", return_value=cache_dir),
+        patch.dict("os.environ", {"SPECIFY_OFFLINE": "1"}),
+    ):
+        from specify_cli import download_template_from_github
+        with pytest.raises((SystemExit, click.exceptions.Exit)) as exc_info:
+            download_template_from_github(
+                "claude",
+                tmp_path,
+                script_type="sh",
+                verbose=False,
+                show_progress=False,
+                client=mock_client,
+            )
+        exit_obj = exc_info.value
+        code = getattr(exit_obj, "exit_code", None) or getattr(exit_obj, "code", None)
+        assert code == 1, f"Expected exit code 1, got {code}"
+
+    mock_client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: successful download is cached for future use
+# ---------------------------------------------------------------------------
+
+def test_successful_download_is_cached(tmp_path):
+    """After a successful download the zip should appear in the cache dir."""
+    import specify_cli as cli_module
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    mock_client = MagicMock()
+    mock_client.get.side_effect = [
+        _make_response(_make_release("v0.4.4", has_asset=True)),   # latest
+    ]
+    download_resp = _make_response({})
+    download_resp.headers = {"content-length": "16"}
+    download_resp.iter_bytes = MagicMock(return_value=iter([b"fresh-zip-data!!"]))
+    mock_client.stream.return_value = download_resp
+
+    with (
+        patch("specify_cli._get_cache_dir", return_value=cache_dir),
+        patch.dict("os.environ", {"SPECIFY_OFFLINE": ""}),
+    ):
+        from specify_cli import download_template_from_github
+        zip_path, meta = download_template_from_github(
+            "claude",
+            tmp_path,
+            script_type="sh",
+            verbose=False,
+            show_progress=False,
+            client=mock_client,
+        )
+
+    cached_files = list(cache_dir.glob(f"*{PATTERN}*.zip"))
+    assert cached_files, "Expected a cached zip after successful download"
+    meta_path = cache_dir / "cache-meta.json"
+    assert meta_path.exists(), "Expected cache-meta.json to be written"
+    meta_data = json.loads(meta_path.read_text())
+    assert any(PATTERN in k for k in meta_data), "cache-meta.json should contain the template entry"


### PR DESCRIPTION
## Problem

GitHub releases v0.4.5–v0.6.2 ship with zero template assets, causing `specify init` to hard-fail with exit code 1. The last release with template zips was v0.4.4. Tracked in #2185.

## Fix

Four-step download strategy in `download_template_from_github()`:

1. **Cache-first** — return a cached copy if < 7 days old (or always if `SPECIFY_OFFLINE=1`)
2. **Release fallback** — try `/releases/latest`; if no matching assets, walk up to 10 older releases via `/releases?per_page=10`
3. **Stale-cache rescue** — if all releases have no assets but a cached zip exists, return it with a warning instead of hard-failing
4. **Hard fail only** — raise `Exit(1)` only when no release AND no cache can supply the asset, with a clear message listing versions checked

Three cache helpers added before the function:
- `_get_cache_dir()` — returns `~/.cache/specify/templates/` (created on demand)
- `_find_cached_template(pattern)` — returns newest cached zip by mtime (deterministic)
- `_cache_template(zip_path, metadata)` — copies zip + writes `cache-meta.json` (best-effort, never raises)

`SPECIFY_OFFLINE=1` env var skips all network calls and uses the cache directly.

## Changes

- `src/specify_cli/__init__.py` — cache helpers + rewritten download function
- `tests/test_download_fallback.py` — 5 new tests covering all fallback paths
- `tests/conftest.py` — ensures tests import from `src/` not the installed package

## Tests

```
5 passed in 0.10s
✓ test_falls_back_to_older_release_when_latest_has_no_assets
✓ test_uses_stale_cache_when_all_releases_have_no_assets
✓ test_offline_mode_uses_cache_without_network
✓ test_offline_mode_without_cache_raises_exit
✓ test_successful_download_is_cached
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)