### PR TITLE
fix: replace xargs trim with sed to handle quotes in descriptions

### DIFF
--- a/extensions/git/scripts/bash/create-new-feature.sh
+++ b/extensions/git/scripts/bash/create-new-feature.sh
@@ -95,7 +95,7 @@ if [ -z "$FEATURE_DESCRIPTION" ]; then
 fi
 
 # Trim whitespace and validate description is not empty
-FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | xargs)
+FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
 if [ -z "$FEATURE_DESCRIPTION" ]; then
     echo "Error: Feature description cannot be empty or contain only whitespace" >&2
     exit 1

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -84,7 +84,7 @@ if [ -z "$FEATURE_DESCRIPTION" ]; then
 fi
 
 # Trim whitespace and validate description is not empty (e.g., user passed only whitespace)
-FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | xargs)
+FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
 if [ -z "$FEATURE_DESCRIPTION" ]; then
     echo "Error: Feature description cannot be empty or contain only whitespace" >&2
     exit 1

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -1257,3 +1257,67 @@ class TestFeatureDirectoryResolution:
                 break
         else:
             pytest.fail("FEATURE_DIR not found in PowerShell output")
+
+
+# ── Description Quoting Tests (issue #2339) ──────────────────────────────────
+
+
+@requires_bash
+class TestDescriptionQuoting:
+    """Descriptions with quotes, apostrophes, and backslashes must not break the script.
+
+    Regression tests for https://github.com/github/spec-kit/issues/2339
+    """
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "Add user's profile page",
+            "Fix the \"login\" bug",
+            "Handle path\\with\\backslashes",
+            "It's a \"complex\" feature\\here",
+        ],
+        ids=["apostrophe", "double-quotes", "backslashes", "mixed"],
+    )
+    def test_core_script_handles_special_chars(self, git_repo: Path, description: str):
+        """Core create-new-feature.sh succeeds with special characters in description."""
+        result = run_script(git_repo, "--dry-run", "--short-name", "feat", description)
+        assert result.returncode == 0, (
+            f"Script failed for description {description!r}: {result.stderr}"
+        )
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "Add user's profile page",
+            "Fix the \"login\" bug",
+            "Handle path\\with\\backslashes",
+            "It's a \"complex\" feature\\here",
+        ],
+        ids=["apostrophe", "double-quotes", "backslashes", "mixed"],
+    )
+    def test_ext_script_handles_special_chars(self, ext_git_repo: Path, description: str):
+        """Extension create-new-feature.sh succeeds with special characters in description."""
+        script = (
+            ext_git_repo / ".specify" / "extensions" / "git" / "scripts" / "bash" / "create-new-feature.sh"
+        )
+        result = subprocess.run(
+            ["bash", str(script), "--dry-run", "--short-name", "feat", description],
+            cwd=ext_git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"Script failed for description {description!r}: {result.stderr}"
+        )
+
+    def test_whitespace_only_still_rejected(self, git_repo: Path):
+        """Whitespace-only descriptions must still be rejected after trimming."""
+        result = run_script(git_repo, "--dry-run", "--short-name", "feat", "   ")
+        assert result.returncode != 0
+        assert "empty" in result.stderr.lower() or "whitespace" in result.stderr.lower()
+
+    def test_plain_description_still_works(self, git_repo: Path):
+        """Plain description without special characters continues to work."""
+        result = run_script(git_repo, "--dry-run", "--short-name", "feat", "Add login feature")
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

`create-new-feature.sh` uses `xargs` to strip surrounding whitespace from the `FEATURE_DESCRIPTION` argument. Because `xargs` re-parses its stdin as shell-like tokens, any input containing a single quote (`'`), double quote (`"`), or backslash (`\`) aborts with `xargs: unterminated quote`.

Natural-language descriptions frequently include apostrophes (`user's`, `can't`, etc.), so this is easy to trigger in normal usage.

## Changes

Replace the `xargs` call with a `sed`-based trim in both locations:

- `scripts/bash/create-new-feature.sh` (line 87)
- `extensions/git/scripts/bash/create-new-feature.sh` (line 98)

```bash
# Before
FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | xargs)

# After
FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
```

The PowerShell equivalents already use `.Trim()` and are not affected.

## Tests

Added `TestDescriptionQuoting` class to `tests/test_timestamp_branches.py` with 10 tests:

- **8 positive tests** — apostrophes, double quotes, backslashes, and mixed special characters succeed in both core and extension scripts
- **1 negative test** — whitespace-only descriptions are still rejected
- **1 regression guard** — plain descriptions continue to work

Full suite: 1677 passed.

Fixes #2339