### PR TITLE
docs(install): add pipx as alternative installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ To upgrade Specify, see the [Upgrade Guide](./docs/upgrade.md) for detailed inst
 
 ```bash
 uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git@vX.Y.Z
+# pipx users: pipx install --force git+https://github.com/github/spec-kit.git@vX.Y.Z
 ```
 
 #### Option 2: One-time Usage
@@ -459,7 +460,7 @@ Our research and experimentation focus on:
 
 - **Linux/macOS/Windows**
 - [Supported](#-supported-ai-coding-agent-integrations) AI coding agent.
-- [uv](https://docs.astral.sh/uv/) for package management
+- [uv](https://docs.astral.sh/uv/) for package management (recommended) or [pipx](https://pypa.github.io/pipx/) for persistent installation
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX
 
 # Or install latest from main (may include unreleased changes)
 uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+
+# Alternative: using pipx (also works)
+pipx install git+https://github.com/github/spec-kit.git@vX.Y.Z
+pipx install git+https://github.com/github/spec-kit.git
 ```
 
 Then verify the correct version is installed:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,6 +24,13 @@ uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify init <PROJE
 uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME>
 ```
 
+> [!NOTE]
+> For a persistent installation, `pipx` works equally well:
+> ```bash
+> pipx install git+https://github.com/github/spec-kit.git@vX.Y.Z
+> ```
+> The project uses a standard `hatchling` build backend and has no uv-specific dependencies.
+
 Or initialize in the current directory:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 - **Linux/macOS** (or Windows; PowerShell scripts now supported without WSL)
 - AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Codebuddy CLI](https://www.codebuddy.ai/cli), [Gemini CLI](https://github.com/google-gemini/gemini-cli), or [Pi Coding Agent](https://pi.dev)
-- [uv](https://docs.astral.sh/uv/) for package management
+- [uv](https://docs.astral.sh/uv/) for package management (recommended) or [pipx](https://pypa.github.io/pipx/) for persistent installation
 - [Python 3.11+](https://www.python.org/downloads/)
 - [Git](https://git-scm.com/downloads)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,6 +22,12 @@ uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME
 uvx --from git+https://github.com/github/spec-kit.git specify init .
 ```
 
+> [!NOTE]
+> You can also install the CLI persistently with `pipx`:
+> ```bash
+> pipx install git+https://github.com/github/spec-kit.git
+> ```
+
 Pick script type explicitly (optional):
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,7 +33,6 @@ uvx --from git+https://github.com/github/spec-kit.git specify init .
 > specify init .
 > ```
 
-
 Pick script type explicitly (optional):
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,6 +27,12 @@ uvx --from git+https://github.com/github/spec-kit.git specify init .
 > ```bash
 > pipx install git+https://github.com/github/spec-kit.git
 > ```
+> After installing with `pipx`, run `specify` directly instead of `uvx --from ... specify`, for example:
+> ```bash
+> specify init <PROJECT_NAME>
+> specify init .
+> ```
+
 
 Pick script type explicitly (optional):
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -9,6 +9,7 @@
 | What to Upgrade | Command | When to Use |
 |----------------|---------|-------------|
 | **CLI Tool Only** | `uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git@vX.Y.Z` | Get latest CLI features without touching project files |
+| **pipx upgrade** | `pipx install --force git+https://github.com/github/spec-kit.git@vX.Y.Z` | Upgrade pipx-installed CLI |
 | **Project Files** | `specify init --here --force --ai <your-agent>` | Update slash commands, templates, and scripts in your project |
 | **Both** | Run CLI upgrade, then project update | Recommended for major version updates |
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -34,6 +34,14 @@ Specify the desired release tag:
 uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify init --here --ai copilot
 ```
 
+### If you installed with `pipx`
+
+Upgrade to a specific release:
+
+```bash
+pipx install --force git+https://github.com/github/spec-kit.git@vX.Y.Z
+```
+
 ### Verify the upgrade
 
 ```bash

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -9,7 +9,7 @@
 | What to Upgrade | Command | When to Use |
 |----------------|---------|-------------|
 | **CLI Tool Only** | `uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git@vX.Y.Z` | Get latest CLI features without touching project files |
-| **pipx upgrade** | `pipx install --force git+https://github.com/github/spec-kit.git@vX.Y.Z` | Upgrade pipx-installed CLI |
+| **CLI Tool Only (pipx)** | `pipx install --force git+https://github.com/github/spec-kit.git@vX.Y.Z` | Reinstall/upgrade a pipx-installed CLI to a specific release |
 | **Project Files** | `specify init --here --force --ai <your-agent>` | Update slash commands, templates, and scripts in your project |
 | **Both** | Run CLI upgrade, then project update | Recommended for major version updates |
 


### PR DESCRIPTION
## Description

Adds `pipx` as an equally valid alternative installation method to `uv` in all relevant documentation files, addressing user confusion raised in Discussion #2255.

Changes:
- README.md: Added pipx commands in "Option 1: Persistent Installation" section
- docs/installation.md: Added note about pipx compatibility 
- docs/quickstart.md: Mentioned pipx for persistent installation
- docs/upgrade.md: Added pipx upgrade instructions

