### PR TITLE
fix: while/do-while loop condition reads stale iteration-0 step output

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -674,15 +674,24 @@ class WorkflowEngine:
                             break
                         # Namespace nested step IDs per iteration
                         iter_steps = []
+                        original_ids = {}
                         for ns in result.next_steps:
                             ns_copy = dict(ns)
                             if "id" in ns_copy:
-                                ns_copy["id"] = f"{step_id}:{ns_copy['id']}:{_loop_iter + 1}"
+                                orig = ns_copy["id"]
+                                ns_copy["id"] = f"{step_id}:{orig}:{_loop_iter + 1}"
+                                original_ids[ns_copy["id"]] = orig
                             iter_steps.append(ns_copy)
                         self._execute_steps(
                             iter_steps, context, state, registry,
                             step_offset=-1,
                         )
+                        # Copy namespaced results back to unprefixed
+                        # keys so loop conditions see updated values.
+                        for namespaced, orig in original_ids.items():
+                            if namespaced in context.steps:
+                                context.steps[orig] = context.steps[namespaced]
+                                state.step_results[orig] = context.steps[namespaced]
                         if state.status in (
                             RunStatus.PAUSED,
                             RunStatus.FAILED,

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -672,30 +672,30 @@ class WorkflowEngine:
                     for _loop_iter in range(max_iters - 1):
                         if not evaluate_condition(condition, context):
                             break
-                        # Snapshot current results under namespaced
-                        # keys for per-iteration history before they
-                        # are overwritten by the next iteration.
+                        # Namespace nested step IDs per iteration
+                        # so logs and state keys are unique.
+                        # Execute one step at a time and alias each
+                        # result back to the unprefixed key so that
+                        # later steps in the same body and the loop
+                        # condition see the latest values.
                         for ns in result.next_steps:
-                            orig = ns.get("id")
-                            if orig and orig in context.steps:
-                                ns_key = f"{step_id}:{orig}:{_loop_iter}"
-                                context.steps[ns_key] = context.steps[orig]
-                                state.step_results[ns_key] = context.steps[orig]
-                        # Execute body with original step IDs so
-                        # results land at the unprefixed keys.  Both
-                        # inter-step references within the body and
-                        # the loop condition naturally see the latest
-                        # values without a copy-back.
-                        self._execute_steps(
-                            result.next_steps, context, state, registry,
-                            step_offset=-1,
-                        )
-                        if state.status in (
-                            RunStatus.PAUSED,
-                            RunStatus.FAILED,
-                            RunStatus.ABORTED,
-                        ):
-                            return
+                            ns_copy = dict(ns)
+                            orig = ns_copy.get("id")
+                            if orig:
+                                ns_copy["id"] = f"{step_id}:{orig}:{_loop_iter + 1}"
+                            self._execute_steps(
+                                [ns_copy], context, state, registry,
+                                step_offset=-1,
+                            )
+                            if orig and ns_copy["id"] in context.steps:
+                                context.steps[orig] = context.steps[ns_copy["id"]]
+                                state.step_results[orig] = context.steps[ns_copy["id"]]
+                            if state.status in (
+                                RunStatus.PAUSED,
+                                RunStatus.FAILED,
+                                RunStatus.ABORTED,
+                            ):
+                                return
 
             # Fan-out: execute nested step template per item with unique IDs
             if step_type == "fan-out":

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -678,11 +678,11 @@ class WorkflowEngine:
                         # result back to the unprefixed key so that
                         # later steps in the same body and the loop
                         # condition see the latest values.
-                        for ns in result.next_steps:
+                        for ns_idx, ns in enumerate(result.next_steps):
                             ns_copy = dict(ns)
                             orig = ns_copy.get("id")
-                            if orig:
-                                ns_copy["id"] = f"{step_id}:{orig}:{_loop_iter + 1}"
+                            base_id = orig or f"step-{ns_idx}"
+                            ns_copy["id"] = f"{step_id}:{base_id}:{_loop_iter + 1}"
                             self._execute_steps(
                                 [ns_copy], context, state, registry,
                                 step_offset=-1,

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -695,18 +695,21 @@ class WorkflowEngine:
                             iter_steps, context, state, registry,
                             step_offset=-1,
                         )
-                        # Copy namespaced results back to unprefixed
-                        # keys so loop conditions see updated values.
-                        for namespaced, orig in original_ids.items():
-                            if namespaced in context.steps:
-                                context.steps[orig] = context.steps[namespaced]
-                                state.step_results[orig] = context.steps[namespaced]
                         if state.status in (
                             RunStatus.PAUSED,
                             RunStatus.FAILED,
                             RunStatus.ABORTED,
                         ):
                             return
+                        # Copy namespaced results back to unprefixed
+                        # keys so loop conditions see updated values.
+                        # Only after a fully completed iteration —
+                        # partial results from paused/failed steps
+                        # must not overwrite the unprefixed key.
+                        for namespaced, orig in original_ids.items():
+                            if namespaced in context.steps:
+                                context.steps[orig] = context.steps[namespaced]
+                                state.step_results[orig] = context.steps[namespaced]
 
             # Fan-out: execute nested step template per item with unique IDs
             if step_type == "fan-out":

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -687,15 +687,15 @@ class WorkflowEngine:
                                 [ns_copy], context, state, registry,
                                 step_offset=-1,
                             )
