### PR TITLE
Add a11y-governance to community catalog

### DIFF
--- a/docs/community/presets.md
+++ b/docs/community/presets.md
@@ -7,6 +7,7 @@ The following community-contributed presets customize how Spec Kit behaves — o
 
 | Preset | Purpose | Provides | Requires | URL |
 |--------|---------|----------|----------|-----|
+| A11Y Governance | Adds WCAG 2.2 AA accessibility checks, bilingual DE/EN delivery, CEFR-B2 readability, CLI accessibility, and inclusive-content guidance | 9 templates, 3 commands | — | [spec-kit-preset-a11y-governance](https://github.com/hindermath/spec-kit-preset-a11y-governance) |
 | AIDE In-Place Migration | Adapts the AIDE extension workflow for in-place technology migrations (X → Y pattern) — adds migration objectives, verification gates, knowledge documents, and behavioral equivalence criteria | 2 templates, 8 commands | AIDE extension | [spec-kit-presets](https://github.com/mnriem/spec-kit-presets) |
 | Canon Core | Adapts original Spec Kit workflow to work together with Canon extension | 2 templates, 8 commands | — | [spec-kit-canon](https://github.com/maximiliamus/spec-kit-canon) |
 | Claude AskUserQuestion | Upgrades `/speckit.clarify` and `/speckit.checklist` on Claude Code from Markdown-table prompts to the native AskUserQuestion picker, with a recommended option and reasoning on every question | 2 commands | — | [spec-kit-preset-claude-ask-questions](https://github.com/0xrafasec/spec-kit-preset-claude-ask-questions) |

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -1,8 +1,36 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-04-15T00:00:00Z",
+  "updated_at": "2026-04-27T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/presets/catalog.community.json",
   "presets": {
+    "a11y-governance": {
+      "name": "A11Y Governance",
+      "id": "a11y-governance",
+      "version": "0.2.0",
+      "description": "Adds accessibility, bilingual DE/EN delivery, CEFR-B2 readability, and inclusive-content governance to Spec Kit.",
+      "author": "Thorsten Hindermann",
+      "repository": "https://github.com/hindermath/spec-kit-preset-a11y-governance",
+      "download_url": "https://github.com/hindermath/spec-kit-preset-a11y-governance/archive/refs/tags/v0.2.0.zip",
+      "homepage": "https://github.com/hindermath/spec-kit-preset-a11y-governance",
+      "documentation": "https://github.com/hindermath/spec-kit-preset-a11y-governance/blob/main/README.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.8.0"
+      },
+      "provides": {
+        "templates": 9,
+        "commands": 3
+      },
+      "tags": [
+        "a11y",
+        "accessibility",
+        "bilingual",
+        "wcag",
+        "inclusion"
+      ],
+      "created_at": "2026-04-27T00:00:00Z",
+      "updated_at": "2026-04-27T00:00:00Z"
+    },
     "aide-in-place": {
       "name": "AIDE In-Place Migration",
       "id": "aide-in-place",
@@ -16,7 +44,9 @@
       "license": "MIT",
       "requires": {
         "speckit_version": ">=0.2.0",
-        "extensions": ["aide"]
+        "extensions": [
+          "aide"
+        ]
       },
       "provides": {
         "templates": 2,


### PR DESCRIPTION
## Preset Submission

**Preset Name**: A11Y Governance
**Preset ID**: a11y-governance
**Version**: 0.2.0
**Repository**: https://github.com/hindermath/spec-kit-preset-a11y-governance

### Checklist
- [x] Valid preset.yml manifest
- [x] README.md with description and usage
- [x] LICENSE file included
- [x] GitHub release created
- [x] Preset tested with specify preset add --dev
- [x] Templates resolve correctly (specify preset resolve)
- [x] Commands register to agent directories
- [x] Commands match template sections (command + template are coherent)
- [x] Added to presets/catalog.community.json
- [x] Added row to docs/community/presets.md table

### Verification
- Published version tag and GitHub release are available.
- Smoke-tested installation from the GitHub tag ZIP URL with Spec Kit 0.8.1.
- Smoke-tested the stacked six-preset setup in priority order.
- Verified composed constitution-template resolution and standalone agent-guidance addendum resolution.