### PR TITLE
chore(catalog): bump v-model extension to v0.6.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -2397,8 +2397,8 @@
       "id": "v-model",
       "description": "Enforces V-Model paired generation of development specs and test specs with full traceability.",
       "author": "leocamello",
-      "version": "0.5.0",
-      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.5.0.zip",
+      "version": "0.6.0",
+      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.6.0.zip",
       "repository": "https://github.com/leocamello/spec-kit-v-model",
       "homepage": "https://github.com/leocamello/spec-kit-v-model",
       "documentation": "https://github.com/leocamello/spec-kit-v-model/blob/main/README.md",
@@ -2420,9 +2420,9 @@
       ],
       "verified": false,
       "downloads": 0,
-      "stars": 0,
+      "stars": 21,
       "created_at": "2026-02-20T00:00:00Z",
-      "updated_at": "2026-04-06T00:00:00Z"
+      "updated_at": "2026-04-25T00:00:00Z"
     },
     "verify": {
       "name": "Verify Extension",


### PR DESCRIPTION
Updates the `v-model` entry in `extensions/catalog.community.json` to point at the new [v0.6.0 release](https://github.com/leocamello/spec-kit-v-model/releases/tag/v0.6.0).

Follows the same pattern as the previous bumps:
- v0.2.0 → #1656
- v0.3.0 → #1661
- v0.4.0 → #1665
- v0.5.0 → #2108

## Catalog changes

| Field | Before | After |
|---|---|---|
| `version` | 0.5.0 | **0.6.0** |
| `download_url` | …/v0.5.0.zip | **…/v0.6.0.zip** |
| `stars` | 0 | **21** (live count from GitHub API) |
| `updated_at` | 2026-04-06 | **2026-04-25** (release date) |

`commands` count stays at **14** — no new commands were added in this release; the work was domain overlays, lifecycle, and standards enrichment on the existing command set.

## What's new in v0.6.0

- **Domain Overlay Architecture** — All 11 V-Model commands are now domain-agnostic. A `domain:` field in `config-template.yml` activates the correct overlay (`automotive`, `medical`, `aerospace`, `general`), injecting domain-specific standards, terminology, and output conventions without changing core command logic. **9 overlay manifests** ship out of the box.
- **ID Lifecycle Model** — Every V-Model ID now has an explicit state machine: **Proposed → Active → Deprecated → Removed**. All templates and agent prompts include a mandatory `## Lifecycle History` section, preserving the append-only audit trail required for regulatory submissions.
- **Standards Enrichment** — All 11 commands declare their governing standards and map them to specific execution steps (e.g. `### Step 3. Quality Criteria (IEEE 1012:2016 / ISO 25010:2023)`). Standards applied: IEEE 1012:2016, ISO 25010:2023, ISO 42030:2019, ISO 12207:2017, INCOSE SE Handbook, IEEE 1016, IEEE 29148, ISO 29119-4, ISO 14971, DO-178C, ARP4761A.
- **Aerospace (DO-178C) Support** — New **Flight Warning Computer (FWC)** golden fixture: a full DO-178C DAL-A benchmark with 10 artifact files covering a 5-function avionics system (overspeed, stall, altitude alerting, GPWS, attitude limit). Includes 11 new LLM-as-judge eval tests and a brownfield-evolution guide.
- **Test Infrastructure** — Fixtures reorganised into `tests/fixtures/commands/` namespace with `input/` + `expected/` sub-directories; traceability LLM eval timeout fix; minimal interface contract fixture enriched with explicit types and protocol specs.

| Metric | v0.5.0 | v0.6.0 |
|---|---|---|
| Commands | 14 | 14 |
| Domain overlays | 0 | **9** |
| LLM-as-judge evals | 42 | **53** |
| Dogfooded feature specs | 5 | **7** |

Full details: [CHANGELOG.md](https://github.com/leocamello/spec-kit-v-model/blob/v0.6.0/CHANGELOG.md)