### PR TITLE
chore: release 0.8.2, begin 0.8.3.dev0 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,6 @@
 
 ### Changed
 
-- Potential fix for pull request finding
-- Potential fix for pull request finding
-- Potential fix for pull request finding
-- Potential fix for pull request finding
-- Potential fix for pull request finding
-- Potential fix for pull request finding
-- Potential fix for pull request finding
 - Add MarkItDown Document Converter extension to community catalog (#2390)
 - feat: Speckit preset fiction book v1.7 - Support for RAG (Chroma DB) offline semantic search (#2367)
 - fix(extensions): use explicit UTF-8 encoding when reading manifest YAML (#2370)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 <!-- insert new changelog below this comment -->
 
+## [0.8.2] - 2026-04-28
+
+### Changed
+
+- Potential fix for pull request finding
+- Potential fix for pull request finding
+- Potential fix for pull request finding
+- Potential fix for pull request finding
+- Potential fix for pull request finding
+- Potential fix for pull request finding
+- Potential fix for pull request finding
+- Add MarkItDown Document Converter extension to community catalog (#2390)
+- feat: Speckit preset fiction book v1.7 - Support for RAG (Chroma DB) offline semantic search (#2367)
+- fix(extensions): use explicit UTF-8 encoding when reading manifest YAML (#2370)
+- catalog: add m365 community extension
+- docs: replace deprecated --ai flag with --integration in all documentation (#2359)
+- feat(extensions,presets): authenticate GitHub-hosted catalog and download requests with GITHUB_TOKEN/GH_TOKEN (#2331)
+- Update extensify to v1.1.0 in community catalog (#2337)
+- feat(init): deprecate --no-git flag, gate deprecations at v0.10.0 (#2357)
+- Add Spec Orchestrator extension to community catalog (#2350)
+- chore: release 0.8.1, begin 0.8.2.dev0 development (#2356)
+
 ## [0.8.1] - 2026-04-24
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.8.2.dev0"
+version = "0.8.2"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "specify-cli"
-version = "0.8.2"
+version = "0.8.3.dev0"
 description = "Specify CLI, part of GitHub Spec Kit. A tool to bootstrap your projects for Spec-Driven Development (SDD)."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Automated release of 0.8.2.

This PR was created by the Release Trigger workflow. The git tag `v0.8.2` has already been pushed and the release artifacts are being built.

Merging this PR will set `main` to `0.8.3.dev0` so that development installs are clearly marked as pre-release.