-                            if orig and ns_copy["id"] in context.steps:
-                                context.steps[orig] = context.steps[ns_copy["id"]]
-                                state.step_results[orig] = context.steps[ns_copy["id"]]
                             if state.status in (
                                 RunStatus.PAUSED,
                                 RunStatus.FAILED,
                                 RunStatus.ABORTED,
                             ):
                                 return
+                            if orig and ns_copy["id"] in context.steps:
+                                context.steps[orig] = context.steps[ns_copy["id"]]
+                                state.step_results[orig] = context.steps[ns_copy["id"]]
 
             # Fan-out: execute nested step template per item with unique IDs
             if step_type == "fan-out":

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -672,6 +672,15 @@ class WorkflowEngine:
                     for _loop_iter in range(max_iters - 1):
                         if not evaluate_condition(condition, context):
                             break
+                        # Snapshot iteration-0 results under a
+                        # namespaced key before the first overwrite.
+                        if _loop_iter == 0:
+                            for ns in result.next_steps:
+                                orig = ns.get("id")
+                                if orig and orig in context.steps:
+                                    ns_key = f"{step_id}:{orig}:0"
+                                    context.steps[ns_key] = context.steps[orig]
+                                    state.step_results[ns_key] = context.steps[orig]
                         # Namespace nested step IDs per iteration
                         iter_steps = []
                         original_ids = {}

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -672,27 +672,22 @@ class WorkflowEngine:
                     for _loop_iter in range(max_iters - 1):
                         if not evaluate_condition(condition, context):
                             break
-                        # Snapshot iteration-0 results under a
-                        # namespaced key before the first overwrite.
-                        if _loop_iter == 0:
-                            for ns in result.next_steps:
-                                orig = ns.get("id")
-                                if orig and orig in context.steps:
-                                    ns_key = f"{step_id}:{orig}:0"
-                                    context.steps[ns_key] = context.steps[orig]
-                                    state.step_results[ns_key] = context.steps[orig]
-                        # Namespace nested step IDs per iteration
-                        iter_steps = []
-                        original_ids = {}
+                        # Snapshot current results under namespaced
+                        # keys for per-iteration history before they
+                        # are overwritten by the next iteration.
                         for ns in result.next_steps:
