### PR TITLE
Add util for windows sub-process

### DIFF
--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -24,6 +24,16 @@ from ..base import IntegrationBase, IntegrationOption, SkillsIntegration
 from ..manifest import IntegrationManifest
 
 
+def _copilot_executable() -> str:
+    """Return the executable name for Copilot CLI on this platform.
+
+    On Windows, subprocess invocation is reliable with `copilot.cmd`.
+    """
+    if os.name == "nt":
+        return "copilot.cmd"
+    return "copilot"
+
+
 def _allow_all() -> bool:
     """Return True if the Copilot CLI should run with full permissions.
 

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -148,7 +148,7 @@ class CopilotIntegration(IntegrationBase):
         # Controlled by SPECKIT_COPILOT_ALLOW_ALL_TOOLS env var
         # (default: enabled).  The deprecated SPECKIT_ALLOW_ALL_TOOLS
         # is also honoured as a fallback.
-        args = ["copilot", "-p", prompt]
+        args = [_copilot_executable(), "-p", prompt]
         if _allow_all():
             args.append("--yolo")
         if model:
@@ -216,7 +216,7 @@ class CopilotIntegration(IntegrationBase):
             agent_name = f"speckit.{stem}"
             prompt = args or ""
 
-        cli_args = ["copilot", "-p", prompt]
+        cli_args = [_copilot_executable(), "-p", prompt]
         if not skills_mode:
             cli_args.extend(["--agent", agent_name])
         if _allow_all():

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -13,6 +13,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -373,7 +374,8 @@ class TestBuildExecArgs:
         from specify_cli.integrations.copilot import CopilotIntegration
         impl = CopilotIntegration()
         args = impl.build_exec_args("do stuff", model="claude-sonnet-4-20250514")
-        assert args[0] == "copilot"
+        expected_exec = "copilot.cmd" if os.name == "nt" else "copilot"
+        assert args[0] == expected_exec
         assert "-p" in args
         assert "--yolo" in args
         assert "--model" in args


### PR DESCRIPTION
This pull request adds a utility function to determine the correct executable name for the Copilot CLI based on the operating system. This helps ensure that subprocess calls work reliably across platforms.

Platform compatibility improvement:

* Added the `_copilot_executable()` function to return the appropriate Copilot CLI executable name (`copilot.cmd` on Windows, `copilot` otherwise), improving subprocess invocation reliability on different platforms.## Description

<!-- What does this PR do? Why is it needed? -->

## Testing

<!-- How did you test your changes? -->

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

> 16 failed, 2952 passed, 3 skipped in 335.38s (0:05:35)

```
========================================================================================================================= short test summary info =========================================================================================================================
FAILED tests/integrations/test_cli.py::TestInitIntegrationFlag::test_shared_infra_skip_warning_displayed - AssertionError: assert 'specify integration upgrade --force' in '\x1b[33m⚠\x1b[0m 1 shared infrastructure file(s) already exist and were not updated: .specify/scripts/bash/common.sh To refresh shared infrastructure, run \x1b[36mspecify init --here --force\x1b[0m ...
FAILED tests/integrations/test_integration_subcommand.py::TestIntegrationList::test_list_shows_multi_install_safe_status - StopIteration
FAILED tests/integrations/test_integration_subcommand.py::TestIntegrationInstall::test_install_already_installed - assert 'specify integration upgrade copilot' in "\x1b[33mIntegration 'copilot' is already installed.\x1b[0m It is already the default integration. To refresh its managed files or options, run \x1b[36mspecify integration upgrade \x1b[0m \x1b[36mcopilot\x1b[0m. No ...
FAILED tests/integrations/test_integration_subcommand.py::TestIntegrationInstall::test_install_different_when_one_exists - assert 'Default integration: copilot' in "\x1b[31mError:\x1b[0m Installed integrations: copilot.\nDefault integration: \x1b[36mcopilot\x1b[0m.\nInstalling multiple integrations is only automatic when all involved \nintegrations are declared multi-install safe.\nT...
FAILED tests/integrations/test_integration_subcommand.py::TestIntegrationInstall::test_install_multi_unsafe_requires_force - assert 'retry the same install command with --force' in "\x1b[31mError:\x1b[0m Installed integrations: copilot. Default integration: \x1b[36mcopilot\x1b[0m. Installing multiple integrations is only automatic when all involved integrations are declared multi-insta...
FAILED tests/test_setup_tasks.py::test_setup_tasks_bash_core_template_resolved - AssertionError: TASKS_TEMPLATE must be an absolute path
FAILED tests/test_setup_tasks.py::test_setup_tasks_bash_override_wins - AssertionError: TASKS_TEMPLATE must be an absolute path
FAILED tests/test_setup_tasks.py::test_setup_tasks_bash_extension_wins_over_core - AssertionError: TASKS_TEMPLATE must be an absolute path
FAILED tests/test_setup_tasks.py::test_setup_tasks_bash_preset_wins_over_extension - AssertionError: TASKS_TEMPLATE must be an absolute path
FAILED tests/test_setup_tasks.py::test_setup_tasks_bash_preset_priority_order - AssertionError: TASKS_TEMPLATE must be an absolute path
FAILED tests/test_timestamp_branches.py::TestTimestampBranch::test_long_name_truncation - AssertionError: [specify] Warning: Branch name exceeded GitHub's 244-byte limit
FAILED tests/test_timestamp_branches.py::TestGetFeaturePathsSinglePrefix::test_bash_specify_feature_prefixed_resolves_by_prefix - AssertionError: assert '/tmp/pytest-...1-target-spec' == 'C:\\Users\\Z...1-target-spec'
FAILED tests/test_timestamp_branches.py::TestFeatureDirectoryResolution::test_env_var_overrides_branch_lookup - assert 'C:\\Users\\<MachineName>\\AppData\\Local\\Temp\\pytest-of-<MachineName>\\pytest-34\\test_env_var_overrides_branch_0\\my-custom-specs\\my-feature' in 'REPO_ROOT=/tmp/pytest-of-<MachineName>/pytest-34/test_env_var_overrides_branch_0\nCURRENT_BRANCH=master\nHAS_GIT=true\nFEATURE_DI...
FAILED tests/test_timestamp_branches.py::TestFeatureDirectoryResolution::test_feature_json_overrides_branch_lookup - AssertionError: assert '/tmp/pytest-...ustom-feature' == 'C:\\Users\\Z...ustom-feature'
FAILED tests/test_timestamp_branches.py::TestFeatureDirectoryResolution::test_env_var_takes_priority_over_feature_json - AssertionError: assert '/tmp/pytest-...\\env-feature' == 'C:\\Users\\Z...\\env-feature'
FAILED tests/test_timestamp_branches.py::TestFeatureDirectoryResolution::test_fallback_to_branch_lookup - AssertionError: assert '/tmp/pytest-...001-test-feat' == 'C:\\Users\\Z...001-test-feat'
========================================================================================================= 16 failed, 2952 passed, 3 skipped in 335.38s (0:05:35) ==========================================================================================================

<MachineName>@<MachineName> MINGW64 /c/Github/spec-kit (main)
```



## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

<!-- If you used AI, briefly describe how (e.g., "Code generated by Copilot", "Consulted ChatGPT for approach"): -->
Ran into this after install when working on other project, probably handy to have

