### PR TITLE
fix(cursor-agent): enable headless CLI dispatch end-to-end (-p --trust --approve-mcps --force + Windows .cmd shim resolution)

### DIFF
--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -202,6 +202,16 @@ class IntegrationBase(ABC):
             )
             raise NotImplementedError(msg)
 
+        # Windows: ``subprocess.run`` calls ``CreateProcess`` which does not
+        # consult ``PATHEXT``, so a bare command name like ``cursor-agent``
+        # that resolves to ``cursor-agent.cmd`` fails with ``WinError 2``.
+        # Resolve via ``shutil.which`` (which does honor ``PATHEXT``) so
+        # ``.cmd``/``.bat`` shims work transparently.  On POSIX this is a
+        # no-op for absolute paths and a harmless lookup otherwise.
+        resolved = shutil.which(exec_args[0])
+        if resolved:
+            exec_args = [resolved, *exec_args[1:]]
+
         cwd = str(project_root) if project_root else None
 
         if stream:

--- a/src/specify_cli/integrations/cursor_agent/__init__.py
+++ b/src/specify_cli/integrations/cursor_agent/__init__.py
@@ -41,14 +41,30 @@ class CursorAgentIntegration(SkillsIntegration):
     ) -> list[str] | None:
         """Build CLI arguments for non-interactive ``cursor-agent`` execution.
 
-        Uses ``-p`` (print/headless mode, which gives access to all
-        tools including write and shell) plus ``--trust`` (bypass the
-        Workspace Trust prompt — mandatory for headless execution; the
-        CLI exits non-zero without it).
+        Mandatory headless flags:
+
+        * ``-p`` — print/headless mode (access to all tools)
+        * ``--trust`` — bypass Workspace Trust prompt (CLI exits non-zero
+          otherwise)
+        * ``--approve-mcps`` — auto-approve MCP server loading (otherwise
+          MCP servers stay ``not loaded (needs approval)`` and tool calls
+          to them are silently dropped)
+        * ``--force`` — auto-approve tool invocations (shell/write/MCP),
+          matching the implicit "trusted environment" semantics that other
+          integrations (``claude -p``, ``codex --exec``) get by default
+
+        Together these are the minimum set required to make
+        ``specify workflow run speckit --input integration=cursor-agent``
+        behave the same way as it does for ``claude`` / ``codex``.
+        Verified locally: with ``--approve-mcps --force`` the agent can
+        call any configured MCP server (e.g. ``dingtalk-doc``) and write
+        files during ``/speckit-*`` skill execution; without them the run
+        either drops tool calls or exits non-zero on the first approval
+        prompt.
         """
         if not self.config or not self.config.get("requires_cli"):
             return None
-        args = [self.key, "-p", "--trust", prompt]
+        args = [self.key, "-p", "--trust", "--approve-mcps", "--force", prompt]
         if model:
             args.extend(["--model", model])
         if output_json:

--- a/src/specify_cli/integrations/cursor_agent/__init__.py
+++ b/src/specify_cli/integrations/cursor_agent/__init__.py
@@ -3,9 +3,11 @@
 Cursor Agent uses the ``.cursor/skills/speckit-<name>/SKILL.md`` layout.
 Commands are deprecated; ``--skills`` defaults to ``True``.
 
