### PR TITLE
fix: resolve skill placeholders for all SKILL.md agents, not just codex/kimi

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -920,7 +920,6 @@ def _get_skills_dir(project_path: Path, selected_ai: str) -> Path:
 
 # Constants kept for backward compatibility with presets and extensions.
 DEFAULT_SKILLS_DIR = ".agents/skills"
-NATIVE_SKILLS_AGENTS = {"codex", "kimi"}
 SKILL_DESCRIPTIONS = {
     "specify": "Create or update feature specifications from natural language descriptions.",
     "plan": "Generate technical implementation plans from feature specifications.",

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -282,7 +282,8 @@ class CommandRegistrar:
         if not isinstance(frontmatter, dict):
             frontmatter = {}
 
-        if agent_name in {"codex", "kimi"}:
+        agent_config = self.AGENT_CONFIGS.get(agent_name, {})
+        if agent_config.get("extension") == "/SKILL.md":
             body = self.resolve_skill_placeholders(
                 agent_name, frontmatter, body, project_root
             )

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1361,6 +1361,79 @@ Agent __AGENT__
         assert "{ARGS}" not in content
         assert '.specify/scripts/bash/setup-plan.sh --json "$ARGUMENTS"' in content
 
+    @pytest.mark.parametrize("agent_name,skills_path", [
+        ("codex", ".agents/skills"),
+        ("kimi", ".kimi/skills"),
+        ("claude", ".claude/skills"),
+        ("cursor-agent", ".cursor/skills"),
+        ("trae", ".trae/skills"),
+        ("agy", ".agents/skills"),
+    ])
+    def test_all_skill_agents_register_commands_with_resolved_placeholders(
+        self, project_dir, temp_dir, agent_name, skills_path
+    ):
+        """All SKILL.md agents must produce fully resolved SKILL.md files when commands are registered."""
+        import yaml
+
+        ext_dir = temp_dir / f"ext-{agent_name}"
+        ext_dir.mkdir()
+        (ext_dir / "commands").mkdir()
+
+        manifest_data = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": f"ext-{agent_name}",
+                "name": "Scripted Extension",
+                "version": "1.0.0",
+                "description": "Test",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "commands": [
+                    {
+                        "name": f"speckit.ext-{agent_name}.run",
+                        "file": "commands/run.md",
+                        "description": "Scripted command",
+                    }
+                ]
+            },
+        }
+        with open(ext_dir / "extension.yml", "w") as f:
+            yaml.dump(manifest_data, f)
+
+        (ext_dir / "commands" / "run.md").write_text(
+            "---\n"
+            "description: Scripted command\n"
+            "scripts:\n"
+            '  sh: ../../scripts/bash/setup-plan.sh --json "{ARGS}"\n'
+            "---\n\n"
+            "Run {SCRIPT}\n"
+            "Agent is __AGENT__.\n"
+        )
+
+        init_options = project_dir / ".specify" / "init-options.json"
+        init_options.parent.mkdir(parents=True, exist_ok=True)
+        init_options.write_text(f'{{"ai":"{agent_name}","script":"sh"}}')
+
+        skills_dir = project_dir
+        for part in skills_path.split("/"):
+            skills_dir = skills_dir / part
+        skills_dir.mkdir(parents=True)
+
+        manifest = ExtensionManifest(ext_dir / "extension.yml")
+        registrar = CommandRegistrar()
+        registrar.register_commands_for_agent(agent_name, manifest, ext_dir, project_dir)
+
+        skill_dir_name = f"speckit-ext-{agent_name}-run"
+        skill_file = skills_dir / skill_dir_name / "SKILL.md"
+        assert skill_file.exists(), f"SKILL.md not created for {agent_name}"
+
+        content = skill_file.read_text()
+        assert "{SCRIPT}" not in content, f"{{SCRIPT}} not resolved for {agent_name}"
+        assert "__AGENT__" not in content, f"__AGENT__ not resolved for {agent_name}"
+        assert "{ARGS}" not in content, f"{{ARGS}} not resolved for {agent_name}"
+        assert '.specify/scripts/bash/setup-plan.sh' in content
+
     def test_codex_skill_alias_frontmatter_matches_alias_name(self, project_dir, temp_dir):
         """Codex alias skills should render their own matching `name:` frontmatter."""
         import yaml


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

When using Claude Code, adding a spec-kit extension produced a `SKILL.md` with unresolved placeholders: raw `{SCRIPT}` and `__AGENT__` tokens instead of the actual script path and agent name. With Codex it worked correctly, so the bug wasn't obvious until I tested with a different agent.

The root cause was a hardcoded check that only allowed `codex` and `kimi` to go through placeholder resolution. Any agent added after that was silently skipped.

The hardcoded set was replaced with a registry check so all current and future SKILL.md agents are covered automatically.

A parametrized test covering all six skill agents has been added as well.

## Testing

<!-- How did you test your changes? -->

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

### Test selection reasoning

| Changed file | Affects | Test | Why |
|---|---|---|---|
| `src/specify_cli/agents.py` | `specify extension add` (skill agents) | T1 | `render_skill_command()` runs when an extension is added to a SKILL.md agent — the fix must be validated end-to-end by adding an extension and inspecting the written SKILL.md |
| `src/specify_cli/agents.py` | `specify init` (skill agents) | T2 | Init scaffolds default commands as skills; confirms no regression in baseline skill file generation |
| `tests/test_extensions.py` | — | — | Test-only file; no slash command impact |

### Required tests

- T1: `specify init` with a skill agent (e.g., `--ai codex`) — prerequisite; creates the project and installs the integration before extension commands can be tested
- T2: `specify extension add <ext> --dev` on the T1 project using each skill agent type — verifies that the SKILL.md written by the fixed `render_skill_command()` contains resolved script paths and agent names with no raw `{SCRIPT}` or `__AGENT__` tokens remaining

## Manual test results

**Agent**: Codex CLI + Claude Code (both tested)  |  **OS/Shell**: macOS/zsh

| Command tested | Notes |
|----------------|-------|
| `specify init` with a skill agent (`--ai codex`, `--ai claude`) | Pass — works fine |
| `specify extension add <ext> --dev` on each skill agent type | Pass — works fine with both agents; SKILL.md files contain fully resolved placeholders |

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [x] I **did** use AI assistance (describe below)

<!-- If you used AI, briefly describe how (e.g., "Code generated by Copilot", "Consulted ChatGPT for approach"): -->
I used Copilot to understand the project structure and code intention, but the implementation changes are my own. The test result table and test selection analysis in this PR were also generated with Copilot (as requested in CONTRIBUTING.md).