-                            ns_copy = dict(ns)
-                            if "id" in ns_copy:
-                                orig = ns_copy["id"]
-                                ns_copy["id"] = f"{step_id}:{orig}:{_loop_iter + 1}"
-                                original_ids[ns_copy["id"]] = orig
-                            iter_steps.append(ns_copy)
+                            orig = ns.get("id")
+                            if orig and orig in context.steps:
+                                ns_key = f"{step_id}:{orig}:{_loop_iter}"
+                                context.steps[ns_key] = context.steps[orig]
+                                state.step_results[ns_key] = context.steps[orig]
+                        # Execute body with original step IDs so
+                        # results land at the unprefixed keys.  Both
+                        # inter-step references within the body and
+                        # the loop condition naturally see the latest
+                        # values without a copy-back.
                         self._execute_steps(
-                            iter_steps, context, state, registry,
+                            result.next_steps, context, state, registry,
                             step_offset=-1,
                         )
                         if state.status in (
@@ -701,15 +696,6 @@ class WorkflowEngine:
                             RunStatus.ABORTED,
                         ):
                             return
-                        # Copy namespaced results back to unprefixed
-                        # keys so loop conditions see updated values.
-                        # Only after a fully completed iteration —
-                        # partial results from paused/failed steps
-                        # must not overwrite the unprefixed key.
-                        for namespaced, orig in original_ids.items():
-                            if namespaced in context.steps:
-                                context.steps[orig] = context.steps[namespaced]
-                                state.step_results[orig] = context.steps[namespaced]
 
             # Fan-out: execute nested step template per item with unique IDs
             if step_type == "fan-out":

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1934,7 +1934,7 @@ steps:
     steps:
       - id: attempt
         type: shell
-        run: {py} {script_file}
+        run: '"{py}" "{script_file}"'
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)
@@ -1985,7 +1985,7 @@ steps:
     steps:
       - id: attempt
         type: shell
-        run: {py} {script_file}
+        run: '"{py}" "{script_file}"'
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)
@@ -2031,7 +2031,7 @@ steps:
     steps:
       - id: tick
         type: shell
-        run: {py} {script_file}
+        run: '"{py}" "{script_file}"'
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)
@@ -2083,7 +2083,7 @@ steps:
     steps:
       - id: tick
         type: shell
-        run: {py} {script_file}
+        run: '"{py}" "{script_file}"'
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2114,17 +2114,9 @@ steps:
             encoding="utf-8",
         )
 
-        # Step B: reads step A's stdout from a marker file written by
-        # the test harness (since shell steps can't read context).
-        # Instead, step B just echoes its own value — we verify via
-        # the engine that step B's namespaced result was aliased back.
-        step_b_file = project_dir / "_step_b.py"
-        step_b_file.write_text(
-            f"import pathlib; p = pathlib.Path(r'{counter_file}')\n"
-            "print('b-saw-' + p.read_text().strip(), end='')\n",
-            encoding="utf-8",
-        )
-
+        # Step B uses {{ steps.step-a.output.stdout }} expression
+        # substitution in its run command so the engine resolves the
+        # aliased unprefixed key — this is the real inter-step test.
         yaml_str = f"""
 schema_version: "1.0"
 workflow:
@@ -2142,7 +2134,7 @@ steps:
         run: '"{py}" "{step_a_file}"'
       - id: step-b
         type: shell
-        run: '"{py}" "{step_b_file}"'
+        run: "echo b-saw-{{{{ steps.step-a.output.stdout }}}}"
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)
@@ -2151,7 +2143,8 @@ steps:
         assert state.status == RunStatus.COMPLETED
         # Both unprefixed keys reflect the latest iteration's results.
         assert state.step_results["step-a"]["output"]["stdout"] == "3"
-        assert state.step_results["step-b"]["output"]["stdout"] == "b-saw-3"
+        # Step B saw step A's output via expression substitution.
+        assert "b-saw-3" in state.step_results["step-b"]["output"]["stdout"]
         # Namespaced keys exist for loop iterations.
         assert "retry-loop:step-a:1" in state.step_results
         assert "retry-loop:step-b:1" in state.step_results

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1907,8 +1907,18 @@ steps:
         # Iteration 1: counter=2, echoes "done" → condition false → stop
         # Without the fix, condition always reads iteration-0 stdout,
         # so the loop runs all max_iterations.
+        import sys
+
         counter_file = project_dir / ".counter"
         counter_file.write_text("0", encoding="utf-8")
+        py = sys.executable
+        script_file = project_dir / "_tick.py"
+        script_file.write_text(
+            f"import pathlib; p = pathlib.Path(r'{counter_file}')\n"
+            "n = int(p.read_text()) + 1; p.write_text(str(n))\n"
+            "print('done' if n >= 2 else str(n), end='')\n",
+            encoding="utf-8",
+        )
 
         yaml_str = f"""
 schema_version: "1.0"