-CLI dispatch via ``cursor-agent -p --trust <prompt>`` is supported so
-``specify workflow run`` can drive cursor-agent headlessly, in addition
-to the existing in-IDE skill flow.
+The IDE/skills flow is the primary path and works without the
+``cursor-agent`` CLI being installed (``requires_cli=False``).  Workflow
+dispatch via ``cursor-agent -p --trust <prompt>`` is offered as an
+opt-in capability — the presence of ``build_exec_args()`` is what
+indicates dispatch support, mirroring ``CopilotIntegration``.
 """
 
 from __future__ import annotations
@@ -20,7 +22,12 @@ class CursorAgentIntegration(SkillsIntegration):
         "folder": ".cursor/",
         "commands_subdir": "skills",
         "install_url": "https://docs.cursor.com/en/cli/overview",
-        "requires_cli": True,
+        # IDE-first integration: ``specify init --ai cursor-agent`` must
+        # work without the ``cursor-agent`` CLI installed (the IDE flow
+        # uses skills directly).  Workflow dispatch additionally requires
+        # the CLI on PATH, but that's enforced at dispatch time via
+        # ``shutil.which`` rather than as a hard ``specify init`` precheck.
+        "requires_cli": False,
     }
     registrar_config = {
         "dir": ".cursor/skills",
@@ -40,6 +47,13 @@ class CursorAgentIntegration(SkillsIntegration):
         output_json: bool = True,
     ) -> list[str] | None:
         """Build CLI arguments for non-interactive ``cursor-agent`` execution.
+
+        Always returns argv (no ``requires_cli`` guard) so workflow
+        dispatch is supported even though the integration's ``config``
+        sets ``requires_cli=False`` to keep the IDE-only flow unblocked.
+        This mirrors ``CopilotIntegration``: dispatch support is signalled
+        by overriding ``build_exec_args()``, not by the ``requires_cli``
+        flag (which is reserved for the ``specify init`` precheck).
 
         Mandatory headless flags:
 
@@ -62,8 +76,6 @@ class CursorAgentIntegration(SkillsIntegration):
         either drops tool calls or exits non-zero on the first approval
         prompt.
         """
-        if not self.config or not self.config.get("requires_cli"):
-            return None
         args = [self.key, "-p", "--trust", "--approve-mcps", "--force", prompt]
         if model:
             args.extend(["--model", model])

--- a/src/specify_cli/integrations/cursor_agent/__init__.py
+++ b/src/specify_cli/integrations/cursor_agent/__init__.py
@@ -5,9 +5,9 @@ Commands are deprecated; ``--skills`` defaults to ``True``.
 
 The IDE/skills flow is the primary path and works without the
 ``cursor-agent`` CLI being installed (``requires_cli=False``).  Workflow
-dispatch via ``cursor-agent -p --trust <prompt>`` is offered as an
-opt-in capability — the presence of ``build_exec_args()`` is what
-indicates dispatch support, mirroring ``CopilotIntegration``.
+dispatch via ``cursor-agent -p --trust --approve-mcps --force <prompt>``
+is offered as an opt-in capability — the presence of ``build_exec_args()``
+is what indicates dispatch support, mirroring ``CopilotIntegration``.
 """
 
 from __future__ import annotations

--- a/src/specify_cli/integrations/cursor_agent/__init__.py
+++ b/src/specify_cli/integrations/cursor_agent/__init__.py
@@ -2,6 +2,10 @@
 
 Cursor Agent uses the ``.cursor/skills/speckit-<name>/SKILL.md`` layout.
 Commands are deprecated; ``--skills`` defaults to ``True``.
