### PR TITLE
feat(integrations): support SPECIFY_<KEY>_EXTRA_ARGS env var for agent subprocess flags

### DIFF
--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -13,7 +13,9 @@ Provides:
 
 from __future__ import annotations
 
+import os
 import re
+import shlex
 import shutil
 from abc import ABC
 from dataclasses import dataclass
@@ -137,6 +139,31 @@ class IntegrationBase(ABC):
         Subclasses for CLI-based integrations should override this.
         """
         return None
+
+    def _apply_extra_args_env_var(self, args: list[str]) -> None:
+        """Append `SPECIFY_<KEY>_EXTRA_ARGS` env-var value to *args*.
+
+        Operators can inject extra CLI flags into the spawned agent
+        subprocess by setting an env var named for the integration key,
+        e.g. `SPECIFY_CLAUDE_EXTRA_ARGS="--dangerously-skip-permissions"`.
+        Hyphens in the integration key are replaced with underscores
+        and the key is uppercased
+        (e.g. `kiro-cli` → `SPECIFY_KIRO_CLI_EXTRA_ARGS`).
+
+        Useful in CI / non-interactive contexts where the spawned agent
+        needs flags that change its prompt-handling behaviour.
+        Default behaviour (env var unset or whitespace-only) is a no-op
+        — *args* is unchanged. Multi-token values are parsed via
+        `shlex.split`.
+
+        See issue #2595.
+        """
+        env_name = (
+            f"SPECIFY_{self.key.upper().replace('-', '_')}_EXTRA_ARGS"
+        )
+        extra = os.environ.get(env_name, "").strip()
+        if extra:
+            args.extend(shlex.split(extra))
 
     def build_command_invocation(self, command_name: str, args: str = "") -> str:
         """Build the native slash-command invocation for a Spec Kit command.
@@ -851,6 +878,7 @@ class MarkdownIntegration(IntegrationBase):
         if not self.config or not self.config.get("requires_cli"):
             return None
         args = [self.key, "-p", prompt]
+        self._apply_extra_args_env_var(args)
         if model:
             args.extend(["--model", model])
         if output_json:
@@ -938,6 +966,7 @@ class TomlIntegration(IntegrationBase):
         if not self.config or not self.config.get("requires_cli"):
             return None
         args = [self.key, "-p", prompt]
+        self._apply_extra_args_env_var(args)
         if model:
             args.extend(["-m", model])
         if output_json:
@@ -1356,6 +1385,7 @@ class SkillsIntegration(IntegrationBase):
         if not self.config or not self.config.get("requires_cli"):
             return None
         args = [self.key, "-p", prompt]
+        self._apply_extra_args_env_var(args)
         if model:
             args.extend(["--model", model])
         if output_json:

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -141,14 +141,16 @@ class IntegrationBase(ABC):
         return None
 
     def _apply_extra_args_env_var(self, args: list[str]) -> None:
-        """Append `SPECIFY_<KEY>_EXTRA_ARGS` env-var value to *args*.
+        """Append `SPECIFY_INTEGRATION_<KEY>_EXTRA_ARGS` env-var value to *args*.
 
         Operators can inject extra CLI flags into the spawned agent
         subprocess by setting an env var named for the integration key,
-        e.g. `SPECIFY_CLAUDE_EXTRA_ARGS="--dangerously-skip-permissions"`.
+        e.g. `SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS="--dangerously-skip-permissions"`.
+        The `INTEGRATION` segment scopes the variable to this subsystem
+        so it does not collide with other Spec Kit env-var namespaces.
         Hyphens in the integration key are replaced with underscores
         and the key is uppercased
-        (e.g. `kiro-cli` → `SPECIFY_KIRO_CLI_EXTRA_ARGS`).
+        (e.g. `kiro-cli` → `SPECIFY_INTEGRATION_KIRO_CLI_EXTRA_ARGS`).
 
         Useful in CI / non-interactive contexts where the spawned agent
         needs flags that change its prompt-handling behaviour.
@@ -159,7 +161,7 @@ class IntegrationBase(ABC):
         See issue #2595.
         """
         env_name = (
-            f"SPECIFY_{self.key.upper().replace('-', '_')}_EXTRA_ARGS"
+            f"SPECIFY_INTEGRATION_{self.key.upper().replace('-', '_')}_EXTRA_ARGS"
         )
         extra = os.environ.get(env_name, "").strip()
         if extra:

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -164,8 +164,18 @@ class IntegrationBase(ABC):
             f"SPECIFY_INTEGRATION_{self.key.upper().replace('-', '_')}_EXTRA_ARGS"
         )
         extra = os.environ.get(env_name, "").strip()
-        if extra:
-            args.extend(shlex.split(extra))
+        if not extra:
+            return
+        try:
+            tokens = shlex.split(extra)
+        except ValueError as exc:
+            raise ValueError(
+                f"{env_name} is not parseable as a POSIX-quoted command line "
+                f"(value: {extra!r}). shlex reported: {exc}. "
+                f"Use single or double quotes to group multi-word values, e.g. "
+                f'{env_name}=\'--flag "value with spaces"\'.'
+            ) from exc
+        args.extend(tokens)
 
     def build_command_invocation(self, command_name: str, args: str = "") -> str:
         """Build the native slash-command invocation for a Spec Kit command.

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -141,16 +141,16 @@ class IntegrationBase(ABC):
         return None
 
     def _apply_extra_args_env_var(self, args: list[str]) -> None:
-        """Append `SPECIFY_INTEGRATION_<KEY>_EXTRA_ARGS` env-var value to *args*.
+        """Append `SPECKIT_INTEGRATION_<KEY>_EXTRA_ARGS` env-var value to *args*.
 
         Operators can inject extra CLI flags into the spawned agent
         subprocess by setting an env var named for the integration key,
-        e.g. `SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS="--dangerously-skip-permissions"`.
+        e.g. `SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS="--dangerously-skip-permissions"`.
         The `INTEGRATION` segment scopes the variable to this subsystem
         so it does not collide with other Spec Kit env-var namespaces.
         Hyphens in the integration key are replaced with underscores
         and the key is uppercased
-        (e.g. `kiro-cli` → `SPECIFY_INTEGRATION_KIRO_CLI_EXTRA_ARGS`).
+        (e.g. `kiro-cli` → `SPECKIT_INTEGRATION_KIRO_CLI_EXTRA_ARGS`).
 
         Useful in CI / non-interactive contexts where the spawned agent
         needs flags that change its prompt-handling behaviour.
