### PR TITLE
Fix opencode workflow dispatch to use run subcommand

### DIFF
--- a/src/specify_cli/integrations/opencode/__init__.py
+++ b/src/specify_cli/integrations/opencode/__init__.py
@@ -19,3 +19,27 @@ class OpencodeIntegration(MarkdownIntegration):
         "extension": ".md",
     }
     context_file = "AGENTS.md"
+
+    def build_exec_args(
+        self,
+        prompt: str,
+        *,
+        model: str | None = None,
+        output_json: bool = True,
+    ) -> list[str] | None:
+        args = [self.key, "run"]
+
+        message = prompt
+        if prompt.startswith("/"):
+            command, _, remainder = prompt[1:].partition(" ")
+            if command:
+                args.extend(["--command", command])
+                message = remainder
+
+        if model:
+            args.extend(["-m", model])
+        if output_json:
+            args.extend(["--format", "json"])
+        if message:
+            args.append(message)
+        return args

--- a/tests/integrations/test_integration_opencode.py
+++ b/tests/integrations/test_integration_opencode.py
@@ -1,5 +1,7 @@
 """Tests for OpencodeIntegration."""
 
+from specify_cli.integrations import get_integration
+
 from .test_integration_base_markdown import MarkdownIntegrationTests
 
 
@@ -9,3 +11,49 @@ class TestOpencodeIntegration(MarkdownIntegrationTests):
     COMMANDS_SUBDIR = "command"
     REGISTRAR_DIR = ".opencode/command"
     CONTEXT_FILE = "AGENTS.md"
+
+    def test_build_exec_args_uses_run_command_dispatch(self):
+        integration = get_integration(self.KEY)
+
+        args = integration.build_exec_args(
+            "/speckit.specify build a login page",
+            output_json=False,
+        )
+
+        assert args == [
+            "opencode",
+            "run",
+            "--command",
+            "speckit.specify",
+            "build a login page",
+        ]
+        assert "-p" not in args
+        assert "--output-format" not in args
+
+    def test_build_exec_args_maps_model_and_json_flags(self):
+        integration = get_integration(self.KEY)
+
+        args = integration.build_exec_args(
+            "/speckit.plan add OAuth",
+            model="anthropic/claude-sonnet-4",
+            output_json=True,
+        )
+
+        assert args == [
+            "opencode",
+            "run",
+            "--command",
+            "speckit.plan",
+            "-m",
+            "anthropic/claude-sonnet-4",
+            "--format",
+            "json",
+            "add OAuth",
+        ]
+
+    def test_build_exec_args_keeps_plain_prompt_dispatch(self):
+        integration = get_integration(self.KEY)
+
+        args = integration.build_exec_args("explain this repository", output_json=False)
+
+        assert args == ["opencode", "run", "explain this repository"]


### PR DESCRIPTION
## Description

Fixes #2409.

This updates the opencode integration dispatch path to use `opencode run --command <command>` instead of inheriting the generic Markdown integration’s `-p` prompt flag. The inherited dispatch generated unsupported opencode CLI arguments, causing workflow command execution to print help output instead of running the requested Spec Kit command.

The fix also maps opencode-specific flags correctly:
- `--command` for command dispatch
- `-m` for model selection
- `--format json` for captured JSON output

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv run python -m pytest -q`
- [ ] Tested with a sample project (if applicable)

Additional focused checks:
- `uv run python -m pytest tests/integrations/test_integration_opencode.py -q`
- `uv run python -m pytest tests/integrations/test_base.py tests/integrations/test_integration_opencode.py tests/test_agent_config_consistency.py -q`

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

I used Codex to inspect the issue and code path, implement the focused fix, add regression tests, and run validation locally.
