### PR TITLE
Add Workflow Preset to community catalog

### DIFF
--- a/docs/community/presets.md
+++ b/docs/community/presets.md
@@ -27,5 +27,6 @@ The following community-contributed presets customize how Spec Kit behaves — o
 | Spec2Cloud | Spec-driven workflow tuned for shipping to Azure: spec → plan → tasks → implement → deploy | 5 templates, 8 commands | — | [spec2cloud](https://github.com/Azure-Samples/Spec2Cloud) |
 | Table of Contents Navigation | Adds a navigable Table of Contents to generated spec.md, plan.md, and tasks.md documents | 3 templates, 3 commands | — | [spec-kit-preset-toc-navigation](https://github.com/Quratulain-bilal/spec-kit-preset-toc-navigation) |
 | VS Code Ask Questions | Enhances the clarify command to use `vscode/askQuestions` for batched interactive questioning. | 1 command | — | [spec-kit-presets](https://github.com/fdcastel/spec-kit-presets) |
+| Workflow Preset | Adds design-aware planning artifacts and agent-native implementation handoff orchestration with Core, Vertical Planner, and Worker boundaries | 4 templates, 3 commands | — | [spec-kit-workflow-preset](https://github.com/bigsmartben/spec-kit-workflow-preset) |
 
 To build and publish your own preset, see the [Presets Publishing Guide](https://github.com/github/spec-kit/blob/main/presets/PUBLISHING.md).

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -523,7 +523,7 @@
       ],
       "created_at": "2026-04-30T00:00:00Z",
       "updated_at": "2026-04-30T00:00:00Z"
-    }, 
+    },
     "toc-navigation": {
       "name": "Table of Contents Navigation",
       "id": "toc-navigation",
@@ -572,6 +572,34 @@
         "clarify",
         "interactive"
       ]
+    },
+    "workflow-preset": {
+      "name": "Workflow Preset",
+      "id": "workflow-preset",
+      "version": "1.0.3",
+      "description": "Adds design-aware planning artifacts and agent-native implementation handoff orchestration with Core, Vertical Planner, and Worker boundaries.",
+      "author": "bigsmartben",
+      "repository": "https://github.com/bigsmartben/spec-kit-workflow-preset",
+      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/archive/refs/tags/v1.0.3.zip",
+      "homepage": "https://github.com/bigsmartben/spec-kit-workflow-preset",
+      "documentation": "https://github.com/bigsmartben/spec-kit-workflow-preset/blob/main/README.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.8.10.dev0"
+      },
+      "provides": {
+        "templates": 4,
+        "commands": 3
+      },
+      "tags": [
+        "planning",
+        "design",
+        "implementation",
+        "orchestration",
+        "handoff"
+      ],
+      "created_at": "2026-05-20T00:00:00Z",
+      "updated_at": "2026-05-20T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add workflow-preset to presets/catalog.community.json
- Add Workflow Preset to the community presets documentation table

## Preset
- Repository: https://github.com/bigsmartben/spec-kit-workflow-preset
- Version: 1.0.3
- Archive: https://github.com/bigsmartben/spec-kit-workflow-preset/archive/refs/tags/v1.0.3.zip

## Validation
- python3 -m unittest tests/test_preset_contract.py in preset repo: 36 tests OK
- python3 -m json.tool presets/catalog.community.json
- git diff --check
- specify preset add --dev /home/bigben/文档/github/spec-kit-workflow-preset
- specify preset add --from https://github.com/bigsmartben/spec-kit-workflow-preset/archive/refs/tags/v1.0.3.zip