### PR TITLE
chore(catalog): bump v-model extension to v0.7.2

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-05-15T00:00:00Z",
+  "updated_at": "2026-05-17T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -3102,8 +3102,8 @@
       "id": "v-model",
       "description": "Enforces V-Model paired generation of development specs and test specs with full traceability.",
       "author": "leocamello",
-      "version": "0.6.0",
-      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.6.0.zip",
+      "version": "0.7.1",
+      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.7.1.zip",
       "repository": "https://github.com/leocamello/spec-kit-v-model",
       "homepage": "https://github.com/leocamello/spec-kit-v-model",
       "documentation": "https://github.com/leocamello/spec-kit-v-model/blob/main/README.md",
@@ -3113,8 +3113,8 @@
         "speckit_version": ">=0.1.0"
       },
       "provides": {
-        "commands": 14,
-        "hooks": 1
+        "commands": 17,
+        "hooks": 4
       },
       "tags": [
         "v-model",
@@ -3125,9 +3125,9 @@
       ],
       "verified": false,
       "downloads": 0,
-      "stars": 21,
+      "stars": 27,
       "created_at": "2026-02-20T00:00:00Z",
-      "updated_at": "2026-04-25T00:00:00Z"
+      "updated_at": "2026-05-17T00:00:00Z"
     },
     "verify": {
       "name": "Verify Extension",

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -3133,8 +3133,8 @@
       "id": "v-model",
       "description": "Enforces V-Model paired generation of development specs and test specs with full traceability.",
       "author": "leocamello",
-      "version": "0.6.0",
-      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.6.0.zip",
+      "version": "0.7.2",
+      "download_url": "https://github.com/leocamello/spec-kit-v-model/archive/refs/tags/v0.7.2.zip",
       "repository": "https://github.com/leocamello/spec-kit-v-model",
       "homepage": "https://github.com/leocamello/spec-kit-v-model",
       "documentation": "https://github.com/leocamello/spec-kit-v-model/blob/main/README.md",
@@ -3144,8 +3144,8 @@
         "speckit_version": ">=0.1.0"
       },
       "provides": {
-        "commands": 14,
-        "hooks": 1
+        "commands": 17,
+        "hooks": 4
       },
       "tags": [
         "v-model",
@@ -3156,9 +3156,9 @@
       ],
       "verified": false,
       "downloads": 0,
-      "stars": 21,
+      "stars": 27,
       "created_at": "2026-02-20T00:00:00Z",
-      "updated_at": "2026-04-25T00:00:00Z"
+      "updated_at": "2026-05-21T00:00:00Z"
     },
     "verify": {
       "name": "Verify Extension",


### PR DESCRIPTION
Updates the `v-model` entry in `extensions/catalog.community.json` to point at the new [v0.7.1 release](https://github.com/leocamello/spec-kit-v-model/releases/tag/v0.7.1).

v0.7.0 was never submitted upstream, so this single bump catches the catalog up from `0.6.0` directly to `0.7.1`. Follows the same pattern as the previous bumps:

- v0.2.0 → #1656
- v0.3.0 → #1661
- v0.4.0 → #1665
- v0.5.0 → #2108
- v0.6.0 → #2399

## Catalog changes

| Field | Before | After |
|---|---|---|
| `version` | 0.6.0 | **0.7.1** |
| `download_url` | …/v0.6.0.zip | **…/v0.7.1.zip** |
| `provides.commands` | 14 | **17** (+3 bridge commands) |
| `provides.hooks` | 1 | **4** (+3 lifecycle hooks) |
| `stars` | 21 | **27** (live count from GitHub API) |
| `updated_at` | 2026-04-25 | **2026-05-17** (v0.7.1 release date) |

Top-level catalog `updated_at` bumped `2026-05-15 → 2026-05-17`.

## What's new since v0.6.0

**v0.7.0 — Bridge Commands** (catalog-relevant)

Three new commands and three new lifecycle hooks connect V-Model specification artifacts to executable implementation, completing the spec-to-code gap:

| Command | Wraps | Adds |
|---|---|---|
| `/speckit.v-model.plan` | `/speckit.plan` | V-Model-enriched `plan.md` synthesis with additive HTML-comment traceability; pinned-schema validation; structured run summary. |
| `/speckit.v-model.tasks` | `/speckit.tasks` | TDD-ordered task decomposition consuming `unit-test.md` / `integration-test.md` / `system-test.md` / `acceptance-plan.md`; hazard-driven priority elevation; per-task `Implements`-directive headers. |
| `/speckit.v-model.implement` | `/speckit.implement` | Pre-flight V-Model gate (`run-v-model-gate.sh`); four-level test generation; sentinel-managed splicing into existing sources; `Implements`-directive hallucination guard; post-implement trace hook. |

New hooks: `after_specify` → `v-model.requirements`; `before_implement` → `v-model.trace`; `after_implement` → `v-model.trace`. Plus eight validator/MF hardenings (status gate, domain profile, schema validator, splicer hardening, etc.).

**v0.7.1 — Bridge Command Reconciliation & Governance**

Reconciles the v0.7.0 bridge commands with their user-facing intent — that `/speckit.v-model.implement` produces a fully working and validated implementation from the V-Model artefact set:

- **All 8 V-Model artefacts mandatory for `implement`.** No graceful skip on missing test plans or design artefacts; iterates `module-design.md` directly per the V-Model design; explicit test-first emphasis pulling all V-Model artefacts into code-gen context.
- **`/speckit.v-model.plan` and `tasks` clarified as OPTIONAL.** The Direct Path via `/speckit.v-model.implement` is self-sufficient; the optional bridges exist for users mixing V-Model with spec-kit-core's downstream toolchain.
- **Real contributor operating manual.** New `AGENTS.md` (replaces auto-generated `CLAUDE.md`); constitution v1.0.0 → v1.1.0 with additive Bridge Command Discipline, V-Model Artifact Map, and expanded ID schema.
- **Canonical-ID grammar generalised.** Accepts any 2–3-letter uppercase sub-prefix on any root (REQ-DR, REQ-LC, REQ-SEC, SYS-DR, etc.), matching the project's actual conventions.

No new commands or hooks in v0.7.1.

## Verification

| Suite | Result |
|---|---|
| `python3 -c "import json; json.load(open('extensions/catalog.community.json'))"` | ✅ valid JSON |
| Spec-kit-v-model pytest structural | 122 passed, 0 failed |
| Spec-kit-v-model BATS | 457 passed, 0 failed |
| Spec-kit-v-model LLM-judge | 10/10 effectively passing (1 LLM-variance flake passes on re-run) |
| Download URL HEAD | HTTP 302 (matches v0.7.0's verified-redirect pattern) |

Full release narratives:

- [v0.7.0 CHANGELOG](https://github.com/leocamello/spec-kit-v-model/blob/v0.7.0/CHANGELOG.md)
- [v0.7.1 CHANGELOG](https://github.com/leocamello/spec-kit-v-model/blob/v0.7.1/CHANGELOG.md)