### PR TITLE
feat: add CITATION.cff and .zenodo.json for academic citation support

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,31 @@
+{
+  "title": "Spec Kit",
+  "description": "Spec Kit is an open source toolkit for Spec-Driven Development (SDD) — a methodology that helps software teams build high-quality software faster by focusing on product scenarios and predictable outcomes. It provides a specify CLI, slash-command templates, and integrations for popular AI coding agents.",
+  "creators": [
+    {
+      "name": "Delimarsky, Den",
+      "orcid": ""
+    },
+    {
+      "name": "Riem, Manfred",
+      "orcid": ""
+    }
+  ],
+  "license": "MIT",
+  "upload_type": "software",
+  "keywords": [
+    "spec-driven development",
+    "ai coding agents",
+    "software engineering",
+    "cli",
+    "copilot",
+    "specification"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/github/spec-kit",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,14 +1,12 @@
 {
   "title": "Spec Kit",
-  "description": "Spec Kit is an open source toolkit for Spec-Driven Development (SDD) — a methodology that helps software teams build high-quality software faster by focusing on product scenarios and predictable outcomes. It provides a specify CLI, slash-command templates, and integrations for popular AI coding agents.",
+  "description": "Spec Kit is an open source toolkit for Spec-Driven Development (SDD) — a methodology that helps software teams build high-quality software faster by focusing on product scenarios and predictable outcomes. It provides the Specify CLI, slash-command templates, extensions, presets, workflows, and integrations for popular AI coding agents.",
   "creators": [
     {
-      "name": "Delimarsky, Den",
-      "orcid": ""
+      "name": "Delimarsky, Den"
     },
     {
-      "name": "Riem, Manfred",
-      "orcid": ""
+      "name": "Riem, Manfred"
     }
   ],
   "license": "MIT",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.2.0
+message: >-
+  If you use Spec Kit in your research or reference it in a paper,
+  please cite it using the metadata below.
+type: software
+title: "Spec Kit"
+abstract: >-
+  Spec Kit is an open source toolkit for Spec-Driven Development (SDD) —
+  a methodology that helps software teams build high-quality software faster
+  by focusing on product scenarios and predictable outcomes. It provides a
+  specify CLI, slash-command templates, and integrations for popular AI
+  coding agents.
+authors:
+  - given-names: Den
+    family-names: Delimarsky
+    alias: localden
+  - given-names: Manfred
+    family-names: Riem
+    alias: mnriem
+repository-code: "https://github.com/github/spec-kit"
+url: "https://github.github.com/spec-kit/"
+license: MIT
+version: "0.7.3"
+date-released: "2025-08-21"
+keywords:
+  - spec-driven development
+  - ai coding agents
+  - software engineering
+  - cli
+  - copilot
+  - specification

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,9 +7,9 @@ title: "Spec Kit"
 abstract: >-
   Spec Kit is an open source toolkit for Spec-Driven Development (SDD) —
   a methodology that helps software teams build high-quality software faster
-  by focusing on product scenarios and predictable outcomes. It provides a
-  specify CLI, slash-command templates, and integrations for popular AI
-  coding agents.
+  by focusing on product scenarios and predictable outcomes. It provides the
+  Specify CLI, slash-command templates, extensions, presets, workflows, and
+  integrations for popular AI coding agents.
 authors:
   - given-names: Den
     family-names: Delimarsky
@@ -21,7 +21,7 @@ repository-code: "https://github.com/github/spec-kit"
 url: "https://github.github.com/spec-kit/"
 license: MIT
 version: "0.7.3"
-date-released: "2025-08-21"
+date-released: "2026-04-17"
 keywords:
   - spec-driven development
   - ai coding agents

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,7 +18,7 @@ authors:
     family-names: Riem
     alias: mnriem
 repository-code: "https://github.com/github/spec-kit"
-url: "https://github.github.com/spec-kit/"
+url: "https://github.github.io/spec-kit/"
 license: MIT
 version: "0.7.3"
 date-released: "2026-04-17"


### PR DESCRIPTION
## Summary

- Adds `CITATION.cff` (Citation File Format 1.2.0) — GitHub natively surfaces a **"Cite this repository"** button once this file is on `main`, no further setup needed.
- Adds `.zenodo.json` — Zenodo reads this to pre-fill the DOI metadata record. Once a maintainer enables the integration at [zenodo.org](https://zenodo.org) (Settings → GitHub → enable spec-kit), Zenodo will mint a DOI on the next release automatically.

Closes #2269

## What maintainers still need to do

1. Go to [zenodo.org](https://zenodo.org) and sign in via GitHub.
2. Under **GitHub → Settings**, enable the **spec-kit** repository.
3. On the next GitHub release, Zenodo will archive the repo and mint a DOI.

The `CITATION.cff` file works independently of Zenodo — GitHub will show the cite button as soon as this PR merges.

## Manual test results

No slash commands are affected by this change (metadata files only, no scripts or templates modified).

**Agent**: Claude Code (claude-sonnet-4-6) | **OS/Shell**: Windows 11 / bash

| Command tested | Notes |
|----------------|-------|
| `pytest tests/ -q` | 1394 passed, 112 skipped, 3 pre-existing symlink failures on Windows (WinError 1314 — not introduced by this PR) |

## AI disclosure

This PR was written with Claude Code (Anthropic) assistance. The file contents, authorship choices, and metadata values were reviewed and approved by the human contributor before submission.