@@ -1924,11 +1934,7 @@ steps:
     steps:
       - id: attempt
         type: shell
-        run: |
-          n=$(cat {counter_file})
-          n=$((n + 1))
-          printf '%s' $n > {counter_file}
-          if [ "$n" -ge 2 ]; then printf done; else printf $n; fi
+        run: {py} {script_file}
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)
@@ -1939,6 +1945,8 @@ steps:
         assert state.step_results["attempt"]["output"]["stdout"] == "done"
         # Namespaced iteration-1 result should also exist.
         assert "retry-loop:attempt:1" in state.step_results
+        # Iteration-0 history preserved under namespaced key.
+        assert "retry-loop:attempt:0" in state.step_results
         # Counter should be 2 (iteration 0 + iteration 1), not 5.
         assert counter_file.read_text(encoding="utf-8").strip() == "2"
 
@@ -1950,8 +1958,18 @@ steps:
         from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
         from specify_cli.workflows.base import RunStatus
 
+        import sys
+
         counter_file = project_dir / ".counter"
         counter_file.write_text("0", encoding="utf-8")
+        py = sys.executable
+        script_file = project_dir / "_tick.py"
+        script_file.write_text(
+            f"import pathlib; p = pathlib.Path(r'{counter_file}')\n"
+            "n = int(p.read_text()) + 1; p.write_text(str(n))\n"
+            "print('done' if n >= 2 else str(n), end='')\n",
+            encoding="utf-8",
+        )
 
         yaml_str = f"""
 schema_version: "1.0"
@@ -1967,11 +1985,7 @@ steps:
     steps:
       - id: attempt
         type: shell
-        run: |
-          n=$(cat {counter_file})
-          n=$((n + 1))
-          printf '%s' $n > {counter_file}
-          if [ "$n" -ge 2 ]; then printf done; else printf $n; fi
+        run: {py} {script_file}
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)
@@ -1990,8 +2004,18 @@ steps:
         from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
         from specify_cli.workflows.base import RunStatus
 
+        import sys
+
         counter_file = project_dir / ".counter"
         counter_file.write_text("0", encoding="utf-8")
+        py = sys.executable
+        script_file = project_dir / "_tick.py"
+        script_file.write_text(
+            f"import pathlib; p = pathlib.Path(r'{counter_file}')\n"
+            "n = int(p.read_text()) + 1; p.write_text(str(n))\n"
+            "print('pending', end='')\n",
+            encoding="utf-8",
+        )
 
         yaml_str = f"""
 schema_version: "1.0"
@@ -2007,11 +2031,7 @@ steps:
     steps:
       - id: tick
         type: shell
-        run: |
-          n=$(cat {counter_file})
-          n=$((n + 1))
-          printf '%s' $n > {counter_file}
-          printf 'pending'
+        run: {py} {script_file}
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)
@@ -2022,7 +2042,8 @@ steps:
         assert counter_file.read_text(encoding="utf-8").strip() == "3"
         # Unprefixed key holds the last iteration's result.
         assert state.step_results["tick"]["output"]["stdout"] == "pending"
-        # Namespaced keys for loop iterations 1 and 2 exist.
+        # Namespaced keys for all iterations exist.
+        assert "retry-loop:tick:0" in state.step_results
         assert "retry-loop:tick:1" in state.step_results
         assert "retry-loop:tick:2" in state.step_results
 
