### PR TITLE
Update Agent Governance extension to v1.1.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -73,8 +73,8 @@
       "id": "agent-governance",
       "description": "Project-local agent governance memory and context projection.",
       "author": "bigben",
-      "version": "1.0.0",
-      "download_url": "https://github.com/bigsmartben/spec-kit-agent-governance/archive/refs/tags/v1.0.0.zip",
+      "version": "1.1.0",
+      "download_url": "https://github.com/bigsmartben/spec-kit-agent-governance/archive/refs/tags/v1.1.0.zip",
       "repository": "https://github.com/bigsmartben/spec-kit-agent-governance",
       "homepage": "https://github.com/bigsmartben/spec-kit-agent-governance",
       "documentation": "https://github.com/bigsmartben/spec-kit-agent-governance/blob/main/README.md",
@@ -103,7 +103,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-14T00:00:00Z",
-      "updated_at": "2026-05-14T00:00:00Z"
+      "updated_at": "2026-05-15T00:00:00Z"
     },
     "agent-orchestrator": {
       "name": "Intelligent Agent Orchestrator",


### PR DESCRIPTION
Updates the `agent-governance` community extension from v1.0.0 to v1.1.0 per submission #2569.

## Validation

- ✅ Repository public: https://github.com/bigsmartben/spec-kit-agent-governance
- ✅ Release `v1.1.0` published (commit `aa13336`)
- ✅ `extension.yml`, `README.md`, `LICENSE` all present at tag
- ✅ Download URL accessible: `https://github.com/bigsmartben/spec-kit-agent-governance/archive/refs/tags/v1.1.0.zip`
- ✅ `extension.yml` confirms 1 command, 3 hooks, optional `python3` tool dependency
- ✅ Catalog JSON validated with `python3 -c "import json; json.load(...)"`
- ✅ `created_at`, `downloads`, `stars` preserved from existing entry

## Changes

- `extensions/catalog.community.json`: bumped `version`, `download_url`, and `updated_at` for `agent-governance`

The `docs/community/extensions.md` row description and top-level catalog `updated_at` were already current — no changes needed there.

## What's new in v1.1.0 (per submitter)

- Decoupled the agent governance domain from specific project-governance source files
- Updated generated projections to describe project governance as an independent domain
- Added tests for template and projection domain boundaries
- Excluded development-only test/cache artifacts from installed extension packages

Closes #2569

cc @bigsmartben