### PR TITLE
Update version-guard to v1.2.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-22T17:54:00Z",
+  "updated_at": "2026-04-22T21:10:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -2351,8 +2351,8 @@
       "id": "version-guard",
       "description": "Verify tech stack versions against live registries before planning and implementation",
       "author": "KevinBrown5280",
-      "version": "1.1.0",
-      "download_url": "https://github.com/KevinBrown5280/spec-kit-version-guard/archive/refs/tags/v1.1.0.zip",
+      "version": "1.2.0",
+      "download_url": "https://github.com/KevinBrown5280/spec-kit-version-guard/archive/refs/tags/v1.2.0.zip",
       "repository": "https://github.com/KevinBrown5280/spec-kit-version-guard",
       "homepage": "https://github.com/KevinBrown5280/spec-kit-version-guard",
       "documentation": "https://github.com/KevinBrown5280/spec-kit-version-guard/blob/main/README.md",
@@ -2375,7 +2375,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-04-20T00:00:00Z",
-      "updated_at": "2026-04-22T17:54:00Z"
+      "updated_at": "2026-04-22T21:10:00Z"
     },
     "whatif": {
       "name": "What-if Analysis",


### PR DESCRIPTION
## Extension Update

**Extension Name**: Version Guard
**Extension ID**: version-guard
**Version**: 1.1.0 → 1.2.0
**Author**: KevinBrown5280
**Repository**: https://github.com/KevinBrown5280/spec-kit-version-guard

### What's New in v1.2.0

#### Fixed
- All-current path: self-instruction referenced Migration References URLs that did not exist when all packages were current — internal contradiction resolved

#### Changed
- **Current-Version References**: check.md now populates Migration References with documentation URLs for current packages (both all-current and mixed reports)
- **Training-data cutoff warning**: self-instructions in check.md and load.md explicitly address the risk of stale training data for current-version packages
- **Load summary count**: load.md reports count of current-version documentation references when available
- **Compatibility Rules hint**: empty rules block now cross-references Migration References

#### Unchanged
- validate.md (no changes)
- Check-time network calls (no new HTTP fetches; URLs are statically embedded)
- Behind-packages path (no regression)

### Catalog Changes
- version: 1.1.0 → 1.2.0
- download_url: updated to v1.2.0 tag
- updated_at: updated to current date

### Checklist
- [x] Valid extension.yml manifest
- [x] README.md with installation and usage docs
- [x] LICENSE file included
- [x] GitHub release created (v1.2.0)
- [x] Extension tested
- [x] All commands working
- [x] No security vulnerabilities
- [x] Updated extensions/catalog.community.json

**Process**: 4-of-4 multi-model debate consensus, 4-of-4 polish round approval, 3-round GPT 5.4 adversarial review (A+)

**Full Changelog**: https://github.com/KevinBrown5280/spec-kit-version-guard/blob/main/CHANGELOG.md