@@ -2035,8 +2056,18 @@ steps:
         from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
         from specify_cli.workflows.base import RunStatus
 
+        import sys
+
         counter_file = project_dir / ".counter"
         counter_file.write_text("0", encoding="utf-8")
+        py = sys.executable
+        script_file = project_dir / "_tick.py"
+        script_file.write_text(
+            f"import pathlib; p = pathlib.Path(r'{counter_file}')\n"
+            "n = int(p.read_text()) + 1; p.write_text(str(n))\n"
+            "print('pending', end='')\n",
+            encoding="utf-8",
+        )
 
         yaml_str = f"""
 schema_version: "1.0"
@@ -2052,11 +2083,7 @@ steps:
     steps:
       - id: tick
         type: shell
-        run: |
-          n=$(cat {counter_file})
-          n=$((n + 1))
-          printf '%s' $n > {counter_file}
-          printf 'pending'
+        run: {py} {script_file}
 """
         definition = WorkflowDefinition.from_string(yaml_str)
         engine = WorkflowEngine(project_dir)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1943,9 +1943,8 @@ steps:
         assert state.status == RunStatus.COMPLETED
         # The unprefixed key should reflect the latest iteration's result.
         assert state.step_results["attempt"]["output"]["stdout"] == "done"
-        # Iteration-0 history preserved under namespaced key.
-        assert "retry-loop:attempt:0" in state.step_results
-        assert state.step_results["retry-loop:attempt:0"]["output"]["stdout"] != "done"
+        # Namespaced iteration-1 result should also exist.
+        assert "retry-loop:attempt:1" in state.step_results
         # Counter should be 2 (iteration 0 + iteration 1), not 5.
         assert counter_file.read_text(encoding="utf-8").strip() == "2"
 
@@ -2041,9 +2040,9 @@ steps:
         assert counter_file.read_text(encoding="utf-8").strip() == "3"
         # Unprefixed key holds the last iteration's result.
         assert state.step_results["tick"]["output"]["stdout"] == "pending"
-        # Namespaced history keys for previous iterations exist.
-        assert "retry-loop:tick:0" in state.step_results
+        # Namespaced keys for loop iterations exist.
         assert "retry-loop:tick:1" in state.step_results
+        assert "retry-loop:tick:2" in state.step_results
 
     def test_do_while_loop_runs_to_max_when_condition_stays_true(self, project_dir):
         """Do-while loop must still run to max_iterations when the condition

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1943,10 +1943,9 @@ steps:
         assert state.status == RunStatus.COMPLETED
         # The unprefixed key should reflect the latest iteration's result.
         assert state.step_results["attempt"]["output"]["stdout"] == "done"
-        # Namespaced iteration-1 result should also exist.
-        assert "retry-loop:attempt:1" in state.step_results
         # Iteration-0 history preserved under namespaced key.
         assert "retry-loop:attempt:0" in state.step_results
+        assert state.step_results["retry-loop:attempt:0"]["output"]["stdout"] != "done"
         # Counter should be 2 (iteration 0 + iteration 1), not 5.
         assert counter_file.read_text(encoding="utf-8").strip() == "2"
 
@@ -2042,10 +2041,9 @@ steps:
         assert counter_file.read_text(encoding="utf-8").strip() == "3"
         # Unprefixed key holds the last iteration's result.
         assert state.step_results["tick"]["output"]["stdout"] == "pending"
-        # Namespaced keys for all iterations exist.
+        # Namespaced history keys for previous iterations exist.
         assert "retry-loop:tick:0" in state.step_results
         assert "retry-loop:tick:1" in state.step_results
-        assert "retry-loop:tick:2" in state.step_results
 
     def test_do_while_loop_runs_to_max_when_condition_stays_true(self, project_dir):
         """Do-while loop must still run to max_iterations when the condition

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2090,6 +2090,74 @@ steps:
         assert counter_file.read_text(encoding="utf-8").strip() == "3"
         assert state.step_results["tick"]["output"]["stdout"] == "pending"
 