+
+CLI dispatch via ``cursor-agent -p --trust <prompt>`` is supported so
+``specify workflow run`` can drive cursor-agent headlessly, in addition
+to the existing in-IDE skill flow.
 """
 
 from __future__ import annotations
@@ -15,8 +19,8 @@ class CursorAgentIntegration(SkillsIntegration):
         "name": "Cursor",
         "folder": ".cursor/",
         "commands_subdir": "skills",
-        "install_url": None,
-        "requires_cli": False,
+        "install_url": "https://docs.cursor.com/en/cli/overview",
+        "requires_cli": True,
     }
     registrar_config = {
         "dir": ".cursor/skills",
@@ -27,6 +31,29 @@ class CursorAgentIntegration(SkillsIntegration):
 
     context_file = ".cursor/rules/specify-rules.mdc"
     multi_install_safe = True
+
+    def build_exec_args(
+        self,
+        prompt: str,
+        *,
+        model: str | None = None,
+        output_json: bool = True,
+    ) -> list[str] | None:
+        """Build CLI arguments for non-interactive ``cursor-agent`` execution.
+
+        Uses ``-p`` (print/headless mode, which gives access to all
+        tools including write and shell) plus ``--trust`` (bypass the
+        Workspace Trust prompt — mandatory for headless execution; the
+        CLI exits non-zero without it).
+        """
+        if not self.config or not self.config.get("requires_cli"):
+            return None
+        args = [self.key, "-p", "--trust", prompt]
+        if model:
+            args.extend(["--model", model])
+        if output_json:
+            args.extend(["--output-format", "json"])
+        return args
 
     @classmethod
     def options(cls) -> list[IntegrationOption]:

--- a/tests/integrations/test_integration_cursor_agent.py
+++ b/tests/integrations/test_integration_cursor_agent.py
@@ -1,6 +1,7 @@
 """Tests for CursorAgentIntegration."""
 
 from pathlib import Path
+from urllib.parse import urlparse
 
 from specify_cli.integrations import get_integration
 from specify_cli.integrations.manifest import IntegrationManifest
@@ -116,15 +117,29 @@ class TestCursorAgentCliDispatch:
     shape that the workflow runner will use.
     """
 
-    def test_requires_cli_is_true(self):
+    def test_requires_cli_is_false_for_ide_first_flow(self):
+        """``requires_cli`` must stay False so the IDE-only flow keeps working.
+
+        ``specify init --ai cursor-agent`` (without ``--ignore-agent-tools``)
+        treats ``requires_cli=True`` as a hard precheck and fails when the
+        ``cursor-agent`` CLI isn't on PATH — even though the Cursor IDE
+        / skills flow can run without it.  Workflow dispatch support is
+        signalled by overriding ``build_exec_args()`` instead, mirroring
+        ``CopilotIntegration``.
+        """
         i = get_integration("cursor-agent")
-        assert i.config.get("requires_cli") is True
+        assert i.config.get("requires_cli") is False
 
     def test_install_url_is_set(self):
         i = get_integration("cursor-agent")
         url = i.config.get("install_url")
         assert url is not None
