### PR TITLE
fix(copilot): use --yolo to grant all permissions in non-interactive mode

### DIFF
--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -10,12 +10,38 @@ Copilot has several unique behaviors compared to standard markdown agents:
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import warnings
 from pathlib import Path
 from typing import Any
 
 from ..base import IntegrationBase
 from ..manifest import IntegrationManifest
+
+
+def _allow_all() -> bool:
+    """Return True if the Copilot CLI should run with full permissions.
+
+    Checks ``SPECKIT_COPILOT_ALLOW_ALL_TOOLS`` first (new canonical name).
+    Falls back to the deprecated ``SPECKIT_ALLOW_ALL_TOOLS`` if set,
+    emitting a deprecation warning.  Default when neither is set: enabled.
+    """
+    new_var = os.environ.get("SPECKIT_COPILOT_ALLOW_ALL_TOOLS")
+    if new_var is not None:
+        return new_var != "0"
+
+    old_var = os.environ.get("SPECKIT_ALLOW_ALL_TOOLS")
+    if old_var is not None:
+        warnings.warn(
+            "SPECKIT_ALLOW_ALL_TOOLS is deprecated; "
+            "use SPECKIT_COPILOT_ALLOW_ALL_TOOLS instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return old_var != "0"
+
+    return True
 
 
 class CopilotIntegration(IntegrationBase):
@@ -53,10 +79,11 @@ class CopilotIntegration(IntegrationBase):
         # non-interactive mode.  --yolo enables all permissions
         # (tools, paths, and URLs) so the agent can perform file
         # edits and shell commands without interactive prompts.
-        # Controlled by SPECKIT_COPILOT_ALLOW_ALL env var (default: enabled).
-        import os
+        # Controlled by SPECKIT_COPILOT_ALLOW_ALL_TOOLS env var
+        # (default: enabled).  The deprecated SPECKIT_ALLOW_ALL_TOOLS
+        # is also honoured as a fallback.
         args = ["copilot", "-p", prompt]
-        if os.environ.get("SPECKIT_COPILOT_ALLOW_ALL", "1") != "0":
+        if _allow_all():
             args.append("--yolo")
         if model:
             args.extend(["--model", model])
@@ -92,12 +119,11 @@ class CopilotIntegration(IntegrationBase):
         agent_name = f"speckit.{stem}"
 
         prompt = args or ""
-        import os
         cli_args = [
             "copilot", "-p", prompt,
             "--agent", agent_name,
         ]
-        if os.environ.get("SPECKIT_COPILOT_ALLOW_ALL", "1") != "0":
+        if _allow_all():
             cli_args.append("--yolo")
         if model:
             cli_args.extend(["--model", model])

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -50,13 +50,14 @@ class CopilotIntegration(IntegrationBase):
         output_json: bool = True,
     ) -> list[str] | None:
         # GitHub Copilot CLI uses ``copilot -p "prompt"`` for
-        # non-interactive mode.  --allow-all-tools is required for the
-        # agent to perform file edits and shell commands.  Controlled
-        # by SPECKIT_ALLOW_ALL_TOOLS env var (default: enabled).
+        # non-interactive mode.  --yolo enables all permissions
+        # (tools, paths, and URLs) so the agent can perform file
+        # edits and shell commands without interactive prompts.
+        # Controlled by SPECKIT_COPILOT_ALLOW_ALL env var (default: enabled).
         import os
         args = ["copilot", "-p", prompt]
-        if os.environ.get("SPECKIT_ALLOW_ALL_TOOLS", "1") != "0":
-            args.append("--allow-all-tools")
+        if os.environ.get("SPECKIT_COPILOT_ALLOW_ALL", "1") != "0":
+            args.append("--yolo")
         if model:
             args.extend(["--model", model])
         if output_json:
@@ -96,8 +97,8 @@ class CopilotIntegration(IntegrationBase):
             "copilot", "-p", prompt,
             "--agent", agent_name,
         ]
-        if os.environ.get("SPECKIT_ALLOW_ALL_TOOLS", "1") != "0":
-            cli_args.append("--allow-all-tools")
+        if os.environ.get("SPECKIT_COPILOT_ALLOW_ALL", "1") != "0":
+            cli_args.append("--yolo")
         if model:
             cli_args.extend(["--model", model])
         if not stream:

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -36,7 +36,7 @@ def _allow_all() -> bool:
         warnings.warn(
             "SPECKIT_ALLOW_ALL_TOOLS is deprecated; "
             "use SPECKIT_COPILOT_ALLOW_ALL_TOOLS instead.",
-            DeprecationWarning,
+            UserWarning,
             stacklevel=2,
         )
         return old_var != "0"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -367,7 +367,9 @@ class TestBuildExecArgs:
         assert args[2] == "do stuff"
         assert "--json" in args
 
