### PR TITLE
Update Superpowers Implementation Bridge extension to v0.5.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-05-15T00:00:00Z",
+  "updated_at": "2026-05-20T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -2617,8 +2617,8 @@
       "id": "speckit-superpowers-bridge",
       "description": "Thin orchestrator between Spec Kit (design) and Superpowers (implementation). Cross-agent.",
       "author": "lihan3238",
-      "version": "0.4.1",
-      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v0.4.1/speckit-superpowers-bridge-v0.4.1.zip",
+      "version": "0.5.0",
+      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v0.5.0/speckit-superpowers-bridge-v0.5.0.zip",
       "repository": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "homepage": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "documentation": "https://github.com/lihan3238/speckit-superpowers-bridge#readme",
@@ -2659,7 +2659,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-15T00:00:00Z",
-      "updated_at": "2026-05-15T00:00:00Z"
+      "updated_at": "2026-05-20T00:00:00Z"
     },
     "speckit-utils": {
       "name": "SDD Utilities",


### PR DESCRIPTION
## Update Superpowers Implementation Bridge extension to v0.5.0

Update `speckit-superpowers-bridge` extension submitted by @lihan3238 in #2601.

### Validation summary

| Check | Result |
|-------|--------|
| Repository exists and is public | ✅ |
| `extension.yml` manifest present | ✅ |
| README.md present | ✅ |
| LICENSE file present | ✅ |
| GitHub release exists matching version | ✅ [v0.5.0](https://github.com/lihan3238/speckit-superpowers-bridge/releases/tag/v0.5.0) |
| Download URL asset exists | ✅ `speckit-superpowers-bridge-v0.5.0.zip` |
| Extension ID is lowercase-with-hyphens | ✅ `speckit-superpowers-bridge` |
| Version follows semver | ✅ `0.5.0` |
| Submission checklists all checked | ✅ |

### Changes

- `extensions/catalog.community.json`:
  - `version`: `0.4.1` → `0.5.0`
  - `download_url`: updated to v0.5.0 ZIP
  - `updated_at`: refreshed to `2026-05-20`
  - Top-level catalog `updated_at`: refreshed to `2026-05-20`
  - `created_at`, `downloads`, `stars`: preserved

Closes #2601

cc @lihan3238