@@ -161,7 +161,7 @@ class IntegrationBase(ABC):
         See issue #2595.
         """
         env_name = (
-            f"SPECIFY_INTEGRATION_{self.key.upper().replace('-', '_')}_EXTRA_ARGS"
+            f"SPECKIT_INTEGRATION_{self.key.upper().replace('-', '_')}_EXTRA_ARGS"
         )
         extra = os.environ.get(env_name, "").strip()
         if not extra:

--- a/src/specify_cli/integrations/codex/__init__.py
+++ b/src/specify_cli/integrations/codex/__init__.py
@@ -53,6 +53,7 @@ class CodexIntegration(SkillsIntegration):
     ) -> list[str] | None:
         # Codex uses ``codex exec "prompt"`` for non-interactive mode.
         args: list[str] = ["codex", "exec", prompt]
+        self._apply_extra_args_env_var(args)
         if model:
             args.extend(["--model", model])
         if output_json:

--- a/src/specify_cli/integrations/codex/__init__.py
+++ b/src/specify_cli/integrations/codex/__init__.py
@@ -52,7 +52,11 @@ class CodexIntegration(SkillsIntegration):
         output_json: bool = True,
     ) -> list[str] | None:
         # Codex uses ``codex exec "prompt"`` for non-interactive mode.
-        args: list[str] = ["codex", "exec", prompt]
+        # Use ``self.key`` so the executable name stays coupled to the
+        # env-var lookup (which also derives from ``self.key``), matching
+        # the pattern in Devin/Opencode and avoiding drift if the key
+        # ever changes.
+        args: list[str] = [self.key, "exec", prompt]
         self._apply_extra_args_env_var(args)
         if model:
             args.extend(["--model", model])

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -149,6 +149,7 @@ class CopilotIntegration(IntegrationBase):
         # (default: enabled).  The deprecated SPECKIT_ALLOW_ALL_TOOLS
         # is also honoured as a fallback.
         args = [_copilot_executable(), "-p", prompt]
+        self._apply_extra_args_env_var(args)
         if _allow_all():
             args.append("--yolo")
         if model:
@@ -368,7 +369,11 @@ class CopilotIntegration(IntegrationBase):
         created: list[Path] = []
 
         script_type = opts.get("script_type", "sh")
-        arg_placeholder = self.registrar_config.get("args", "$ARGUMENTS")
+        arg_placeholder = (
+            self.registrar_config.get("args", "$ARGUMENTS")
+            if self.registrar_config
+            else "$ARGUMENTS"
+        )
 
         # 1. Process and write command files as .agent.md
         for src_file in templates:

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -218,7 +218,7 @@ class CopilotIntegration(IntegrationBase):
             prompt = args or ""
 
         cli_args = [_copilot_executable(), "-p", prompt]
-        # Honour SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS for real workflow
+        # Honour SPECKIT_INTEGRATION_COPILOT_EXTRA_ARGS for real workflow
         # runs.  `dispatch_command` builds cli_args inline rather than
         # going through `build_exec_args`, so the hook must be invoked
         # here too — otherwise the env var is silently ignored.
@@ -374,11 +374,7 @@ class CopilotIntegration(IntegrationBase):
         created: list[Path] = []
 
         script_type = opts.get("script_type", "sh")
-        arg_placeholder = (
-            self.registrar_config.get("args", "$ARGUMENTS")
-            if self.registrar_config
-            else "$ARGUMENTS"
-        )
+        arg_placeholder = self.registrar_config.get("args", "$ARGUMENTS")
 
         # 1. Process and write command files as .agent.md
         for src_file in templates:

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -218,6 +218,11 @@ class CopilotIntegration(IntegrationBase):
             prompt = args or ""
 
         cli_args = [_copilot_executable(), "-p", prompt]
+        # Honour SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS for real workflow
+        # runs.  `dispatch_command` builds cli_args inline rather than
+        # going through `build_exec_args`, so the hook must be invoked
+        # here too — otherwise the env var is silently ignored.
+        self._apply_extra_args_env_var(cli_args)
         if not skills_mode:
             cli_args.extend(["--agent", agent_name])
         if _allow_all():

--- a/src/specify_cli/integrations/devin/__init__.py
+++ b/src/specify_cli/integrations/devin/__init__.py
@@ -49,6 +49,7 @@ class DevinIntegration(SkillsIntegration):
         kept on the integration for tool detection.
         """
         args = [self.key, "-p", prompt]
+        self._apply_extra_args_env_var(args)
         if model:
             args.extend(["--model", model])
         return args

--- a/src/specify_cli/integrations/opencode/__init__.py
+++ b/src/specify_cli/integrations/opencode/__init__.py
@@ -29,6 +29,11 @@ class OpencodeIntegration(MarkdownIntegration):
         output_json: bool = True,
     ) -> list[str] | None:
         args = [self.key, "run"]
+        # Apply operator-injected extra args before the prompt-derived
+        # --command and the canonical --format/-m flags so Spec Kit's
+        # later appends remain authoritative under repeated-flag CLI
+        # semantics.
+        self._apply_extra_args_env_var(args)
 
         message = prompt
         if prompt.startswith("/"):
@@ -37,7 +42,6 @@ class OpencodeIntegration(MarkdownIntegration):
                 args.extend(["--command", command])
                 message = remainder
 
-        self._apply_extra_args_env_var(args)
         if model:
             args.extend(["-m", model])
         if output_json:

--- a/src/specify_cli/integrations/opencode/__init__.py
+++ b/src/specify_cli/integrations/opencode/__init__.py
@@ -37,6 +37,7 @@ class OpencodeIntegration(MarkdownIntegration):
                 args.extend(["--command", command])
                 message = remainder
 
