### PR TITLE
feat(catalog): add red-team extension to community catalog

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1528,8 +1528,8 @@
       "id": "red-team",
       "description": "Adversarial review of functional specs before /speckit.plan. Parallel adversarial lens agents catch hostile actors, silent failures, and regulatory blind spots that clarify/analyze cannot.",
       "author": "Ash Brener",
-      "version": "1.0.1",
-      "download_url": "https://github.com/ashbrener/spec-kit-red-team/releases/download/v1.0.1/red-team-v1.0.1.zip",
+      "version": "1.0.2",
+      "download_url": "https://github.com/ashbrener/spec-kit-red-team/releases/download/v1.0.2/red-team-v1.0.2.zip",
       "repository": "https://github.com/ashbrener/spec-kit-red-team",
       "homepage": "https://github.com/ashbrener/spec-kit-red-team",
       "documentation": "https://github.com/ashbrener/spec-kit-red-team/blob/main/README.md",
@@ -1539,8 +1539,8 @@
         "speckit_version": ">=0.1.0"
       },
       "provides": {
-        "commands": 1,
-        "hooks": 0
+        "commands": 2,
+        "hooks": 1
       },
       "tags": [
         "adversarial-review",

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1526,7 +1526,7 @@
     "red-team": {
       "name": "Red Team",
       "id": "red-team",
-      "description": "Adversarial review of functional specs before /speckit.plan locks in architecture. Dispatches 3-5 parallel lens agents, aggregates findings into a structured report, and walks the maintainer through spec-fix / new-OQ / accepted-risk / out-of-scope resolution.",
+      "description": "Adversarial review of functional specs before /speckit.plan. Parallel adversarial lens agents catch hostile actors, silent failures, and regulatory blind spots that clarify/analyze cannot.",
       "author": "Ash Brener",
       "version": "1.0.0",
       "download_url": "https://github.com/ashbrener/spec-kit-red-team/releases/download/v1.0.0/red-team-v1.0.0.zip",

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-21T00:00:00Z",
+  "updated_at": "2026-04-22T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -1522,6 +1522,38 @@
       "stars": 0,
       "created_at": "2026-03-14T00:00:00Z",
       "updated_at": "2026-03-14T00:00:00Z"
+    },
+    "red-team": {
+      "name": "Red Team",
+      "id": "red-team",
+      "description": "Adversarial review of functional specs before /speckit.plan locks in architecture. Dispatches 3-5 parallel lens agents, aggregates findings into a structured report, and walks the maintainer through spec-fix / new-OQ / accepted-risk / out-of-scope resolution.",
+      "author": "Ash Brener",
+      "version": "1.0.0",
+      "download_url": "https://github.com/ashbrener/spec-kit-red-team/releases/download/v1.0.0/red-team-v1.0.0.zip",
+      "repository": "https://github.com/ashbrener/spec-kit-red-team",
+      "homepage": "https://github.com/ashbrener/spec-kit-red-team",
+      "documentation": "https://github.com/ashbrener/spec-kit-red-team/blob/main/README.md",
+      "changelog": "https://github.com/ashbrener/spec-kit-red-team/blob/main/CHANGELOG.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.7.0"
+      },
+      "provides": {
+        "commands": 1,
+        "hooks": 0
+      },
+      "tags": [
+        "adversarial-review",
+        "quality-gate",
+        "spec-hardening",
+        "pre-plan",
+        "audit"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-04-22T00:00:00Z",
+      "updated_at": "2026-04-22T00:00:00Z"
     },
     "refine": {
       "name": "Spec Refine",

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1528,15 +1528,15 @@
       "id": "red-team",
       "description": "Adversarial review of functional specs before /speckit.plan. Parallel adversarial lens agents catch hostile actors, silent failures, and regulatory blind spots that clarify/analyze cannot.",
       "author": "Ash Brener",
-      "version": "1.0.0",
-      "download_url": "https://github.com/ashbrener/spec-kit-red-team/releases/download/v1.0.0/red-team-v1.0.0.zip",
+      "version": "1.0.1",
+      "download_url": "https://github.com/ashbrener/spec-kit-red-team/releases/download/v1.0.1/red-team-v1.0.1.zip",
       "repository": "https://github.com/ashbrener/spec-kit-red-team",
       "homepage": "https://github.com/ashbrener/spec-kit-red-team",
       "documentation": "https://github.com/ashbrener/spec-kit-red-team/blob/main/README.md",
       "changelog": "https://github.com/ashbrener/spec-kit-red-team/blob/main/CHANGELOG.md",
       "license": "MIT",
       "requires": {
-        "speckit_version": ">=0.7.0"
+        "speckit_version": ">=0.1.0"
       },
       "provides": {
         "commands": 1,


### PR DESCRIPTION
## Summary

Adds the `red-team` community extension to `extensions/catalog.community.json` for **discovery**.

**Extension repo:** https://github.com/ashbrener/spec-kit-red-team
**Release:** https://github.com/ashbrener/spec-kit-red-team/releases/tag/v1.0.2

## Install model (important)

`catalog.community.json` is discovery-only (`install_allowed: false` in the default catalog stack — see `extensions/EXTENSION-USER-GUIDE.md` §Extension Catalogs and `extensions/RFC-EXTENSION-SYSTEM.md` §Default Built-in Stack). Merging this PR makes the extension visible to `specify extension search`, but `specify extension add <name>` against the community catalog is NOT the expected install path.

End users install the extension via one of:

1. **Direct-from-repository install** (recommended):
   ```bash
   specify extension add --from https://github.com/ashbrener/spec-kit-red-team
   ```
2. **Direct-from-release-asset install**:
   ```bash
   specify extension add --from https://github.com/ashbrener/spec-kit-red-team/releases/download/v1.0.2/red-team-v1.0.2.zip
   ```
3. **Opt the community catalog into installability** via a project-level or user-level `.specify/extension-catalogs.yml` that overrides the default `install_allowed: false`.

The PR's value is **discoverability** — `specify extension search red-team` surfaces the entry, and `specify extension info red-team` returns the metadata (repo, docs, homepage, changelog, version, release asset URL), pointing users to the install-ready release. This is the intended role of `catalog.community.json` per the RFC.

## What the extension does

Adversarial review of functional specs before `/speckit.plan` locks in architecture. Complements `/speckit.clarify` (correctness) and `/speckit.analyze` (consistency) with parallel adversarial lens agents.

| Command | Role |
|---|---|
| `/speckit.clarify` | Correctness |
| `/speckit.analyze` | Consistency |
| **`/speckit.red-team.run`** (new extension) | **Adversarial** |
| **`/speckit.red-team.gate`** (new extension, `before_plan` hook) | **Enforcement** — blocks `/speckit.plan` if a qualifying spec has no findings on record |

Clarify and analyze are structurally incapable of surfacing certain classes of issue — prompt injection in untrusted LLM inputs, self-approval segregation-of-duties gaps in workflows that are internally consistent, race conditions at configuration-change boundaries, cross-spec drift between cooperating halves of an interface contract, missing audit-chain integrity on "immutable" records. The red team adds an adversarial layer.

- **Commands:** `speckit.red-team.run` + `speckit.red-team.gate` (2 commands, 1 hook)
- **License:** MIT
- **Requires:** spec-kit ≥ 0.1.0 (extension uses only stable extension-kit primitives; does not require any 0.7.x-specific API)
- **Tags:** adversarial-review, quality-gate, spec-hardening, pre-plan, audit

## Origin

Originally proposed as a core command (#2303). Per @mnriem's maintainer direction — [comment on #2303](https://github.com/github/spec-kit/pull/2303#issuecomment-4292360028):

> Nice! Please deliver this as an extensions as per https://github.com/github/spec-kit/tree/main/extensions and host the extensions in your own GitHub repository so we can add it to the community catalog

This PR delivers on that direction: the protocol has been restructured as a community extension in its own public repo ([ashbrener/spec-kit-red-team](https://github.com/ashbrener/spec-kit-red-team)), released at [v1.0.2](https://github.com/ashbrener/spec-kit-red-team/releases/tag/v1.0.2), and this PR adds the entry to the community catalog for discovery via `specify extension search`.

The command body and design also incorporate two rounds of Copilot review feedback from #2303 (dot-notation alignment, CLI contract hygiene, inline error-message shapes, US spelling, threshold consistency, simplified interactivity model). All 10 review threads on #2303 are resolved.

## Versioning note

- **v1.0.0** — initial release, `requires.speckit_version: ">=0.7.0"`.
- **v1.0.1** — lowered to `">=0.1.0"` (v1.0.0 requirement was overly conservative; extension uses no 0.7.x-specific API surface; confirmed via local install verification). Matches community norm used by `reconcile`, `refine`, and other catalog entries.
- **v1.0.2** — adds `speckit.red-team.gate` command and a mandatory `before_plan` hook. `/speckit.plan` auto-invokes the gate on every run; non-qualifying specs return `PROCEED` silently; qualifying specs with findings on record return `SATISFIED`; qualifying specs without findings return `HALT` with explicit remediation options. Closes the Principle-VIII enforcement gap that left the protocol reliant on maintainer memory.

The catalog entry in this PR reflects v1.0.2 metadata.

## Dogfood validation

The protocol was validated against real 500-line + 1,400-line functional specs in a private project before this PR. Two red team sessions (RT-005 on the triage engine, RT-002 on the project's anchor PRD) dispatched five adversary agents in parallel and returned 25 findings each in ~2 min wall-clock — well under the 30-min soft target. In both sessions, ≥ 75% of findings met the "meaningful finding" bar: severity ≥ HIGH AND represents an adversarial scenario clarify/analyze structurally cannot catch. Notable catches include a cross-spec identifier-type drift between two halves of the same interface contract introduced by a separate commit 1 hour earlier, a hallucinated-extraction defect that defeated a downstream citation-verification hardening layer, and four parallel "immutable" storage claims with no storage-layer enforcement.

## Test plan

- [ ] Catalog JSON parses (verified locally — 75 entries total, red-team at alphabetical position 47)
- [ ] Download URL resolves (https://github.com/ashbrener/spec-kit-red-team/releases/download/v1.0.2/red-team-v1.0.2.zip — release asset, 11 files)
- [ ] Entry is surfaced by `specify extension search red-team` once catalog is live (discovery path — the primary value of this PR)
- [ ] Direct-from-repo install succeeds: `specify extension add --from https://github.com/ashbrener/spec-kit-red-team` (verified locally against spec-kit 0.6.2 for v1.0.1; same code path for v1.0.2)
- [ ] After install, commands `/speckit.red-team.run` and `/speckit.red-team.gate` register, and the `before_plan` hook auto-invokes `/speckit.red-team.gate` on next `/speckit.plan` run

## Related

- Supersedes #2303 per the maintainer direction linked above. #2303 has been closed with a pointer to this PR and the extension repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)