### PR TITLE
Document project-customizable Articles IV-VI in spec-driven.md

### DIFF
--- a/spec-driven.md
+++ b/spec-driven.md
@@ -318,6 +318,22 @@ No implementation code shall be written before:
 
 This completely inverts traditional AI code generation. Instead of generating code and hoping it works, the LLM must first generate comprehensive tests that define behavior, get them approved, and only then generate implementation.
 
+#### Articles IV, V, and VI: Project-Defined Operational Guardrails
+
+The constitution still defines nine articles, but Articles IV, V, and VI are intentionally project-customizable rather than fixed by Spec Kit itself. In practice, these articles usually capture operational concerns that vary by team and domain, such as integration testing boundaries, observability requirements, and versioning or breaking-change policy.
+
+The default constitution template explicitly leaves these slots open for each project to define:
+
+```text
+### [PRINCIPLE_4_NAME]
+<!-- Example: IV. Integration Testing -->
+
+### [PRINCIPLE_5_NAME]
+<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
+```
+
+That flexibility is deliberate. When a project adopts Spec Kit, maintainers tailor these articles to the system's real constraints, and downstream commands validate against the constitution the project actually defines rather than assuming a single universal wording for IV-VI.
+
 #### Articles VII & VIII: Simplicity and Anti-Abstraction
 
 These paired articles combat over-engineering:


### PR DESCRIPTION
## Summary

Discovered an eligible external Python repository, github/spec-kit, and selected a minimal low-risk follow-up aligned with open issue #2466: spec-driven.md said the constitution defines nine articles but only explained I, II, III, VII, VIII, and IX. The task was to clarify that Articles IV, V, and VI are intentionally project-defined and referenced by the constitution template.

## Verification

Ran `python3 -m compileall .` in the repository after the edit; it completed successfully with exit code 0. For a docs-only patch, this is a lightweight sanity check that the workspace remained intact.

## Risk

- Selected task risk: low
- Files changed: spec-driven.md

## External Live PR Notice

This PR was opened by the ContribArena harness through a bot account after local quality, eligibility, maintainer-fit, and governance gates passed. The change was AI-assisted and is intended to be low-risk and reviewable.