+        self._apply_extra_args_env_var(args)
         if model:
             args.extend(["-m", model])
         if output_json:

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -1,0 +1,163 @@
+"""Tests for the per-integration `SPECIFY_<KEY>_EXTRA_ARGS` env-var hook
+in `SkillsIntegration.build_exec_args`. See issue #2595."""
+
+import pytest
+
+from specify_cli.integrations.base import SkillsIntegration
+
+
+class _ClaudeStub(SkillsIntegration):
+    """Minimal Claude-like SkillsIntegration for testing."""
+
+    key = "claude"
+    config = {
+        "name": "Claude (test stub)",
+        "folder": ".claude/",
+        "commands_subdir": "skills",
+        "install_url": None,
+        "requires_cli": True,
+    }
+    registrar_config = {
+        "dir": ".claude/skills",
+        "format": "markdown",
+        "args": "$ARGUMENTS",
+        "extension": "/SKILL.md",
+    }
+    context_file = "CLAUDE.md"
+
+
+class _KiroCliStub(SkillsIntegration):
+    """SkillsIntegration with a hyphenated key to exercise key
+    normalization (`kiro-cli` → `KIRO_CLI`)."""
+
+    key = "kiro-cli"
+    config = {
+        "name": "Kiro CLI (test stub)",
+        "folder": ".kiro/",
+        "commands_subdir": "commands",
+        "install_url": None,
+        "requires_cli": True,
+    }
+    registrar_config = {
+        "dir": ".kiro/commands",
+        "format": "markdown",
+        "args": "$ARGUMENTS",
+        "extension": ".md",
+    }
+    context_file = "KIRO.md"
+
+
+class _NoCliStub(SkillsIntegration):
+    """SkillsIntegration with requires_cli=False — build_exec_args
+    must return None and the env-var hook must not fire."""
+
+    key = "no-cli"
+    config = {
+        "name": "No-CLI agent (test stub)",
+        "folder": ".no-cli/",
+        "commands_subdir": "commands",
+        "install_url": None,
+        "requires_cli": False,
+    }
+    registrar_config = {
+        "dir": ".no-cli/commands",
+        "format": "markdown",
+        "args": "$ARGUMENTS",
+        "extension": ".md",
+    }
+    context_file = "NOCLI.md"
+
+
+@pytest.fixture(autouse=True)
+def _clean_extra_args_env(monkeypatch):
+    """Strip any leaked SPECIFY_*_EXTRA_ARGS from the test env so a
+    developer's shell setting doesn't pollute results."""
+    for key in list(__import__("os").environ):
+        if key.startswith("SPECIFY_") and key.endswith("_EXTRA_ARGS"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_env_var_unset_byte_identical_argv():
+    """Default behaviour: env var unset → no extra args inserted.
+
+    Locks the backward-compatibility guarantee that existing
+    operators see no change.
+    """
+    args = _ClaudeStub().build_exec_args("hello prompt")
+    assert args == ["claude", "-p", "hello prompt", "--output-format", "json"]
+
+
+def test_env_var_set_flag_inserted_before_model_and_output_format(
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "SPECIFY_CLAUDE_EXTRA_ARGS", "--dangerously-skip-permissions"
+    )
+    args = _ClaudeStub().build_exec_args("hello prompt", model="sonnet")
+    assert args == [
+        "claude",
+        "-p",
+        "hello prompt",
+        "--dangerously-skip-permissions",
+        "--model",
+        "sonnet",
+        "--output-format",
+        "json",
+    ]
+
+
+def test_env_var_multi_token_parsed_via_shlex(monkeypatch):
+    monkeypatch.setenv(
+        "SPECIFY_CLAUDE_EXTRA_ARGS",
+        "--dangerously-skip-permissions --max-turns 3",
+    )
+    args = _ClaudeStub().build_exec_args("p")
+    assert args == [
+        "claude",
+        "-p",
+        "p",
+        "--dangerously-skip-permissions",
+        "--max-turns",
+        "3",
+        "--output-format",
+        "json",
+    ]
+
+
+def test_env_var_empty_or_whitespace_is_noop(monkeypatch):
+    """An env var set to '' or '   ' is treated as unset."""
+    monkeypatch.setenv("SPECIFY_CLAUDE_EXTRA_ARGS", "   ")
+    args = _ClaudeStub().build_exec_args("p")
+    assert args == ["claude", "-p", "p", "--output-format", "json"]
+
+
+def test_other_integration_env_var_ignored(monkeypatch):
+    """`SPECIFY_GEMINI_EXTRA_ARGS` set must NOT leak into
+    Claude's argv (per-integration scoping)."""
+    monkeypatch.setenv("SPECIFY_GEMINI_EXTRA_ARGS", "--gemini-only-flag")
+    args = _ClaudeStub().build_exec_args("p")
+    assert args == ["claude", "-p", "p", "--output-format", "json"]
+
+
+def test_key_normalization_hyphen_to_underscore_uppercase(monkeypatch):
+    """`kiro-cli` key looks up `SPECIFY_KIRO_CLI_EXTRA_ARGS`
+    (hyphens replaced with underscores, then uppercased)."""
+    monkeypatch.setenv(
+        "SPECIFY_KIRO_CLI_EXTRA_ARGS", "--some-kiro-flag"
+    )
+    args = _KiroCliStub().build_exec_args("p")
+    assert args == [
+        "kiro-cli",
+        "-p",
+        "p",
+        "--some-kiro-flag",
+        "--output-format",
+        "json",
+    ]
+
+
+def test_requires_cli_false_returns_none(monkeypatch):
+    """`requires_cli: False` short-circuits to None — the env-var
+    hook is never reached and no argv is built."""
+    monkeypatch.setenv("SPECIFY_NO_CLI_EXTRA_ARGS", "--should-not-appear")
+    assert _NoCliStub().build_exec_args("p") is None

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -135,6 +135,21 @@ def test_env_var_multi_token_parsed_via_shlex(monkeypatch):
     ]
 
 
+def test_malformed_quoting_raises_actionable_value_error(monkeypatch):
+    """An unmatched quote in the env-var value must surface a clear
+    error naming the offending env var and showing the invalid value,
+    rather than crashing workflow dispatch with a bare shlex traceback."""
+    monkeypatch.setenv(
+        "SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS",
+        '--flag "unterminated',
+    )
+    with pytest.raises(ValueError) as excinfo:
+        _ClaudeStub().build_exec_args("p")
+    msg = str(excinfo.value)
+    assert "SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS" in msg
+    assert "--flag \"unterminated" in msg
+
+
 def test_env_var_empty_or_whitespace_is_noop(monkeypatch):
     """An env var set to '' or '   ' is treated as unset."""
     monkeypatch.setenv("SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS", "   ")

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -274,7 +274,10 @@ def test_opencode_extra_args_cannot_clobber_prompt_derived_command(
 
 
 def test_copilot_integration_honours_extra_args(monkeypatch):
-    from specify_cli.integrations.copilot import CopilotIntegration
+    from specify_cli.integrations.copilot import (
+        CopilotIntegration,
+        _copilot_executable,
+    )
 
     # Disable --yolo so the argv shape stays deterministic.
     monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "0")
@@ -282,8 +285,10 @@ def test_copilot_integration_honours_extra_args(monkeypatch):
         "SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
     )
     args = CopilotIntegration().build_exec_args("p")
