### PR TITLE
fix(plan): use .specify/feature.json to allow /speckit.plan on custom git branches (#2305)

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -153,32 +153,47 @@ check_feature_branch() {
     return 0
 }
 
+# Safely read .specify/feature.json's "feature_directory" value.
+# Prints the raw value (possibly relative) to stdout, or empty string if the file
+# is missing, unparseable, or does not contain the key. Always returns 0 so callers
+# under `set -e` cannot be aborted by parser failure.
+# Parser order mirrors the historical get_feature_paths behavior: jq -> python3 -> grep/sed.
+read_feature_json_feature_directory() {
+    local repo_root="$1"
+    local fj="$repo_root/.specify/feature.json"
+    [[ -f "$fj" ]] || { printf '%s' ''; return 0; }
+
+    local _fd=''
+    if command -v jq >/dev/null 2>&1; then
+        if ! _fd=$(jq -r '.feature_directory // empty' "$fj" 2>/dev/null); then
+            _fd=''
+        fi
+    elif command -v python3 >/dev/null 2>&1; then
+        # Use Python so pretty-printed/multi-line JSON still parses correctly.
+        if ! _fd=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); v=d.get('feature_directory'); print(v if v else '')" "$fj" 2>/dev/null); then
+            _fd=''
+        fi
+    else
+        # Last-resort single-line grep/sed fallback. The `|| true` guards against
+        # grep returning 1 (no match) aborting under `set -e` / `pipefail`.
+        _fd=$( { grep -E '"feature_directory"[[:space:]]*:' "$fj" 2>/dev/null || true; } \
+            | head -n 1 \
+            | sed -E 's/^[^:]*:[[:space:]]*"([^"]*)".*$/\1/' )
+    fi
+
+    printf '%s' "$_fd"
+    return 0
+}
+
 # Returns 0 when .specify/feature.json lists feature_directory that exists as a directory
 # and matches the resolved active FEATURE_DIR (so /speckit.plan can skip git branch pattern checks).