-    def test_copilot_exec_args(self):
+    def test_copilot_exec_args(self, monkeypatch):
+        monkeypatch.delenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", raising=False)
+        monkeypatch.delenv("SPECKIT_ALLOW_ALL_TOOLS", raising=False)
         from specify_cli.integrations.copilot import CopilotIntegration
         impl = CopilotIntegration()
         args = impl.build_exec_args("do stuff", model="claude-sonnet-4-20250514")
@@ -375,6 +377,34 @@ class TestBuildExecArgs:
         assert "-p" in args
         assert "--yolo" in args
         assert "--model" in args
+
+    def test_copilot_new_env_var_disables_yolo(self, monkeypatch):
+        monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "0")
+        monkeypatch.delenv("SPECKIT_ALLOW_ALL_TOOLS", raising=False)
+        from specify_cli.integrations.copilot import CopilotIntegration
+        impl = CopilotIntegration()
+        args = impl.build_exec_args("do stuff")
+        assert "--yolo" not in args
+
+    def test_copilot_deprecated_env_var_still_honoured(self, monkeypatch):
+        monkeypatch.delenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", raising=False)
+        monkeypatch.setenv("SPECKIT_ALLOW_ALL_TOOLS", "0")
+        import warnings
+        from specify_cli.integrations.copilot import CopilotIntegration
+        impl = CopilotIntegration()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            args = impl.build_exec_args("do stuff")
+        assert "--yolo" not in args
+        assert any("SPECKIT_ALLOW_ALL_TOOLS is deprecated" in str(x.message) for x in w)
+
+    def test_copilot_new_env_var_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "1")
+        monkeypatch.setenv("SPECKIT_ALLOW_ALL_TOOLS", "0")
+        from specify_cli.integrations.copilot import CopilotIntegration
+        impl = CopilotIntegration()
+        args = impl.build_exec_args("do stuff")
+        assert "--yolo" in args
 
     def test_ide_only_returns_none(self):
         from specify_cli.integrations.windsurf import WindsurfIntegration

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -373,7 +373,7 @@ class TestBuildExecArgs:
         args = impl.build_exec_args("do stuff", model="claude-sonnet-4-20250514")
         assert args[0] == "copilot"
         assert "-p" in args
-        assert "--allow-all-tools" in args
+        assert "--yolo" in args
         assert "--model" in args
 
     def test_ide_only_returns_none(self):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -396,7 +396,11 @@ class TestBuildExecArgs:
             warnings.simplefilter("always")
             args = impl.build_exec_args("do stuff")
         assert "--yolo" not in args
-        assert any("SPECKIT_ALLOW_ALL_TOOLS is deprecated" in str(x.message) for x in w)
+        assert any(
+            "SPECKIT_ALLOW_ALL_TOOLS is deprecated" in str(x.message)
+            and issubclass(x.category, UserWarning)
+            for x in w
+        )
 
     def test_copilot_new_env_var_takes_precedence(self, monkeypatch):
         monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "1")


### PR DESCRIPTION
## Summary

Fixes #2294

The Copilot CLI's `--allow-all-tools` flag only covers tool execution permissions but does **not** grant path or URL access. When the Copilot agent autonomously runs shell commands (e.g. `npm run build`) during workflow execution, the CLI blocks path access and cannot prompt for approval in non-interactive mode, producing:

```
Permission denied and could not request permission from user
```

## Changes

- Replace `--allow-all-tools` with `--yolo` (equivalent to `--allow-all-tools --allow-all-paths --allow-all-urls`) in both `build_exec_args()` and `dispatch_command()` to grant all three permission types
- Rename the opt-out env var from `SPECKIT_ALLOW_ALL_TOOLS` to `SPECKIT_COPILOT_ALLOW_ALL_TOOLS` and scope it to the Copilot integration
- Deprecate the old `SPECKIT_ALLOW_ALL_TOOLS` env var with a `UserWarning` fallback so existing opt-outs are not silently ignored
- New env var takes precedence when both are set
- Use `monkeypatch` in tests to avoid flakiness from ambient env vars
- Add tests for deprecation warning, precedence, and opt-out paths

## Files changed

- `src/specify_cli/integrations/copilot/__init__.py` — flag, env var, and deprecation logic
- `tests/test_workflows.py` — test assertion updates and new env var tests

## Testing

All 141 tests pass (workflow + copilot integration suites).