### PR TITLE
Fix paths-only validation in check-prerequisites

### DIFF
--- a/scripts/bash/check-prerequisites.sh
+++ b/scripts/bash/check-prerequisites.sh
@@ -78,11 +78,10 @@ done
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
-# Get feature paths and validate branch
+# Get feature paths
 _paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
 eval "$_paths_output"
 unset _paths_output
-check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 
 # If paths-only mode, output paths and exit (support JSON + paths-only combined)
 if $PATHS_ONLY; then
@@ -111,6 +110,8 @@ if $PATHS_ONLY; then
     fi
     exit 0
 fi
+
+check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 
 # Validate required directories and files
 if [[ ! -d "$FEATURE_DIR" ]]; then

--- a/scripts/powershell/check-prerequisites.ps1
+++ b/scripts/powershell/check-prerequisites.ps1
@@ -56,12 +56,8 @@ EXAMPLES:
 # Source common functions
 . "$PSScriptRoot/common.ps1"
 
-# Get feature paths and validate branch
+# Get feature paths
 $paths = Get-FeaturePathsEnv
-
-if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit:$paths.HAS_GIT)) { 
-    exit 1 
-}
 
 # If paths-only mode, output paths and exit (support combined -Json -PathsOnly)
 if ($PathsOnly) {
@@ -83,6 +79,10 @@ if ($PathsOnly) {
         Write-Output "TASKS: $($paths.TASKS)"
     }
     exit 0
+}
+
+if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit:$paths.HAS_GIT)) { 
+    exit 1 
 }
 
 # Validate required directories and files

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -1,0 +1,64 @@
+"""Regression tests for check-prerequisites paths-only behavior."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import requires_bash
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+BASH_SCRIPT = PROJECT_ROOT / "scripts" / "bash" / "check-prerequisites.sh"
+PS_SCRIPT = PROJECT_ROOT / "scripts" / "powershell" / "check-prerequisites.ps1"
+HAS_PWSH = shutil.which("pwsh") is not None
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """Create a minimal spec-kit-style git repo with a fixed feature directory."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "checkout", "-b", "main"], cwd=tmp_path, check=True)
+
+    specify_dir = tmp_path / ".specify"
+    specify_dir.mkdir()
+    (specify_dir / "feature.json").write_text(
+        json.dumps({"feature_directory": "specs/001-test"}), encoding="utf-8"
+    )
+    (tmp_path / "specs" / "001-test").mkdir(parents=True)
+    return tmp_path
+
+
+@requires_bash
+def test_bash_paths_only_skips_branch_validation(git_repo: Path) -> None:
+    result = subprocess.run(
+        ["bash", str(BASH_SCRIPT), "--json", "--paths-only"],
+        cwd=git_repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["BRANCH"] == "main"
+    assert payload["FEATURE_DIR"].endswith("specs/001-test")
+
+
+@pytest.mark.skipif(not HAS_PWSH, reason="pwsh not available")
+def test_powershell_paths_only_skips_branch_validation(git_repo: Path) -> None:
+    result = subprocess.run(
+        ["pwsh", "-NoLogo", "-NoProfile", "-File", str(PS_SCRIPT), "-Json", "-PathsOnly"],
+        cwd=git_repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["BRANCH"] == "main"
+    assert payload["FEATURE_DIR"].endswith("specs/001-test")

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -1,6 +1,7 @@
 """Regression tests for check-prerequisites paths-only behavior."""
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -15,13 +16,20 @@ PS_SCRIPT = PROJECT_ROOT / "scripts" / "powershell" / "check-prerequisites.ps1"
 HAS_PWSH = shutil.which("pwsh") is not None
 
 
+def _clean_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("SPECIFY_FEATURE", None)
+    env.pop("SPECIFY_FEATURE_DIRECTORY", None)
+    return env
+
+
 @pytest.fixture
 def git_repo(tmp_path: Path) -> Path:
     """Create a minimal spec-kit-style git repo with a fixed feature directory."""
-    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "init", "-q", "--initial-branch", "main"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "checkout", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "init", "-q"], cwd=tmp_path, check=True)
 
     specify_dir = tmp_path / ".specify"
     specify_dir.mkdir()
@@ -40,6 +48,7 @@ def test_bash_paths_only_skips_branch_validation(git_repo: Path) -> None:
         text=True,
         capture_output=True,
         check=False,
+        env=_clean_env(),
     )
 
     assert result.returncode == 0, result.stderr
@@ -56,6 +65,7 @@ def test_powershell_paths_only_skips_branch_validation(git_repo: Path) -> None:
         text=True,
         capture_output=True,
         check=False,
+        env=_clean_env(),
     )
 
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Fixes #2477.

- Move branch validation after the paths-only early exit in bash and PowerShell
- Add a regression test for paths-only on a non-feature branch

Validated with:
- bash scripts/bash/check-prerequisites.sh --json --paths-only
- bash scripts/bash/check-prerequisites.sh --json (still fails on main as expected)