+    # `_copilot_executable()` returns "copilot.cmd" on Windows and
+    # "copilot" elsewhere; the test must mirror that to stay portable.
     assert args == [
-        "copilot",
+        _copilot_executable(),
         "-p",
         "p",
         "--allow-tool",

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -1,6 +1,8 @@
 """Tests for the per-integration `SPECIFY_<KEY>_EXTRA_ARGS` env-var hook
 in `SkillsIntegration.build_exec_args`. See issue #2595."""
 
+import os
+
 import pytest
 
 from specify_cli.integrations.base import SkillsIntegration
@@ -72,7 +74,7 @@ class _NoCliStub(SkillsIntegration):
 def _clean_extra_args_env(monkeypatch):
     """Strip any leaked SPECIFY_*_EXTRA_ARGS from the test env so a
     developer's shell setting doesn't pollute results."""
-    for key in list(__import__("os").environ):
+    for key in list(os.environ):
         if key.startswith("SPECIFY_") and key.endswith("_EXTRA_ARGS"):
             monkeypatch.delenv(key, raising=False)
 
@@ -161,3 +163,74 @@ def test_requires_cli_false_returns_none(monkeypatch):
     hook is never reached and no argv is built."""
     monkeypatch.setenv("SPECIFY_NO_CLI_EXTRA_ARGS", "--should-not-appear")
     assert _NoCliStub().build_exec_args("p") is None
+
+
+# ---------------------------------------------------------------------------
+# Override-integration coverage
+#
+# CodexIntegration, DevinIntegration, OpencodeIntegration and
+# CopilotIntegration each override `build_exec_args` rather than using the
+# base implementations. The env-var hook must be wired into every override
+# so the documented behaviour ("works for every requires_cli integration")
+# is honoured. These tests lock that contract per integration.
+# ---------------------------------------------------------------------------
+
+
+def test_codex_integration_honours_extra_args(monkeypatch):
+    from specify_cli.integrations.codex import CodexIntegration
+
+    monkeypatch.setenv("SPECIFY_CODEX_EXTRA_ARGS", "--sandbox read-only")
+    args = CodexIntegration().build_exec_args("p", model="gpt-5")
+    assert args == [
+        "codex",
+        "exec",
+        "p",
+        "--sandbox",
+        "read-only",
+        "--model",
+        "gpt-5",
+        "--json",
+    ]
+
+
+def test_devin_integration_honours_extra_args(monkeypatch):
+    from specify_cli.integrations.devin import DevinIntegration
+
+    monkeypatch.setenv("SPECIFY_DEVIN_EXTRA_ARGS", "--no-confirm")
+    args = DevinIntegration().build_exec_args("p")
+    assert args == ["devin", "-p", "p", "--no-confirm"]
+
+
+def test_opencode_integration_honours_extra_args(monkeypatch):
+    from specify_cli.integrations.opencode import OpencodeIntegration
+
+    monkeypatch.setenv("SPECIFY_OPENCODE_EXTRA_ARGS", "--quiet")
+    args = OpencodeIntegration().build_exec_args("p")
+    assert args == [
+        "opencode",
+        "run",
+        "--quiet",
+        "--format",
+        "json",
+        "p",
+    ]
+
+
+def test_copilot_integration_honours_extra_args(monkeypatch):
+    from specify_cli.integrations.copilot import CopilotIntegration
+
+    # Disable --yolo so the argv shape stays deterministic.
+    monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "0")
+    monkeypatch.setenv(
+        "SPECIFY_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
+    )
+    args = CopilotIntegration().build_exec_args("p")
+    assert args == [
+        "copilot",
+        "-p",
+        "p",
+        "--allow-tool",
+        "shell(echo)",
+        "--output-format",
+        "json",
+    ]

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -12,7 +12,11 @@ import os
 
 import pytest
 
-from specify_cli.integrations.base import SkillsIntegration
+from specify_cli.integrations.base import (
+    MarkdownIntegration,
+    SkillsIntegration,
+    TomlIntegration,
+)
 
 
 class _ClaudeStub(SkillsIntegration):
@@ -75,6 +79,51 @@ class _NoCliStub(SkillsIntegration):
         "extension": ".md",
     }
     context_file = "NOCLI.md"
+
+
+class _MarkdownAgentStub(MarkdownIntegration):
+    """Bare MarkdownIntegration subclass — does NOT override
+    `build_exec_args`. Locks the base implementation in
+    `MarkdownIntegration.build_exec_args` for the common case
+    (most concrete integrations: Amp, Auggie, Generic, …)."""
+
+    key = "md-agent"
+    config = {
+        "name": "Markdown agent (test stub)",
+        "folder": ".md-agent/",
+        "commands_subdir": "commands",
+        "install_url": None,
+        "requires_cli": True,
+    }
+    registrar_config = {
+        "dir": ".md-agent/commands",
+        "format": "markdown",
+        "args": "$ARGUMENTS",
+        "extension": ".md",
+    }
+    context_file = "MDAGENT.md"
+
+
+class _TomlAgentStub(TomlIntegration):
+    """Bare TomlIntegration subclass — does NOT override
+    `build_exec_args`. Locks the base implementation in
+    `TomlIntegration.build_exec_args` (Gemini, Tabnine)."""
+
+    key = "toml-agent"
+    config = {
+        "name": "TOML agent (test stub)",
+        "folder": ".toml-agent/",
+        "commands_subdir": "commands",
+        "install_url": None,
+        "requires_cli": True,
+    }
+    registrar_config = {
+        "dir": ".toml-agent/commands",
+        "format": "toml",
+        "args": "$ARGUMENTS",
+        "extension": ".toml",
+    }
+    context_file = "TOMLAGENT.md"
 
 
 @pytest.fixture(autouse=True)
@@ -187,6 +236,58 @@ def test_requires_cli_false_returns_none(monkeypatch):
     hook is never reached and no argv is built."""
     monkeypatch.setenv("SPECIFY_INTEGRATION_NO_CLI_EXTRA_ARGS", "--should-not-appear")
     assert _NoCliStub().build_exec_args("p") is None
+
+
+# ---------------------------------------------------------------------------
+# Base-class coverage
+#
+# Most integrations inherit `build_exec_args` from `MarkdownIntegration`
+# or `TomlIntegration` without overriding it. The tests above use
+# `SkillsIntegration` stubs (which share the same hook mechanism) — these
+# tests exercise the two other base implementations directly so all three
+# concrete bases are covered.
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_integration_base_honours_extra_args(monkeypatch):
+    """A bare `MarkdownIntegration` subclass — which does not override
+    `build_exec_args` — must honour the env var via the base
+    implementation. Covers the most common integration pattern."""
+    monkeypatch.setenv(
+        "SPECIFY_INTEGRATION_MD_AGENT_EXTRA_ARGS", "--debug --max-tokens 100"
+    )
+    args = _MarkdownAgentStub().build_exec_args("p")
+    assert args == [
+        "md-agent",
+        "-p",
+        "p",
+        "--debug",
+        "--max-tokens",
+        "100",
+        "--output-format",
+        "json",
+    ]
+
+
+def test_toml_integration_base_honours_extra_args(monkeypatch):
+    """A bare `TomlIntegration` subclass — which does not override
+    `build_exec_args` — must honour the env var via the base
+    implementation. Covers Gemini/Tabnine-style integrations."""
+    monkeypatch.setenv(
+        "SPECIFY_INTEGRATION_TOML_AGENT_EXTRA_ARGS", "--yolo"
+    )
+    args = _TomlAgentStub().build_exec_args("p", model="gemini-pro")
+    # TomlIntegration uses `-m` for model (vs Markdown's `--model`).
+    assert args == [
+        "toml-agent",
+        "-p",
+        "p",
+        "--yolo",
+        "-m",
+        "gemini-pro",
+        "--output-format",
+        "json",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -1,4 +1,4 @@
-"""Tests for the per-integration `SPECIFY_INTEGRATION_<KEY>_EXTRA_ARGS` env-var hook.
+"""Tests for the per-integration `SPECKIT_INTEGRATION_<KEY>_EXTRA_ARGS` env-var hook.
 
 The hook is implemented in `IntegrationBase._apply_extra_args_env_var`
 and wired into every concrete `build_exec_args` —
@@ -128,10 +128,10 @@ class _TomlAgentStub(TomlIntegration):
 
 @pytest.fixture(autouse=True)
 def _clean_extra_args_env(monkeypatch):
-    """Strip any leaked SPECIFY_INTEGRATION_*_EXTRA_ARGS from the test
+    """Strip any leaked SPECKIT_INTEGRATION_*_EXTRA_ARGS from the test
     env so a developer's shell setting doesn't pollute results."""
     for key in list(os.environ):
-        if key.startswith("SPECIFY_INTEGRATION_") and key.endswith(
+        if key.startswith("SPECKIT_INTEGRATION_") and key.endswith(
             "_EXTRA_ARGS"
         ):
             monkeypatch.delenv(key, raising=False)
@@ -151,7 +151,7 @@ def test_env_var_set_flag_inserted_before_model_and_output_format(
     monkeypatch,
 ):
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS", "--dangerously-skip-permissions"
+        "SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS", "--dangerously-skip-permissions"
     )
     args = _ClaudeStub().build_exec_args("hello prompt", model="sonnet")
     assert args == [
@@ -168,7 +168,7 @@ def test_env_var_set_flag_inserted_before_model_and_output_format(
 
 def test_env_var_multi_token_parsed_via_shlex(monkeypatch):
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS",
+        "SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS",
         "--dangerously-skip-permissions --max-turns 3",
     )
     args = _ClaudeStub().build_exec_args("p")
@@ -189,36 +189,36 @@ def test_malformed_quoting_raises_actionable_value_error(monkeypatch):
     error naming the offending env var and showing the invalid value,
     rather than crashing workflow dispatch with a bare shlex traceback."""
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS",
+        "SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS",
         '--flag "unterminated',
     )
     with pytest.raises(ValueError) as excinfo:
         _ClaudeStub().build_exec_args("p")
     msg = str(excinfo.value)
-    assert "SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS" in msg
+    assert "SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS" in msg
     assert "--flag \"unterminated" in msg
 
 
 def test_env_var_empty_or_whitespace_is_noop(monkeypatch):
     """An env var set to '' or '   ' is treated as unset."""
-    monkeypatch.setenv("SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS", "   ")
+    monkeypatch.setenv("SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS", "   ")
     args = _ClaudeStub().build_exec_args("p")
     assert args == ["claude", "-p", "p", "--output-format", "json"]
 
 
 def test_other_integration_env_var_ignored(monkeypatch):
-    """`SPECIFY_INTEGRATION_GEMINI_EXTRA_ARGS` set must NOT leak into
+    """`SPECKIT_INTEGRATION_GEMINI_EXTRA_ARGS` set must NOT leak into
     Claude's argv (per-integration scoping)."""
-    monkeypatch.setenv("SPECIFY_INTEGRATION_GEMINI_EXTRA_ARGS", "--gemini-only-flag")
+    monkeypatch.setenv("SPECKIT_INTEGRATION_GEMINI_EXTRA_ARGS", "--gemini-only-flag")
     args = _ClaudeStub().build_exec_args("p")
     assert args == ["claude", "-p", "p", "--output-format", "json"]
 
 
 def test_key_normalization_hyphen_to_underscore_uppercase(monkeypatch):
-    """`kiro-cli` key looks up `SPECIFY_INTEGRATION_KIRO_CLI_EXTRA_ARGS`
+    """`kiro-cli` key looks up `SPECKIT_INTEGRATION_KIRO_CLI_EXTRA_ARGS`
     (hyphens replaced with underscores, then uppercased)."""
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_KIRO_CLI_EXTRA_ARGS", "--some-kiro-flag"
+        "SPECKIT_INTEGRATION_KIRO_CLI_EXTRA_ARGS", "--some-kiro-flag"
     )
     args = _KiroCliStub().build_exec_args("p")
     assert args == [
@@ -234,7 +234,7 @@ def test_key_normalization_hyphen_to_underscore_uppercase(monkeypatch):
 def test_requires_cli_false_returns_none(monkeypatch):
     """`requires_cli: False` short-circuits to None — the env-var
     hook is never reached and no argv is built."""
-    monkeypatch.setenv("SPECIFY_INTEGRATION_NO_CLI_EXTRA_ARGS", "--should-not-appear")
+    monkeypatch.setenv("SPECKIT_INTEGRATION_NO_CLI_EXTRA_ARGS", "--should-not-appear")
     assert _NoCliStub().build_exec_args("p") is None
 
 
@@ -254,7 +254,7 @@ def test_markdown_integration_base_honours_extra_args(monkeypatch):
     `build_exec_args` — must honour the env var via the base
     implementation. Covers the most common integration pattern."""
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_MD_AGENT_EXTRA_ARGS", "--debug --max-tokens 100"
+        "SPECKIT_INTEGRATION_MD_AGENT_EXTRA_ARGS", "--debug --max-tokens 100"
     )
     args = _MarkdownAgentStub().build_exec_args("p")
     assert args == [
@@ -274,7 +274,7 @@ def test_toml_integration_base_honours_extra_args(monkeypatch):
     `build_exec_args` — must honour the env var via the base
     implementation. Covers Gemini/Tabnine-style integrations."""
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_TOML_AGENT_EXTRA_ARGS", "--yolo"
+        "SPECKIT_INTEGRATION_TOML_AGENT_EXTRA_ARGS", "--yolo"
     )
     args = _TomlAgentStub().build_exec_args("p", model="gemini-pro")
     # TomlIntegration uses `-m` for model (vs Markdown's `--model`).
@@ -304,7 +304,7 @@ def test_toml_integration_base_honours_extra_args(monkeypatch):
 def test_codex_integration_honours_extra_args(monkeypatch):
     from specify_cli.integrations.codex import CodexIntegration
 
-    monkeypatch.setenv("SPECIFY_INTEGRATION_CODEX_EXTRA_ARGS", "--sandbox read-only")
+    monkeypatch.setenv("SPECKIT_INTEGRATION_CODEX_EXTRA_ARGS", "--sandbox read-only")
     args = CodexIntegration().build_exec_args("p", model="gpt-5")
     assert args == [
         "codex",
@@ -321,7 +321,7 @@ def test_codex_integration_honours_extra_args(monkeypatch):
 def test_devin_integration_honours_extra_args(monkeypatch):
     from specify_cli.integrations.devin import DevinIntegration
 
-    monkeypatch.setenv("SPECIFY_INTEGRATION_DEVIN_EXTRA_ARGS", "--no-confirm")
+    monkeypatch.setenv("SPECKIT_INTEGRATION_DEVIN_EXTRA_ARGS", "--no-confirm")
     args = DevinIntegration().build_exec_args("p")
     assert args == ["devin", "-p", "p", "--no-confirm"]
 
@@ -329,7 +329,7 @@ def test_devin_integration_honours_extra_args(monkeypatch):
 def test_opencode_integration_honours_extra_args(monkeypatch):
     from specify_cli.integrations.opencode import OpencodeIntegration
 
-    monkeypatch.setenv("SPECIFY_INTEGRATION_OPENCODE_EXTRA_ARGS", "--quiet")
+    monkeypatch.setenv("SPECKIT_INTEGRATION_OPENCODE_EXTRA_ARGS", "--quiet")
     args = OpencodeIntegration().build_exec_args("p")
     assert args == [
         "opencode",
@@ -349,13 +349,13 @@ def test_opencode_extra_args_cannot_clobber_prompt_derived_command(
     repeated-flag CLI semantics (last value typically takes precedence).
 
     Locks against the regression where an operator setting
-    ``SPECIFY_INTEGRATION_OPENCODE_EXTRA_ARGS="--command malicious"`` could redirect
+    ``SPECKIT_INTEGRATION_OPENCODE_EXTRA_ARGS="--command malicious"`` could redirect
     a slash-prefixed prompt to a different command.
     """
     from specify_cli.integrations.opencode import OpencodeIntegration
 
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_OPENCODE_EXTRA_ARGS", "--command operator-override"
+        "SPECKIT_INTEGRATION_OPENCODE_EXTRA_ARGS", "--command operator-override"
     )
     args = OpencodeIntegration().build_exec_args("/speckit body text")
     # Prompt-derived "--command speckit" appears AFTER the