-        assert "cursor.com" in url
+        # CodeQL: use a hostname comparison instead of a substring check
+        # to avoid the "Incomplete URL substring sanitization" warning
+        # (substring "cursor.com" can also appear in attacker-controlled
+        # positions of an arbitrary URL).
+        host = (urlparse(url).hostname or "").lower()
+        assert host == "cursor.com" or host.endswith(".cursor.com")
 
     def test_build_exec_args_default_includes_headless_flags_and_json(self):
         """Default argv emits the full headless flag set: -p --trust
@@ -171,6 +186,22 @@ class TestCursorAgentCliDispatch:
         args = i.build_exec_args("/speckit-implement", output_json=False)
         for flag in ("-p", "--trust", "--approve-mcps", "--force"):
             assert flag in args, f"missing mandatory headless flag: {flag}"
+
+    def test_build_exec_args_supports_dispatch_without_requires_cli(self):
+        """``build_exec_args`` must return argv even though ``requires_cli``
+        is ``False``.
+
+        ``CursorAgentIntegration`` opts out of the ``requires_cli`` hard
+        precheck (so ``specify init`` doesn't fail when the CLI isn't on
+        PATH) but still supports workflow dispatch.  The presence of a
+        non-``None`` argv from ``build_exec_args()`` is what the engine
+        keys off — pin that invariant.
+        """
+        i = get_integration("cursor-agent")
+        assert i.config.get("requires_cli") is False
+        argv = i.build_exec_args("/speckit-plan", output_json=False)
+        assert argv is not None
+        assert argv[0] == "cursor-agent"
 
     def test_build_command_invocation_uses_hyphenated_skill_name(self):
         """SkillsIntegration: /speckit-plan (not /speckit.plan)."""

--- a/tests/integrations/test_integration_cursor_agent.py
+++ b/tests/integrations/test_integration_cursor_agent.py
@@ -126,11 +126,14 @@ class TestCursorAgentCliDispatch:
         assert url is not None
         assert "cursor.com" in url
 
-    def test_build_exec_args_default_includes_trust_and_json(self):
+    def test_build_exec_args_default_includes_headless_flags_and_json(self):
+        """Default argv emits the full headless flag set: -p --trust
+        --approve-mcps --force, then prompt, then --output-format json.
+        """
         i = get_integration("cursor-agent")
         args = i.build_exec_args("/speckit-specify some-feature")
         assert args == [
-            "cursor-agent", "-p", "--trust",
+            "cursor-agent", "-p", "--trust", "--approve-mcps", "--force",
             "/speckit-specify some-feature",
             "--output-format", "json",
         ]
@@ -139,7 +142,8 @@ class TestCursorAgentCliDispatch:
         i = get_integration("cursor-agent")
         args = i.build_exec_args("/speckit-plan", output_json=False)
         assert args == [
-            "cursor-agent", "-p", "--trust", "/speckit-plan",
+            "cursor-agent", "-p", "--trust", "--approve-mcps", "--force",
+            "/speckit-plan",
         ]
 
     def test_build_exec_args_with_model(self):
@@ -148,9 +152,25 @@ class TestCursorAgentCliDispatch:
             "/speckit-specify", model="sonnet-4-thinking", output_json=False
         )
         assert args == [
-            "cursor-agent", "-p", "--trust", "/speckit-specify",
+            "cursor-agent", "-p", "--trust", "--approve-mcps", "--force",
+            "/speckit-specify",
             "--model", "sonnet-4-thinking",
         ]
+
+    def test_build_exec_args_contains_mandatory_headless_flags(self):
+        """The four headless flags must always appear together.
+
+        ``--approve-mcps`` is required so MCP servers (e.g. dingtalk-doc)
+        actually load in headless mode; ``--force`` is required so the
+        agent doesn't block on tool-call approval prompts during the
+        speckit workflow.  Together with ``-p`` and ``--trust`` they
+        bring cursor-agent's headless behaviour in line with
+        ``claude -p`` / ``codex --exec`` from spec-kit's perspective.
+        """
+        i = get_integration("cursor-agent")
+        args = i.build_exec_args("/speckit-implement", output_json=False)
+        for flag in ("-p", "--trust", "--approve-mcps", "--force"):
+            assert flag in args, f"missing mandatory headless flag: {flag}"
 
     def test_build_command_invocation_uses_hyphenated_skill_name(self):
         """SkillsIntegration: /speckit-plan (not /speckit.plan)."""
@@ -189,7 +209,7 @@ class TestCursorAgentCliDispatch:
         assert result["exit_code"] == 0
         argv = mock_run.call_args[0][0]
         assert argv[0] == fake_path, f"expected resolved .CMD path, got: {argv[0]!r}"
-        assert argv[1:4] == ["-p", "--trust", "/speckit-plan feature-x"]
+        assert argv[1:6] == ["-p", "--trust", "--approve-mcps", "--force", "/speckit-plan feature-x"]
 
     def test_dispatch_command_passthrough_when_shutil_which_finds_nothing(self):
         """If ``shutil.which`` returns ``None``, leave argv unchanged so the

--- a/tests/integrations/test_integration_cursor_agent.py
+++ b/tests/integrations/test_integration_cursor_agent.py
@@ -158,3 +158,55 @@ class TestCursorAgentCliDispatch:
         assert i.build_command_invocation("speckit.plan", "feature-x") == "/speckit-plan feature-x"
         assert i.build_command_invocation("plan") == "/speckit-plan"
 
