### PR TITLE
fix: include --from git+... in upgrade hint to avoid PyPI squat package

### DIFF
--- a/extensions/EXTENSION-DEVELOPMENT-GUIDE.md
+++ b/extensions/EXTENSION-DEVELOPMENT-GUIDE.md
@@ -669,7 +669,7 @@ hooks:
 
 **Error**: `Extension requires spec-kit >=0.2.0`
 
-- **Fix**: Update spec-kit with `uv tool install specify-cli --force`
+- **Fix**: Update spec-kit with `uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git`. The bare `specify-cli` package on PyPI is a different, unrelated project — installing it without `--from git+...` will give you a stub CLI that does not include `extension`, `preset`, or other spec-kit commands.
 
 **Error**: `Command file not found`
 

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1108,7 +1108,7 @@ class ExtensionManager:
                 raise CompatibilityError(
                     f"Extension requires spec-kit {required}, "
                     f"but {speckit_version} is installed.\n"
-                    f"Upgrade spec-kit with: uv tool install specify-cli --force"
+                    f"Upgrade spec-kit with: {REINSTALL_COMMAND}"
                 )
         except InvalidSpecifier:
             raise CompatibilityError(f"Invalid version specifier: {required}")

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -27,7 +27,7 @@ import yaml
 from packaging import version as pkg_version
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
 
-from .extensions import ExtensionRegistry, normalize_priority
+from .extensions import REINSTALL_COMMAND, ExtensionRegistry, normalize_priority
 
 
 def _substitute_core_template(
@@ -576,7 +576,7 @@ class PresetManager:
                 raise PresetCompatibilityError(
                     f"Preset requires spec-kit {required}, "
                     f"but {speckit_version} is installed.\n"
-                    f"Upgrade spec-kit with: uv tool install specify-cli --force"
+                    f"Upgrade spec-kit with: {REINSTALL_COMMAND}"
                 )
         except InvalidSpecifier:
             raise PresetCompatibilityError(


### PR DESCRIPTION
## Summary

The upgrade hint surfaced by spec-kit'''s compatibility errors was missing `--from git+https://github.com/github/spec-kit.git`, so users who followed it landed on an unrelated PyPI package called `specify-cli` (no author, no project URLs) which ships a stub CLI that lacks `extension`, `preset`, and most spec-kit commands. This is the root cause behind #1982 ("0.4.2 removed extension command from specify").

Three call sites were affected:

- `src/specify_cli/extensions.py:1111` — `CompatibilityError` on incompatible extension
- `src/specify_cli/presets.py:579` — `PresetCompatibilityError` on incompatible preset
- `extensions/EXTENSION-DEVELOPMENT-GUIDE.md:672` — troubleshooting doc

`extensions.py` already defines `REINSTALL_COMMAND` (the canonical, full command). The fix reuses that constant in `extensions.py` and imports it from `presets.py` so the three sites can never drift again. The doc fix also adds a one-line note explaining the PyPI name collision so the same advice does not get re-stripped during a future copyedit.

## Why a PR (per maintainer request)

In #1982 @mnriem asked for a PR to make this clear:

> No idea so we will have to make sure our docs make it clear that one CANNOT use PyPi. Want to take on a PR for that?

The original reporter said they would bundle it with another fix but it has been ~30 days with no PR, so I picked it up.

## Test plan

- [x] `pytest tests/test_extensions.py tests/test_presets.py` — 434 passed
- [x] `python -c "from specify_cli.extensions import REINSTALL_COMMAND; print(REINSTALL_COMMAND)"` — prints the full GitHub-sourced command
- [x] `python -c "from specify_cli.presets import REINSTALL_COMMAND; print(REINSTALL_COMMAND)"` — same value, re-exported
- [ ] Manual: trigger an extension version mismatch and verify the error message includes `--from git+https://github.com/github/spec-kit.git`

Refs #1982