### PR TITLE
feat(workflows): add gate-on-condition step kind (auto-fire on condition)

### DIFF
--- a/src/specify_cli/workflows/__init__.py
+++ b/src/specify_cli/workflows/__init__.py
@@ -47,6 +47,7 @@ def _register_builtin_steps() -> None:
     from .steps.fan_in import FanInStep
     from .steps.fan_out import FanOutStep
     from .steps.gate import GateStep
+    from .steps.gate_on_condition import GateOnConditionStep
     from .steps.if_then import IfThenStep
     from .steps.prompt import PromptStep
     from .steps.shell import ShellStep
@@ -58,6 +59,7 @@ def _register_builtin_steps() -> None:
     _register_step(FanInStep())
     _register_step(FanOutStep())
     _register_step(GateStep())
+    _register_step(GateOnConditionStep())
     _register_step(IfThenStep())
     _register_step(PromptStep())
     _register_step(ShellStep())

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -93,8 +93,8 @@ def _get_valid_step_types() -> set[str]:
     if STEP_REGISTRY:
         return set(STEP_REGISTRY.keys())
     return {
-        "command", "shell", "prompt", "gate", "if",
-        "switch", "while", "do-while", "fan-out", "fan-in",
+        "command", "shell", "prompt", "gate", "gate-on-condition",
+        "if", "switch", "while", "do-while", "fan-out", "fan-in",
     }
 
 