+    def test_dispatch_command_resolves_cmd_shim_for_subprocess(self):
+        """``.cmd`` shims must be resolved to their full path before ``subprocess.run``.
+
+        ``cursor-agent`` (and other npm-installed CLIs on Windows) ship as
+        ``cursor-agent.cmd`` wrappers.  ``shutil.which`` honors ``PATHEXT``
+        and finds them, but Python's ``subprocess.run`` calls
+        ``CreateProcess`` which does **not** consult ``PATHEXT`` and fails
+        with ``WinError 2`` on a bare ``["cursor-agent", ...]`` argv.  The
+        fix in ``base.py::dispatch_command`` resolves ``exec_args[0]`` via
+        ``shutil.which`` so the full ``.cmd`` path is what reaches
+        ``CreateProcess``.
+        """
+        from unittest.mock import patch, MagicMock
+        i = get_integration("cursor-agent")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "ok"
+        mock_result.stderr = ""
+
+        fake_path = r"C:\Users\foo\AppData\Local\cursor-agent\cursor-agent.CMD"
+        with patch(
+            "specify_cli.integrations.base.shutil.which", return_value=fake_path
+        ), patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = i.dispatch_command(
+                "speckit.plan", args="feature-x", stream=False, timeout=5
+            )
+
+        assert result["exit_code"] == 0
+        argv = mock_run.call_args[0][0]
+        assert argv[0] == fake_path, f"expected resolved .CMD path, got: {argv[0]!r}"
+        assert argv[1:4] == ["-p", "--trust", "/speckit-plan feature-x"]
+
+    def test_dispatch_command_passthrough_when_shutil_which_finds_nothing(self):
+        """If ``shutil.which`` returns ``None``, leave argv unchanged so the
+        existing ``FileNotFoundError`` path remains observable to callers."""
+        from unittest.mock import patch, MagicMock
+        i = get_integration("cursor-agent")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with patch(
+            "specify_cli.integrations.base.shutil.which", return_value=None
+        ), patch("subprocess.run", return_value=mock_result) as mock_run:
+            i.dispatch_command("speckit.plan", stream=False, timeout=5)
+
+        argv = mock_run.call_args[0][0]
+        assert argv[0] == "cursor-agent"
+

--- a/tests/integrations/test_integration_cursor_agent.py
+++ b/tests/integrations/test_integration_cursor_agent.py
@@ -106,3 +106,55 @@ class TestCursorAgentAutoPromote:
         assert result.exit_code == 0, f"init --ai cursor-agent failed: {result.output}"
         assert (target / ".cursor" / "skills" / "speckit-plan" / "SKILL.md").exists()
 
+
+class TestCursorAgentCliDispatch:
+    """Verify the CLI dispatch path for cursor-agent (issue #2629).
+
+    The ``cursor-agent`` CLI supports headless execution via ``-p`` (with
+    full tool access including write/shell) and requires ``--trust`` to
+    bypass the Workspace Trust prompt.  These tests pin the exact argv
+    shape that the workflow runner will use.
+    """
+
+    def test_requires_cli_is_true(self):
+        i = get_integration("cursor-agent")
+        assert i.config.get("requires_cli") is True
+
+    def test_install_url_is_set(self):
+        i = get_integration("cursor-agent")
+        url = i.config.get("install_url")
+        assert url is not None
+        assert "cursor.com" in url
+
+    def test_build_exec_args_default_includes_trust_and_json(self):
+        i = get_integration("cursor-agent")
+        args = i.build_exec_args("/speckit-specify some-feature")
+        assert args == [
+            "cursor-agent", "-p", "--trust",
+            "/speckit-specify some-feature",
+            "--output-format", "json",
+        ]
+
+    def test_build_exec_args_text_output_omits_format(self):
+        i = get_integration("cursor-agent")
+        args = i.build_exec_args("/speckit-plan", output_json=False)
+        assert args == [
+            "cursor-agent", "-p", "--trust", "/speckit-plan",
+        ]
+
+    def test_build_exec_args_with_model(self):
+        i = get_integration("cursor-agent")
+        args = i.build_exec_args(
+            "/speckit-specify", model="sonnet-4-thinking", output_json=False
+        )
+        assert args == [
+            "cursor-agent", "-p", "--trust", "/speckit-specify",
+            "--model", "sonnet-4-thinking",
+        ]
+
+    def test_build_command_invocation_uses_hyphenated_skill_name(self):
+        """SkillsIntegration: /speckit-plan (not /speckit.plan)."""
+        i = get_integration("cursor-agent")
+        assert i.build_command_invocation("speckit.plan", "feature-x") == "/speckit-plan feature-x"
+        assert i.build_command_invocation("plan") == "/speckit-plan"
+

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -555,15 +555,18 @@ class TestCommandStep:
         mock_result.stderr = ""
 
         with patch("specify_cli.workflows.steps.command.shutil.which", return_value="/usr/local/bin/claude"), \