+    def test_while_loop_multi_step_body_inter_step_refs(self, project_dir):
+        """Multi-step loop body: step B must see step A's output from the
+        current iteration, not a stale previous one.
+
+        See https://github.com/github/spec-kit/issues/2592
+        """
+        from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
+        from specify_cli.workflows.base import RunStatus
+
+        import sys
+
+        counter_file = project_dir / ".counter"
+        counter_file.write_text("0", encoding="utf-8")
+        py = sys.executable
+
+        # Step A: increments counter file, echoes the value.
+        step_a_file = project_dir / "_step_a.py"
+        step_a_file.write_text(
+            f"import pathlib; p = pathlib.Path(r'{counter_file}')\n"
+            "n = int(p.read_text()) + 1; p.write_text(str(n))\n"
+            "print(str(n), end='')\n",
+            encoding="utf-8",
+        )
+
+        # Step B: reads step A's stdout from a marker file written by
+        # the test harness (since shell steps can't read context).
+        # Instead, step B just echoes its own value — we verify via
+        # the engine that step B's namespaced result was aliased back.
+        step_b_file = project_dir / "_step_b.py"
+        step_b_file.write_text(
+            f"import pathlib; p = pathlib.Path(r'{counter_file}')\n"
+            "print('b-saw-' + p.read_text().strip(), end='')\n",
+            encoding="utf-8",
+        )
+
+        yaml_str = f"""
+schema_version: "1.0"
+workflow:
+  id: "while-multi-step"
+  name: "While Multi Step"
+  version: "1.0.0"
+steps:
+  - id: retry-loop
+    type: while
+    condition: "{{{{ 'done' not in steps.step-a.output.stdout }}}}"
+    max_iterations: 3
+    steps:
+      - id: step-a
+        type: shell
+        run: '"{py}" "{step_a_file}"'
+      - id: step-b
+        type: shell
+        run: '"{py}" "{step_b_file}"'
+"""
+        definition = WorkflowDefinition.from_string(yaml_str)
+        engine = WorkflowEngine(project_dir)
+        state = engine.execute(definition)
+
+        assert state.status == RunStatus.COMPLETED
+        # Both unprefixed keys reflect the latest iteration's results.
+        assert state.step_results["step-a"]["output"]["stdout"] == "3"
+        assert state.step_results["step-b"]["output"]["stdout"] == "b-saw-3"
+        # Namespaced keys exist for loop iterations.
+        assert "retry-loop:step-a:1" in state.step_results
+        assert "retry-loop:step-b:1" in state.step_results
+        assert "retry-loop:step-a:2" in state.step_results
+        assert "retry-loop:step-b:2" in state.step_results
+
 
 # ===== State Persistence Tests =====
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1889,6 +1889,183 @@ steps:
         errors = validate_workflow(definition)
         assert any("invalid default" in e for e in errors), errors
 