-# Parser fallback order mirrors get_feature_paths: jq -> python3 -> grep/sed.
-# All parser failures are treated as "no match" (return 1) so callers under `set -e`
-# fall through to the existing branch validation instead of aborting the script.
+# Delegates parsing to read_feature_json_feature_directory, which is safe under `set -e`.
 feature_json_matches_feature_dir() {
     local repo_root="$1"
     local active_feature_dir="$2"
-    local fj="$repo_root/.specify/feature.json"
-
-    [[ -f "$fj" ]] || return 1
 
     local _fd
-    if command -v jq >/dev/null 2>&1; then
-        if ! _fd=$(jq -r '.feature_directory // empty' "$fj" 2>/dev/null); then
-            return 1
-        fi
-    elif command -v python3 >/dev/null 2>&1; then
-        if ! _fd=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); v=d.get('feature_directory'); print(v if v else '')" "$fj" 2>/dev/null); then
-            return 1
-        fi
-    else
-        _fd=$(grep -E '"feature_directory"[[:space:]]*:' "$fj" 2>/dev/null \
-            | head -n 1 \
-            | sed -E 's/^[^:]*:[[:space:]]*"([^"]*)".*$/\1/')
-    fi
+    _fd=$(read_feature_json_feature_directory "$repo_root")
 
     [[ -n "$_fd" ]] || return 1
     [[ "$_fd" != /* ]] && _fd="$repo_root/$_fd"
@@ -255,16 +270,10 @@ get_feature_paths() {
         # Normalize relative paths to absolute under repo root
         [[ "$feature_dir" != /* ]] && feature_dir="$repo_root/$feature_dir"
     elif [[ -f "$repo_root/.specify/feature.json" ]]; then
+        # Shared, set -e-safe parser: jq -> python3 -> grep/sed. Returns empty on
+        # missing/unparseable/unset so we fall through to the branch-prefix lookup.
         local _fd
-        if command -v jq >/dev/null 2>&1; then
-            _fd=$(jq -r '.feature_directory // empty' "$repo_root/.specify/feature.json" 2>/dev/null)
-        elif command -v python3 >/dev/null 2>&1; then
-            # Fallback: use Python to parse JSON so pretty-printed/multi-line files work
-            _fd=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('feature_directory',''))" "$repo_root/.specify/feature.json" 2>/dev/null)
-        else
-            # Last resort: single-line grep fallback (won't work on multi-line JSON)
-            _fd=$(grep -o '"feature_directory"[[:space:]]*:[[:space:]]*"[^"]*"' "$repo_root/.specify/feature.json" 2>/dev/null | sed 's/.*"\([^"]*\)"$/\1/')
-        fi
+        _fd=$(read_feature_json_feature_directory "$repo_root")
         if [[ -n "$_fd" ]]; then
             feature_dir="$_fd"
             # Normalize relative paths to absolute under repo root

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -200,8 +200,8 @@ feature_json_matches_feature_dir() {
     [[ -d "$_fd" ]] || return 1
 
     local norm_json norm_active
-    norm_json="$(cd -- "$_fd" 2>/dev/null && pwd)" || return 1
-    norm_active="$(cd -- "$active_feature_dir" 2>/dev/null && pwd)" || return 1
+    norm_json="$(cd -- "$_fd" 2>/dev/null && pwd -P)" || return 1
+    norm_active="$(cd -- "$active_feature_dir" 2>/dev/null && pwd -P)" || return 1
 
     [[ "$norm_json" == "$norm_active" ]]
 }

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -153,6 +153,30 @@ check_feature_branch() {
     return 0
 }
 
+# Returns 0 when .specify/feature.json lists feature_directory that exists as a directory
+# and matches the resolved active FEATURE_DIR (so /speckit.plan can skip git branch pattern checks).
+feature_json_matches_feature_dir() {
+    local repo_root="$1"
+    local active_feature_dir="$2"
+    local fj="$repo_root/.specify/feature.json"
+    [[ -f "$fj" ]] || return 1
+    local _fd
+    if command -v jq >/dev/null 2>&1; then
+        _fd=$(jq -r '.feature_directory // empty' "$fj" 2>/dev/null)
+    elif command -v python3 >/dev/null 2>&1; then
+        _fd=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); v=d.get('feature_directory'); print(v if v else '')" "$fj" 2>/dev/null)
+    else
+        return 1
+    fi
+    [[ -n "$_fd" ]] || return 1
+    [[ "$_fd" != /* ]] && _fd="$repo_root/$_fd"
+    [[ -d "$_fd" ]] || return 1
+    local norm_json norm_active
+    norm_json="$(cd -- "$_fd" 2>/dev/null && pwd)" || return 1
+    norm_active="$(cd -- "$active_feature_dir" 2>/dev/null && pwd)" || return 1
+    [[ "$norm_json" == "$norm_active" ]]
+}
+
 # Find feature directory by numeric prefix instead of exact branch match
 # This allows multiple branches to work on the same spec (e.g., 004-fix-bug, 004-add-feature)
 find_feature_dir_by_prefix() {

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -155,25 +155,39 @@ check_feature_branch() {
 
 # Returns 0 when .specify/feature.json lists feature_directory that exists as a directory
 # and matches the resolved active FEATURE_DIR (so /speckit.plan can skip git branch pattern checks).
+# Parser fallback order mirrors get_feature_paths: jq -> python3 -> grep/sed.
+# All parser failures are treated as "no match" (return 1) so callers under `set -e`
+# fall through to the existing branch validation instead of aborting the script.
 feature_json_matches_feature_dir() {
     local repo_root="$1"
     local active_feature_dir="$2"
     local fj="$repo_root/.specify/feature.json"
+
     [[ -f "$fj" ]] || return 1
+
     local _fd
     if command -v jq >/dev/null 2>&1; then
-        _fd=$(jq -r '.feature_directory // empty' "$fj" 2>/dev/null)
+        if ! _fd=$(jq -r '.feature_directory // empty' "$fj" 2>/dev/null); then
+            return 1
+        fi
     elif command -v python3 >/dev/null 2>&1; then
-        _fd=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); v=d.get('feature_directory'); print(v if v else '')" "$fj" 2>/dev/null)
+        if ! _fd=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); v=d.get('feature_directory'); print(v if v else '')" "$fj" 2>/dev/null); then
+            return 1
+        fi
     else
-        return 1
+        _fd=$(grep -E '"feature_directory"[[:space:]]*:' "$fj" 2>/dev/null \
+            | head -n 1 \
+            | sed -E 's/^[^:]*:[[:space:]]*"([^"]*)".*$/\1/')
     fi
+
     [[ -n "$_fd" ]] || return 1
     [[ "$_fd" != /* ]] && _fd="$repo_root/$_fd"
     [[ -d "$_fd" ]] || return 1
+
     local norm_json norm_active
     norm_json="$(cd -- "$_fd" 2>/dev/null && pwd)" || return 1
     norm_active="$(cd -- "$active_feature_dir" 2>/dev/null && pwd)" || return 1
+
     [[ "$norm_json" == "$norm_active" ]]
 }
 

--- a/scripts/bash/setup-plan.sh
+++ b/scripts/bash/setup-plan.sh
@@ -32,8 +32,10 @@ _paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature p
 eval "$_paths_output"
 unset _paths_output
 
-# Check if we're on a proper feature branch (only for git repos)
-check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
+# If feature.json pins an existing feature directory, branch naming is not required.
+if ! feature_json_matches_feature_dir "$REPO_ROOT" "$FEATURE_DIR"; then
+    check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
+fi
 
 # Ensure the feature directory exists
 mkdir -p "$FEATURE_DIR"

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -197,9 +197,39 @@ function Test-FeatureJsonMatchesFeatureDir {
         return $false
     }
 
-    $normJson = [System.IO.Path]::GetFullPath($fd)
-    $normActive = [System.IO.Path]::GetFullPath($ActiveFeatureDir)
-    return [string]::Equals($normJson, $normActive, [System.StringComparison]::OrdinalIgnoreCase)
+    # Resolve both paths to canonical absolute form. Prefer Resolve-Path (follows
+    # symlinks and is the canonical PS way); fall back to [Path]::GetFullPath when
+    # Resolve-Path can't produce a value. Mirrors the pattern used by Find-SpecifyRoot.
+    $resolvedJson = Resolve-Path -LiteralPath $fd -ErrorAction SilentlyContinue
+    if ($resolvedJson) {
+        $normJson = $resolvedJson.Path
+    } else {
+        $normJson = [System.IO.Path]::GetFullPath($fd)
+    }
+
+    $resolvedActive = Resolve-Path -LiteralPath $ActiveFeatureDir -ErrorAction SilentlyContinue
+    if ($resolvedActive) {
+        $normActive = $resolvedActive.Path
+    } else {
+        $normActive = [System.IO.Path]::GetFullPath($ActiveFeatureDir)
+    }
+
+    # Use case-insensitive compare only on Windows; POSIX filesystems are case-sensitive.
+    # PowerShell 5.1 is Windows-only and does not define $IsWindows, so treat its
+    # absence as "we're on Windows".
+    if ($null -ne $IsWindows) {
+        $onWindows = $IsWindows
+    } else {
+        $onWindows = $true
+    }
+
+    if ($onWindows) {
+        $comparison = [System.StringComparison]::OrdinalIgnoreCase
+    } else {
+        $comparison = [System.StringComparison]::Ordinal
+    }
+
+    return [string]::Equals($normJson, $normActive, $comparison)
 }
 
 # Resolve specs/<feature-dir> by numeric/timestamp prefix (mirrors scripts/bash/common.sh find_feature_dir_by_prefix).

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -164,6 +164,44 @@ function Test-FeatureBranch {
     return $true
 }
 
+# True when .specify/feature.json pins an existing feature directory that matches the
+# active FEATURE_DIR from Get-FeaturePathsEnv (so /speckit.plan can skip git branch pattern checks).
+function Test-FeatureJsonMatchesFeatureDir {
+    param(
+        [Parameter(Mandatory = $true)][string]$RepoRoot,
+        [Parameter(Mandatory = $true)][string]$ActiveFeatureDir
+    )
+
+    $featureJson = Join-Path $RepoRoot '.specify\feature.json'
+    if (-not (Test-Path -LiteralPath $featureJson -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $raw = Get-Content -LiteralPath $featureJson -Raw
+        $cfg = $raw | ConvertFrom-Json
+    } catch {
+        return $false
+    }
+
+    $fd = $cfg.feature_directory
+    if ([string]::IsNullOrWhiteSpace([string]$fd)) {
+        return $false
+    }
+
+    if (-not [System.IO.Path]::IsPathRooted($fd)) {
+        $fd = Join-Path $RepoRoot $fd
+    }
+
+    if (-not (Test-Path -LiteralPath $fd -PathType Container)) {
+        return $false
+    }
+
+    $normJson = [System.IO.Path]::GetFullPath($fd)
+    $normActive = [System.IO.Path]::GetFullPath($ActiveFeatureDir)
+    return [string]::Equals($normJson, $normActive, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 # Resolve specs/<feature-dir> by numeric/timestamp prefix (mirrors scripts/bash/common.sh find_feature_dir_by_prefix).
 function Find-FeatureDirByPrefix {
     param(

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -172,7 +172,7 @@ function Test-FeatureJsonMatchesFeatureDir {
         [Parameter(Mandatory = $true)][string]$ActiveFeatureDir
     )
 
-    $featureJson = Join-Path $RepoRoot '.specify\feature.json'
+    $featureJson = Join-Path (Join-Path $RepoRoot '.specify') 'feature.json'
     if (-not (Test-Path -LiteralPath $featureJson -PathType Leaf)) {
         return $false
     }

--- a/scripts/powershell/setup-plan.ps1
+++ b/scripts/powershell/setup-plan.ps1
@@ -23,9 +23,11 @@ if ($Help) {
 # Get all paths and variables from common functions
 $paths = Get-FeaturePathsEnv
 
-# Check if we're on a proper feature branch (only for git repos)
-if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) { 
-    exit 1 
+# If feature.json pins an existing feature directory, branch naming is not required.
+if (-not (Test-FeatureJsonMatchesFeatureDir -RepoRoot $paths.REPO_ROOT -ActiveFeatureDir $paths.FEATURE_DIR)) {
+    if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) {
+        exit 1
+    }
 }
 
 # Ensure the feature directory exists

--- a/tests/test_setup_plan_feature_json.py
+++ b/tests/test_setup_plan_feature_json.py
@@ -1,6 +1,7 @@
 """Tests for setup-plan bypassing branch-pattern checks when feature.json is valid."""
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -38,6 +39,21 @@ def _minimal_templates(repo: Path) -> None:
     tdir = repo / ".specify" / "templates"
     tdir.mkdir(parents=True, exist_ok=True)
     shutil.copy(PLAN_TEMPLATE, tdir / "plan-template.md")
+
+
+def _clean_env() -> dict[str, str]:
+    """Return a copy of the current environment with any SPECIFY_* vars removed.
+
+    setup-plan.{sh,ps1} honors SPECIFY_FEATURE, SPECIFY_FEATURE_DIRECTORY, etc.,
+    which would otherwise leak from a developer shell or CI runner and make these
+    tests flaky. Stripping them forces every case to rely purely on git branch +
+    .specify/feature.json state set up by the fixture.
+    """
+    env = os.environ.copy()
+    for key in list(env):
+        if key.startswith("SPECIFY_"):
+            env.pop(key)
+    return env
 
 
 def _git_init(repo: Path) -> None:
@@ -84,6 +100,7 @@ def test_setup_plan_passes_custom_branch_when_feature_json_valid(plan_repo: Path
         capture_output=True,
         text=True,
         check=False,
+        env=_clean_env(),
     )
     assert result.returncode == 0, result.stderr + result.stdout
     assert (feat / "plan.md").is_file()
@@ -103,6 +120,7 @@ def test_setup_plan_fails_custom_branch_without_feature_json(plan_repo: Path) ->
         capture_output=True,
         text=True,
         check=False,
+        env=_clean_env(),
     )
     assert result.returncode != 0
     assert "Not on a feature branch" in result.stderr
@@ -127,6 +145,7 @@ def test_setup_plan_numbered_branch_unchanged_without_feature_json(
         capture_output=True,
         text=True,
         check=False,
+        env=_clean_env(),
     )
     assert result.returncode == 0, result.stderr + result.stdout
     assert (feat / "plan.md").is_file()
@@ -154,6 +173,7 @@ def test_setup_plan_ps_passes_custom_branch_when_feature_json_valid(plan_repo: P
         capture_output=True,
         text=True,
         check=False,
+        env=_clean_env(),
     )
     assert result.returncode == 0, result.stderr + result.stdout
     assert (feat / "plan.md").is_file()
@@ -176,6 +196,7 @@ def test_setup_plan_ps_fails_custom_branch_without_feature_json(
         capture_output=True,
         text=True,
         check=False,
+        env=_clean_env(),
     )
     assert result.returncode != 0
     assert "Not on a feature branch" in result.stderr

--- a/tests/test_setup_plan_feature_json.py
+++ b/tests/test_setup_plan_feature_json.py
@@ -1,0 +1,159 @@
+"""Tests for setup-plan bypassing branch-pattern checks when feature.json is valid."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import requires_bash
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+COMMON_SH = PROJECT_ROOT / "scripts" / "bash" / "common.sh"
+SETUP_PLAN_SH = PROJECT_ROOT / "scripts" / "bash" / "setup-plan.sh"
+COMMON_PS = PROJECT_ROOT / "scripts" / "powershell" / "common.ps1"
+SETUP_PLAN_PS = PROJECT_ROOT / "scripts" / "powershell" / "setup-plan.ps1"
+PLAN_TEMPLATE = PROJECT_ROOT / "templates" / "plan-template.md"
+
+HAS_PWSH = shutil.which("pwsh") is not None
+_POWERSHELL = shutil.which("powershell.exe") or shutil.which("powershell")
+
+
+def _install_bash_scripts(repo: Path) -> None:
+    d = repo / ".specify" / "scripts" / "bash"
+    d.mkdir(parents=True, exist_ok=True)
+    shutil.copy(COMMON_SH, d / "common.sh")
+    shutil.copy(SETUP_PLAN_SH, d / "setup-plan.sh")
+
+
+def _install_ps_scripts(repo: Path) -> None:
+    d = repo / ".specify" / "scripts" / "powershell"
+    d.mkdir(parents=True, exist_ok=True)
+    shutil.copy(COMMON_PS, d / "common.ps1")
+    shutil.copy(SETUP_PLAN_PS, d / "setup-plan.ps1")
+
+
+def _minimal_templates(repo: Path) -> None:
+    tdir = repo / ".specify" / "templates"
+    tdir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(PLAN_TEMPLATE, tdir / "plan-template.md")
+
+
+def _git_init(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init", "-q"], cwd=repo, check=True
+    )
+
+
+@pytest.fixture
+def plan_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git_init(repo)
+    (repo / ".specify").mkdir()
+    _minimal_templates(repo)
+    _install_bash_scripts(repo)
+    _install_ps_scripts(repo)
+    return repo
+
+
+@requires_bash
+def test_setup_plan_passes_custom_branch_when_feature_json_valid(plan_repo: Path) -> None:
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feature/my-feature-branch"],
+        cwd=plan_repo,
+        check=True,
+    )
+    feat = plan_repo / "specs" / "001-tiny-notes-app"
+    feat.mkdir(parents=True)
+    (feat / "spec.md").write_text("# spec\n", encoding="utf-8")
+    (plan_repo / ".specify" / "feature.json").write_text(
+        json.dumps({"feature_directory": "specs/001-tiny-notes-app"}),
+        encoding="utf-8",
+    )
+    script = plan_repo / ".specify" / "scripts" / "bash" / "setup-plan.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=plan_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (feat / "plan.md").is_file()
+
+
+@requires_bash
+def test_setup_plan_fails_custom_branch_without_feature_json(plan_repo: Path) -> None:
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feature/my-feature-branch"],
+        cwd=plan_repo,
+        check=True,
+    )
+    script = plan_repo / ".specify" / "scripts" / "bash" / "setup-plan.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=plan_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "Not on a feature branch" in result.stderr
+
+
+@requires_bash
+def test_setup_plan_numbered_branch_unchanged_without_feature_json(
+    plan_repo: Path,
+) -> None:
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "001-tiny-notes-app"],
+        cwd=plan_repo,
+        check=True,
+    )
+    feat = plan_repo / "specs" / "001-tiny-notes-app"
+    feat.mkdir(parents=True)
+    (feat / "spec.md").write_text("# spec\n", encoding="utf-8")
+    script = plan_repo / ".specify" / "scripts" / "bash" / "setup-plan.sh"
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=plan_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (feat / "plan.md").is_file()
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _POWERSHELL), reason="no PowerShell available")
+def test_setup_plan_ps_passes_custom_branch_when_feature_json_valid(plan_repo: Path) -> None:
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feature/my-feature-branch"],
+        cwd=plan_repo,
+        check=True,
+    )
+    feat = plan_repo / "specs" / "001-tiny-notes-app"
+    feat.mkdir(parents=True)
+    (feat / "spec.md").write_text("# spec\n", encoding="utf-8")
+    (plan_repo / ".specify" / "feature.json").write_text(
+        json.dumps({"feature_directory": "specs/001-tiny-notes-app"}),
+        encoding="utf-8",
+    )
+    script = plan_repo / ".specify" / "scripts" / "powershell" / "setup-plan.ps1"
+    exe = "pwsh" if HAS_PWSH else _POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(script)],
+        cwd=plan_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (feat / "plan.md").is_file()

--- a/tests/test_setup_plan_feature_json.py
+++ b/tests/test_setup_plan_feature_json.py
@@ -157,3 +157,25 @@ def test_setup_plan_ps_passes_custom_branch_when_feature_json_valid(plan_repo: P
     )
     assert result.returncode == 0, result.stderr + result.stdout
     assert (feat / "plan.md").is_file()
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _POWERSHELL), reason="no PowerShell available")
+def test_setup_plan_ps_fails_custom_branch_without_feature_json(
+    plan_repo: Path,
+) -> None:
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "feature/my-feature-branch"],
+        cwd=plan_repo,
+        check=True,
+    )
+    script = plan_repo / ".specify" / "scripts" / "powershell" / "setup-plan.ps1"
+    exe = "pwsh" if HAS_PWSH else _POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(script)],
+        cwd=plan_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "Not on a feature branch" in result.stderr


### PR DESCRIPTION
This PR Closes #2305.

## Summary

This PR is based on the discussion in #2305, with clarification from @mnriem that Git branch creation and spec directory creation are intentionally separate in Spec Kit, this change preserves that behavior.

The issue addressed here is narrower than the original directory naming expectation from #2305. After the discussion with @mnriem, I focused this PR on the later `/speckit.plan` behavior: `/speckit.plan` could fail on a custom Git branch like `feature/my-feature-branch` before using the existing feature context from `.specify/feature.json`.

That meant a valid setup like this could still be rejected:

```json
{"feature_directory":"specs/001-notes-app"}
```

This PR updates `setup-plan` so it can continue when `.specify/feature.json` points to a valid existing feature directory. If `feature.json` is missing, stale, points to a non-existent directory, or does not match the resolved feature directory, the existing branch validation behavior still runs.

## What changed

- Added Bash and PowerShell helpers to check whether `.specify/feature.json` matches the resolved feature directory.
- Updated `setup-plan.sh` and `setup-plan.ps1` to use that metadata check before failing on the branch-name pattern.
- Added focused regression tests for the custom-branch plus valid-`feature.json` case and fallback behavior

## What did not change

Based on @mnriem's clarification in #2305, this PR doesn't change `/speckit.specify`, branch naming, spec directory naming, or make Git branch names the source of truth.

`/speckit.specify` still uses the existing feature branch and directory behavior. This change is only about letting `/speckit.plan` continue when existing feature metadata already resolves the correct feature directory.

## Test selection reasoning

| Changed file | Affects | Test | Why |
|---|---|---|---|
| `scripts/bash/setup-plan.sh` | `/speckit.plan` | T1, T2, T3 | `setup-plan.sh` is invoked by the plan workflow |
| `scripts/powershell/setup-plan.ps1` | `/speckit.plan` | T1, T2, T3 | PowerShell setup path for the plan workflow |
| `scripts/bash/common.sh` | `/speckit.plan`, shared script consumers | T1, T2, T3, T4 | Added helper is called by `setup-plan.sh`; file is shared, so existing consistency/full-suite tests were also run |
| `scripts/powershell/common.ps1` | `/speckit.plan`, shared script consumers | T1, T2, T3, T4 | Added helper is called by `setup-plan.ps1`; file is shared, so existing consistency/full-suite tests were also run |
| `tests/test_setup_plan_feature_json.py` | Regression coverage | T1 | Covers custom branch + valid/missing `feature.json` and normal numbered branch behavior |

### Required tests

- T1: focused regression tests for `setup-plan` feature metadata behavior
- T2: `/speckit.specify` manual prerequisite workflow
- T3: `/speckit.plan` manual workflow on a custom branch with valid `.specify/feature.json`
- T4: `/speckit.tasks` downstream smoke test
- T5: `tests/test_agent_config_consistency.py`
- T6: full pytest suite

## Testing

I did focused regression tests from native PowerShell:

```powershell
.\.venv\Scripts\python.exe -m pytest tests/test_setup_plan_feature_json.py -v
# 1 passed, 4 skipped
# The skipped tests are bash-gated and do not run under native PowerShell.
```

also focused regression tests through Git Bash:

```powershell
& "C:\Program Files\Git\bin\bash.exe" -lc "cd /c/Projects/spec-kit && .venv/Scripts/python.exe -m pytest tests/test_setup_plan_feature_json.py -v"
# 5 passed
```

Used the existing consistency test:

```powershell
.\.venv\Scripts\python.exe -m pytest tests/test_agent_config_consistency.py -q
# 24 passed
```

As well as ran a full test suite:

```powershell
python -m pytest -q
# 1556 passed, 0 failed, 115 skipped, 18 warnings in 58.49s
```

Normal diff check just in case:

```powershell
git diff --check
# no output
```

## Script level validation

I also tested the setup scripts directly in temporary repos for both Bash and PowerShell:

- Custom branch with valid `.specify/feature.json`: `setup-plan` exited 0, reused the existing feature directory, created `plan.md`, did not create a duplicate specs folder, and did not switch branches.
- Custom branch without `.specify/feature.json`: `setup-plan` kept the existing behavior and failed with `ERROR: Not on a feature branch`, with no `plan.md` created.
- Normal numbered branch: existing behavior still worked and `plan.md` was created normally.

## Manual testing

I also ran the flow through GitHub Copilot in VS Code on Windows.

I initialized a fresh project with:

```powershell
python -m uv run specify init C:\Projects\speckit-2305-manual-test --integration copilot --offline
```

Then I ran `/speckit.specify`, which created branch `001-notes-app` and `specs/001-notes-app/spec.md`.

To reproduce the custom-branch scenario from #2305, I committed that initial output, switched to `feature/my-feature-branch`, and added:

```json
{"feature_directory":"specs/001-notes-app"}
```

Then I ran `/speckit.plan` in a fresh Copilot chat. It stayed on `feature/my-feature-branch`, reused `specs/001-notes-app`, and created `plan.md` without the previous `ERROR: Not on a feature branch` failure.

I also ran `/speckit.tasks` as a smoke test. It created `tasks.md` in the same feature directory and did not create a duplicate specs folder.

Key evidence after `/speckit.plan`:
<img width="760" height="1210" alt="image" src="https://github.com/user-attachments/assets/bba41f26-9732-4c4c-b4bc-a122762031a8" />

## Follow-up review cleanup

After the Copilot review, I pushed a follow up commit to harden the metadata validation path:

- Guarded Bash `jq` / `python3` parsing so parse failures return non-zero from the helper instead of interacting poorly with `set -e`.
- Added the grep/sed fallback to match the existing feature-path parsing behavior.
- Added PowerShell regression coverage for the custom-branch plus missing `feature.json` fallback path.
- Updated this PRs wording.

## AI disclosure

I used ChatGPT and GitHub Copilot to help investigate the issue, review test coverage and also helping me polish this description (edit: also to fix the last problem which i reviewed myself and commit it with Cursor). I personally wrote the script changes, ran the repro, tests, and manual validation, and reviewed the final diff before submitting.