+             patch("specify_cli.integrations.base.shutil.which", return_value="/usr/local/bin/claude"), \
              patch("subprocess.run", return_value=mock_result) as mock_run:
             result = step.execute(config, ctx)
 
         assert result.status == StepStatus.COMPLETED
         assert result.output["dispatched"] is True
         assert result.output["exit_code"] == 0
-        # Verify the CLI was called with -p and the skill invocation
+        # Verify the CLI was called with the resolved path (via shutil.which,
+        # which honors PATHEXT for ``.cmd``/``.bat`` shims on Windows), then
+        # ``-p`` and the skill invocation.
         call_args = mock_run.call_args
-        assert call_args[0][0][0] == "claude"
+        assert call_args[0][0][0] == "/usr/local/bin/claude"
         assert call_args[0][0][1] == "-p"
         # Claude is a SkillsIntegration so uses /speckit-specify
         assert "/speckit-specify login" in call_args[0][0][2]
@@ -592,6 +595,7 @@ class TestCommandStep:
         mock_result.stderr = "API error"
 
         with patch("specify_cli.workflows.steps.command.shutil.which", return_value="/usr/local/bin/claude"), \
+             patch("specify_cli.integrations.base.shutil.which", return_value="/usr/local/bin/claude"), \
              patch("subprocess.run", return_value=mock_result):
             result = step.execute(config, ctx)
 


### PR DESCRIPTION
﻿## Summary

Enable `specify workflow run` to dispatch the `cursor-agent` CLI headlessly end-to-end on Windows, matching the way it already dispatches `claude` / `codex` / `gemini`. Existing in-IDE skill flow (via `.cursor/skills/speckit-*/SKILL.md`) is preserved exactly — this PR only adds the CLI dispatch path on top.

Fixes #2629.

**Integration config (final):** `requires_cli` remains **`False`** so `specify init --ai cursor-agent` works without the CLI installed (IDE/skills flow unchanged). Workflow dispatch is enabled by overriding `build_exec_args()` — the same pattern as `CopilotIntegration` — with CLI presence enforced at dispatch time via `shutil.which`, not as a hard `specify init` precheck.

## Problem

Before this PR, `specify workflow run speckit --input integration=cursor-agent ...` fails immediately with:

```
Cannot dispatch command 'speckit.specify': integration 'cursor-agent' CLI not found or not installed.
Install the CLI tool or check 'specify integration list'.
```

even when `cursor-agent` is installed and healthy (`cursor-agent --version` returns `2026.05.16-0338208`).

Three separate gaps each independently block the headless path; this PR fixes all three.

## Commits

### Functional fixes (three gaps)

#### 1) `1c55988 fix(cursor-agent): enable CLI dispatch via -p --trust headless mode`

`CursorAgentIntegration` had `requires_cli: False` and did not override `build_exec_args`, so `SkillsIntegration.build_exec_args` returned `None`, the dispatcher in `workflows/steps/command/__init__.py::_try_dispatch` returned `None`, and the misleading CLI-missing error was surfaced. The CLI is actually fully headless-capable:

- `-p / --print` — print mode, "Has access to all tools, including write and shell"
- `--output-format text | json | stream-json`
- `--model <name>`
- `--trust` — "Trust the current workspace without prompting (only works with --print/headless mode)"

Without `--trust`, the CLI exits non-zero with `⚠ Workspace Trust Required`.

