### PR TITLE
Fix support section TOC anchor and add missing emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [🔧 Prerequisites](#-prerequisites)
 - [📖 Learn More](#-learn-more)
 - [📋 Detailed Process](#-detailed-process)
-- [ Support](#-support)
+- [💬 Support](#-support)
 - [🙏 Acknowledgements](#-acknowledgements)
 - [📄 License](#-license)
 
@@ -581,7 +581,7 @@ Once the implementation is complete, test the application and resolve any runtim
 
 ---
 
-##  Support
+## 💬 Support
 
 For support, please open a [GitHub issue](https://github.com/github/spec-kit/issues/new). We welcome bug reports, feature requests, and questions about using Spec-Driven Development.
 


### PR DESCRIPTION
- Added missing 💬 emoji to the Support section in the README
- Fixed the Support entry in the Table of Contents to correctly link to the section anchor generated by GitHub markdown rendering

P.S. This bothered me more than it should have, so I had to fix it 😄