+    def test_while_loop_condition_reads_latest_iteration(self, project_dir):
+        """Regression: while-loop condition must see updated step output
+        from the most recent iteration, not stale iteration-0 data.
+
+        See https://github.com/github/spec-kit/issues/2592
+        """
+        from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
+        from specify_cli.workflows.base import RunStatus
+
+        # Shell step echoes a counter via a file.
+        # Condition: exit_code != 0 means "keep looping" — but a non-zero
+        # exit code would mark the step FAILED and abort the run, so we
+        # use stdout-based comparison instead.
+        #
+        # Iteration 0: counter=1, echoes "1" → not "done" → loop continues
+        # Iteration 1: counter=2, echoes "done" → condition false → stop
+        # Without the fix, condition always reads iteration-0 stdout,
+        # so the loop runs all max_iterations.
+        counter_file = project_dir / ".counter"
+        counter_file.write_text("0", encoding="utf-8")
+
+        yaml_str = f"""
+schema_version: "1.0"
+workflow:
+  id: "while-condition-update"
+  name: "While Condition Update"
+  version: "1.0.0"
+steps:
+  - id: retry-loop
+    type: while
+    condition: "{{{{ 'done' not in steps.attempt.output.stdout }}}}"
+    max_iterations: 5
+    steps:
+      - id: attempt
+        type: shell
+        run: |
+          n=$(cat {counter_file})
+          n=$((n + 1))
+          printf '%s' $n > {counter_file}
+          if [ "$n" -ge 2 ]; then printf done; else printf $n; fi
+"""
+        definition = WorkflowDefinition.from_string(yaml_str)
+        engine = WorkflowEngine(project_dir)
+        state = engine.execute(definition)
+
+        assert state.status == RunStatus.COMPLETED
+        # The unprefixed key should reflect the latest iteration's result.
+        assert state.step_results["attempt"]["output"]["stdout"] == "done"
+        # Namespaced iteration-1 result should also exist.
+        assert "retry-loop:attempt:1" in state.step_results
+        # Counter should be 2 (iteration 0 + iteration 1), not 5.
+        assert counter_file.read_text(encoding="utf-8").strip() == "2"
+
+    def test_do_while_loop_condition_reads_latest_iteration(self, project_dir):
+        """Regression: do-while loop condition must also see updated output.
+
+        See https://github.com/github/spec-kit/issues/2592
+        """
+        from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
+        from specify_cli.workflows.base import RunStatus
+
+        counter_file = project_dir / ".counter"
+        counter_file.write_text("0", encoding="utf-8")
+
+        yaml_str = f"""
+schema_version: "1.0"
+workflow:
+  id: "do-while-condition-update"
+  name: "Do While Condition Update"
+  version: "1.0.0"
+steps:
+  - id: retry-loop
+    type: do-while
+    condition: "{{{{ 'done' not in steps.attempt.output.stdout }}}}"
+    max_iterations: 5
+    steps:
+      - id: attempt
+        type: shell
+        run: |
+          n=$(cat {counter_file})
+          n=$((n + 1))
+          printf '%s' $n > {counter_file}
+          if [ "$n" -ge 2 ]; then printf done; else printf $n; fi
+"""
+        definition = WorkflowDefinition.from_string(yaml_str)
+        engine = WorkflowEngine(project_dir)
+        state = engine.execute(definition)
+
+        assert state.status == RunStatus.COMPLETED
+        assert state.step_results["attempt"]["output"]["stdout"] == "done"
+        assert counter_file.read_text(encoding="utf-8").strip() == "2"
+
+    def test_while_loop_runs_to_max_when_condition_stays_true(self, project_dir):
+        """While loop must still run to max_iterations when the condition
+        never becomes false — copy-back must not break this path.
+
+        See https://github.com/github/spec-kit/issues/2592
+        """
+        from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
+        from specify_cli.workflows.base import RunStatus
+
+        counter_file = project_dir / ".counter"
+        counter_file.write_text("0", encoding="utf-8")
+
+        yaml_str = f"""
+schema_version: "1.0"
+workflow:
+  id: "while-max-iterations"
+  name: "While Max Iterations"
+  version: "1.0.0"
+steps:
+  - id: retry-loop
+    type: while
+    condition: "{{{{ 'done' not in steps.tick.output.stdout }}}}"
+    max_iterations: 3
+    steps:
+      - id: tick
+        type: shell
+        run: |
+          n=$(cat {counter_file})
+          n=$((n + 1))
+          printf '%s' $n > {counter_file}
+          printf 'pending'
+"""
+        definition = WorkflowDefinition.from_string(yaml_str)
+        engine = WorkflowEngine(project_dir)
+        state = engine.execute(definition)
+
+        assert state.status == RunStatus.COMPLETED
+        # All 3 iterations ran (iteration 0 + 2 loop iterations).
+        assert counter_file.read_text(encoding="utf-8").strip() == "3"
+        # Unprefixed key holds the last iteration's result.
+        assert state.step_results["tick"]["output"]["stdout"] == "pending"
+        # Namespaced keys for loop iterations 1 and 2 exist.
+        assert "retry-loop:tick:1" in state.step_results
+        assert "retry-loop:tick:2" in state.step_results
+
+    def test_do_while_loop_runs_to_max_when_condition_stays_true(self, project_dir):
+        """Do-while loop must still run to max_iterations when the condition
+        never becomes false.
+
+        See https://github.com/github/spec-kit/issues/2592
+        """
+        from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
+        from specify_cli.workflows.base import RunStatus
+
+        counter_file = project_dir / ".counter"
+        counter_file.write_text("0", encoding="utf-8")
+
+        yaml_str = f"""
+schema_version: "1.0"
+workflow:
+  id: "do-while-max-iterations"
+  name: "Do While Max Iterations"
+  version: "1.0.0"
+steps:
+  - id: retry-loop
+    type: do-while
+    condition: "{{{{ 'done' not in steps.tick.output.stdout }}}}"
+    max_iterations: 3
+    steps:
+      - id: tick
+        type: shell
+        run: |
+          n=$(cat {counter_file})
+          n=$((n + 1))
+          printf '%s' $n > {counter_file}
+          printf 'pending'
+"""
+        definition = WorkflowDefinition.from_string(yaml_str)
+        engine = WorkflowEngine(project_dir)
+        state = engine.execute(definition)
+
+        assert state.status == RunStatus.COMPLETED
+        assert counter_file.read_text(encoding="utf-8").strip() == "3"
+        assert state.step_results["tick"]["output"]["stdout"] == "pending"
+
 
 # ===== State Persistence Tests =====
 


