### PR TITLE
fix(git-extension): persist .specify/feature.json during feature creation

### DIFF
--- a/extensions/git/scripts/bash/create-new-feature.sh
+++ b/extensions/git/scripts/bash/create-new-feature.sh
@@ -262,6 +262,7 @@ fi
 cd "$REPO_ROOT"
 
 SPECS_DIR="$REPO_ROOT/specs"
+FEATURE_METADATA_FILE="$REPO_ROOT/.specify/feature.json"
 
 # Function to generate branch name with stop word filtering
 generate_branch_name() {
@@ -412,6 +413,20 @@ if [ "$DRY_RUN" != true ]; then
         fi
     else
         >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+    fi
+
+    mkdir -p "$(dirname "$FEATURE_METADATA_FILE")"
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn \
+            --arg feature_directory "specs/$BRANCH_NAME" \
+            '{feature_directory:$feature_directory}' >"$FEATURE_METADATA_FILE"
+    else
+        if type json_escape >/dev/null 2>&1; then
+            _je_feature_dir=$(json_escape "specs/$BRANCH_NAME")
+        else
+            _je_feature_dir="specs/$BRANCH_NAME"
+        fi
+        printf '{"feature_directory":"%s"}\n' "$_je_feature_dir" >"$FEATURE_METADATA_FILE"
     fi
 
     printf '# To persist: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME" >&2

--- a/extensions/git/scripts/powershell/create-new-feature.ps1
+++ b/extensions/git/scripts/powershell/create-new-feature.ps1
@@ -222,6 +222,7 @@ if (Get-Command Test-HasGit -ErrorAction SilentlyContinue) {
 Set-Location $repoRoot
 
 $specsDir = Join-Path $repoRoot 'specs'
+$featureMetadataFile = Join-Path $repoRoot '.specify/feature.json'
 
 function Get-BranchName {
     param([string]$Description)
@@ -379,6 +380,11 @@ if (-not $DryRun) {
             Write-Warning "[specify] Warning: Git repository not detected; skipped branch creation for $branchName"
         }
     }
+
+    New-Item -ItemType Directory -Path (Split-Path $featureMetadataFile -Parent) -Force | Out-Null
+    [PSCustomObject]@{
+        feature_directory = "specs/$branchName"
+    } | ConvertTo-Json -Compress | Set-Content -Path $featureMetadataFile -Encoding utf8
 
     $env:SPECIFY_FEATURE = $branchName
 }

--- a/extensions/git/scripts/powershell/create-new-feature.ps1
+++ b/extensions/git/scripts/powershell/create-new-feature.ps1
@@ -382,9 +382,11 @@ if (-not $DryRun) {
     }
 
     New-Item -ItemType Directory -Path (Split-Path $featureMetadataFile -Parent) -Force | Out-Null
-    [PSCustomObject]@{
+    $featureMetadataJson = [PSCustomObject]@{
         feature_directory = "specs/$branchName"
-    } | ConvertTo-Json -Compress | Set-Content -Path $featureMetadataFile -Encoding utf8
+    } | ConvertTo-Json -Compress
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($featureMetadataFile, $featureMetadataJson, $utf8NoBom)
 
     $env:SPECIFY_FEATURE = $branchName
 }

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -404,7 +404,7 @@ class TestCreateFeaturePowerShell:
 
         metadata_file = project / ".specify" / "feature.json"
         assert metadata_file.exists(), "feature metadata file was not created"
-        metadata = json.loads(metadata_file.read_text(encoding="utf-8-sig"))
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
         assert metadata == {"feature_directory": f"specs/{data['BRANCH_NAME']}"}
 
 

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -337,6 +337,21 @@ class TestCreateFeatureBash:
         assert data.get("DRY_RUN") is True
         assert not (project / "specs" / data["BRANCH_NAME"]).exists()
 
+    def test_persists_feature_metadata(self, tmp_path: Path):
+        """Extension create-new-feature.sh updates .specify/feature.json."""
+        project = _setup_project(tmp_path)
+        result = _run_bash(
+            "create-new-feature.sh", project,
+            "--json", "--short-name", "meta-test", "Metadata test",
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+
+        metadata_file = project / ".specify" / "feature.json"
+        assert metadata_file.exists(), "feature metadata file was not created"
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        assert metadata == {"feature_directory": f"specs/{data['BRANCH_NAME']}"}
+
 
 @pytest.mark.skipif(not HAS_PWSH, reason="pwsh not available")
 class TestCreateFeaturePowerShell:
@@ -376,6 +391,21 @@ class TestCreateFeaturePowerShell:
         data = json.loads(json_line[-1])
         assert "BRANCH_NAME" in data
         assert "FEATURE_NUM" in data
+
+    def test_persists_feature_metadata(self, tmp_path: Path):
+        """Extension create-new-feature.ps1 updates .specify/feature.json."""
+        project = _setup_project(tmp_path)
+        result = _run_pwsh(
+            "create-new-feature.ps1", project,
+            "-Json", "-ShortName", "ps-meta", "PowerShell metadata",
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+
+        metadata_file = project / ".specify" / "feature.json"
+        assert metadata_file.exists(), "feature metadata file was not created"
+        metadata = json.loads(metadata_file.read_text(encoding="utf-8-sig"))
+        assert metadata == {"feature_directory": f"specs/{data['BRANCH_NAME']}"}
 
 
 # ── auto-commit.sh Tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

The current planning helpers resolve the active feature directory using this priority order:

1. `SPECIFY_FEATURE_DIRECTORY`
2. `.specify/feature.json`
3. branch-based fallback

That works only if the active feature pointer is kept up to date.

In the current upstream layout, git-backed projects create features through the git extension scripts:

- `.specify/extensions/git/scripts/bash/create-new-feature.sh`
- `.specify/extensions/git/scripts/powershell/create-new-feature.ps1`

Those scripts created or switched the branch, but did not persist `.specify/feature.json`. As a result, downstream commands like `/speckit.plan` could still follow a stale feature pointer from an older feature and write artifacts into the wrong spec directory.

This PR fixes that by updating the git extension’s feature-creation scripts to persist `.specify/feature.json` with the resolved feature directory, for example:

```json
{
  "feature_directory": "specs/116-my-feature"
}
```

This keeps the active feature pointer aligned with the extension-based feature creation flow that current upstream projects use.

## Testing

- [ ] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Additional verification:
- `pytest tests/extensions/git/test_git_extension.py`

Results in this environment:
- `34 passed, 16 skipped`

The skipped tests are PowerShell-specific tests because `pwsh` is not available in this environment.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Used Codex to review the current upstream flow, identify that the active-feature mismatch now lives in the git extension path, implement the extension-script fix, and add focused regression coverage.
