### PR TITLE
docs(presets): add lean preset README and enrich catalog metadata

### DIFF
--- a/presets/catalog.json
+++ b/presets/catalog.json
@@ -10,7 +10,14 @@
       "description": "Minimal core workflow commands - just the prompt, just the artifact",
       "author": "github",
       "repository": "https://github.com/github/spec-kit",
+      "license": "MIT",
       "bundled": true,
+      "requires": {
+        "speckit_version": ">=0.6.0"
+      },
+      "provides": {
+        "commands": 5
+      },
       "tags": [
         "lean",
         "minimal",

--- a/presets/catalog.json
+++ b/presets/catalog.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-10T00:00:00Z",
+  "updated_at": "2026-04-24T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/presets/catalog.json",
   "presets": {
     "lean": {
@@ -16,7 +16,8 @@
         "speckit_version": ">=0.6.0"
       },
       "provides": {
-        "commands": 5
+        "commands": 5,
+        "templates": 0
       },
       "tags": [
         "lean",

--- a/presets/lean/README.md
+++ b/presets/lean/README.md
@@ -1,0 +1,45 @@
+# Lean Workflow
+
+A minimal preset that strips the Spec Kit workflow down to its essentials — just the prompt, just the artifact.
+
+## When to Use
+
+Use Lean when you want the structured specify → plan → tasks → implement pipeline without the ceremony of the full templates. Each command produces a single focused Markdown file with no boilerplate sections to fill in.
+
+## Commands Included
+
+| Command | Output | Description |
+|---------|--------|-------------|
+| `speckit.specify` | `spec.md` | Create a specification from a feature description |
+| `speckit.plan` | `plan.md` | Create an implementation plan from the spec |
+| `speckit.tasks` | `tasks.md` | Create dependency-ordered tasks from spec and plan |
+| `speckit.implement` | *(code)* | Execute all tasks in order, marking progress |
+| `speckit.constitution` | `constitution.md` | Create or update the project constitution |
+
+## What It Replaces
+
+Lean overrides the five core workflow commands with self-contained prompts that produce each artifact directly — no separate template files involved. The result is a shorter, more direct workflow.
+
+## Installation
+
+```bash
+# Lean is a bundled preset — no download needed
+specify preset add lean
+```
+
+## Development
+
+```bash
+# Test from local directory
+specify preset add --dev ./presets/lean
+
+# Verify commands resolve
+specify preset resolve speckit.specify
+
+# Remove when done
+specify preset remove lean
+```
+
+## License
+
+MIT

--- a/presets/lean/preset.yml
+++ b/presets/lean/preset.yml
@@ -48,3 +48,4 @@ tags:
   - "lean"
   - "minimal"
   - "workflow"
+  - "core"


### PR DESCRIPTION
Adds documentation and metadata improvements for the bundled lean preset:

- **`presets/lean/README.md`** — New README documenting the lean workflow preset, its commands, when to use it, and development instructions.
- **`presets/catalog.json`** — Adds `license`, `requires.speckit_version`, and `provides.commands` fields to the lean preset entry.
- **`presets/lean/preset.yml`** — Adds `"core"` tag for discoverability.