This commit (superseded on `requires_cli` by `ff07cc0` below — kept here for history):

- `config["install_url"]`: `None` → `https://docs.cursor.com/en/cli/overview`
- First override of `build_exec_args` to emit `[self.key, "-p", "--trust", prompt, …]` (later commits add `--approve-mcps --force`; `ff07cc0` sets `requires_cli` back to `False` for IDE-first init).

#### 2) `454d3d0 fix(integrations): resolve .cmd/.bat shims before subprocess.run`

After commit (1), the dispatcher still failed on Windows with `FileNotFoundError [WinError 2]`. Root cause:

- `shutil.which("cursor-agent")` returns `cursor-agent.CMD` (honoring `PATHEXT`).
- `subprocess.run(["cursor-agent", ...])` calls `CreateProcess`, which does **not** consult `PATHEXT`, so the bare command name fails to launch.

The same bug affects every `.cmd`/`.bat`-wrapped CLI on Windows (verified for `codex` as well; only `.exe` CLIs like `claude` were unaffected).

Fix in `IntegrationBase.dispatch_command`: resolve `exec_args[0]` via `shutil.which` before `subprocess.run`. No-op on POSIX (no `PATHEXT` to consult); transparent fix on Windows.

#### 3) `595bcab fix(cursor-agent): inject --approve-mcps --force for headless MCP/tool access`

After commits (1)+(2), `subprocess.run` succeeds and cursor-agent starts, but the first MCP call (e.g. to read a DingTalk PRD) fails with `The tool call was rejected. I can't retrieve the document name without permission to call the tool.` Two more flags are needed:

- `--approve-mcps` — without it, every MCP server stays `not loaded (needs approval)` and tool calls are silently dropped.
- `--force` — without it, the agent halts on the first tool-call approval prompt; the workflow returns a misleading non-zero exit. With it, cursor-agent matches the implicit "trusted environment" semantics that `claude -p` and `codex --exec` already have by default — the right semantics for an unattended `specify workflow run`.

Final argv after all three commits:

```python
args = [self.key, "-p", "--trust", "--approve-mcps", "--force", prompt]
if model: args.extend(["--model", model])
if output_json: args.extend(["--output-format", "json"])
```

### Review feedback (`ff07cc0`, `422b250`, `6e3819c`)

#### 4) `ff07cc0 refactor(cursor-agent): express dispatch support via build_exec_args() instead of requires_cli`

Addresses Copilot review: keep `requires_cli: False` so `specify init` does not hard-fail for IDE-only users. Remove the `requires_cli` guard inside `build_exec_args()`; dispatch support is signalled by overriding `build_exec_args()` (mirrors `CopilotIntegration`). Headless argv shape unchanged: `-p --trust --approve-mcps --force`.

#### 5) `422b250 test(cursor-agent): use urlparse hostname check and cover dispatch without requires_cli`

Addresses CodeQL: replace `"cursor.com" in url` substring check with `urlparse(...).hostname` comparison; add regression test that dispatch works with `requires_cli=False`.

#### 6) `6e3819c` — docstring: mention `--approve-mcps --force` in module-level dispatch description (Copilot doc consistency).

## End-to-end verification (real DingTalk PRD, just a URL as input)

Repro on Windows 10 + cursor-agent `2026.05.16-0338208`:

```powershell
cd D:\Code\MBM\MBM-Backend     # real Maven multi-module Java project
specify workflow run speckit `
  --input "spec=https://alidocs.dingtalk.com/i/nodes/<dingtalk-prd-node>" `
  --input "integration=cursor-agent" `
  --input "scope=full"
```

Two independent runs (`df8c4b9b`, `388d3c15`) both reach the `review-spec` gate:

```
specify step:
  dispatched=true, exit_code=0, status=completed, duration ~156s / ~147s

