### PR TITLE
Add install directory to docfx.json file references

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -6,7 +6,8 @@
           "*.md",
           "toc.yml",
           "community/*.md",
-          "reference/*.md"
+          "reference/*.md",
+          "install/"
         ]
       },
       {

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -7,7 +7,7 @@
           "toc.yml",
           "community/*.md",
           "reference/*.md",
-          "install/"
+          "install/*.md"
         ]
       },
       {


### PR DESCRIPTION
Fixed broken link for https://github.github.com/spec-kit/install/uv.md

## Description
Fixed broken link for [https://github.github.com/spec-kit/install/uv.md](https://github.github.com/spec-kit/install/uv.md) by including `install` directory in docfx content.

## Testing

Documentation bug fix

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

## AI Disclosure
- [x] I **did not** use AI assistance for this contribution
- [ ] I **did** use AI assistance (describe below)