--- a/src/specify_cli/workflows/steps/gate_on_condition/__init__.py
+++ b/src/specify_cli/workflows/steps/gate_on_condition/__init__.py
@@ -1,0 +1,242 @@
+"""Gate-on-condition step — auto-firing review gate."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from specify_cli.workflows.base import StepBase, StepContext, StepResult, StepStatus
+from specify_cli.workflows.expressions import (
+    evaluate_condition,
+    evaluate_expression,
+)
+
+
+class GateOnConditionStep(StepBase):
+    """Review gate that auto-fires a verdict when a condition matches.
+
+    Evaluates each ``conditions:`` entry's ``if:`` expression in
+    declaration order; the first truthy condition's ``then_route`` is
+    recorded as ``output.choice`` and the step completes without
+    operator interaction. When no condition matches, the step falls
+    back to interactive prompt behaviour (``fallback_prompt:``) — or
+    aborts the run if no ``fallback_prompt`` is declared.
+
+    Example YAML::
+
+        - id: review-overview
+          type: gate-on-condition
+          conditions:
+            - if: "{{ steps.detect.output.has_pending_work }}"
+              then_route: regenerate
+            - if: "{{ steps.detect.output.is_clean }}"
+              then_route: continue
+          fallback_prompt:
+            message: "Ambiguous — approve, regenerate, or abort?"
+            options: [approve, regenerate, abort]
+            on_reject: abort
+
+    The ``fallback_prompt`` schema mirrors the regular ``gate`` step's
+    fields (``message``, ``options``, ``on_reject``) so authors writing
+    both kinds use the same vocabulary.
+
+    The recorded ``output.choice`` is the matched route name, so
+    downstream ``switch``/``if`` steps branch on it exactly the same
+    way they branch on a regular ``gate`` step's choice. The output
+    also includes ``output.auto_fired`` (``True`` when a condition
+    matched, ``False`` when the operator chose) so workflow authors
+    can distinguish automatic vs. interactive verdicts.
+    """
+
+    type_key = "gate-on-condition"
+
+    def execute(self, config: dict[str, Any], context: StepContext) -> StepResult:
+        conditions = config.get("conditions") or []
+
+        for index, cond_spec in enumerate(conditions):
+            expr = cond_spec.get("if", "")
+            route = cond_spec.get("then_route", "")
+            if evaluate_condition(expr, context):
+                return StepResult(
+                    status=StepStatus.COMPLETED,
+                    output={
+                        "choice": route,
+                        "auto_fired": True,
+                        "matched_condition_index": index,
+                    },
+                )
+
+        # No condition matched — defer to the fallback prompt.
+        fallback = config.get("fallback_prompt") or {}
+        message = fallback.get("message", "Review required.")
+        if isinstance(message, str) and "{{" in message:
+            message = evaluate_expression(message, context)
+        options = fallback.get("options", ["approve", "reject"])
+        on_reject = fallback.get("on_reject", "abort")
+
+        output: dict[str, Any] = {
+            "choice": None,
+            "auto_fired": False,
+            "matched_condition_index": None,
+            "message": message,
+            "options": options,
+            "on_reject": on_reject,
+        }
+
+        if not fallback:
+            output["aborted"] = True
+            return StepResult(
+                status=StepStatus.FAILED,
+                output=output,
+                error=(
+                    f"gate-on-condition step {config.get('id', '?')!r}: "
+                    f"no condition matched and no fallback_prompt declared."
+                ),
+            )
+
+        # Non-interactive: pause for later resume (same contract as `gate`).
+        if not sys.stdin.isatty():
+            return StepResult(status=StepStatus.PAUSED, output=output)
+
+        # Interactive: prompt the operator.
+        choice = self._prompt(message, options)
+        output["choice"] = choice
+
+        if choice in ("reject", "abort"):
+            if on_reject == "abort":
+                output["aborted"] = True
+                return StepResult(
+                    status=StepStatus.FAILED,
+                    output=output,
+                    error=(
+                        f"gate-on-condition fallback rejected by user at step "
+                        f"{config.get('id', '?')!r}"
+                    ),
+                )
+            if on_reject == "retry":
+                return StepResult(status=StepStatus.PAUSED, output=output)
+            # on_reject == "skip" → completed, downstream steps decide.
+
+        return StepResult(status=StepStatus.COMPLETED, output=output)
+
+    @staticmethod
+    def _prompt(message: str, options: list[str]) -> str:
+        """Display the fallback prompt and read a choice from the operator.
+
+        Matches the visual style and selection semantics of the
+        regular ``gate`` step's prompt so operators see a consistent
+        UX when either kind fires interactively.
+        """
+        print("\n  ┌─ Gate (auto-condition fallback) ───────────")
+        print(f"  │ {message}")
+        print("  │")
+        for i, opt in enumerate(options, 1):
+            print(f"  │  [{i}] {opt}")
+        print("  └────────────────────────────────────────────")
+
+        while True:
+            try:
+                raw = input(f"  Choose [1-{len(options)}]: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return options[-1]
+            if raw.isdigit() and 1 <= int(raw) <= len(options):
+                return options[int(raw) - 1]
+            if raw.lower() in [o.lower() for o in options]:
+                return next(o for o in options if o.lower() == raw.lower())
+            print(f"  Invalid choice. Enter 1-{len(options)} or an option name.")
+
+    def validate(self, config: dict[str, Any]) -> list[str]:
+        errors = super().validate(config)
+        step_id = config.get("id", "?")
+
+        conditions = config.get("conditions")
+        if conditions is None:
+            errors.append(
+                f"gate-on-condition step {step_id!r} is missing "
+                f"'conditions' field."
+            )
+        elif not isinstance(conditions, list):
+            errors.append(
+                f"gate-on-condition step {step_id!r}: 'conditions' must "
+                f"be a list of mappings."
+            )
+        elif not conditions:
+            errors.append(
+                f"gate-on-condition step {step_id!r}: 'conditions' must "
+                f"be a non-empty list."
+            )
+        else:
+            for index, cond in enumerate(conditions):
+                if not isinstance(cond, dict):
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: condition "
+                        f"at index {index} must be a mapping with 'if' "
+                        f"and 'then_route'."
+                    )
+                    continue
+                # 'if' must be present and a string. Without this check
+                # a YAML authoring mistake (`if: 42`) would coerce
+                # through `evaluate_condition` and trigger only at
+                # runtime — better to fail at validation time.
+                if "if" not in cond:
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: condition "
+                        f"at index {index} is missing 'if'."
+                    )
+                elif not isinstance(cond["if"], str):
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: condition "
+                        f"at index {index}: 'if' must be a string "
+                        f"(got {type(cond['if']).__name__})."
+                    )
+                # 'then_route' must be a non-empty string. An empty
+                # route silently matches an empty `switch case: ""`
+                # which is almost always an authoring mistake; reject
+                # it eagerly.
+                if "then_route" not in cond:
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: condition "
+                        f"at index {index} is missing 'then_route'."
+                    )
+                elif not isinstance(cond["then_route"], str):
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: condition "
+                        f"at index {index}: 'then_route' must be a "
+                        f"string (got {type(cond['then_route']).__name__})."
+                    )
+                elif not cond["then_route"]:
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: condition "
+                        f"at index {index}: 'then_route' must be a "
+                        f"non-empty string."
+                    )
+
+        fallback = config.get("fallback_prompt")
+        if fallback is not None:
+            if not isinstance(fallback, dict):
+                errors.append(
+                    f"gate-on-condition step {step_id!r}: "
+                    f"'fallback_prompt' must be a mapping."
+                )
+            else:
+                fb_options = fallback.get("options", ["approve", "reject"])
+                if not isinstance(fb_options, list) or not fb_options:
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: "
+                        f"'fallback_prompt.options' must be a non-empty list."
+                    )
+                elif not all(isinstance(c, str) for c in fb_options):
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: all "
+                        f"'fallback_prompt.options' must be strings."
+                    )
+                fb_on_reject = fallback.get("on_reject", "abort")
+                if fb_on_reject not in ("abort", "skip", "retry"):
+                    errors.append(
+                        f"gate-on-condition step {step_id!r}: "
+                        f"'fallback_prompt.on_reject' must be 'abort', "
+                        f"'skip', or 'retry'."
+                    )
+
+        return errors

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -779,6 +779,378 @@ class TestGateStep:
         assert any("on_reject" in e for e in errors)
 
 
+class TestGateOnConditionStep:
+    """Test the gate-on-condition step type — auto-firing review gate."""
+
+    def test_first_matching_condition_wins(self):
+        """Conditions are evaluated in declaration order; the first
+        truthy one's ``then_route`` is recorded as ``output.choice``
+        and the step auto-completes without operator interaction.
+        """
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = GateOnConditionStep()
+        ctx = StepContext(
+            steps={
+                "detect": {
+                    "output": {
+                        "has_pending_work": True,
+                        "is_clean": False,
+                    }
+                }
+            }
+        )
+        result = step.execute(
+            {
+                "id": "review",
+                "conditions": [
+                    {
+                        "if": "{{ steps.detect.output.has_pending_work }}",
+                        "then_route": "regenerate",
+                    },
+                    {
+                        "if": "{{ steps.detect.output.is_clean }}",
+                        "then_route": "continue",
+                    },
+                ],
+            },
+            ctx,
+        )
+
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["choice"] == "regenerate"
+        assert result.output["auto_fired"] is True
+        assert result.output["matched_condition_index"] == 0
+
+    def test_declaration_order_when_multiple_truthy(self):
+        """When multiple conditions are truthy, only the FIRST matches.
+
+        Locks the declaration-order contract — re-ordering YAML
+        conditions changes routing.
+        """
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = GateOnConditionStep()
+        ctx = StepContext(steps={"d": {"output": {"a": True, "b": True}}})
+        result = step.execute(
+            {
+                "id": "review",
+                "conditions": [
+                    {"if": "{{ steps.d.output.a }}", "then_route": "first"},
+                    {"if": "{{ steps.d.output.b }}", "then_route": "second"},
+                ],
+            },
+            ctx,
+        )
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["choice"] == "first"
+
+    def test_no_match_no_fallback_aborts(self):
+        """No condition matches AND no ``fallback_prompt`` declared →
+        the step fails with ``output.aborted = True`` so the engine
+        treats it like a deliberate gate abort.
+        """
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = GateOnConditionStep()
+        ctx = StepContext(steps={"d": {"output": {"flag": False}}})
+        result = step.execute(
+            {
+                "id": "review",
+                "conditions": [
+                    {"if": "{{ steps.d.output.flag }}", "then_route": "x"},
+                ],
+            },
+            ctx,
+        )
+        assert result.status == StepStatus.FAILED
+        assert result.output["aborted"] is True
+        assert result.output["auto_fired"] is False
+        assert result.error is not None
+        assert "no condition matched" in result.error
+
+    def test_no_match_with_fallback_pauses_non_tty(self, monkeypatch):
+        """No condition matches AND ``fallback_prompt`` declared,
+        with stdin NOT a TTY → step PAUSES for ``specify workflow
+        resume`` (same contract as the regular ``gate`` step).
+        """
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+        from specify_cli.workflows.steps import gate_on_condition as goc_module
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        monkeypatch.setattr(goc_module.sys.stdin, "isatty", lambda: False)
+
+        step = GateOnConditionStep()
+        ctx = StepContext(steps={"d": {"output": {"flag": False}}})
+        result = step.execute(
+            {
+                "id": "review",
+                "conditions": [
+                    {"if": "{{ steps.d.output.flag }}", "then_route": "x"},
+                ],
+                "fallback_prompt": {
+                    "message": "Ambiguous — pick one.",
+                    "options": ["approve", "reject"],
+                },
+            },
+            ctx,
+        )
+        assert result.status == StepStatus.PAUSED
+        assert result.output["auto_fired"] is False
+        assert result.output["choice"] is None
+        assert result.output["message"] == "Ambiguous — pick one."
+
+    def test_no_match_with_fallback_prompts_tty(self, monkeypatch):
+        """No condition matches AND ``fallback_prompt`` declared, with
+        stdin IS a TTY → step prompts the operator and records the
+        verdict in ``output.choice``.
+        """
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+        from specify_cli.workflows.steps import gate_on_condition as goc_module
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        monkeypatch.setattr(goc_module.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(
+            GateOnConditionStep,
+            "_prompt",
+            staticmethod(lambda _msg, _opts: "approve"),
+        )
+
+        step = GateOnConditionStep()
+        ctx = StepContext(steps={"d": {"output": {"flag": False}}})
+        result = step.execute(
+            {
+                "id": "review",
+                "conditions": [
+                    {"if": "{{ steps.d.output.flag }}", "then_route": "x"},
+                ],
+                "fallback_prompt": {
+                    "message": "Pick one.",
+                    "options": ["approve", "reject"],
+                },
+            },
+            ctx,
+        )
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["choice"] == "approve"
+        assert result.output["auto_fired"] is False
+
+    def test_fallback_reject_with_abort_marks_aborted(self, monkeypatch):
+        """When the fallback prompt is rejected and
+        ``on_reject: abort`` is declared, the step fails with
+        ``aborted=True`` so the run halts. Matches regular ``gate``
+        semantics.
+        """
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+        from specify_cli.workflows.steps import gate_on_condition as goc_module
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        monkeypatch.setattr(goc_module.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(
+            GateOnConditionStep,
+            "_prompt",
+            staticmethod(lambda _msg, _opts: "reject"),
+        )
+
+        step = GateOnConditionStep()
+        ctx = StepContext(steps={"d": {"output": {"flag": False}}})
+        result = step.execute(
+            {
+                "id": "review",
+                "conditions": [
+                    {"if": "{{ steps.d.output.flag }}", "then_route": "x"},
+                ],
+                "fallback_prompt": {
+                    "message": "Pick one.",
+                    "options": ["approve", "reject"],
+                    "on_reject": "abort",
+                },
+            },
+            ctx,
+        )
+        assert result.status == StepStatus.FAILED
+        assert result.output["aborted"] is True
+
+    def test_validate_missing_conditions(self):
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+
+        step = GateOnConditionStep()
+        errors = step.validate({"id": "review"})
+        assert any("'conditions'" in e and "missing" in e for e in errors)
+
+    def test_validate_empty_conditions(self):
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+
+        step = GateOnConditionStep()
+        errors = step.validate({"id": "review", "conditions": []})
+        assert any("non-empty" in e for e in errors)
+
+    def test_validate_condition_missing_then_route(self):
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+
+        step = GateOnConditionStep()
+        errors = step.validate(
+            {
+                "id": "review",
+                "conditions": [{"if": "{{ true }}"}],  # no then_route
+            }
+        )
+        assert any("then_route" in e for e in errors)
+
+    def test_validate_fallback_invalid_on_reject(self):
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+
+        step = GateOnConditionStep()
+        errors = step.validate(
+            {
+                "id": "review",
+                "conditions": [
+                    {"if": "{{ true }}", "then_route": "x"},
+                ],
+                "fallback_prompt": {
+                    "message": "Pick.",
+                    "on_reject": "invalid",
+                },
+            }
+        )
+        assert any("on_reject" in e for e in errors)
+
+    def test_validate_rejects_non_string_if(self):
+        """``if:`` must be a string template; a bare int / list would
+        coerce through ``evaluate_condition`` and surface only at
+        runtime, so the validator catches it eagerly.
+        """
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+
+        step = GateOnConditionStep()
+        errors = step.validate(
+            {
+                "id": "review",
+                "conditions": [{"if": 42, "then_route": "x"}],
+            }
+        )
+        assert any("'if' must be a string" in e for e in errors)
+
+    def test_validate_rejects_non_string_then_route(self):
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+
+        step = GateOnConditionStep()
+        errors = step.validate(
+            {
+                "id": "review",
+                "conditions": [
+                    {"if": "{{ true }}", "then_route": ["a", "b"]}
+                ],
+            }
+        )
+        assert any("'then_route' must be a" in e for e in errors)
+
+    def test_validate_rejects_empty_then_route(self):
+        """An empty ``then_route`` would silently match a downstream
+        ``switch case: ""`` which is almost always an authoring
+        mistake. Validator rejects it eagerly.
+        """
+        from specify_cli.workflows.steps.gate_on_condition import (
+            GateOnConditionStep,
+        )
+
+        step = GateOnConditionStep()
+        errors = step.validate(
+            {
+                "id": "review",
+                "conditions": [{"if": "{{ true }}", "then_route": ""}],
+            }
+        )
+        assert any("'then_route' must be a non-empty" in e for e in errors)
+
+    def test_registered_in_step_registry(self):
+        """The step type must be registered so workflow YAML can
+        reference ``type: gate-on-condition``.
+        """
+        from specify_cli.workflows import STEP_REGISTRY
+
+        assert "gate-on-condition" in STEP_REGISTRY
+
+    def test_end_to_end_in_workflow_routes_via_switch(self, project_dir):
+        """End-to-end: a gate-on-condition step's ``output.choice``
+        drives a downstream switch, exactly the same way a regular
+        gate's choice does. Locks the contract that downstream
+        branching is identical between the two gate kinds.
+        """
+        from specify_cli.workflows.engine import (
+            WorkflowDefinition,
+            WorkflowEngine,
+        )
+        from specify_cli.workflows.base import RunStatus
+
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "auto-gate-routes"
+  name: "Auto Gate Routes"
+  version: "1.0.0"
+inputs:
+  state:
+    type: string
+    default: "pending"
+steps:
+  - id: review
+    type: gate-on-condition
+    conditions:
+      - if: "{{ inputs.state == 'clean' }}"
+        then_route: continue
+      - if: "{{ inputs.state == 'pending' }}"
+        then_route: regenerate
+  - id: route
+    type: switch
+    expression: "{{ steps.review.output.choice }}"
+    cases:
+      regenerate:
+        - id: rerun
+          type: shell
+          run: "echo rerun"
+      continue:
+        - id: noop
+          type: shell
+          run: "echo noop"
+""")
+        engine = WorkflowEngine(project_dir)
+        state = engine.execute(definition, {"state": "pending"})
+
+        assert state.status == RunStatus.COMPLETED
+        assert state.step_results["review"]["output"]["choice"] == "regenerate"
+        assert state.step_results["review"]["output"]["auto_fired"] is True
+        assert "rerun" in state.step_results
+        assert "noop" not in state.step_results
+
+
 class TestIfThenStep:
     """Test the if/then/else step type."""
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -78,7 +78,7 @@ specify workflow run speckit \
 
 ## Step Types
 