agent behaviour (autonomously, from a URL-only spec input):
  - calls dingtalk-doc MCP get_document_content to fetch the PRD
  - reads project constitution + existing specs/ layout
  - decides specs/ subpath itself (e.g. specs/tooling/mold-assembly/202605/<feature>/)
  - produces spec.md (31.5 KB) + checklists/requirements.md
  - updates .specify/feature.json and specs/menu-dictionary.md
  - marks 3 [NEEDS CLARIFICATION] items for Gate 1 review

next step (review-spec gate):
  (gate started; status would be `paused` on a normal completion)
```

(Both runs above were eventually cancelled by `Ctrl+C` while the gate step was just starting, which surfaced an `[Errno 22] Invalid argument` from the interrupted `subprocess.run`. That was an artifact of my cancellation, **not** a gate-step bug — `review-spec` is a `gate` step and its designed terminal status is `paused`. Independent of this PR either way.)

## Backward compatibility

- In-IDE skill flow (`.cursor/skills/speckit-*/SKILL.md`, `--skills` default) — **unchanged**.
- `multi_install_safe`, `context_file`, `registrar_config`, `options()` — unchanged.
- POSIX behaviour — `shutil.which` lookup is a no-op for already-absolute exec_args[0], and the `--approve-mcps --force` flags exist on Linux/macOS cursor-agent identically.
- `catalog.json`, `workflow.yml`, templates — untouched.
- Other integrations (`claude`, `codex`, `gemini`) — their `build_exec_args` paths are not touched; the only shared change is `base.py::dispatch_command` adding the `shutil.which` shim resolution, which only takes effect when `shutil.which` returns a *different* path than the input (i.e. `.cmd`/`.bat` shim case on Windows).

## Testing

```
$ uv run python -m pytest tests/integrations/test_integration_cursor_agent.py -v
============================= 43 passed in 3.72s ==============================

$ uv run python -m pytest -q
========== 12 failed, 2867 passed, 109 skipped in 372.85s (0:06:12) ===========
```

- 44 cursor-agent integration tests pass (CI green on this branch).
- New tests pin:
  - `requires_cli is False` (IDE-first init) and `install_url` is set; dispatch via `build_exec_args()` override
  - `install_url` hostname validated with `urlparse` (not substring match)
  - Exact argv layout `[cursor-agent, -p, --trust, --approve-mcps, --force, …]` (default + text-output + with-model variants)
  - All four mandatory headless flags are always present together
  - Hyphenated skill invocation (`/speckit-plan` not `/speckit.plan`)
  - `.cmd` shim resolution: subprocess receives full `cursor-agent.CMD` path, not bare `cursor-agent`
  - Passthrough when `shutil.which` returns `None`
- Existing `tests/test_workflows.py::TestCommandStep::test_dispatch_with_mock_cli` and `test_dispatch_failure_returns_failed_status` updated to patch `shutil.which` at the `base.py` layer (was previously only patching the dispatcher layer, which made the test environment-sensitive — passed on CI with no `claude` on PATH, failed locally with `claude` installed).
- Full repo: **2867 passed, 0 regressions from this PR.** The 12 remaining pre-existing failures are unrelated Windows `symlink` privilege issues (`WinError 1314`) requiring elevated runner — not introduced or affected by this PR.

## Out of scope (deliberately)

- The misleading `"CLI not found or not installed. Install the CLI tool."` error message itself (it conflates 5 distinct dispatch failure modes into one). Worth a separate PR to split per-failure-mode messages — happy to do that as a follow-up if maintainers want.
- Adding `cursor-agent` to bundled `speckit` workflow's `requires.integrations.any` list (currently `["copilot", "claude", "gemini"]`). Not strictly required — `specify workflow run` does not enforce that list strictly today — but worth a follow-up so `specify workflow info speckit` is consistent with the actual support matrix.
- `docs/reference/integrations.md` page for cursor-agent (none exists today; happy to add if wanted).
- Adding a `speckit.git.feature` step to `speckit` workflow.yml (current workflow doesn't auto-create feature branches; that's by design but worth surfacing as an opt-in for teams that want branch-per-feature).

