### PR TITLE
Change Phase 1 to Phase 2 for agent context update

### DIFF
--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -67,7 +67,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Evaluate gates (ERROR if violations unjustified)
    - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md
-   - Phase 1: Update agent context by running the agent script
+   - Phase 2: Update agent context by running the agent script
    - Re-evaluate Constitution Check post-design
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.


### PR DESCRIPTION
## Description

Fixes inconsistent phase labels in [`templates/commands/plan.md`](https://github.com/github/spec-kit/blob/main/templates/commands/plan.md): under **Outline** → step 3 (“Execute plan workflow”), two consecutive bullets were both **Phase 1**. Step 4 says the command ends after **Phase 2** planning, so the second bullet (agent context update) is renamed to **Phase 2** for clarity and consistency.

No CLI, script, or packaging changes—template wording only.

## Testing

This change only updates instructional text in `templates/commands/plan.md` (no agent wiring or `src/` edits). I verified the edit in the forked branch and that the rendered Markdown reads correctly.

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project
## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [x] I **did not** use AI assistance for this contribution
- [ ] I **did** use AI assistance (describe below)

<!-- If you used AI, briefly describe how (e.g., "Code generated by Copilot", "Consulted ChatGPT for approach"): -->