-Workflows support 10 built-in step types:
+Workflows support 11 built-in step types:
 
 ### Command Steps (default)
 
@@ -125,6 +125,37 @@ Pause for human review. The workflow resumes when `specify workflow resume` is c
   options: [approve, edit, reject]
   on_reject: abort
 ```
+
+### Gate-on-Condition Steps
+
+Auto-firing review gate that records a verdict without operator
+interaction when a condition matches. Conditions are evaluated in
+declaration order; the first truthy condition's `then_route` is
+recorded as `output.choice` exactly like a regular gate's verdict.
+
+When no condition matches, the step falls back to an interactive
+prompt (`fallback_prompt:`) — or aborts the run if no fallback is
+declared.
+
+```yaml
+- id: review-overview
+  type: gate-on-condition
+  conditions:
+    - if: "{{ steps.detect.output.has_pending_work }}"
+      then_route: regenerate
+    - if: "{{ steps.detect.output.is_clean }}"
+      then_route: continue
+  fallback_prompt:
+    message: "Ambiguous — approve, regenerate, or abort?"
+    options: [approve, regenerate, abort]
+    on_reject: abort
+```
+
+Downstream `switch` / `if` steps branch on `output.choice` exactly
+the same way they branch on a regular gate's choice. The output also
+includes `output.auto_fired` (`True` when a condition matched,
+`False` when the operator chose) so workflows can distinguish
+automatic from interactive verdicts.
 
 ### If/Then/Else Steps
 


### PR DESCRIPTION
## Description

Closes #2593.

Adds a new step kind, `gate-on-condition`, that auto-fires a gate
verdict when a condition matches, falling back to interactive
prompt behaviour when no condition matches. The existing `gate`
step is unchanged.

> **Note for maintainers:** the issue was flagged as "long-shot,
> fine to close politely if not aligned with the project's
> direction." Submitting the PR so reviewers can see the concrete
> shape — happy to close cleanly if the direction is no.

### Why

Spec Kit `gate` steps require operator interaction. There was no
way to express "auto-fire this gate's `<verdict>` branch when
condition X holds, otherwise prompt the operator." This blocks any
workflow where downstream steps should auto-rerun based on
detected state without prompting on the no-op path (e.g. stale
artifact cascades, conditional review loops).

### Canonical usage

```yaml
- id: review-overview
  type: gate-on-condition
  conditions:
    - if: "{{ steps.detect.output.has_pending_work }}"
      then_route: regenerate
    - if: "{{ steps.detect.output.is_clean }}"
      then_route: continue
  fallback_prompt:
    message: "Ambiguous — approve, regenerate, or abort?"
    options: [approve, regenerate, abort]
    on_reject: abort

