### PR TITLE
fix(yaml): add parameter definitions for goose recipe validation

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -255,7 +255,17 @@ class CommandRegistrar:
         description = frontmatter.get("description", "")
         if not isinstance(description, str):
             description = str(description) if description is not None else ""
-        return YamlIntegration._render_yaml(title, description, body, source_id)
+        params = None
+        if "{{args}}" in body:
+            params = [
+                {
+                    "key": "args",
+                    "input_type": "string",
+                    "requirement": "user_prompt",
+                    "description": "Arguments to pass to the command",
+                }
+            ]
+        return YamlIntegration._render_yaml(title, description, body, source_id, parameters=params)
 
     def render_skill_command(
         self,

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -1202,7 +1202,13 @@ class YamlIntegration(IntegrationBase):
         return text.replace(".", " ").replace("-", " ").replace("_", " ").title()
 
     @staticmethod
-    def _render_yaml(title: str, description: str, body: str, source_id: str) -> str:
+    def _render_yaml(
+        title: str,
+        description: str,
+        body: str,
+        source_id: str,
+        parameters: list[dict[str, Any]] | None = None,
+    ) -> str:
         """Render a YAML recipe file from title, description, and body.
 
         Produces a Goose-compatible recipe with a literal block scalar
@@ -1219,6 +1225,9 @@ class YamlIntegration(IntegrationBase):
             "extensions": [{"type": "builtin", "name": "developer"}],
             "activities": ["Spec-Driven Development"],
         }
+
+        if parameters:
+            header["parameters"] = parameters
 
         header_yaml = yaml.safe_dump(
             header,
@@ -1286,8 +1295,21 @@ class YamlIntegration(IntegrationBase):
                 context_file=self.context_file or "",
             )
             _, body = self._split_frontmatter(processed)
+            # Build parameter definitions for template variables used in the body
+            params = None
+            if "{{args}}" in body:
+                params = [
+                    {
+                        "key": "args",
+                        "input_type": "string",
+                        "requirement": "user_prompt",
+                        "description": "Arguments to pass to the command",
+                    }
+                ]
+
             yaml_content = self._render_yaml(
-                title, description, body, f"templates/commands/{src_file.name}"
+                title, description, body, f"templates/commands/{src_file.name}",
+                parameters=params,
             )
             dst_name = self.command_filename(src_file.stem)
             dst_file = self.write_file_and_record(

--- a/tests/integrations/test_integration_base_yaml.py
+++ b/tests/integrations/test_integration_base_yaml.py
@@ -142,6 +142,28 @@ class YamlIntegrationTests:
             "YAML recipe still contains $ARGUMENTS instead of {{args}}"
         )
 
+
+    def test_yaml_has_parameters_when_args_placeholder(self, tmp_path):
+        """YAML recipes with {{args}} must include a parameters definition."""
+        i = get_integration(self.KEY)
+        m = IntegrationManifest(self.KEY, tmp_path)
+        created = i.setup(tmp_path, m)
+        cmd_files = [f for f in created if "scripts" not in f.parts]
+        assert len(cmd_files) > 0
+        for f in cmd_files:
+            content = f.read_text(encoding="utf-8")
+            if "{{args}}" in content:
+                lines = content.split("\n")
+                yaml_lines = [l for l in lines if not l.startswith("# Source:")]
+                parsed = yaml.safe_load("\n".join(yaml_lines))
+                assert "parameters" in parsed, (
+                    f"{f.name} uses {{{{args}}}} but has no parameters definition"
+                )
+                params = parsed["parameters"]
+                assert any(p.get("key") == "args" for p in params), (
+                    f"{f.name} parameters missing 'args' key"
+                )
+
     def test_yaml_is_valid(self, tmp_path):
         """Every generated YAML file must parse without errors."""
         i = get_integration(self.KEY)


### PR DESCRIPTION
## Summary

- Add `parameters` field to generated YAML recipe files when `{{args}}` placeholder is used
- Goose recipe validation requires that all template variables have corresponding parameter definitions

## Problem

When running `goose recipe validate` on spec-kit generated recipe files, validation fails with:

```
Error: recipe file is invalid: Missing definitions for parameters in the recipe file: args.
```

This happens because the generated YAML recipes use `{{args}}` in the prompt body but don't define the `args` parameter in the recipe header.

## Fix

- Modified `_render_yaml()` to accept an optional `parameters` argument and include it in the YAML header
- Updated `setup()` to detect `{{args}}` in the prompt body and pass the corresponding parameter definition

## Testing

- Existing YAML integration tests continue to pass
- Generated recipes now include the `parameters` field when `{{args}}` is used

Fixes #2423