### PR TITLE
fix(scripts): persist .specify/feature.json during feature creation

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -372,4 +372,3 @@ except Exception:
     # Callers running under set -e should use: TEMPLATE=$(resolve_template ...) || true
     return 1
 }
-

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -324,6 +324,7 @@ fi
 
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 SPEC_FILE="$FEATURE_DIR/spec.md"
+FEATURE_METADATA_FILE="$REPO_ROOT/.specify/feature.json"
 
 if [ "$DRY_RUN" != true ]; then
     if [ "$HAS_GIT" = true ]; then
@@ -366,6 +367,7 @@ if [ "$DRY_RUN" != true ]; then
     fi
 
     mkdir -p "$FEATURE_DIR"
+    mkdir -p "$(dirname "$FEATURE_METADATA_FILE")"
 
     if [ ! -f "$SPEC_FILE" ]; then
         TEMPLATE=$(resolve_template "spec-template" "$REPO_ROOT") || true
@@ -375,6 +377,14 @@ if [ "$DRY_RUN" != true ]; then
             echo "Warning: Spec template not found; created empty spec file" >&2
             touch "$SPEC_FILE"
         fi
+    fi
+
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn \
+            --arg feature_directory "specs/$BRANCH_NAME" \
+            '{feature_directory:$feature_directory}' >"$FEATURE_METADATA_FILE"
+    else
+        printf '{"feature_directory":"%s"}\n' "$(json_escape "specs/$BRANCH_NAME")" >"$FEATURE_METADATA_FILE"
     fi
 
     # Inform the user how to persist the feature variable in their own shell

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -353,4 +353,3 @@ function Resolve-Template {
 
     return $null
 }
-

--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -289,6 +289,7 @@ if ($branchName.Length -gt $maxBranchLength) {
 
 $featureDir = Join-Path $specsDir $branchName
 $specFile = Join-Path $featureDir 'spec.md'
+$featureMetadataFile = Join-Path $repoRoot '.specify/feature.json'
 
 if (-not $DryRun) {
     if ($hasGit) {
@@ -346,6 +347,7 @@ if (-not $DryRun) {
     }
 
     New-Item -ItemType Directory -Path $featureDir -Force | Out-Null
+    New-Item -ItemType Directory -Path (Split-Path $featureMetadataFile -Parent) -Force | Out-Null
 
     if (-not (Test-Path -PathType Leaf $specFile)) {
         $template = Resolve-Template -TemplateName 'spec-template' -RepoRoot $repoRoot
@@ -355,6 +357,10 @@ if (-not $DryRun) {
             New-Item -ItemType File -Path $specFile -Force | Out-Null
         }
     }
+
+    [PSCustomObject]@{
+        feature_directory = "specs/$branchName"
+    } | ConvertTo-Json -Compress | Set-Content -Path $featureMetadataFile -Encoding utf8
 
     # Set the SPECIFY_FEATURE environment variable for the current session
     $env:SPECIFY_FEATURE = $branchName

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -180,6 +180,19 @@ class TestTimestampBranch:
             assert key in data, f"missing {key} in JSON: {data}"
         assert re.match(r"^\d{8}-\d{6}$", data["FEATURE_NUM"])
 
+    def test_writes_feature_metadata_file(self, git_repo: Path):
+        """The create script persists .specify/feature.json for downstream commands."""
+        import json
+
+        result = run_script(git_repo, "--json", "--short-name", "meta-test", "Metadata test")
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+
+        metadata_file = git_repo / ".specify" / "feature.json"
+        assert metadata_file.exists(), "feature metadata file was not created"
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        assert metadata == {"feature_directory": f"specs/{data['BRANCH_NAME']}"}
+
     def test_long_name_truncation(self, git_repo: Path):
         """Test 5: Long branch name is truncated to <= 244 chars."""
         long_name = "a-" * 150 + "end"
@@ -993,7 +1006,19 @@ class TestPowerShellDryRun:
         assert result.returncode == 0, result.stderr
         data = json.loads(result.stdout)
         assert "DRY_RUN" not in data, f"DRY_RUN should not be in normal JSON: {data}"
+    
+    def test_ps_writes_feature_metadata_file(self, ps_git_repo: Path):
+        """PowerShell create script persists .specify/feature.json."""
+        result = run_ps_script(
+            ps_git_repo, "-Json", "-ShortName", "ps-meta", "PowerShell metadata"
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
 
+        metadata_file = ps_git_repo / ".specify" / "feature.json"
+        assert metadata_file.exists(), "feature metadata file was not created"
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8-sig"))
+        assert metadata == {"feature_directory": f"specs/{data['BRANCH_NAME']}"}
 
 # ── GIT_BRANCH_NAME Override Tests ──────────────────────────────────────────
 

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -181,7 +181,7 @@ class TestTimestampBranch:
         assert re.match(r"^\d{8}-\d{6}$", data["FEATURE_NUM"])
 
     def test_writes_feature_metadata_file(self, git_repo: Path):
-        """The create script persists .specify/feature.json for downstream commands."""
+        """Feature creation persists .specify/feature.json with the created spec dir."""
         import json
 
         result = run_script(git_repo, "--json", "--short-name", "meta-test", "Metadata test")
@@ -656,6 +656,12 @@ class TestAllowExistingBranchPowerShell:
         assert "-AllowExistingBranch" in contents
         # Ensure the flag is referenced in script logic, not just declared
         assert "AllowExistingBranch" in contents.replace("-AllowExistingBranch", "")
+
+    def test_powershell_persists_feature_metadata(self):
+        """Static guard: PS script writes .specify/feature.json."""
+        contents = CREATE_FEATURE_PS.read_text(encoding="utf-8")
+        assert "feature_directory = \"specs/$branchName\"" in contents
+        assert "feature.json" in contents
 
     def test_powershell_surfaces_checkout_errors(self):
         """Static guard: PS script preserves checkout stderr on existing-branch failures."""


### PR DESCRIPTION
## Description

The current `/speckit.specify` workflow expects `.specify/feature.json` to exist, but the shipped `create-new-feature` scripts do not persist it.

That creates a mismatch between documented behavior and actual script behavior:
- the command flow and downstream tooling expect `feature_directory` metadata
- feature creation creates the branch and spec directory
- but no `.specify/feature.json` file is written

As a result, later steps may rely on metadata that the standard feature-creation flow never produces.

This PR fixes that by persisting `.specify/feature.json` during feature creation in both the Bash and PowerShell scripts. It keeps the change intentionally small and aligns the shipped scripts with the workflow’s existing expectations.

## Testing

- [ ] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Additional verification:
- `pytest tests/test_timestamp_branches.py`

Results in this environment:
- `44 passed, 6 skipped`

The skipped tests are PowerShell runtime tests because `pwsh` is not available in this environment.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Used Codex to inspect the existing `/speckit.specify` flow, implement the minimal script changes, and add/update regression tests.