- id: route
  type: switch
  expression: "{{ steps.review-overview.output.choice }}"
  cases:
    regenerate:
      - id: rerun-overview
        command: speckit.overview
    continue:
      - id: noop
        type: shell
        run: "echo skipped"
```

### Implementation

Conditions are evaluated in declaration order via the existing
`expressions.evaluate_condition` — no new evaluator. The first
truthy condition's `then_route` is recorded as `output.choice`
**exactly the same way** a regular `gate` step's verdict is
recorded, so downstream `switch` / `if` steps branch on it
identically.

The `fallback_prompt` schema uses the same field names as the
regular `gate` step (`message`, `options`, `on_reject`) so authors
writing both kinds share one vocabulary. `output.auto_fired`
records `True` when a condition matched and `False` when the
operator picked from the fallback prompt.

### Behaviour matrix

| Scenario | Result |
|---|---|
| First truthy condition | `COMPLETED`, `output.choice = then_route`, `output.auto_fired = True` |
| Multiple truthy conditions | First wins (declaration-order semantics) |
| No condition matches, no `fallback_prompt` | `FAILED` with `output.aborted = True` |
| No match, `fallback_prompt` declared, no TTY | `PAUSED` (same as regular `gate`) |
| No match, `fallback_prompt` declared, TTY | Interactive prompt; verdict in `output.choice`, `output.auto_fired = False` |
| Fallback rejected + `on_reject: abort` | `FAILED` with `output.aborted = True` |
| Fallback rejected + `on_reject: skip` | `COMPLETED` (downstream decides) |
| Fallback rejected + `on_reject: retry` | `PAUSED` |

### Default behaviour preserved

The existing `gate` step kind is unchanged. Workflows that don't
opt into `type: gate-on-condition` see no difference. The new step
type is registered alongside the existing ten built-ins (now
eleven).

### Validation

`GateOnConditionStep.validate` rejects:

- Missing or empty `conditions`.
- Condition entries missing `if` or `then_route`.
- Malformed `fallback_prompt` (non-mapping, non-list `options`,
  non-string entries in `options`).
- Invalid `fallback_prompt.on_reject` (must be
  `abort`/`skip`/`retry`, matching `gate`).

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
      → **2972 passed, 35 skipped** (was 2960 before; +12 new
      tests added in this PR).
- [x] Tested with a sample workflow: ran a 2-step workflow where
      a `gate-on-condition` selects `regenerate` based on a
      string input, and a downstream `switch` routes to the
      matching case. Verified `output.auto_fired = True` and the
      regenerate branch ran. Re-ran with an input that matches no
      condition and no fallback declared — workflow aborted with
      `output.aborted = True` as expected.

### New test coverage

`TestGateOnConditionStep` in `tests/test_workflows.py` adds 12 new
tests covering:

| Test | What it locks |
|---|---|
| `test_first_matching_condition_wins` | Basic auto-fire; output shape. |
| `test_declaration_order_when_multiple_truthy` | First-wins semantics. |
| `test_no_match_no_fallback_aborts` | Sensible failure mode when no fallback declared. |
| `test_no_match_with_fallback_pauses_non_tty` | Same `PAUSED` semantics as regular gate. |
| `test_no_match_with_fallback_prompts_tty` | Interactive prompt works; verdict recorded. |
| `test_fallback_reject_with_abort_marks_aborted` | Fallback `on_reject: abort` halts. |
| `test_validate_missing_conditions` | Validator rejects missing field. |
| `test_validate_empty_conditions` | Validator rejects empty list. |
| `test_validate_condition_missing_then_route` | Validator rejects malformed condition entry. |
| `test_validate_fallback_invalid_on_reject` | Validator rejects bad fallback on_reject. |
| `test_registered_in_step_registry` | Locks registration; `STEP_REGISTRY['gate-on-condition']` exists. |
| `test_end_to_end_in_workflow_routes_via_switch` | End-to-end: `output.choice` drives a downstream `switch` identically to a regular gate. |

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (described below)

Used Claude Opus to draft the step module, the test suite, the
docs section, and this PR body. The proposed shape
(`gate-on-condition` + `conditions[]` + `fallback_prompt`) was
specified in issue #2593; this PR implements that proposal with one
naming refinement (`fallback_prompt.options` instead of `choices`)
to keep the vocabulary aligned with the existing `gate` step. Code,
tests, and design decisions were human-reviewed before submission.


---

## Update (post-open audit)

Tightened the validator after a self-review pass:

- `if:` must be a string (rejects YAML mistakes like `if: 42` that
  would silently coerce through `evaluate_condition` and surface
  only at runtime).
- `then_route:` must be a string AND non-empty (an empty
  `then_route` would match a downstream `switch case: ""` which is
  almost always an authoring mistake).

Three new validator tests pin these rejections:

- `test_validate_rejects_non_string_if`
- `test_validate_rejects_non_string_then_route`
- `test_validate_rejects_empty_then_route`

Suite is now **2975 passed** (was 2960 baseline; +15 new tests
covering this PR).
