### PR TITLE
Add workflow-preset to community catalog

### DIFF
--- a/docs/community/presets.md
+++ b/docs/community/presets.md
@@ -27,5 +27,6 @@ The following community-contributed presets customize how Spec Kit behaves — o
 | Spec2Cloud | Spec-driven workflow tuned for shipping to Azure: spec → plan → tasks → implement → deploy | 5 templates, 8 commands | — | [spec2cloud](https://github.com/Azure-Samples/Spec2Cloud) |
 | Table of Contents Navigation | Adds a navigable Table of Contents to generated spec.md, plan.md, and tasks.md documents | 3 templates, 3 commands | — | [spec-kit-preset-toc-navigation](https://github.com/Quratulain-bilal/spec-kit-preset-toc-navigation) |
 | VS Code Ask Questions | Enhances the clarify command to use `vscode/askQuestions` for batched interactive questioning. | 1 command | — | [spec-kit-presets](https://github.com/fdcastel/spec-kit-presets) |
+| Workflow Preset | Adds optional class, sequence, and test planning artifacts plus an orchestrated implementation workflow with isolated handoff shards | 1 template, 3 commands, 2 scripts, 1 workflow | — | [spec-kit-workflow-preset](https://github.com/bigsmartben/spec-kit-workflow-preset) |
 
 To build and publish your own preset, see the [Presets Publishing Guide](https://github.com/github/spec-kit/blob/main/presets/PUBLISHING.md).

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -572,6 +572,36 @@
         "clarify",
         "interactive"
       ]
+    },
+    "workflow-preset": {
+      "name": "Workflow Preset",
+      "id": "workflow-preset",
+      "version": "1.0.0",
+      "description": "Adds optional design planning artifacts and an orchestrated implementation workflow with isolated handoff shards.",
+      "author": "bigsmartben",
+      "repository": "https://github.com/bigsmartben/spec-kit-workflow-preset",
+      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/archive/refs/tags/v1.0.0.zip",
+      "homepage": "https://github.com/bigsmartben/spec-kit-workflow-preset",
+      "documentation": "https://github.com/bigsmartben/spec-kit-workflow-preset/blob/main/README.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.8.10.dev0"
+      },
+      "provides": {
+        "templates": 1,
+        "commands": 3,
+        "scripts": 2,
+        "workflows": 1
+      },
+      "tags": [
+        "planning",
+        "design",
+        "implementation",
+        "orchestration",
+        "workflow"
+      ],
+      "created_at": "2026-05-18T00:00:00Z",
+      "updated_at": "2026-05-18T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Preset Submission

**Preset Name**: Workflow Preset
**Preset ID**: workflow-preset
**Version**: 1.0.0
**Repository**: https://github.com/bigsmartben/spec-kit-workflow-preset

### Checklist
- [x] Valid preset.yml manifest
- [x] README.md with description and usage
- [x] LICENSE file included
- [x] GitHub release tag created
- [x] Preset tested with `specify preset add --dev`
- [x] Commands register to agent directories
- [x] Commands match template sections
- [x] Added to presets/catalog.community.json
- [x] Added row to docs/community/presets.md table

## Summary
- Adds `workflow-preset` v1.0.0 to the community preset catalog.
- Documents the preset in the community presets table.

## Verification
- `python3 -m unittest tests/test_preset_contract.py` in the preset repository: 11 passed
- `uv run --extra test pytest tests/test_presets.py` in spec-kit: 245 passed
- Installed release archive with `specify preset add workflow-preset --from https://github.com/bigsmartben/spec-kit-workflow-preset/archive/refs/tags/v1.0.0.zip` and verified `specify preset info workflow-preset`.