### PR TITLE
Add workflow-preset to community catalog

### DIFF
--- a/docs/community/presets.md
+++ b/docs/community/presets.md
@@ -27,5 +27,6 @@ The following community-contributed presets customize how Spec Kit behaves — o
 | Spec2Cloud | Spec-driven workflow tuned for shipping to Azure: spec → plan → tasks → implement → deploy | 5 templates, 8 commands | — | [spec2cloud](https://github.com/Azure-Samples/Spec2Cloud) |
 | Table of Contents Navigation | Adds a navigable Table of Contents to generated spec.md, plan.md, and tasks.md documents | 3 templates, 3 commands | — | [spec-kit-preset-toc-navigation](https://github.com/Quratulain-bilal/spec-kit-preset-toc-navigation) |
 | VS Code Ask Questions | Enhances the clarify command to use `vscode/askQuestions` for batched interactive questioning. | 1 command | — | [spec-kit-presets](https://github.com/fdcastel/spec-kit-presets) |
+| Workflow Preset | Behavior-first specification, design artifacts, and agent-native handoff orchestration for Spec Kit | 23 templates, 7 commands | — | [spec-kit-workflow-preset](https://github.com/bigsmartben/spec-kit-workflow-preset) |
 
 To build and publish your own preset, see the [Presets Publishing Guide](https://github.com/github/spec-kit/blob/main/presets/PUBLISHING.md).

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-05-05T10:00:00Z",
+  "updated_at": "2026-05-26T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/presets/catalog.community.json",
   "presets": {
     "a11y-governance": {
@@ -523,7 +523,7 @@
       ],
       "created_at": "2026-04-30T00:00:00Z",
       "updated_at": "2026-04-30T00:00:00Z"
-    }, 
+    },
     "toc-navigation": {
       "name": "Table of Contents Navigation",
       "id": "toc-navigation",
@@ -572,6 +572,34 @@
         "clarify",
         "interactive"
       ]
+    },
+    "workflow-preset": {
+      "name": "Workflow Preset",
+      "id": "workflow-preset",
+      "version": "1.2.0",
+      "description": "Behavior-first specification, design artifacts, and agent-native handoff orchestration for Spec Kit.",
+      "author": "bigsmartben",
+      "repository": "https://github.com/bigsmartben/spec-kit-workflow-preset",
+      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/archive/refs/tags/v1.2.0.zip",
+      "homepage": "https://github.com/bigsmartben/spec-kit-workflow-preset",
+      "documentation": "https://github.com/bigsmartben/spec-kit-workflow-preset/blob/main/README.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.8.10.dev0"
+      },
+      "provides": {
+        "templates": 23,
+        "commands": 7
+      },
+      "tags": [
+        "behavior",
+        "bdd",
+        "planning",
+        "implementation",
+        "handoff"
+      ],
+      "created_at": "2026-05-26T00:00:00Z",
+      "updated_at": "2026-05-26T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Preset Submission

**Preset Name**: Workflow Preset
**Preset ID**: workflow-preset
**Version**: 1.2.0
**Repository**: https://github.com/bigsmartben/spec-kit-workflow-preset

### Checklist
- [x] Valid preset.yml manifest
- [x] README.md with description and usage
- [x] LICENSE file included
- [x] GitHub release created
- [x] Preset tested with `specify preset add --dev`
- [x] Archive install tested with `specify preset add --from https://github.com/bigsmartben/spec-kit-workflow-preset/archive/refs/tags/v1.2.0.zip`
- [x] Templates resolve through preset installation metadata
- [x] Commands register through preset installation metadata
- [x] Commands match template sections (command + template are coherent)
- [x] Added to presets/catalog.community.json
- [x] Added row to docs/community/presets.md table

## Verification
- `/tmp/spec-kit-workflow-preset-venv/bin/python -m unittest tests/test_preset_contract.py` -> 57 tests OK
- Release archive install verified in a temporary Spec Kit project; `specify preset info workflow-preset` reported Version 1.2.0
- Community catalog JSON entry validated locally for sorted preset IDs and v1.2.0 download URL