### PR TITLE
ci: add diff whitespace check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Run git diff --check
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "+${PR_BASE_SHA}:refs/checks/pr-base"
+            git diff --check refs/checks/pr-base HEAD
+          elif [ "$PUSH_BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            git diff-tree --check --no-commit-id --root -r "$GITHUB_SHA"
+          else
+            git fetch --no-tags --depth=1 origin "+${PUSH_BEFORE_SHA}:refs/checks/push-before"
+            git diff --check refs/checks/push-before HEAD
+          fi
 
       - name: Run markdownlint-cli2
         uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23


### PR DESCRIPTION
## Summary

Adds a lightweight `git diff --check` validation step to the existing lint workflow.

## Changes

- Keep checkout shallow with `fetch-depth: 1`.
- Fetch only the comparison base needed for the current event.
- Run `git diff --check` against the PR base/checked-out head range on pull requests.
- Run `git diff --check` against the before/checked-out head range on pushes to `main`.

## Notes

This mirrors the local whitespace check we have been using before opening PRs. It catches trailing whitespace, space-before-tab issues, and conflict markers in the changed diff without fetching full repository history.

## Validation

Local:

- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml', encoding='utf-8'))"`
- `git diff --check origin/main`
- `git diff-tree --check --no-commit-id --root -r HEAD`

CI:

- This PR exercises the updated lint workflow through GitHub Actions.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Used AI assistance to inspect the existing lint workflow, add the scoped CI check, and run local validation. The changes were reviewed before submission.