### PR DESCRIPTION
## Summary

Fixes #2592 — `while`/`do-while` loop conditions always read the iteration-0 step output, ignoring updates from subsequent iterations.

## Root cause

The engine namespaces nested step IDs per iteration (e.g., `my-loop:my-gate:1`) to preserve per-iteration history. However, the condition resolver (`evaluate_condition` → `_resolve_dot_path`) looks up step output by the original unprefixed key (`steps.my-gate`), which is only written during iteration 0 and never updated afterward.

## Fix

Keep namespaced step IDs for execution (preserving unique log entries, state keys, and `on_step_start` callback IDs per iteration), but execute each body step individually and immediately alias its result back to the unprefixed key after it completes successfully. This ensures:

- `evaluate_condition()` sees the latest iteration's output
- Inter-step references within multi-step loop bodies work correctly (step B sees step A's output from the current iteration, not a stale previous one)
- Namespaced history entries are preserved for debugging (`parent:child:1`, `parent:child:2`, etc.)
- Pause/fail is checked after each step — aliasing only occurs for successfully completed steps
- Fully backward-compatible — same namespaced key format, same log IDs, no changes to condition syntax or workflow YAML

## Changes

- **`src/specify_cli/workflows/engine.py`** — Execute loop body steps one at a time with namespaced IDs, aliasing each result back to the unprefixed key immediately after successful completion
- **`tests/test_workflows.py`** — 5 new engine-level regression tests in `TestWorkflowEngine`:
  - `test_while_loop_condition_reads_latest_iteration` (positive: loop stops early)
  - `test_do_while_loop_condition_reads_latest_iteration` (positive: loop stops early)
  - `test_while_loop_runs_to_max_when_condition_stays_true` (negative: loop exhausts max_iterations)
  - `test_do_while_loop_runs_to_max_when_condition_stays_true` (negative: loop exhausts max_iterations)
  - `test_while_loop_multi_step_body_inter_step_refs` (multi-step body: step B sees step A's current-iteration output)

## Testing

All 2998 existing + new tests pass (2998 passed, 1 skipped, 0 failures).