### PR TITLE
fix(workflows): require project for catalog list

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -5806,7 +5806,7 @@ def workflow_catalog_list():
     """List configured workflow catalog sources."""
     from .workflows.catalog import WorkflowCatalog, WorkflowCatalogError
 
-    project_root = Path.cwd()
+    project_root = _require_specify_project()
     catalog = WorkflowCatalog(project_root)
 
     try:

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -1117,6 +1117,7 @@ class TestIntegrationCatalogDiscoveryCLI:
             ["workflow", "remove", "demo"],
             ["workflow", "search"],
             ["workflow", "info", "demo"],
+            ["workflow", "catalog", "list"],
             ["workflow", "catalog", "add", "https://example.com/catalog.yml"],
             ["workflow", "catalog", "remove", "0"],
         ]


### PR DESCRIPTION
Follow-up to #2428.

## What changed

- Make `specify workflow catalog list` use the shared spec-kit project guard.
- Extend the project guard regression test to cover that subcommand.

## Validation

- `uvx ruff check src/specify_cli/__init__.py tests/integrations/test_cli.py`
- `uv run pytest tests/integrations/test_cli.py -q`
- `uv run pytest tests/test_workflows.py -q`