### PR TITLE
docs: add minimal, trial-basis Spec Kit Constitution (dogfooding)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@
 
 The toolkit supports multiple AI coding assistants, allowing teams to use their preferred tools while maintaining consistent project structure and development practices.
 
+Repository governance lives in `memory/constitution.md`. Keep this file focused
+on agent-operational context, conventions, and architecture notes; reference the
+constitution for SDD process rules instead of duplicating them here.
+
 ---
 
 ## Integration Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,10 @@ When working on spec-kit:
 3. Test script functionality in the `scripts/` directory
 4. Ensure memory files (`memory/constitution.md`) are updated if major process changes are made
 
+The repository constitution lives at `memory/constitution.md`. Consult it when
+deciding whether a change warrants Spec-Driven Development artifacts and when
+making process or governance changes.
+
 ### Recommended validation flow
 
 For the smoothest review experience, validate changes in this order:

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -1,0 +1,62 @@
+<!--
+Sync Impact Report
+- Version change: none → 1.0.0 (initial ratification)
+- Modified principles: N/A (initial constitution)
+- Added sections:
+  - Scope
+  - Core Principles
+    - I. Selective Spec-Driven Development
+    - II. Spec-Forward, Historical Once Shipped
+  - Governance
+- Removed sections: none
+- Templates requiring updates:
+  - ⚠ none required for downstream templates (`templates/plan-template.md`,
+    `templates/spec-template.md`, `templates/tasks-template.md`,
+    `templates/commands/*.md` are consumed by downstream projects and remain
+    unaffected — this constitution governs only spec-kit's own work)
+- Follow-up TODOs: none
+- Provenance: see GitHub Discussion #2504 and Issue #2698
+-->
+
+# Spec Kit Constitution
+
+## Scope
+
+This constitution governs work in the spec-kit repository. It does not prescribe behavior for downstream projects, which produce their own constitutions via the shipped `/constitution` workflow.
+
+## Core Principles
+
+### I. Selective Spec-Driven Development
+
+SDD MUST be applied to a change in this repository when **at least one** of the following holds:
+
+- **Non-trivial scope**: the change spans multiple modules, introduces new public surface, or touches more than a handful of files cohesively.
+- **Ambiguous design space**: more than one viable implementation exists and the trade-offs are not obvious from the issue or discussion.
+- **Cross-cutting impact**: the change affects shipped templates, command files, or any artifact consumed by downstream projects.
+- **Security or correctness stakes**: the change touches authentication, authorization, input handling, redirect handling, or any path where incorrect behavior has a material blast radius beyond the contributor's environment.
+
+SDD MUST NOT be applied as theater. Refactors, plumbing changes, dependency bumps, catalog updates, documentation fixes, and other changes that do not meet any of the criteria above SHOULD ship without spec artifacts. Manufacturing spec artifacts on changes that do not need them dilutes the signal value of the ones that do.
+
+### II. Spec-Forward, Historical Once Shipped
+
+Spec artifacts in this repository (`specs/<feature>/{spec,plan,tasks}.md`, and this constitution) are **spec-forward**: they describe work to be done, not work that has been done.
+
+Once a feature merges, its spec artifacts are a **frozen historical snapshot**. They MUST NOT be maintained as living documents that track subsequent code evolution. Drift between merged specs and current code is expected and acceptable; the spec records what the unit of work was at the time, not the present state of the codebase.
+
+When the same surface is meaningfully revisited later, the contributor MAY produce new spec artifacts under a new `specs/<feature>/` directory rather than amending the historical ones.
+
+**Rationale**: the spec-kit codebase evolves rapidly. Treating specs as living documents would create a maintenance burden out of proportion to their value. Treating them as snapshots makes them low-cost to merge and useful as evidence of "this was the unit of work, this is what shipped." This stance was established by maintainer guidance in GitHub Discussion #2504.
+
+## Governance
+
+**Amendments**: changes to this constitution require a pull request explicitly identifying the amendment, its rationale, and a version bump per the policy below. Amendments that introduce or remove a principle SHOULD be discussed in a GitHub Discussion under the `Ideas` category before opening a PR.
+
+**Versioning**:
+
+- **MAJOR**: a principle is removed, redefined in a backwards-incompatible way, or a governance rule is replaced.
+- **MINOR**: a new principle or new section is added, or guidance is materially expanded.
+- **PATCH**: clarifications, wording fixes, or non-semantic refinements.
+
+**Compliance review**: pull request reviewers MAY reference this constitution when asking a contributor whether a change warrants SDD artifacts. Whether the criteria in Principle I are met is a judgment call made by the contributor with reviewer input; this constitution does not bind reviewers to demand or refuse spec artifacts in any specific case.
+
+**Version**: 1.0.0 | **Ratified**: 2026-05-26 | **Last Amended**: 2026-05-26

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -1,15 +1,13 @@
 <!--
 Sync Impact Report
-- Version change: none → 1.0.0 (initial ratification)
-- Modified principles: N/A (initial constitution)
-- Added sections:
-  - Scope
-  - Core Principles
-    - I. Selective Spec-Driven Development
-    - II. Spec-Forward, Historical Once Shipped
-    - III. Governance and Agent Context Separation
-  - Governance
-- Removed sections: none
+- Version change: none → 1.0.0 (initial, deliberately minimal)
+- Principles: I. Selective Spec-Driven Development (proposed criteria);
+  II. Spec-Forward, Historical Once Shipped (maintainer-stated stance)
+- Sections: Status & Scope; Core Principles; Dogfooding On-Ramp; Governance
+- Removed vs. earlier draft: standalone "Governance and Agent Context
+  Separation" principle — #2476 is an open community question, not a settled
+  one; reduced to a one-line working split under Governance rather than
+  ratified as a principle.
 - Templates requiring updates:
   - ⚠ none required for downstream templates (`templates/plan-template.md`,
     `templates/spec-template.md`, `templates/tasks-template.md`,
@@ -17,28 +15,56 @@ Sync Impact Report
     unaffected — this constitution governs only spec-kit's own work)
 - Follow-up TODOs: none
 - Provenance:
-  - https://github.com/github/spec-kit/discussions/2504
-  - https://github.com/github/spec-kit/discussions/2476
+  - https://github.com/github/spec-kit/discussions/2504 (spec-forward stance,
+    "try it out and see where it leads" — @mnriem)
+  - https://github.com/github/spec-kit/discussions/2476 (constitution vs agent
+    context — informs the scope boundary, not resolved here)
 -->
 
 # Spec Kit Constitution
 
