### PR TITLE
feat: add self-check tip to check output

### DIFF
--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -69,6 +69,8 @@ specify check
 
 Checks that required tools are available on your system: `git` and any CLI-based AI coding agents. IDE-based agents are skipped since they don't require a CLI tool.
 
+This command stays offline. If a command behaves like an older Spec Kit version or an expected CLI feature is missing, run `specify self check` to check whether your local CLI is behind the latest release.
+
 ## Version Information
 
 ```bash

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -388,6 +388,14 @@ Only Spec Kit infrastructure files:
 
 ### "CLI upgrade doesn't seem to work"
 
+If a command behaves like an older Spec Kit version, first check for local CLI drift:
+
+```bash
+specify self check
+```
+
+`specify check` is an offline environment scan; `specify self check` is the CLI version lookup.
+
 Verify the installation:
 
 ```bash

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -1157,6 +1157,8 @@ def check():
     if not any(agent_results.values()):
         console.print("[dim]Tip: Install a coding agent for the best experience[/dim]")
 
+    console.print("[dim]Tip: Run 'specify self check' to verify you have the latest CLI version.[/dim]")
+
 
 def _feature_capabilities() -> dict[str, bool]:
     """Return stable local CLI capability flags for humans and agents."""

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -1157,7 +1157,7 @@ def check():
     if not any(agent_results.values()):
         console.print("[dim]Tip: Install a coding agent for the best experience[/dim]")
 
-    console.print("[dim]Tip: Run 'specify self check' to verify you have the latest CLI version.[/dim]")
+    console.print("[dim]Tip: Run 'specify self check' to verify you have the latest CLI version[/dim]")
 
 
 def _feature_capabilities() -> dict[str, bool]:

--- a/tests/test_check_tool.py
+++ b/tests/test_check_tool.py
@@ -7,7 +7,13 @@ Covers issue https://github.com/github/spec-kit/issues/550:
 
 from unittest.mock import patch, MagicMock
 
-from specify_cli import check_tool
+from typer.testing import CliRunner
+
+from specify_cli import app, check_tool
+from tests.conftest import strip_ansi
+
+
+runner = CliRunner()
 
 
 class TestCheckToolClaude:
@@ -104,3 +110,31 @@ class TestCheckToolOther:
 
         with patch("shutil.which", side_effect=fake_which):
             assert check_tool("kiro-cli") is True
+
+
+class TestCheckTip:
+    """`specify check` should point users to the existing version check."""
+
+    def test_check_shows_self_check_tip(self):
+        with patch("specify_cli.check_tool", return_value=True):
+            result = runner.invoke(app, ["check"])
+
+        output = strip_ansi(result.output)
+        assert result.exit_code == 0
+        assert (
+            "Tip: Run 'specify self check' to verify you have the latest CLI version."
+            in output
+        )
+
+    def test_check_tip_does_not_fetch_latest_release(self):
+        with (
+            patch("specify_cli.check_tool", return_value=True),
+            patch(
+                "specify_cli._version._fetch_latest_release_tag",
+                side_effect=AssertionError("latest release lookup should not run"),
+            ) as fetch_latest,
+        ):
+            result = runner.invoke(app, ["check"])
+
+        assert result.exit_code == 0
+        fetch_latest.assert_not_called()

--- a/tests/test_check_tool.py
+++ b/tests/test_check_tool.py
@@ -122,7 +122,7 @@ class TestCheckTip:
         output = strip_ansi(result.output)
         assert result.exit_code == 0
         assert (
-            "Tip: Run 'specify self check' to verify you have the latest CLI version."
+            "Tip: Run 'specify self check' to verify you have the latest CLI version"
             in output
         )
 


### PR DESCRIPTION
## Summary

Closes #2573.

Keeps `specify check` as an offline environment scan and adds a discoverability tip for the existing `specify self check` version lookup.

## Changes

- Add a `specify self check` tip to `specify check` output.
- Keep `specify check` network-free; no `--latest` option is added.
- Document the offline/version-check split in the core command reference and upgrade troubleshooting.
- Add tests that assert the tip is shown and that `specify check` does not call the latest-release lookup.

## Validation

Local:

- `uv run pytest tests/test_check_tool.py tests/test_upgrade.py -q`
- `uvx ruff check src/ tests/test_check_tool.py tests/test_upgrade.py`
- `git diff --check origin/main`
- `uv run specify check --help`

CI:

- GitHub Actions will run the full PR validation suite.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Used AI assistance to inspect the existing check/self-check flow, adjust the PR based on review feedback, add tests/docs, and run local validation. The changes were reviewed before submission.
