### PR TITLE
chore(catalog): Bump architecture-guard to v1.8.0 and memory-md to v0.8.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -174,8 +174,8 @@
       "id": "architecture-guard",
       "description": "Continuous architecture governance for AI-assisted development. Reviews specs, plans, and code for architecture drift, producing structured refactor tasks and evolution proposals.",
       "author": "DyanGalih",
-      "version": "1.6.7",
-      "download_url": "https://github.com/DyanGalih/spec-kit-architecture-guard/archive/refs/tags/v1.6.7.zip",
+      "version": "1.8.0",
+      "download_url": "https://github.com/DyanGalih/spec-kit-architecture-guard/archive/refs/tags/v1.8.0.zip",
       "repository": "https://github.com/DyanGalih/spec-kit-architecture-guard",
       "homepage": "https://github.com/DyanGalih/spec-kit-architecture-guard",
       "documentation": "https://github.com/DyanGalih/spec-kit-architecture-guard/blob/main/README.md",
@@ -200,7 +200,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-05T07:26:00Z",
-      "updated_at": "2026-05-06T22:28:55Z"
+      "updated_at": "2026-05-07T15:37:14Z"
     },
     "archive": {
       "name": "Archive Extension",
@@ -1452,8 +1452,8 @@
       "id": "memory-md",
       "description": "Spec Kit extension for repository-native Markdown memory that captures durable decisions, bugs, and project context",
       "author": "DyanGalih",
-      "version": "0.7.9",
-      "download_url": "https://github.com/DyanGalih/spec-kit-memory-hub/archive/refs/tags/v0.7.9.zip",
+      "version": "0.8.0",
+      "download_url": "https://github.com/DyanGalih/spec-kit-memory-hub/archive/refs/tags/v0.8.0.zip",
       "repository": "https://github.com/DyanGalih/spec-kit-memory-hub",
       "homepage": "https://github.com/DyanGalih/spec-kit-memory-hub",
       "documentation": "https://github.com/DyanGalih/spec-kit-memory-hub/blob/main/README.md",
@@ -1478,7 +1478,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-04-23T00:00:00Z",
-      "updated_at": "2026-05-06T22:28:55Z"
+      "updated_at": "2026-05-07T15:37:14Z"
     },
     "memorylint": {
       "name": "MemoryLint",


### PR DESCRIPTION
## Changes

Updates the community extensions catalog metadata:

1. **Root catalog timestamp** - Updated `updated_at` to `2026-05-07T15:37:14Z`
2. **Extension version updates:**
   - `architecture-guard`: bumped to v1.8.0 with updated download URL
   - `memory-md`: bumped to v0.8.0 with updated download URL
3. **Extension entry timestamps** - Updated `updated_at` fields for both entries to match the catalog refresh time

### Modified Files
- `extensions/catalog.community.json` - Updated root `updated_at`, extension versions, and entry-level timestamps

### Rationale
Keeping catalog and extension-level timestamps current ensures consumers can accurately track when extensions were last verified and when specific extension records changed.