-## Scope
+## Status & Scope
 
-This constitution governs work in the spec-kit repository. It does not prescribe behavior for downstream projects, which produce their own constitutions via the shipped `/speckit.constitution` workflow.
+This document governs how Spec-Driven Development is applied **to work in the
+spec-kit repository itself**. It does not prescribe behavior for downstream
+projects, which generate their own constitutions via the shipped
+`/speckit.constitution` workflow.
+
+It is **deliberately minimal and adopted on a trial basis**, per maintainer
+guidance to "try it out and see where it leads"
+([Discussion #2504](https://github.com/github/spec-kit/discussions/2504)). It
+records a small number of decisions to avoid relitigating them, and is expected
+to be revised once the project has actually run SDD on one of its own features.
+
+It is **non-binding and loaded on demand**: Spec Kit commands read it during
+`plan`, `tasks`, and `implement`, so it only takes effect when SDD is actually
+run on this repository — not on every contribution or every LLM call.
 
 ## Core Principles
 
 ### I. Selective Spec-Driven Development
 
-SDD MUST be applied to a change in this repository when **at least one** of the following holds:
+SDD pays off — and SHOULD be applied — when **at least one** of the following
+holds:
 
-- **Non-trivial scope**: the change spans multiple modules, introduces new public surface, or touches more than a handful of files cohesively.
-- **Ambiguous design space**: more than one viable implementation exists and the trade-offs are not obvious from the issue or discussion.
-- **Cross-cutting impact**: the change affects shipped templates, command files, or any artifact consumed by downstream projects.
-- **Security or correctness stakes**: the change touches authentication, authorization, input handling, redirect handling, or any path where incorrect behavior has a material blast radius beyond the contributor's environment.
+- **Non-trivial scope**: the change spans multiple modules, introduces new
+  public surface, or touches more than a handful of files cohesively.
+- **Ambiguous design space**: more than one viable implementation exists and
+  the trade-offs are not obvious from the issue or discussion.
+- **Cross-cutting impact**: the change affects shipped templates, command
+  files, or any artifact consumed by downstream projects.
+- **Security or correctness stakes**: the change touches authentication,
+  authorization, input handling, redirect handling, or any path where incorrect
+  behavior has a material blast radius beyond the contributor's environment.
 
-SDD MUST NOT be applied as theater. Refactors, plumbing changes, dependency bumps, catalog updates, documentation fixes, and other changes that do not meet any of the criteria above SHOULD ship without spec artifacts. Manufacturing spec artifacts on changes that do not need them dilutes the signal value of the ones that do.
+Refactors, plumbing changes, dependency bumps, catalog updates, documentation
+fixes, and other changes that meet none of these SHOULD ship without spec
+artifacts. Manufacturing spec artifacts on changes that do not need them
+dilutes the signal value of the ones that do.
+
+These criteria are **guidance for contributor judgment, not a gate**. Reviewers
+MAY reference them when asking whether a change warrants SDD artifacts; nothing
+here binds anyone to demand or refuse them in any specific case.
 
 ### II. Spec-Forward, Historical Once Shipped
 
@@ -46,55 +72,66 @@ Feature spec artifacts in this repository
 (`specs/<feature>/{spec,plan,tasks}.md`) are **spec-forward**: they describe
 work to be done, not work that has been done.
 
-Once a feature merges, its spec artifacts are a **frozen historical snapshot**. They MUST NOT be maintained as living documents that track subsequent code evolution. Drift between merged specs and current code is expected and acceptable; the spec records what the unit of work was at the time, not the present state of the codebase.
+Once a feature merges, its spec artifacts become a **frozen historical
+snapshot**. They MUST NOT be maintained as living documents that track
+subsequent code evolution. Drift between merged specs and current code is
+expected and acceptable; the spec records what the unit of work was at the
+time, not the present state of the codebase. When the same surface is
+meaningfully revisited later, the contributor produces new spec artifacts under
+a new `specs/<feature>/` directory rather than amending the historical ones.
 
-When the same surface is meaningfully revisited later, the contributor MAY produce new spec artifacts under a new `specs/<feature>/` directory rather than amending the historical ones.
+**Rationale**: the spec-kit codebase evolves rapidly; treating specs as living
+documents would create a maintenance burden out of proportion to their value,
+whereas snapshots are cheap to merge and serve as evidence of "this was the
+unit of work, this is what shipped." This is the maintainer-stated stance for
+this repository
+([Discussion #2504](https://github.com/github/spec-kit/discussions/2504): "the
+spec defines the unit of work and once it is done it is historical").
 
-**Rationale**: the spec-kit codebase evolves rapidly. Treating specs as living
-documents would create a maintenance burden out of proportion to their value.
-Treating them as snapshots makes them low-cost to merge and useful as evidence
-of "this was the unit of work, this is what shipped." This stance was
-established by maintainer guidance in
-[GitHub Discussion #2504](https://github.com/github/spec-kit/discussions/2504).
+## Dogfooding On-Ramp
 
-### III. Governance and Agent Context Separation
+This document is the **governance half** of dogfooding. The operative half is
+running the workflow on a real spec-kit feature and committing its artifacts.
 
-This constitution MUST define repository-level governance and phase-scoped SDD
-rules: when spec artifacts are warranted, how specs/plans/tasks are treated,
-and how these rules change. It MUST NOT duplicate agent-specific operating
-instructions, local workflow recipes, codebase maps, or day-to-day
-implementation conventions that belong in `AGENTS.md`,
-`.github/copilot-instructions.md`, `CLAUDE.md`, or other tool-specific context
-files.
-
-Agent context files MAY reference this constitution, but SHOULD avoid mirroring
-its rules. Conversely, this constitution MAY reference agent context files for
-operational details instead of copying them. If a rule must influence every
-normal agent interaction, it belongs in agent context; if it governs when or
-how spec artifacts and repo process are created, reviewed, or amended, it
-belongs here.
-
-**Rationale**: the constitution is loaded by Spec Kit workflows when relevant;
-it is not a catch-all context file for every LLM call. Keeping governance
-separate from agent context avoids DRY drift across multiple instruction
-surfaces. This distinction follows the concerns raised in
-[GitHub Discussion #2476](https://github.com/github/spec-kit/discussions/2476).
+- **Trigger**: the next change that clearly meets Principle I's criteria SHOULD
+  be developed with committed `specs/<feature>/{spec,plan,tasks}.md`, making
+  this constitution the artifact loaded during that feature's `plan`, `tasks`,
+  and `implement` phases.
+- **Proof-of-concept candidate**: PR #2393 (config-driven opt-in authentication
+  registry) is a textbook fit — the security model pivoted mid-PR, the
+  `AuthProvider` contract was reshaped twice, and roughly ten follow-up commits
+  patched threat-model gaps surfaced in review. A retroactive
+  `specs/auth-registry/` would demonstrate the workflow on real product work.
+  It is tracked separately and does not block this document.
+- **Goal**: give contributors and downstream adopters a real upstream spec to
+  point to, not a fixture — the gap originally raised in #2504.
 
 ## Governance
 
-**Amendments**: unlike merged feature spec artifacts, this constitution is the
-current governance record and remains amendable through this section. Changes
-to this constitution require a pull request explicitly identifying the
+**Scope boundary** (a working split for this repository, not a resolution of
+the open [#2476](https://github.com/github/spec-kit/discussions/2476) debate):
+this document covers when SDD artifacts are warranted and how they are treated.
+Agent-operational context, codebase maps, and day-to-day implementation
+conventions live in `AGENTS.md`, `.github/copilot-instructions.md`,
+`CLAUDE.md`, and similar tool-specific files, and are not duplicated here.
+
+**Amendments**: changes require a pull request explicitly identifying the
 amendment, its rationale, and a version bump per the policy below. Amendments
 that introduce or remove a principle SHOULD be discussed in a GitHub Discussion
 under the `Ideas` category before opening a PR.
 
 **Versioning**:
 
-- **MAJOR**: a principle is removed, redefined in a backwards-incompatible way, or a governance rule is replaced.
-- **MINOR**: a new principle or new section is added, or guidance is materially expanded.
+- **MAJOR**: a principle is removed, redefined in a backwards-incompatible way,
+  or a governance rule is replaced.
+- **MINOR**: a new principle or new section is added, or guidance is materially
+  expanded.
 - **PATCH**: clarifications, wording fixes, or non-semantic refinements.
 
-**Compliance review**: pull request reviewers MAY reference this constitution when asking a contributor whether a change warrants SDD artifacts. Whether the criteria in Principle I are met is a judgment call made by the contributor with reviewer input; this constitution does not bind reviewers to demand or refuse spec artifacts in any specific case.
+**Compliance review**: pull request reviewers MAY reference this document when
+asking a contributor whether a change warrants SDD artifacts. Whether the
+criteria in Principle I are met is a judgment call made by the contributor with
+reviewer input; this document does not bind reviewers to demand or refuse spec
+artifacts in any specific case.
 
-**Version**: 1.0.0 | **Ratified**: 2026-05-26 | **Last Amended**: 2026-05-26
+**Version**: 1.0.0 | **Ratified**: 2026-05-26 | **Last Amended**: 2026-05-29

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -7,6 +7,7 @@ Sync Impact Report
   - Core Principles
     - I. Selective Spec-Driven Development
     - II. Spec-Forward, Historical Once Shipped
+    - III. Governance and Agent Context Separation
   - Governance
 - Removed sections: none
 - Templates requiring updates:
@@ -15,7 +16,9 @@ Sync Impact Report
     `templates/commands/*.md` are consumed by downstream projects and remain
     unaffected — this constitution governs only spec-kit's own work)
 - Follow-up TODOs: none
-- Provenance: see https://github.com/github/spec-kit/discussions/2504
+- Provenance:
+  - https://github.com/github/spec-kit/discussions/2504
+  - https://github.com/github/spec-kit/discussions/2476
 -->
 
 # Spec Kit Constitution
@@ -53,6 +56,29 @@ Treating them as snapshots makes them low-cost to merge and useful as evidence
 of "this was the unit of work, this is what shipped." This stance was
 established by maintainer guidance in
 [GitHub Discussion #2504](https://github.com/github/spec-kit/discussions/2504).
+
+### III. Governance and Agent Context Separation
+
+This constitution MUST define repository-level governance and phase-scoped SDD
+rules: when spec artifacts are warranted, how specs/plans/tasks are treated,
+and how these rules change. It MUST NOT duplicate agent-specific operating
+instructions, local workflow recipes, codebase maps, or day-to-day
+implementation conventions that belong in `AGENTS.md`,
+`.github/copilot-instructions.md`, `CLAUDE.md`, or other tool-specific context
+files.
+
+Agent context files MAY reference this constitution, but SHOULD avoid mirroring
+its rules. Conversely, this constitution MAY reference agent context files for
+operational details instead of copying them. If a rule must influence every
+normal agent interaction, it belongs in agent context; if it governs when or
+how spec artifacts and repo process are created, reviewed, or amended, it
+belongs here.
+
+**Rationale**: the constitution is loaded by Spec Kit workflows when relevant;
+it is not a catch-all context file for every LLM call. Keeping governance
+separate from agent context avoids DRY drift across multiple instruction
+surfaces. This distinction follows the concerns raised in
+[GitHub Discussion #2476](https://github.com/github/spec-kit/discussions/2476).
 
 ## Governance
 

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -15,7 +15,7 @@ Sync Impact Report
     `templates/commands/*.md` are consumed by downstream projects and remain
     unaffected — this constitution governs only spec-kit's own work)
 - Follow-up TODOs: none
-- Provenance: see GitHub Discussion #2504
+- Provenance: see https://github.com/github/spec-kit/discussions/2504
 -->
 
 # Spec Kit Constitution
@@ -39,17 +39,29 @@ SDD MUST NOT be applied as theater. Refactors, plumbing changes, dependency bump
 
 ### II. Spec-Forward, Historical Once Shipped
 
-Spec artifacts in this repository (`specs/<feature>/{spec,plan,tasks}.md`, and this constitution) are **spec-forward**: they describe work to be done, not work that has been done.
+Feature spec artifacts in this repository
+(`specs/<feature>/{spec,plan,tasks}.md`) are **spec-forward**: they describe
+work to be done, not work that has been done.
 
 Once a feature merges, its spec artifacts are a **frozen historical snapshot**. They MUST NOT be maintained as living documents that track subsequent code evolution. Drift between merged specs and current code is expected and acceptable; the spec records what the unit of work was at the time, not the present state of the codebase.
 
 When the same surface is meaningfully revisited later, the contributor MAY produce new spec artifacts under a new `specs/<feature>/` directory rather than amending the historical ones.
 
-**Rationale**: the spec-kit codebase evolves rapidly. Treating specs as living documents would create a maintenance burden out of proportion to their value. Treating them as snapshots makes them low-cost to merge and useful as evidence of "this was the unit of work, this is what shipped." This stance was established by maintainer guidance in GitHub Discussion #2504.
+**Rationale**: the spec-kit codebase evolves rapidly. Treating specs as living
+documents would create a maintenance burden out of proportion to their value.
+Treating them as snapshots makes them low-cost to merge and useful as evidence
+of "this was the unit of work, this is what shipped." This stance was
+established by maintainer guidance in
+[GitHub Discussion #2504](https://github.com/github/spec-kit/discussions/2504).
 
 ## Governance
 
-**Amendments**: changes to this constitution require a pull request explicitly identifying the amendment, its rationale, and a version bump per the policy below. Amendments that introduce or remove a principle SHOULD be discussed in a GitHub Discussion under the `Ideas` category before opening a PR.
+**Amendments**: unlike merged feature spec artifacts, this constitution is the
+current governance record and remains amendable through this section. Changes
+to this constitution require a pull request explicitly identifying the
+amendment, its rationale, and a version bump per the policy below. Amendments
+that introduce or remove a principle SHOULD be discussed in a GitHub Discussion
+under the `Ideas` category before opening a PR.
 
 **Versioning**:
 

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -25,7 +25,7 @@ Sync Impact Report
 
 ## Scope
 
-This constitution governs work in the spec-kit repository. It does not prescribe behavior for downstream projects, which produce their own constitutions via the shipped `/constitution` workflow.
+This constitution governs work in the spec-kit repository. It does not prescribe behavior for downstream projects, which produce their own constitutions via the shipped `/speckit.constitution` workflow.
 
 ## Core Principles
 

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -15,7 +15,7 @@ Sync Impact Report
     `templates/commands/*.md` are consumed by downstream projects and remain
     unaffected — this constitution governs only spec-kit's own work)
 - Follow-up TODOs: none
-- Provenance: see GitHub Discussion #2504 and Issue #2698
+- Provenance: see GitHub Discussion #2504
 -->
 
 # Spec Kit Constitution


### PR DESCRIPTION
## Summary

Adds `memory/constitution.md`, an initial Spec Kit repository constitution — the project dogfooding its own flagship artifact on itself.

**What this PR is**: a *deliberately minimal, trial-basis* constitution, adopted per maintainer guidance in #2504 to *"try it out and see where it leads"* — not a claim of fully-settled governance. Two principles:

- **I. Selective Spec-Driven Development** — *proposed, non-binding* criteria for when SDD pays off on this repo (non-trivial scope, ambiguous design, cross-cutting impact, security/correctness stakes), plus an anti-theater clause. Guidance for contributor judgment; reviewers MAY reference it, it gates nothing.
- **II. Spec-Forward, Historical Once Shipped** — the *maintainer-stated stance* from #2504: a spec defines the unit of work and becomes a frozen historical snapshot once shipped. Quoted verbatim as provenance.

**What it deliberately is *not***: it does not resolve the constitution-vs-`AGENTS.md` question. #2476 is still an open community debate, so that concern is reduced to a one-line scope boundary under Governance, explicitly framed as this repo's working split — not ratified as a principle.

## Dogfooding on-ramp

The document is the **governance half** of dogfooding; the operative half is running the workflow on a real feature and committing its artifacts. The PR sets that up explicitly:

- **Mechanism**: the constitution is loaded on demand during `plan`, `tasks`, and `implement` (per #2476), so it takes effect the moment SDD is run on a spec-kit feature.
- **Trigger**: the next change meeting Principle I's criteria SHOULD be developed with committed `specs/<feature>/` artifacts.
- **Proof-of-concept candidate**: #2393 (opt-in auth registry) — security model pivoted mid-PR, `AuthProvider` reshaped twice, ~ten follow-up commits patched threat-model gaps. A retroactive `specs/auth-registry/` is named as a parked, non-blocking next step.

## Path choice

The constitution lives at `memory/constitution.md`, not `.specify/memory/constitution.md`. The `.specify/` path is for downstream projects initialized by `specify init`; this repository keeps its own governance artifact at the repo root.

## Compliance posture

Non-binding by design. Reviewers MAY reference Principle I when asking whether a change warrants spec artifacts; whether the criteria are met is a contributor judgment call. The document explicitly avoids becoming a process tax.

## Out of scope

Broader principles (agent neutrality, template stability, extension surfaces) and the constitution-vs-agent-context resolution (#2476) are not asserted in v1.0.0. They may be added via future amendments after the trial-basis document has seen real use.

## Test plan

- [x] `memory/constitution.md` renders correctly on GitHub
- [x] Sync Impact Report header is accurate
- [x] No bracket-token placeholders remain
- [x] Cross-references resolve (#2504, #2476, #2393)
- [x] `AGENTS.md` references the constitution without duplicating governance rules
- [x] `/speckit.constitution` still targets `.specify/memory/constitution.md` for downstream projects

Closes #2698
Refs #2504
Refs #2476