@@ -383,7 +383,7 @@ def test_copilot_integration_honours_extra_args(monkeypatch):
     # Disable --yolo so the argv shape stays deterministic.
     monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "0")
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
+        "SPECKIT_INTEGRATION_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
     )
     args = CopilotIntegration().build_exec_args("p")
     # `_copilot_executable()` returns "copilot.cmd" on Windows and
@@ -431,7 +431,7 @@ class _RunCapture:
 
 def test_copilot_dispatch_command_includes_extra_args(monkeypatch):
     """Locks the bypass fix: `CopilotIntegration.dispatch_command`
-    must honour `SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS`, not just `build_exec_args`.
+    must honour `SPECKIT_INTEGRATION_COPILOT_EXTRA_ARGS`, not just `build_exec_args`.
     """
     import subprocess
 
@@ -441,7 +441,7 @@ def test_copilot_dispatch_command_includes_extra_args(monkeypatch):
     monkeypatch.setattr(subprocess, "run", capture)
     monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "0")
     monkeypatch.setenv(
-        "SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
+        "SPECKIT_INTEGRATION_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
     )
 
     CopilotIntegration().dispatch_command(
@@ -469,7 +469,7 @@ def test_codex_dispatch_command_includes_extra_args(monkeypatch):
 
     capture = _RunCapture()
     monkeypatch.setattr(subprocess, "run", capture)
-    monkeypatch.setenv("SPECIFY_INTEGRATION_CODEX_EXTRA_ARGS", "--sandbox read-only")
+    monkeypatch.setenv("SPECKIT_INTEGRATION_CODEX_EXTRA_ARGS", "--sandbox read-only")
 
     CodexIntegration().dispatch_command(
         "speckit.plan", args="body", stream=False

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -1,4 +1,4 @@
-"""Tests for the per-integration `SPECIFY_<KEY>_EXTRA_ARGS` env-var hook.
+"""Tests for the per-integration `SPECIFY_INTEGRATION_<KEY>_EXTRA_ARGS` env-var hook.
 
 The hook is implemented in `IntegrationBase._apply_extra_args_env_var`
 and wired into every concrete `build_exec_args` —
@@ -79,10 +79,12 @@ class _NoCliStub(SkillsIntegration):
 
 @pytest.fixture(autouse=True)
 def _clean_extra_args_env(monkeypatch):
-    """Strip any leaked SPECIFY_*_EXTRA_ARGS from the test env so a
-    developer's shell setting doesn't pollute results."""
+    """Strip any leaked SPECIFY_INTEGRATION_*_EXTRA_ARGS from the test
+    env so a developer's shell setting doesn't pollute results."""
     for key in list(os.environ):
-        if key.startswith("SPECIFY_") and key.endswith("_EXTRA_ARGS"):
+        if key.startswith("SPECIFY_INTEGRATION_") and key.endswith(
+            "_EXTRA_ARGS"
+        ):
             monkeypatch.delenv(key, raising=False)
 
 
@@ -100,7 +102,7 @@ def test_env_var_set_flag_inserted_before_model_and_output_format(
     monkeypatch,
 ):
     monkeypatch.setenv(
-        "SPECIFY_CLAUDE_EXTRA_ARGS", "--dangerously-skip-permissions"
+        "SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS", "--dangerously-skip-permissions"
     )
     args = _ClaudeStub().build_exec_args("hello prompt", model="sonnet")
     assert args == [
@@ -117,7 +119,7 @@ def test_env_var_set_flag_inserted_before_model_and_output_format(
 
 def test_env_var_multi_token_parsed_via_shlex(monkeypatch):
     monkeypatch.setenv(
-        "SPECIFY_CLAUDE_EXTRA_ARGS",
+        "SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS",
         "--dangerously-skip-permissions --max-turns 3",
     )
     args = _ClaudeStub().build_exec_args("p")
@@ -135,24 +137,24 @@ def test_env_var_multi_token_parsed_via_shlex(monkeypatch):
 
 def test_env_var_empty_or_whitespace_is_noop(monkeypatch):
     """An env var set to '' or '   ' is treated as unset."""
-    monkeypatch.setenv("SPECIFY_CLAUDE_EXTRA_ARGS", "   ")
+    monkeypatch.setenv("SPECIFY_INTEGRATION_CLAUDE_EXTRA_ARGS", "   ")
     args = _ClaudeStub().build_exec_args("p")
     assert args == ["claude", "-p", "p", "--output-format", "json"]
 
 
 def test_other_integration_env_var_ignored(monkeypatch):
-    """`SPECIFY_GEMINI_EXTRA_ARGS` set must NOT leak into
+    """`SPECIFY_INTEGRATION_GEMINI_EXTRA_ARGS` set must NOT leak into
     Claude's argv (per-integration scoping)."""
-    monkeypatch.setenv("SPECIFY_GEMINI_EXTRA_ARGS", "--gemini-only-flag")
+    monkeypatch.setenv("SPECIFY_INTEGRATION_GEMINI_EXTRA_ARGS", "--gemini-only-flag")
     args = _ClaudeStub().build_exec_args("p")
     assert args == ["claude", "-p", "p", "--output-format", "json"]
 
 
 def test_key_normalization_hyphen_to_underscore_uppercase(monkeypatch):
-    """`kiro-cli` key looks up `SPECIFY_KIRO_CLI_EXTRA_ARGS`
+    """`kiro-cli` key looks up `SPECIFY_INTEGRATION_KIRO_CLI_EXTRA_ARGS`
     (hyphens replaced with underscores, then uppercased)."""
     monkeypatch.setenv(
-        "SPECIFY_KIRO_CLI_EXTRA_ARGS", "--some-kiro-flag"
+        "SPECIFY_INTEGRATION_KIRO_CLI_EXTRA_ARGS", "--some-kiro-flag"
     )
     args = _KiroCliStub().build_exec_args("p")
     assert args == [
@@ -168,7 +170,7 @@ def test_key_normalization_hyphen_to_underscore_uppercase(monkeypatch):
 def test_requires_cli_false_returns_none(monkeypatch):
     """`requires_cli: False` short-circuits to None — the env-var
     hook is never reached and no argv is built."""
-    monkeypatch.setenv("SPECIFY_NO_CLI_EXTRA_ARGS", "--should-not-appear")
+    monkeypatch.setenv("SPECIFY_INTEGRATION_NO_CLI_EXTRA_ARGS", "--should-not-appear")
     assert _NoCliStub().build_exec_args("p") is None
 
 
@@ -186,7 +188,7 @@ def test_requires_cli_false_returns_none(monkeypatch):
 def test_codex_integration_honours_extra_args(monkeypatch):
     from specify_cli.integrations.codex import CodexIntegration
 
-    monkeypatch.setenv("SPECIFY_CODEX_EXTRA_ARGS", "--sandbox read-only")
+    monkeypatch.setenv("SPECIFY_INTEGRATION_CODEX_EXTRA_ARGS", "--sandbox read-only")
     args = CodexIntegration().build_exec_args("p", model="gpt-5")
     assert args == [
         "codex",
@@ -203,7 +205,7 @@ def test_codex_integration_honours_extra_args(monkeypatch):
 def test_devin_integration_honours_extra_args(monkeypatch):
     from specify_cli.integrations.devin import DevinIntegration
 
-    monkeypatch.setenv("SPECIFY_DEVIN_EXTRA_ARGS", "--no-confirm")
+    monkeypatch.setenv("SPECIFY_INTEGRATION_DEVIN_EXTRA_ARGS", "--no-confirm")
     args = DevinIntegration().build_exec_args("p")
     assert args == ["devin", "-p", "p", "--no-confirm"]
 
@@ -211,7 +213,7 @@ def test_devin_integration_honours_extra_args(monkeypatch):
 def test_opencode_integration_honours_extra_args(monkeypatch):
     from specify_cli.integrations.opencode import OpencodeIntegration
 
-    monkeypatch.setenv("SPECIFY_OPENCODE_EXTRA_ARGS", "--quiet")
+    monkeypatch.setenv("SPECIFY_INTEGRATION_OPENCODE_EXTRA_ARGS", "--quiet")
     args = OpencodeIntegration().build_exec_args("p")
     assert args == [
         "opencode",
@@ -231,13 +233,13 @@ def test_opencode_extra_args_cannot_clobber_prompt_derived_command(
     repeated-flag CLI semantics (last value typically takes precedence).
 
     Locks against the regression where an operator setting
-    ``SPECIFY_OPENCODE_EXTRA_ARGS="--command malicious"`` could redirect
+    ``SPECIFY_INTEGRATION_OPENCODE_EXTRA_ARGS="--command malicious"`` could redirect
     a slash-prefixed prompt to a different command.
     """
     from specify_cli.integrations.opencode import OpencodeIntegration
 
     monkeypatch.setenv(
-        "SPECIFY_OPENCODE_EXTRA_ARGS", "--command operator-override"
+        "SPECIFY_INTEGRATION_OPENCODE_EXTRA_ARGS", "--command operator-override"
     )
     args = OpencodeIntegration().build_exec_args("/speckit body text")
     # Prompt-derived "--command speckit" appears AFTER the
@@ -262,7 +264,7 @@ def test_copilot_integration_honours_extra_args(monkeypatch):
     # Disable --yolo so the argv shape stays deterministic.
     monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "0")
     monkeypatch.setenv(
-        "SPECIFY_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
+        "SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
     )
     args = CopilotIntegration().build_exec_args("p")
     assert args == [
@@ -308,7 +310,7 @@ class _RunCapture:
 
 def test_copilot_dispatch_command_includes_extra_args(monkeypatch):
     """Locks the bypass fix: `CopilotIntegration.dispatch_command`
-    must honour `SPECIFY_COPILOT_EXTRA_ARGS`, not just `build_exec_args`.
+    must honour `SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS`, not just `build_exec_args`.
     """
     import subprocess
 
@@ -318,7 +320,7 @@ def test_copilot_dispatch_command_includes_extra_args(monkeypatch):
     monkeypatch.setattr(subprocess, "run", capture)
     monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "0")
     monkeypatch.setenv(
-        "SPECIFY_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
+        "SPECIFY_INTEGRATION_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
     )
 
     CopilotIntegration().dispatch_command(
@@ -346,7 +348,7 @@ def test_codex_dispatch_command_includes_extra_args(monkeypatch):
 
     capture = _RunCapture()
     monkeypatch.setattr(subprocess, "run", capture)
-    monkeypatch.setenv("SPECIFY_CODEX_EXTRA_ARGS", "--sandbox read-only")
+    monkeypatch.setenv("SPECIFY_INTEGRATION_CODEX_EXTRA_ARGS", "--sandbox read-only")
 
     CodexIntegration().dispatch_command(
         "speckit.plan", args="body", stream=False

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -274,3 +274,84 @@ def test_copilot_integration_honours_extra_args(monkeypatch):
         "--output-format",
         "json",
     ]
+
+
+# ---------------------------------------------------------------------------
+# `dispatch_command` end-to-end coverage
+#
+# Workflow execution calls `impl.dispatch_command(...)`, not
+# `build_exec_args` directly. `IntegrationBase.dispatch_command` delegates
+# to `build_exec_args` (so the override fixes above flow through), but
+# `CopilotIntegration` overrides `dispatch_command` and constructs
+# `cli_args` inline — the hook must be invoked there too or the env var
+# is silently ignored at workflow runtime. These tests monkeypatch
+# `subprocess.run` and assert the env-var args reach the executed argv.
+# ---------------------------------------------------------------------------
+
+
+class _RunCapture:
+    """Test double that captures argv passed to subprocess.run."""
+
+    def __init__(self):
+        self.captured_args: list[str] | None = None
+
+    def __call__(self, args, **kwargs):
+        self.captured_args = list(args)
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Result()
+
+
+def test_copilot_dispatch_command_includes_extra_args(monkeypatch):
+    """Locks the bypass fix: `CopilotIntegration.dispatch_command`
+    must honour `SPECIFY_COPILOT_EXTRA_ARGS`, not just `build_exec_args`.
+    """
+    import subprocess
+
+    from specify_cli.integrations.copilot import CopilotIntegration
+
+    capture = _RunCapture()
+    monkeypatch.setattr(subprocess, "run", capture)
+    monkeypatch.setenv("SPECKIT_COPILOT_ALLOW_ALL_TOOLS", "0")
+    monkeypatch.setenv(
+        "SPECIFY_COPILOT_EXTRA_ARGS", "--allow-tool 'shell(echo)'"
+    )
+
+    CopilotIntegration().dispatch_command(
+        "speckit.plan", args="body", stream=False
+    )
+
+    assert capture.captured_args is not None
+    # Hook inserted between `-p prompt` and the canonical Copilot flags.
+    p_idx = capture.captured_args.index("-p")
+    agent_idx = capture.captured_args.index("--agent")
+    extra_idx = capture.captured_args.index("--allow-tool")
+    assert p_idx < extra_idx < agent_idx
+    assert "shell(echo)" in capture.captured_args
+
+
+def test_codex_dispatch_command_includes_extra_args(monkeypatch):
+    """Lock the inherited `IntegrationBase.dispatch_command` path:
+    Codex (and by transitivity Devin, Opencode) flow through
+    `build_exec_args`, so the env var must reach argv at workflow
+    runtime.
+    """
+    import subprocess
+
+    from specify_cli.integrations.codex import CodexIntegration
+
+    capture = _RunCapture()
+    monkeypatch.setattr(subprocess, "run", capture)
+    monkeypatch.setenv("SPECIFY_CODEX_EXTRA_ARGS", "--sandbox read-only")
+
+    CodexIntegration().dispatch_command(
+        "speckit.plan", args="body", stream=False
+    )
+
+    assert capture.captured_args is not None
+    assert "--sandbox" in capture.captured_args
+    assert "read-only" in capture.captured_args

--- a/tests/integrations/test_extra_args.py
+++ b/tests/integrations/test_extra_args.py
@@ -1,5 +1,12 @@
-"""Tests for the per-integration `SPECIFY_<KEY>_EXTRA_ARGS` env-var hook
-in `SkillsIntegration.build_exec_args`. See issue #2595."""
+"""Tests for the per-integration `SPECIFY_<KEY>_EXTRA_ARGS` env-var hook.
+
+The hook is implemented in `IntegrationBase._apply_extra_args_env_var`
+and wired into every concrete `build_exec_args` —
+`MarkdownIntegration`, `TomlIntegration`, `SkillsIntegration`, plus the
+overrides in Codex, Devin, Opencode and Copilot. These tests cover both
+the shared mechanism (via `SkillsIntegration` stubs near the top of the
+file) and each override integration end-to-end (further down). See
+issue #2595."""
 
 import os
 
@@ -213,6 +220,39 @@ def test_opencode_integration_honours_extra_args(monkeypatch):
         "--format",
         "json",
         "p",
+    ]
+
+
+def test_opencode_extra_args_cannot_clobber_prompt_derived_command(
+    monkeypatch,
+):
+    """Operator-injected extra args must appear BEFORE the prompt-derived
+    ``--command <X>`` so that Spec Kit's command selection wins under
+    repeated-flag CLI semantics (last value typically takes precedence).
+
+    Locks against the regression where an operator setting
+    ``SPECIFY_OPENCODE_EXTRA_ARGS="--command malicious"`` could redirect
+    a slash-prefixed prompt to a different command.
+    """
+    from specify_cli.integrations.opencode import OpencodeIntegration
+
+    monkeypatch.setenv(
+        "SPECIFY_OPENCODE_EXTRA_ARGS", "--command operator-override"
+    )
+    args = OpencodeIntegration().build_exec_args("/speckit body text")
+    # Prompt-derived "--command speckit" appears AFTER the
+    # operator-injected one, so a CLI that resolves repeated flags
+    # last-wins will honour Spec Kit's choice.
+    assert args == [
+        "opencode",
+        "run",
+        "--command",
+        "operator-override",
+        "--command",
+        "speckit",
+        "--format",
+        "json",
+        "body text",
     ]
 
 


### PR DESCRIPTION
## Description

Closes #2595.

Adds a per-integration env-var hook
(`SPECKIT_INTEGRATION_<KEY>_EXTRA_ARGS`) so operators can inject
extra CLI flags into the spawned agent subprocess without modifying
any SKILL or workflow YAML. The motivating use case is
non-interactive contexts (CI, batch, sandboxed eval) where the
spawned `<agent> -p ...` hangs silently on an internal permission
or input prompt invisible to the parent `specify workflow run`
process.

The `INTEGRATION` segment scopes the variable to this subsystem so
it does not collide with other Spec Kit env-var namespaces. The
`SPECKIT_` prefix matches the existing integration-subsystem env
vars (`SPECKIT_INTEGRATION_CATALOG_URL`,
`SPECKIT_COPILOT_ALLOW_ALL_TOOLS`), keeping the namespace
consistent. (Original draft and linked issue #2595 used the
`SPECIFY_*` prefix; the implementation landed on `SPECKIT_*` for
namespace alignment.)

### What changed

- New helper `IntegrationBase._apply_extra_args_env_var(args)` —
  reads `SPECKIT_INTEGRATION_<KEY>_EXTRA_ARGS` from env (key
  normalized: `-` → `_`, uppercased), parses with `shlex.split`,
  and appends to *args*. No-op when the env var is unset or
  whitespace-only.
- `MarkdownIntegration.build_exec_args`,
  `TomlIntegration.build_exec_args`, and
  `SkillsIntegration.build_exec_args` each call the helper between
  `args = [self.key, "-p", prompt]` and the model / output-format
  appends — so extra args sit between `-p prompt` and the
  canonical Spec Kit flags and cannot clobber them.
- The four integrations that override `build_exec_args`
  (`CodexIntegration`, `DevinIntegration`, `OpencodeIntegration`,
  `CopilotIntegration`) also call the helper in the matching
  position so the env var works for every `requires_cli`
  integration.
- `CopilotIntegration.dispatch_command` builds `cli_args` inline
  rather than going through `build_exec_args`; the hook is invoked
  there too so workflow execution honours the env var (not just
  `build_exec_args` callers).
- New `tests/integrations/test_extra_args.py` with 17 tests
  covering: default no-op, single-token, multi-token via shlex,
  whitespace-only treated as unset, malformed-quoting actionable
  error, other-integration env var ignored (per-key scoping),
  key normalization (`kiro-cli` → `KIRO_CLI`), `requires_cli: False`
  short-circuit, per-integration `build_exec_args` checks for
  Codex/Devin/Opencode/Copilot plus base-class coverage for
  `MarkdownIntegration` and `TomlIntegration`, Opencode precedence
  vs. prompt-derived `--command`, and end-to-end `dispatch_command`
  checks (Copilot
  override path + inherited base path).

### Default behaviour preserved

When `SPECKIT_INTEGRATION_<KEY>_EXTRA_ARGS` is unset for the active
integration, `build_exec_args` returns byte-identical argv to
before this change. Existing operators see no difference.

### Examples

```bash
# Non-interactive Claude run in CI
SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS="--dangerously-skip-permissions" \
    specify workflow run my-pipeline

# Per-integration scoping
SPECKIT_INTEGRATION_GEMINI_EXTRA_ARGS="--max-turns 3" specify workflow run …

# Multi-token via shlex
SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS="--dangerously-skip-permissions --max-turns 3" …

# Hyphenated keys
SPECKIT_INTEGRATION_KIRO_CLI_EXTRA_ARGS="--some-flag" specify workflow run …
```

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests: `pytest tests/ -q` →
      **3011 passed, 40 skipped** (was 2997 on the pre-PR base;
      +17 new tests added in this PR — full suite green locally
      and across the CI matrix on Ubuntu 3.11/3.12/3.13 +
      Windows 3.11/3.12/3.13).
- [x] Tested with a sample project: invoked `specify workflow run`
      against a Claude command step with
      `SPECKIT_INTEGRATION_CLAUDE_EXTRA_ARGS=--dangerously-skip-permissions`
      set — flag reaches the spawned `claude -p ...` subprocess
      and the run completes non-interactively. Same workflow
      without the env var still hangs as before (consistent with
      the pre-PR behaviour).

### Manual test results

**Agent**: Claude Code (CLI)  |  **OS/Shell**: macOS 14 / zsh

| Test | Result | Notes |
|---|---|---|
| Env var set → flag in argv | PASS | `--dangerously-skip-permissions` appears between `-p prompt` and `--model` |
| Env var unset → byte-identical argv | PASS | argv matches pre-PR shape exactly |
| Other-integration env var ignored | PASS | `SPECKIT_INTEGRATION_GEMINI_EXTRA_ARGS=...` does not affect Claude argv |
| Multi-token via shlex | PASS | `"--flag-a --flag-b 3"` splits into 3 tokens |
| Whitespace-only treated as unset | PASS | `"   "` → no-op |
| Key normalization `kiro-cli` → `KIRO_CLI` | PASS | env var `SPECKIT_INTEGRATION_KIRO_CLI_EXTRA_ARGS` correctly read |
| `requires_cli: False` short-circuit | PASS | `build_exec_args` returns None; env-var hook never reached |

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (described below)

Used Claude Opus to draft the implementation (env-var hook +
helper extraction), the test suite, the issue body for #2595, and
this PR body. The reproducer scenario (non-interactive `claude -p`
hang on permission prompts) was a real-world problem encountered
in operator practice. Code, tests, and design decisions were
human-reviewed before submission.

