### PR TITLE
feat(workflows): add --dry-run flag to specify workflow run

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2970,30 +2970,44 @@ def workflow_run(
         # ``--json`` consumer actually wants.
         console.print("[bold yellow]DRY RUN — no AI invocation will occur[/bold yellow]\n")
 
-    try:
-        with _stdout_to_stderr_when(json_output):
+    # The redirect must enclose *both* the engine call and the
+    # exception handlers below: the previous shape raised out of
+    # ``_stdout_to_stderr_when``'s ``with`` block before the
+    # redirect's ``finally`` ran, then printed ``[red]Workflow
+    # failed:[/red] ...`` to stdout — corrupting the JSON contract
+    # under ``--json``. Wrapping both halves keeps any Rich-formatted
+    # error message on stderr in JSON mode (and on the terminal in
+    # non-JSON mode, where ``_stdout_to_stderr_when`` is a no-op).
+    # ``typer.Exit(1)`` is a regular exception that propagates after
+    # the redirect's ``finally`` restores stdout, so we never reach
+    # the post-with code on the failure path.
+    with _stdout_to_stderr_when(json_output):
+        try:
             state = engine.execute(definition, inputs, dry_run=dry_run)
-    except ValueError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        # When a step throws during template resolution in --dry-run mode,
-        # any previews already resolved by earlier steps are still the
-        # most useful debug signal we can offer — surface them before
-        # exiting instead of silently dropping them. The engine attaches
-        # the partial state to the exception as ``exc.partial_state``.
-        # Skipped under --json so the contract of "stdout is a single
-        # JSON object" holds; in the JSON branch the partial state will
-        # still be on disk and ``workflow status <run_id>`` will show it.
-        partial = getattr(exc, "partial_state", None)
-        if partial is not None and dry_run and not json_output:
-            _print_dry_run_previews(partial)
-        raise typer.Exit(1)
-    except Exception as exc:
-        console.print(f"[red]Workflow failed:[/red] {exc}")
-        # See ValueError branch above — keep partial previews on failure.
-        partial = getattr(exc, "partial_state", None)
-        if partial is not None and dry_run and not json_output:
-            _print_dry_run_previews(partial)
-        raise typer.Exit(1)
+        except ValueError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            # When a step throws during template resolution in
+            # --dry-run mode, any previews already resolved by
+            # earlier steps are still the most useful debug signal
+            # we can offer — surface them before exiting instead
+            # of silently dropping them. The engine attaches the
+            # partial state to the exception as
+            # ``exc.partial_state``. Skipped under --json so the
+            # contract of "stdout is a single JSON object" holds;
+            # in the JSON branch the partial state will still be
+            # on disk and ``workflow status <run_id>`` will show it.
+            partial = getattr(exc, "partial_state", None)
+            if partial is not None and dry_run and not json_output:
+                _print_dry_run_previews(partial)
+            raise typer.Exit(1)
+        except Exception as exc:
+            console.print(f"[red]Workflow failed:[/red] {exc}")
+            # See ValueError branch above — keep partial previews
+            # on failure.
+            partial = getattr(exc, "partial_state", None)
+            if partial is not None and dry_run and not json_output:
+                _print_dry_run_previews(partial)
+            raise typer.Exit(1)
 
     if json_output:
         _emit_workflow_json(_workflow_run_payload(state))

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -57,7 +57,7 @@ from ._console import (
 )
 from ._assets import (
     _locate_bundled_extension,
-    _locate_bundled_preset as _locate_bundled_preset,
+    _locate_bundled_preset,
     _locate_bundled_workflow as _locate_bundled_workflow,
     _locate_core_pack,
     _repo_root,
@@ -443,6 +443,16 @@ SKILL_DESCRIPTIONS = {
 from .commands import init as _init_cmd  # noqa: E402
 _init_cmd.register(app)
 
+# Workflow commands are defined in-module below (see the
+# ``workflow_app = typer.Typer(...)`` block near the end of this file).
+# An earlier draft of #2661 also tried to register the
+# ``src/specify_cli/commands/workflow.py`` module, which defined a second
+# ``workflow`` Typer group with the same name. Typer raises on duplicate
+# command names at startup, so the redundant registration has been
+# removed here and ``commands/workflow.py`` deleted. The in-module
+# commands (``specify workflow run``, ``... resume``, ``... status``,
+# ``... list``, ``... add``, etc.) are the single source of truth.
+
 
 @app.command()
 def check():
@@ -561,6 +571,14 @@ def version(
 app.add_typer(_self_app, name="self")
 
 
+# NOTE: ``specify spec`` / ``specify plan`` were intentionally NOT added
+# to this CLI. The ``specify`` CLI is scaffolding + workflow orchestration
+# only; the per-stage surface (``/speckit.specify``, ``/speckit.plan``,
+# \u2026) belongs to the agent, not the CLI. Adding a CLI shortcut would
+# duplicate that surface with a weaker, second invocation path. See
+# review #4624465842 from @mnriem on PR #2704.
+
+
 # ===== Extension Commands =====
 
 extension_app = typer.Typer(
@@ -576,6 +594,20 @@ catalog_app = typer.Typer(
     add_completion=False,
 )
 extension_app.add_typer(catalog_app, name="catalog")
+
+preset_app = typer.Typer(
+    name="preset",
+    help="Manage spec-kit presets",
+    add_completion=False,
+)
+app.add_typer(preset_app, name="preset")
+
+preset_catalog_app = typer.Typer(
+    name="catalog",
+    help="Manage preset catalogs",
+    add_completion=False,
+)
+preset_app.add_typer(preset_catalog_app, name="catalog")
 
 
 # ===== Integration Commands =====
@@ -604,9 +636,665 @@ def _require_specify_project() -> Path:
 
 # ===== Preset Commands =====
 
-# Moved to presets/_commands.py — registered here to preserve CLI surface.
-from .presets._commands import register as _register_preset_cmds  # noqa: E402
-_register_preset_cmds(app)
+
+@preset_app.command("list")
+def preset_list():
+    """List installed presets."""
+    from .presets import PresetManager
+
+    project_root = _require_specify_project()
+    manager = PresetManager(project_root)
+    installed = manager.list_installed()
+
+    if not installed:
+        console.print("[yellow]No presets installed.[/yellow]")
+        console.print("\nInstall a preset with:")
+        console.print("  [cyan]specify preset add <pack-name>[/cyan]")
+        return
+
+    console.print("\n[bold cyan]Installed Presets:[/bold cyan]\n")
+    for pack in installed:
+        status = "[green]enabled[/green]" if pack.get("enabled", True) else "[red]disabled[/red]"
+        pri = pack.get('priority', 10)
+        console.print(f"  [bold]{pack['name']}[/bold] ({pack['id']}) v{pack['version']} — {status} — priority {pri}")
+        console.print(f"    {pack['description']}")
+        if pack.get("tags"):
+            tags_str = ", ".join(pack["tags"])
+            console.print(f"    [dim]Tags: {tags_str}[/dim]")
+        console.print(f"    [dim]Templates: {pack['template_count']}[/dim]")
+        console.print()
+
+
+@preset_app.command("add")
+def preset_add(
+    preset_id: str = typer.Argument(None, help="Preset ID to install from catalog"),
+    from_url: str = typer.Option(None, "--from", help="Install from a URL (ZIP file)"),
+    dev: str = typer.Option(None, "--dev", help="Install from local directory (development mode)"),
+    priority: int = typer.Option(10, "--priority", help="Resolution priority (lower = higher precedence, default 10)"),
+):
+    """Install a preset."""
+    from .presets import (
+        PresetManager,
+        PresetCatalog,
+        PresetError,
+        PresetValidationError,
+        PresetCompatibilityError,
+    )
+
+    project_root = _require_specify_project()
+    # Validate priority
+    if priority < 1:
+        console.print("[red]Error:[/red] Priority must be a positive integer (1 or higher)")
+        raise typer.Exit(1)
+
+    manager = PresetManager(project_root)
+    speckit_version = get_speckit_version()
+
+    try:
+        if dev:
+            dev_path = Path(dev).resolve()
+            if not dev_path.exists():
+                console.print(f"[red]Error:[/red] Directory not found: {dev}")
+                raise typer.Exit(1)
+
+            console.print(f"Installing preset from [cyan]{dev_path}[/cyan]...")
+            manifest = manager.install_from_directory(dev_path, speckit_version, priority)
+            console.print(f"[green]✓[/green] Preset '{manifest.name}' v{manifest.version} installed (priority {priority})")
+
+        elif from_url:
+            # Validate URL scheme before downloading
+            from ipaddress import ip_address
+            from urllib.parse import urlparse as _urlparse
+
+            _parsed = _urlparse(from_url)
+
+            def _is_allowed_download_url(parsed_url):
+                host = parsed_url.hostname
+                if not host:
+                    return False
+                is_loopback = host == "localhost"
+                if not is_loopback:
+                    try:
+                        is_loopback = ip_address(host).is_loopback
+                    except ValueError:
+                        # Host is not an IP literal (e.g., a regular hostname); treat as non-loopback.
+                        pass
+                return parsed_url.scheme == "https" or (parsed_url.scheme == "http" and is_loopback)
+
+            def _validate_download_redirect(old_url, new_url):
+                if not _is_allowed_download_url(_urlparse(new_url)):
+                    import urllib.error
+
+                    raise urllib.error.URLError(
+                        "redirect target must use HTTPS with a hostname, "
+                        "or HTTP for localhost/loopback"
+                    )
+
+            if not _is_allowed_download_url(_parsed):
+                console.print(
+                    "[red]Error:[/red] URL must use HTTPS with a hostname, "
+                    "or HTTP for localhost/loopback."
+                )
+                raise typer.Exit(1)
+
+            console.print(f"Installing preset from [cyan]{from_url}[/cyan]...")
+            import urllib.error
+            import tempfile
+            import shutil
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                zip_path = Path(tmpdir) / "preset.zip"
+                try:
+                    from specify_cli.authentication.http import open_url as _open_url
+                    from specify_cli._github_http import resolve_github_release_asset_api_url
+
+                    _preset_extra_headers = None
+                    _resolved_from_url = resolve_github_release_asset_api_url(from_url, _open_url)
+                    if _resolved_from_url:
+                        from_url = _resolved_from_url
+                        _preset_extra_headers = {"Accept": "application/octet-stream"}
+
+                    with _open_url(
+                        from_url,
+                        timeout=60,
+                        extra_headers=_preset_extra_headers,
+                        redirect_validator=_validate_download_redirect,
+                    ) as response:
+                        final_url = response.geturl() if hasattr(response, "geturl") else from_url
+                        if not _is_allowed_download_url(_urlparse(final_url)):
+                            console.print(
+                                "[red]Error:[/red] Preset URL redirected to a disallowed URL: "
+                                f"{final_url}. Redirect targets must use HTTPS with a hostname, "
+                                "or HTTP for localhost/loopback."
+                            )
+                            raise typer.Exit(1)
+                        with zip_path.open("wb") as output:
+                            try:
+                                shutil.copyfileobj(response, output)
+                            except TypeError:
+                                output.write(response.read())
+                except urllib.error.URLError as e:
+                    console.print(f"[red]Error:[/red] Failed to download: {e}")
+                    raise typer.Exit(1)
+
+                manifest = manager.install_from_zip(zip_path, speckit_version, priority)
+
+            console.print(f"[green]✓[/green] Preset '{manifest.name}' v{manifest.version} installed (priority {priority})")
+
+        elif preset_id:
+            # Try bundled preset first, then catalog
+            bundled_path = _locate_bundled_preset(preset_id)
+            if bundled_path:
+                console.print(f"Installing bundled preset [cyan]{preset_id}[/cyan]...")
+                manifest = manager.install_from_directory(bundled_path, speckit_version, priority)
+                console.print(f"[green]✓[/green] Preset '{manifest.name}' v{manifest.version} installed (priority {priority})")
+            else:
+                catalog = PresetCatalog(project_root)
+                pack_info = catalog.get_pack_info(preset_id)
+
+                if not pack_info:
+                    console.print(f"[red]Error:[/red] Preset '{preset_id}' not found in catalog")
+                    raise typer.Exit(1)
+
+                # Bundled presets should have been caught above; if we reach
+                # here the bundled files are missing from the installation.
+                if pack_info.get("bundled") and not pack_info.get("download_url"):
+                    from .extensions import REINSTALL_COMMAND
+                    console.print(
+                        f"[red]Error:[/red] Preset '{preset_id}' is bundled with spec-kit "
+                        f"but could not be found in the installed package."
+                    )
+                    console.print(
+                        "\nThis usually means the spec-kit installation is incomplete or corrupted."
+                    )
+                    console.print("Try reinstalling spec-kit:")
+                    console.print(f"  {REINSTALL_COMMAND}")
+                    raise typer.Exit(1)
+
+                if not pack_info.get("_install_allowed", True):
+                    catalog_name = pack_info.get("_catalog_name", "unknown")
+                    console.print(f"[red]Error:[/red] Preset '{preset_id}' is from the '{catalog_name}' catalog which is discovery-only (install not allowed).")
+                    console.print("Add the catalog with --install-allowed or install from the preset's repository directly with --from.")
+                    raise typer.Exit(1)
+
+                console.print(f"Installing preset [cyan]{pack_info.get('name', preset_id)}[/cyan]...")
+
+                try:
+                    zip_path = catalog.download_pack(preset_id)
+                    manifest = manager.install_from_zip(zip_path, speckit_version, priority)
+                    console.print(f"[green]✓[/green] Preset '{manifest.name}' v{manifest.version} installed (priority {priority})")
+                finally:
+                    if 'zip_path' in locals() and zip_path.exists():
+                        zip_path.unlink(missing_ok=True)
+        else:
+            console.print("[red]Error:[/red] Specify a preset ID, --from URL, or --dev path")
+            raise typer.Exit(1)
+
+    except PresetCompatibilityError as e:
+        console.print(f"[red]Compatibility Error:[/red] {e}")
+        raise typer.Exit(1)
+    except PresetValidationError as e:
+        console.print(f"[red]Validation Error:[/red] {e}")
+        raise typer.Exit(1)
+    except PresetError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@preset_app.command("remove")
+def preset_remove(
+    preset_id: str = typer.Argument(..., help="Preset ID to remove"),
+):
+    """Remove an installed preset."""
+    from .presets import PresetManager
+
+    project_root = _require_specify_project()
+    manager = PresetManager(project_root)
+
+    if not manager.registry.is_installed(preset_id):
+        console.print(f"[red]Error:[/red] Preset '{preset_id}' is not installed")
+        raise typer.Exit(1)
+
+    if manager.remove(preset_id):
+        console.print(f"[green]✓[/green] Preset '{preset_id}' removed successfully")
+    else:
+        console.print(f"[red]Error:[/red] Failed to remove preset '{preset_id}'")
+        raise typer.Exit(1)
+
+
+@preset_app.command("search")
+def preset_search(
+    query: str = typer.Argument(None, help="Search query"),
+    tag: str = typer.Option(None, "--tag", help="Filter by tag"),
+    author: str = typer.Option(None, "--author", help="Filter by author"),
+):
+    """Search for presets in the catalog."""
+    from .presets import PresetCatalog, PresetError
+
+    project_root = _require_specify_project()
+    catalog = PresetCatalog(project_root)
+
+    try:
+        results = catalog.search(query=query, tag=tag, author=author)
+    except PresetError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    if not results:
+        console.print("[yellow]No presets found matching your criteria.[/yellow]")
+        return
+
+    console.print(f"\n[bold cyan]Presets ({len(results)} found):[/bold cyan]\n")
+    for pack in results:
+        console.print(f"  [bold]{pack.get('name', pack['id'])}[/bold] ({pack['id']}) v{pack.get('version', '?')}")
+        console.print(f"    {pack.get('description', '')}")
+        if pack.get("tags"):
+            tags_str = ", ".join(pack["tags"])
+            console.print(f"    [dim]Tags: {tags_str}[/dim]")
+        console.print()
+
+
+@preset_app.command("resolve")
+def preset_resolve(
+    template_name: str = typer.Argument(..., help="Template name to resolve (e.g., spec-template)"),
+):
+    """Show which template will be resolved for a given name."""
+    from .presets import PresetResolver
+
+    project_root = _require_specify_project()
+    resolver = PresetResolver(project_root)
+    layers = resolver.collect_all_layers(template_name)
+
+    if layers:
+        # Use the highest-priority layer for display because the final output
+        # may be composed and may not map to resolve_with_source()'s single path.
+        display_layer = layers[0]
+        console.print(f"  [bold]{template_name}[/bold]: {display_layer['path']}")
+        console.print(f"    [dim](top layer from: {display_layer['source']})[/dim]")
+
+        has_composition = (
+            layers[0]["strategy"] != "replace"
+            and any(layer["strategy"] != "replace" for layer in layers)
+        )
+        if has_composition:
+            # Verify composition is actually possible
+            try:
+                composed = resolver.resolve_content(template_name)
+            except Exception as exc:
+                composed = None
+                console.print(f"    [yellow]Warning: composition error: {exc}[/yellow]")
+            if composed is None:
+                console.print("    [yellow]Warning: composition cannot produce output (no base layer with 'replace' strategy)[/yellow]")
+            else:
+                console.print("    [dim]Final output is composed from multiple preset layers; the path above is the highest-priority contributing layer.[/dim]")
+            console.print("\n  [bold]Composition chain:[/bold]")
+            # Compute the effective base: first replace layer scanning from
+            # highest priority (matching resolve_content top-down logic).
+            # Only show layers from the base upward (lower layers are ignored).
+            effective_base_idx = None
+            for idx, lyr in enumerate(layers):
+                if lyr["strategy"] == "replace":
+                    effective_base_idx = idx
+                    break
+            # Show only contributing layers (base and above)
+            if effective_base_idx is not None:
+                contributing = layers[:effective_base_idx + 1]
+            else:
+                contributing = layers
+            for i, layer in enumerate(reversed(contributing)):
+                strategy_label = layer["strategy"]
+                if strategy_label == "replace" and i == 0:
+                    strategy_label = "base"
+                console.print(f"    {i + 1}. [{strategy_label}] {layer['source']} → {layer['path']}")
+    else:
+        # No layers found — fall back to resolve_with_source for non-composition cases
+        result = resolver.resolve_with_source(template_name)
+        if result:
+            console.print(f"  [bold]{template_name}[/bold]: {result['path']}")
+            console.print(f"    [dim](from: {result['source']})[/dim]")
+        else:
+            console.print(f"  [yellow]{template_name}[/yellow]: not found")
+            console.print("    [dim]No template with this name exists in the resolution stack[/dim]")
+
+
+@preset_app.command("info")
+def preset_info(
+    preset_id: str = typer.Argument(..., help="Preset ID to get info about"),
+):
+    """Show detailed information about a preset."""
+    from .extensions import normalize_priority
+    from .presets import PresetCatalog, PresetManager, PresetError
+
+    project_root = _require_specify_project()
+    # Check if installed locally first
+    manager = PresetManager(project_root)
+    local_pack = manager.get_pack(preset_id)
+
+    if local_pack:
+        console.print(f"\n[bold cyan]Preset: {local_pack.name}[/bold cyan]\n")
+        console.print(f"  ID:          {local_pack.id}")
+        console.print(f"  Version:     {local_pack.version}")
+        console.print(f"  Description: {local_pack.description}")
+        if local_pack.author:
+            console.print(f"  Author:      {local_pack.author}")
+        if local_pack.tags:
+            console.print(f"  Tags:        {', '.join(local_pack.tags)}")
+        console.print(f"  Templates:   {len(local_pack.templates)}")
+        for tmpl in local_pack.templates:
+            console.print(f"    - {tmpl['name']} ({tmpl['type']}): {tmpl.get('description', '')}")
+        repo = local_pack.data.get("preset", {}).get("repository")
+        if repo:
+            console.print(f"  Repository:  {repo}")
+        license_val = local_pack.data.get("preset", {}).get("license")
+        if license_val:
+            console.print(f"  License:     {license_val}")
+        console.print("\n  [green]Status: installed[/green]")
+        # Get priority from registry
+        pack_metadata = manager.registry.get(preset_id)
+        priority = normalize_priority(pack_metadata.get("priority") if isinstance(pack_metadata, dict) else None)
+        console.print(f"  [dim]Priority:[/dim] {priority}")
+        console.print()
+        return
+
+    # Fall back to catalog
+    catalog = PresetCatalog(project_root)
+    try:
+        pack_info = catalog.get_pack_info(preset_id)
+    except PresetError:
+        pack_info = None
+
+    if not pack_info:
+        console.print(f"[red]Error:[/red] Preset '{preset_id}' not found (not installed and not in catalog)")
+        raise typer.Exit(1)
+
+    console.print(f"\n[bold cyan]Preset: {pack_info.get('name', preset_id)}[/bold cyan]\n")
+    console.print(f"  ID:          {pack_info['id']}")
+    console.print(f"  Version:     {pack_info.get('version', '?')}")
+    console.print(f"  Description: {pack_info.get('description', '')}")
+    if pack_info.get("author"):
+        console.print(f"  Author:      {pack_info['author']}")
+    if pack_info.get("tags"):
+        console.print(f"  Tags:        {', '.join(pack_info['tags'])}")
+    if pack_info.get("repository"):
+        console.print(f"  Repository:  {pack_info['repository']}")
+    if pack_info.get("license"):
+        console.print(f"  License:     {pack_info['license']}")
+    console.print("\n  [yellow]Status: not installed[/yellow]")
+    console.print(f"  Install with: [cyan]specify preset add {preset_id}[/cyan]")
+    console.print()
+
+
+@preset_app.command("set-priority")
+def preset_set_priority(
+    preset_id: str = typer.Argument(help="Preset ID"),
+    priority: int = typer.Argument(help="New priority (lower = higher precedence)"),
+):
+    """Set the resolution priority of an installed preset."""
+    from .presets import PresetManager
+
+    project_root = _require_specify_project()
+    # Validate priority
+    if priority < 1:
+        console.print("[red]Error:[/red] Priority must be a positive integer (1 or higher)")
+        raise typer.Exit(1)
+
+    manager = PresetManager(project_root)
+
+    # Check if preset is installed
+    if not manager.registry.is_installed(preset_id):
+        console.print(f"[red]Error:[/red] Preset '{preset_id}' is not installed")
+        raise typer.Exit(1)
+
+    # Get current metadata
+    metadata = manager.registry.get(preset_id)
+    if metadata is None or not isinstance(metadata, dict):
+        console.print(f"[red]Error:[/red] Preset '{preset_id}' not found in registry (corrupted state)")
+        raise typer.Exit(1)
+
+    from .extensions import normalize_priority
+    raw_priority = metadata.get("priority")
+    # Only skip if the stored value is already a valid int equal to requested priority
+    # This ensures corrupted values (e.g., "high") get repaired even when setting to default (10)
+    if isinstance(raw_priority, int) and raw_priority == priority:
+        console.print(f"[yellow]Preset '{preset_id}' already has priority {priority}[/yellow]")
+        raise typer.Exit(0)
+
+    old_priority = normalize_priority(raw_priority)
+
+    # Update priority
+    manager.registry.update(preset_id, {"priority": priority})
+
+    console.print(f"[green]✓[/green] Preset '{preset_id}' priority changed: {old_priority} → {priority}")
+    console.print("\n[dim]Lower priority = higher precedence in template resolution[/dim]")
+
+
+@preset_app.command("enable")
+def preset_enable(
+    preset_id: str = typer.Argument(help="Preset ID to enable"),
+):
+    """Enable a disabled preset."""
+    from .presets import PresetManager
+
+    project_root = _require_specify_project()
+    manager = PresetManager(project_root)
+
+    # Check if preset is installed
+    if not manager.registry.is_installed(preset_id):
+        console.print(f"[red]Error:[/red] Preset '{preset_id}' is not installed")
+        raise typer.Exit(1)
+
+    # Get current metadata
+    metadata = manager.registry.get(preset_id)
+    if metadata is None or not isinstance(metadata, dict):
+        console.print(f"[red]Error:[/red] Preset '{preset_id}' not found in registry (corrupted state)")
+        raise typer.Exit(1)
+
+    if metadata.get("enabled", True):
+        console.print(f"[yellow]Preset '{preset_id}' is already enabled[/yellow]")
+        raise typer.Exit(0)
+
+    # Enable the preset
+    manager.registry.update(preset_id, {"enabled": True})
+
+    console.print(f"[green]✓[/green] Preset '{preset_id}' enabled")
+    console.print("\nTemplates from this preset will now be included in resolution.")
+    console.print("[dim]Note: Previously registered commands/skills remain active.[/dim]")
+
+
+@preset_app.command("disable")
+def preset_disable(
+    preset_id: str = typer.Argument(help="Preset ID to disable"),
+):
+    """Disable a preset without removing it."""
+    from .presets import PresetManager
+
+    project_root = _require_specify_project()
+    manager = PresetManager(project_root)
+
+    # Check if preset is installed
+    if not manager.registry.is_installed(preset_id):
+        console.print(f"[red]Error:[/red] Preset '{preset_id}' is not installed")
+        raise typer.Exit(1)
+
+    # Get current metadata
+    metadata = manager.registry.get(preset_id)
+    if metadata is None or not isinstance(metadata, dict):
+        console.print(f"[red]Error:[/red] Preset '{preset_id}' not found in registry (corrupted state)")
+        raise typer.Exit(1)
+
+    if not metadata.get("enabled", True):
+        console.print(f"[yellow]Preset '{preset_id}' is already disabled[/yellow]")
+        raise typer.Exit(0)
+
+    # Disable the preset
+    manager.registry.update(preset_id, {"enabled": False})
+
+    console.print(f"[green]✓[/green] Preset '{preset_id}' disabled")
+    console.print("\nTemplates from this preset will be skipped during resolution.")
+    console.print("[dim]Note: Previously registered commands/skills remain active until preset removal.[/dim]")
+    console.print(f"To re-enable: specify preset enable {preset_id}")
+
+
+# ===== Preset Catalog Commands =====
+
+
+@preset_catalog_app.command("list")
+def preset_catalog_list():
+    """List all active preset catalogs."""
+    from .presets import PresetCatalog, PresetValidationError
+
+    project_root = _require_specify_project()
+    catalog = PresetCatalog(project_root)
+
+    try:
+        active_catalogs = catalog.get_active_catalogs()
+    except PresetValidationError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    console.print("\n[bold cyan]Active Preset Catalogs:[/bold cyan]\n")
+    for entry in active_catalogs:
+        install_str = (
+            "[green]install allowed[/green]"
+            if entry.install_allowed
+            else "[yellow]discovery only[/yellow]"
+        )
+        console.print(f"  [bold]{entry.name}[/bold] (priority {entry.priority})")
+        if entry.description:
+            console.print(f"     {entry.description}")
+        console.print(f"     URL: {entry.url}")
+        console.print(f"     Install: {install_str}")
+        console.print()
+
+    config_path = project_root / ".specify" / "preset-catalogs.yml"
+    user_config_path = Path.home() / ".specify" / "preset-catalogs.yml"
+    if os.environ.get("SPECKIT_PRESET_CATALOG_URL"):
+        console.print("[dim]Catalog configured via SPECKIT_PRESET_CATALOG_URL environment variable.[/dim]")
+    else:
+        try:
+            proj_loaded = config_path.exists() and catalog._load_catalog_config(config_path) is not None
+        except PresetValidationError:
+            proj_loaded = False
+        if proj_loaded:
+            console.print(f"[dim]Config: {_display_project_path(project_root, config_path)}[/dim]")
+        else:
+            try:
+                user_loaded = user_config_path.exists() and catalog._load_catalog_config(user_config_path) is not None
+            except PresetValidationError:
+                user_loaded = False
+            if user_loaded:
+                console.print("[dim]Config: ~/.specify/preset-catalogs.yml[/dim]")
+            else:
+                console.print("[dim]Using built-in default catalog stack.[/dim]")
+                console.print(
+                    "[dim]Add .specify/preset-catalogs.yml to customize.[/dim]"
+                )
+
+
+@preset_catalog_app.command("add")
+def preset_catalog_add(
+    url: str = typer.Argument(help="Catalog URL (must use HTTPS)"),
+    name: str = typer.Option(..., "--name", help="Catalog name"),
+    priority: int = typer.Option(10, "--priority", help="Priority (lower = higher priority)"),
+    install_allowed: bool = typer.Option(
+        False, "--install-allowed/--no-install-allowed",
+        help="Allow presets from this catalog to be installed",
+    ),
+    description: str = typer.Option("", "--description", help="Description of the catalog"),
+):
+    """Add a catalog to .specify/preset-catalogs.yml."""
+    from .presets import PresetCatalog, PresetValidationError
+
+    project_root = _require_specify_project()
+    specify_dir = project_root / ".specify"
+
+    # Validate URL
+    tmp_catalog = PresetCatalog(project_root)
+    try:
+        tmp_catalog._validate_catalog_url(url)
+    except PresetValidationError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+    config_path = specify_dir / "preset-catalogs.yml"
+
+    # Load existing config
+    if config_path.exists():
+        try:
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        except Exception as e:
+            config_label = _display_project_path(project_root, config_path)
+            console.print(f"[red]Error:[/red] Failed to read {config_label}: {e}")
+            raise typer.Exit(1)
+    else:
+        config = {}
+
+    catalogs = config.get("catalogs", [])
+    if not isinstance(catalogs, list):
+        console.print("[red]Error:[/red] Invalid catalog config: 'catalogs' must be a list.")
+        raise typer.Exit(1)
+
+    # Check for duplicate name
+    for existing in catalogs:
+        if isinstance(existing, dict) and existing.get("name") == name:
+            console.print(f"[yellow]Warning:[/yellow] A catalog named '{name}' already exists.")
+            console.print("Use 'specify preset catalog remove' first, or choose a different name.")
+            raise typer.Exit(1)
+
+    catalogs.append({
+        "name": name,
+        "url": url,
+        "priority": priority,
+        "install_allowed": install_allowed,
+        "description": description,
+    })
+
+    config["catalogs"] = catalogs
+    config_path.write_text(yaml.safe_dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+    install_label = "install allowed" if install_allowed else "discovery only"
+    console.print(f"\n[green]✓[/green] Added catalog '[bold]{name}[/bold]' ({install_label})")
+    console.print(f"  URL: {url}")
+    console.print(f"  Priority: {priority}")
+    console.print(f"\nConfig saved to {_display_project_path(project_root, config_path)}")
+
+
+@preset_catalog_app.command("remove")
+def preset_catalog_remove(
+    name: str = typer.Argument(help="Catalog name to remove"),
+):
+    """Remove a catalog from .specify/preset-catalogs.yml."""
+    project_root = _require_specify_project()
+    specify_dir = project_root / ".specify"
+
+    config_path = specify_dir / "preset-catalogs.yml"
+    if not config_path.exists():
+        console.print("[red]Error:[/red] No preset catalog config found. Nothing to remove.")
+        raise typer.Exit(1)
+
+    try:
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        console.print("[red]Error:[/red] Failed to read preset catalog config.")
+        raise typer.Exit(1)
+
+    catalogs = config.get("catalogs", [])
+    if not isinstance(catalogs, list):
+        console.print("[red]Error:[/red] Invalid catalog config: 'catalogs' must be a list.")
+        raise typer.Exit(1)
+    original_count = len(catalogs)
+    catalogs = [c for c in catalogs if isinstance(c, dict) and c.get("name") != name]
+
+    if len(catalogs) == original_count:
+        console.print(f"[red]Error:[/red] Catalog '{name}' not found.")
+        raise typer.Exit(1)
+
+    config["catalogs"] = catalogs
+    config_path.write_text(yaml.safe_dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+    console.print(f"[green]✓[/green] Removed catalog '{name}'")
+    if not catalogs:
+        console.print("\n[dim]No catalogs remain in config. Built-in defaults will be used.[/dim]")
 
 
 # ===== Bundle Commands =====
@@ -2066,20 +2754,6 @@ workflow_catalog_app = typer.Typer(
 )
 workflow_app.add_typer(workflow_catalog_app, name="catalog")
 
-workflow_step_app = typer.Typer(
-    name="step",
-    help="Manage workflow step types",
-    add_completion=False,
-)
-workflow_app.add_typer(workflow_step_app, name="step")
-
-workflow_step_catalog_app = typer.Typer(
-    name="catalog",
-    help="Manage step catalogs",
-    add_completion=False,
-)
-workflow_step_app.add_typer(workflow_step_catalog_app, name="catalog")
-
 
 def _parse_input_values(input_values: list[str] | None) -> dict[str, Any]:
     """Parse repeated ``key=value`` CLI inputs into a dict.
@@ -2180,16 +2854,6 @@ def _normalize_gate_options(options: Any) -> list[str] | None:
     return [str(options)]
 
 
-def _run_outcome_exit_code(status_value: str) -> int:
-    """Exit code for a finished run/resume: non-zero on terminal failure.
-
-    ``failed`` and ``aborted`` map to 1 so scripts and orchestrators can
-    rely on the process exit code; ``completed`` and ``paused`` map to 0
-    (paused is a legitimate waiting state, not a failure).
-    """
-    return 1 if status_value in ("failed", "aborted") else 0
-
-
 def _emit_workflow_json(payload: dict[str, Any]) -> None:
     """Write a workflow payload as machine-readable JSON to stdout.
 
@@ -2236,6 +2900,14 @@ def workflow_run(
     input_values: list[str] | None = typer.Option(
         None, "--input", "-i", help="Input values as key=value pairs"
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Show the rendered prompt/inputs for each step without invoking the AI. "
+            "Suppressed when --json is set so the JSON object is the only thing on stdout."
+        ),
+    ),
     json_output: bool = typer.Option(
         False,
         "--json",
@@ -2243,7 +2915,6 @@ def workflow_run(
     ),
 ):
     """Run a workflow from an installed ID or local YAML path."""
-    from .workflows import load_custom_steps
     from .workflows.engine import WorkflowEngine
 
     source_path = Path(source).expanduser()
@@ -2263,7 +2934,6 @@ def workflow_run(
     else:
         project_root = _require_specify_project()
 
-    load_custom_steps(project_root)
     engine = WorkflowEngine(project_root)
     if not json_output:
         engine.on_step_start = lambda sid, label: console.print(f"  \u25b8 [{sid}] {label} \u2026")
@@ -2292,19 +2962,42 @@ def workflow_run(
         console.print(f"\n[bold cyan]Running workflow:[/bold cyan] {definition.name} ({definition.id})")
         console.print(f"[dim]Version: {definition.version}[/dim]\n")
 
+    if dry_run and not json_output:
+        # When ``--json`` is set, the dry-run banner (and the per-step
+        # preview loop below) are suppressed entirely so stdout stays
+        # a single, well-formed JSON object.  Redirecting to stderr
+        # would also work but is noisier than a script-friendly
+        # ``--json`` consumer actually wants.
+        console.print("[bold yellow]DRY RUN — no AI invocation will occur[/bold yellow]\n")
+
     try:
         with _stdout_to_stderr_when(json_output):
-            state = engine.execute(definition, inputs)
+            state = engine.execute(definition, inputs, dry_run=dry_run)
     except ValueError as exc:
         console.print(f"[red]Error:[/red] {exc}")
+        # When a step throws during template resolution in --dry-run mode,
+        # any previews already resolved by earlier steps are still the
+        # most useful debug signal we can offer — surface them before
+        # exiting instead of silently dropping them. The engine attaches
+        # the partial state to the exception as ``exc.partial_state``.
+        # Skipped under --json so the contract of "stdout is a single
+        # JSON object" holds; in the JSON branch the partial state will
+        # still be on disk and ``workflow status <run_id>`` will show it.
+        partial = getattr(exc, "partial_state", None)
+        if partial is not None and dry_run and not json_output:
+            _print_dry_run_previews(partial)
         raise typer.Exit(1)
     except Exception as exc:
         console.print(f"[red]Workflow failed:[/red] {exc}")
+        # See ValueError branch above — keep partial previews on failure.
+        partial = getattr(exc, "partial_state", None)
+        if partial is not None and dry_run and not json_output:
+            _print_dry_run_previews(partial)
         raise typer.Exit(1)
 
     if json_output:
         _emit_workflow_json(_workflow_run_payload(state))
-        raise typer.Exit(_run_outcome_exit_code(state.status.value))
+        return
 
     status_colors = {
         "completed": "green",
@@ -2319,7 +3012,38 @@ def workflow_run(
     if state.status.value == "paused":
         console.print(f"\nResume with: [cyan]specify workflow resume {state.run_id}[/cyan]")
 
-    raise typer.Exit(_run_outcome_exit_code(state.status.value))
+    if dry_run and not json_output:
+        _print_dry_run_previews(state)
+
+
+def _print_dry_run_previews(state: Any) -> None:
+    """Print the rendered dry-run previews for each step that produced one.
+
+    Used by ``specify workflow run --dry-run`` to surface what the engine
+    *would* have dispatched for each step, so the user can verify the
+    rendered prompts, commands, and gate choices before running for real.
+    Prefers the dedicated ``dry_run_message`` field on each step's output
+    (set by step implementations in dry-run mode) and falls back to
+    ``message`` for compatibility with custom step types that have not
+    adopted the new field. Step IDs and messages are both escaped /
+    rendered as plain text so valid workflow IDs (e.g. containing ``[``
+    or ``]``) cannot break Rich markup parsing.
+    """
+    from rich.markup import escape as _escape_markup
+
+    for step_id, step_data in state.step_results.items():
+        output = step_data.get("output", {})
+        if not output.get("dry_run"):
+            continue
+        msg = output.get("dry_run_message") or output.get("message", "")
+        if not msg:
+            continue
+        console.print(f"\n[bold cyan]Step:[/bold cyan] {_escape_markup(step_id)}")
+        # ``msg`` is plain text from the step implementation
+        # (e.g. ``[DRY RUN] Command: ...``). Disable Rich markup parsing
+        # so the literal ``[DRY RUN]`` bracket pair is shown verbatim
+        # and does not raise a ``MarkupError`` for an unknown tag.
+        console.print(msg, markup=False)
 
 
 @workflow_app.command("resume")
@@ -2335,11 +3059,9 @@ def workflow_resume(
     ),
 ):
     """Resume a paused or failed workflow run."""
-    from .workflows import load_custom_steps
     from .workflows.engine import WorkflowEngine
 
     project_root = _require_specify_project()
-    load_custom_steps(project_root)
     engine = WorkflowEngine(project_root)
     if not json_output:
         engine.on_step_start = lambda sid, label: console.print(f"  \u25b8 [{sid}] {label} \u2026")
@@ -2361,7 +3083,7 @@ def workflow_resume(
 
     if json_output:
         _emit_workflow_json(_workflow_run_payload(state))
-        raise typer.Exit(_run_outcome_exit_code(state.status.value))
+        return
 
     status_colors = {
         "completed": "green",
@@ -2371,8 +3093,6 @@ def workflow_resume(
     }
     color = status_colors.get(state.status.value, "white")
     console.print(f"\n[{color}]Status: {state.status.value}[/{color}]")
-
-    raise typer.Exit(_run_outcome_exit_code(state.status.value))
 
 
 @workflow_app.command("status")
@@ -2929,662 +3649,6 @@ def workflow_catalog_remove(
         raise typer.Exit(1)
 
     console.print(f"[green]✓[/green] Catalog source '{removed_name}' removed")
-
-
-# ===== Workflow Step Commands =====
-
-@workflow_step_app.command("list")
-def workflow_step_list():
-    """List installed step types (built-in and custom)."""
-    from .workflows import STEP_REGISTRY
-    from .workflows.catalog import StepRegistry
-
-    project_root = _require_specify_project()
-    specify_dir = project_root / ".specify"
-
-    # Read installed custom steps from registry only — no dynamic imports
-    installed: dict = {}
-    if specify_dir.exists():
-        registry = StepRegistry(project_root)
-        installed = registry.list()
-
-    console.print("\n[bold cyan]Installed Step Types:[/bold cyan]\n")
-
-    built_in = sorted(k for k in STEP_REGISTRY if k not in installed)
-    if built_in:
-        console.print("  [bold]Built-in:[/bold]")
-        for key in built_in:
-            console.print(f"    • {key}")
-        console.print()
-
-    if installed:
-        console.print("  [bold]Custom (installed):[/bold]")
-        for key in sorted(installed):
-            meta = installed[key] or {}
-            name = meta.get("name", key)
-            version = meta.get("version", "?")
-            console.print(f"    • [bold]{name}[/bold] ({key}) v{version}")
-        console.print()
-
-    if not built_in and not installed:
-        console.print("[yellow]No step types found.[/yellow]")
-
-    if specify_dir.exists():
-        console.print(
-            "  Install a new step type with: [cyan]specify workflow step add <id>[/cyan]"
-        )
-
-
-# IDs that map to internal names used under .specify/workflows/steps/ and must
-# not be used as custom step IDs (dotfile check is done separately at runtime).
-_RESERVED_STEP_IDS: frozenset[str] = frozenset({".cache", "step-registry.json"})
-
-# Windows reserved device names (case-insensitive, with or without extensions)
-_WINDOWS_RESERVED_NAMES: frozenset[str] = frozenset({
-    "con", "prn", "aux", "nul",
-    "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
-    "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
-})
-
-# Characters invalid in filenames on Windows
-_WINDOWS_INVALID_CHARS: frozenset[str] = frozenset('<>:"|?*')
-
-
-def _validate_step_id_or_exit(step_id: str) -> None:
-    """Validate that ``step_id`` is a single safe path component.
-
-    Rejects empty strings, whitespace-only strings, leading/trailing whitespace,
-    path separators, ``.``/``..`` components, dotfile prefixes, reserved names,
-    Windows-invalid filename characters, trailing dots/spaces, and Windows
-    reserved device names. Exits with code 1 on failure.
-    """
-    # Strip the stem (before first dot) for Windows reserved-name check
-    stem = step_id.split(".")[0].lower() if step_id else ""
-    if (
-        not step_id
-        or not step_id.strip()
-        or step_id != step_id.strip()
-        or "/" in step_id
-        or "\\" in step_id
-        or step_id in (".", "..")
-        or step_id.startswith(".")
-        or step_id.endswith(".")
-        or step_id.endswith(" ")
-        or step_id.lower() in _RESERVED_STEP_IDS
-        or stem in _WINDOWS_RESERVED_NAMES
-        or any(c in _WINDOWS_INVALID_CHARS for c in step_id)
-        or any(ord(c) < 32 for c in step_id)
-    ):
-        console.print(
-            f"[red]Error:[/red] Invalid step id '{step_id}': must be a single safe "
-            "path component (no separators, no leading dot, not a reserved name, "
-            "no invalid filename characters)"
-        )
-        raise typer.Exit(1)
-
-
-def _resolve_steps_base_dir_or_exit(project_root: Path) -> Path:
-    """Resolve .specify/workflows/steps while refusing symlinked parent directories."""
-    project_root_resolved = project_root.resolve()
-    steps_base_dir_unresolved = project_root / ".specify" / "workflows" / "steps"
-
-    current = project_root
-    for part in (".specify", "workflows", "steps"):
-        current = current / part
-        if current.is_symlink():
-            console.print(
-                f"[red]Error:[/red] Refusing to use symlinked step directory '{current}'"
-            )
-            raise typer.Exit(1)
-        if current.exists() and not current.is_dir():
-            console.print(
-                f"[red]Error:[/red] Step directory path is not a directory: '{current}'"
-            )
-            raise typer.Exit(1)
-
-    steps_base_dir = steps_base_dir_unresolved.resolve()
-    try:
-        steps_base_dir.relative_to(project_root_resolved)
-    except ValueError:
-        console.print(
-            f"[red]Error:[/red] Step directory escapes project root: '{steps_base_dir}'"
-        )
-        raise typer.Exit(1)
-
-    return steps_base_dir
-
-
-@workflow_step_app.command("add")
-def workflow_step_add(
-    step_id: str = typer.Argument(..., help="Step type ID from catalog"),
-):
-    """Install a custom step type from the step catalog."""
-    from .workflows.catalog import StepCatalog, StepCatalogError, StepRegistry, StepValidationError
-
-    project_root = _require_specify_project()
-
-    catalog = StepCatalog(project_root)
-    try:
-        info = catalog.get_step_info(step_id)
-    except StepCatalogError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1)
-
-    if not info:
-        console.print(f"[red]Error:[/red] Step type '{step_id}' not found in catalog")
-        raise typer.Exit(1)
-
-    if not info.get("_install_allowed", True):
-        console.print(
-            f"[yellow]Warning:[/yellow] Step type '{step_id}' is from a discovery-only catalog"
-        )
-        console.print("Direct installation is not enabled for this catalog source.")
-        raise typer.Exit(1)
-
-    # Reject step IDs that collide with built-in step types
-    from .workflows import STEP_REGISTRY as _step_reg
-    if step_id in _step_reg:
-        console.print(
-            f"[red]Error:[/red] Step type '{step_id}' conflicts with a built-in step type"
-        )
-        raise typer.Exit(1)
-
-    # Reject if already installed
-    registry = StepRegistry(project_root)
-    if registry.is_installed(step_id):
-        console.print(
-            f"[red]Error:[/red] Step type '{step_id}' is already installed. "
-            "Remove it first with: [cyan]specify workflow step remove "
-            f"{step_id}[/cyan]"
-        )
-        raise typer.Exit(1)
-
-    step_yml_url = info.get("step_yml_url") or info.get("url")
-    if not step_yml_url:
-        console.print(f"[red]Error:[/red] Catalog entry for '{step_id}' has no URL")
-        raise typer.Exit(1)
-
-    # Derive __init__.py URL: replace trailing step.yml with __init__.py
-    # or use explicit init_url if provided.
-    init_url = info.get("init_url")
-    if not init_url:
-        if step_yml_url.endswith("step.yml"):
-            init_url = step_yml_url[: -len("step.yml")] + "__init__.py"
-        else:
-            console.print(
-                f"[red]Error:[/red] Cannot derive __init__.py URL from '{step_yml_url}'. "
-                "Catalog entry should provide 'init_url' or a 'url' ending in 'step.yml'."
-            )
-            raise typer.Exit(1)
-
-    from urllib.parse import urlparse
-    from specify_cli.authentication.http import open_url as _open_url
-
-    def _safe_fetch(url: str) -> bytes:
-        parsed = urlparse(url)
-        is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
-        if parsed.scheme != "https" and not (parsed.scheme == "http" and is_localhost):
-            raise ValueError(f"Refusing to fetch from non-HTTPS URL: {url}")
-        if not parsed.hostname:
-            raise ValueError(f"Refusing to fetch from URL with no hostname: {url}")
-        with _open_url(url, timeout=30) as resp:
-            final_url = resp.geturl()
-            final_parsed = urlparse(final_url)
-            final_is_localhost = final_parsed.hostname in ("localhost", "127.0.0.1", "::1")
-            if final_parsed.scheme != "https" and not (
-                final_parsed.scheme == "http" and final_is_localhost
-            ):
-                raise ValueError(f"Redirect to non-HTTPS URL: {final_url}")
-            if not final_parsed.hostname:
-                raise ValueError(f"Redirect to URL with no hostname: {final_url}")
-            return resp.read()
-
-    _validate_step_id_or_exit(step_id)
-
-    steps_base_dir = _resolve_steps_base_dir_or_exit(project_root)
-    step_dir = (steps_base_dir / step_id).resolve()
-    # Defense-in-depth: ensure the resolved directory is a direct child of
-    # steps_base_dir even after symlink resolution.
-    try:
-        rel_parts = step_dir.relative_to(steps_base_dir).parts
-    except ValueError:
-        console.print(f"[red]Error:[/red] Invalid step id '{step_id}'")
-        raise typer.Exit(1)
-    if rel_parts != (step_id,):
-        console.print(f"[red]Error:[/red] Invalid step id '{step_id}'")
-        raise typer.Exit(1)
-
-    import shutil
-    import tempfile
-
-    # Refuse if step_dir already exists (e.g. leftover from a previous failed/manual
-    # install that wasn't registered). The user should remove it before retrying.
-    if step_dir.exists():
-        console.print(
-            f"[red]Error:[/red] Step directory already exists at '{step_dir}'. "
-            f"Remove it manually or use: [cyan]specify workflow step remove {step_id}[/cyan]"
-        )
-        raise typer.Exit(1)
-
-    # Create steps_base_dir now so the staging temp dir is on the same filesystem,
-    # enabling a truly atomic os.rename() below.
-    try:
-        steps_base_dir.mkdir(parents=True, exist_ok=True)
-        tmp_path = Path(tempfile.mkdtemp(prefix="speckit_step_tmp_", dir=steps_base_dir))
-    except OSError as exc:
-        console.print(f"[red]Error:[/red] Failed to create staging directory: {exc}")
-        raise typer.Exit(1)
-    try:
-        try:
-            step_yml_content = _safe_fetch(step_yml_url)
-            init_py_content = _safe_fetch(init_url)
-        except Exception as exc:
-            console.print(f"[red]Error:[/red] Failed to download step files: {exc}")
-            raise typer.Exit(1)
-
-        # Validate step.yml
-        try:
-            import yaml as _yaml
-
-            meta = _yaml.safe_load(step_yml_content.decode("utf-8")) or {}
-        except Exception as exc:
-            console.print(f"[red]Error:[/red] Invalid step.yml: {exc}")
-            raise typer.Exit(1)
-
-        if not isinstance(meta, dict):
-            console.print("[red]Error:[/red] step.yml must be a YAML mapping")
-            raise typer.Exit(1)
-
-        step_meta = meta.get("step", {})
-        if not isinstance(step_meta, dict):
-            console.print("[red]Error:[/red] step.yml 'step' field must be a mapping")
-            raise typer.Exit(1)
-        type_key = step_meta.get("type_key", "")
-        if not type_key:
-            console.print("[red]Error:[/red] step.yml missing 'step.type_key' field")
-            raise typer.Exit(1)
-
-        if type_key != step_id:
-            console.print(
-                f"[red]Error:[/red] step.yml type_key ({type_key!r}) does not match "
-                f"catalog ID ({step_id!r})"
-            )
-            raise typer.Exit(1)
-
-        # Write the two required files.
-        try:
-            (tmp_path / "step.yml").write_bytes(step_yml_content)
-            (tmp_path / "__init__.py").write_bytes(init_py_content)
-        except OSError as exc:
-            console.print(
-                f"[red]Error:[/red] Failed to write step files to staging directory: {exc}"
-            )
-            raise typer.Exit(1)
-
-        # Optionally download additional package files declared in the catalog entry
-        # (e.g. helper modules). Each entry in ``extra_files`` is a mapping of
-        # relative-path → URL. step.yml and __init__.py are ignored here (already
-        # written). Paths are validated to stay within the step package directory to
-        # prevent path-traversal attacks.
-        extra_files = info.get("extra_files")
-        if extra_files is not None and not isinstance(extra_files, dict):
-            console.print(
-                "[yellow]Warning:[/yellow] Catalog entry 'extra_files' is not a mapping; "
-                "additional package files will not be downloaded."
-            )
-            extra_files = {}
-        for rel_path, file_url in (extra_files or {}).items():
-            if not isinstance(rel_path, str) or not rel_path.strip():
-                console.print(
-                    "[red]Error:[/red] Catalog entry 'extra_files' contains an "
-                    "empty or non-string path key"
-                )
-                raise typer.Exit(1)
-            if rel_path in ("step.yml", "__init__.py"):
-                continue  # already written above
-            # Reject dot-path segments ('', '.', '..') that would refer to the
-            # package directory itself (IsADirectoryError) or escape it.
-            rel_parts = Path(rel_path).parts
-            if not rel_parts or any(seg in ("", ".", "..") for seg in rel_parts):
-                console.print(
-                    f"[red]Error:[/red] extra_files path '{rel_path}' is not a "
-                    "valid relative file path"
-                )
-                raise typer.Exit(1)
-            if not isinstance(file_url, str) or not file_url.strip():
-                console.print(
-                    f"[red]Error:[/red] extra_files entry '{rel_path}' has an "
-                    "empty or non-string URL"
-                )
-                raise typer.Exit(1)
-            # Resolve both destination and base to handle any symlinks in tmp_path itself,
-            # ensuring the traversal check is robust even on non-canonical paths.
-            resolved_base = tmp_path.resolve()
-            dest = (tmp_path / rel_path).resolve()
-            try:
-                dest.relative_to(resolved_base)
-            except ValueError:
-                console.print(
-                    f"[red]Error:[/red] extra_files path '{rel_path}' is outside "
-                    "the step package directory"
-                )
-                raise typer.Exit(1)
-            try:
-                file_content = _safe_fetch(file_url)
-            except Exception as exc:
-                console.print(
-                    f"[red]Error:[/red] Failed to download extra file '{rel_path}': {exc}"
-                )
-                raise typer.Exit(1)
-            try:
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                dest.write_bytes(file_content)
-            except OSError as exc:
-                console.print(
-                    f"[red]Error:[/red] Failed to write extra file '{rel_path}': {exc}"
-                )
-                raise typer.Exit(1)
-
-        # Atomically rename the staging directory to the final location.
-        # Both paths are under steps_base_dir (same filesystem), so os.rename()
-        # is atomic on POSIX and won't leave a partially-written directory at
-        # step_dir on failure.
-        try:
-            os.rename(tmp_path, step_dir)
-        except OSError as exc:
-            console.print(f"[red]Error:[/red] Failed to install step '{step_id}': {exc}")
-            raise typer.Exit(1)
-    finally:
-        # Clean up if the rename hasn't moved tmp_path yet (i.e. on any failure).
-        shutil.rmtree(tmp_path, ignore_errors=True)
-
-    step_name = info.get("name") or step_id
-    step_version = info.get("version") or step_meta.get("version") or "0.0.0"
-
-    # Register in step registry
-    registry = StepRegistry(project_root)
-    try:
-        registry.add(
-            step_id,
-            {
-                "name": step_name,
-                "version": step_version,
-                "description": info.get("description", step_meta.get("description", "")),
-                "author": info.get("author", step_meta.get("author", "")),
-                "source": "catalog",
-                "catalog_name": info.get("_catalog_name", ""),
-                "type_key": type_key,
-            },
-        )
-    except StepValidationError as exc:
-        # Roll back the just-installed directory so the system isn't left with
-        # an unregistered step package on disk after a registry write failure
-        # (e.g. read-only filesystem, permission denied).
-        shutil.rmtree(step_dir, ignore_errors=True)
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1)
-
-    console.print(
-        f"[green]✓[/green] Step type '{step_name}' ({step_id}) installed"
-    )
-    console.print(
-        "  Use [cyan]specify workflow step list[/cyan] to verify the installation."
-    )
-
-
-@workflow_step_app.command("remove")
-def workflow_step_remove(
-    step_id: str = typer.Argument(..., help="Step type ID to uninstall"),
-):
-    """Uninstall a custom step type."""
-    from .workflows.catalog import StepRegistry, StepValidationError
-
-    project_root = _require_specify_project()
-
-    _validate_step_id_or_exit(step_id)
-
-    registry = StepRegistry(project_root)
-    in_registry = registry.is_installed(step_id)
-
-    steps_base_dir = _resolve_steps_base_dir_or_exit(project_root)
-    step_dir = (steps_base_dir / step_id).resolve()
-    # Defense-in-depth: even though _validate_step_id_or_exit rejects path
-    # separators, ensure that the resolved directory is a single child of
-    # steps_base_dir and is not steps_base_dir itself.
-    try:
-        rel_parts = step_dir.relative_to(steps_base_dir).parts
-    except ValueError:
-        console.print(f"[red]Error:[/red] Invalid step id '{step_id}'")
-        raise typer.Exit(1)
-    if rel_parts != (step_id,):
-        console.print(f"[red]Error:[/red] Invalid step id '{step_id}'")
-        raise typer.Exit(1)
-
-    dir_exists = step_dir.exists()
-
-    if not in_registry and not dir_exists:
-        console.print(f"[red]Error:[/red] Step type '{step_id}' is not installed")
-        raise typer.Exit(1)
-
-    if not in_registry and dir_exists:
-        # The registry was likely reset due to corruption.  Warn the user that the
-        # directory is being removed even though there is no registry entry, so
-        # the orphaned package can be cleaned up and a fresh install attempted.
-        console.print(
-            f"[yellow]Warning:[/yellow] '{step_id}' has no registry entry "
-            "(registry may have been reset). Removing the orphaned directory."
-        )
-
-    if dir_exists and not in_registry:
-        # No registry write needed; just delete the orphaned directory.
-        import shutil
-        try:
-            shutil.rmtree(step_dir)
-        except OSError as exc:
-            console.print(
-                f"[red]Error:[/red] Failed to remove step directory {step_dir}: {exc}"
-            )
-            raise typer.Exit(1)
-    elif in_registry:
-        # Remove the registry entry, then the directory. If the directory
-        # delete fails, restore the registry entry so state stays consistent
-        # and a future `step add` isn't blocked by an orphaned directory
-        # with no registry entry.
-        registry_metadata = registry.get(step_id)
-        try:
-            registry.remove(step_id)
-        except StepValidationError as exc:
-            console.print(f"[red]Error:[/red] {exc}")
-            raise typer.Exit(1)
-        if dir_exists:
-            import shutil
-            try:
-                shutil.rmtree(step_dir)
-            except OSError as exc:
-                # Restore the original registry entry verbatim (bypass add()
-                # which would overwrite timestamps).
-                try:
-                    if registry_metadata is not None:
-                        registry.data["steps"][step_id] = registry_metadata
-                        registry.save()
-                except Exception as restore_exc:  # noqa: BLE001
-                    console.print(
-                        f"[yellow]Warning:[/yellow] Failed to restore registry entry "
-                        f"for '{step_id}' after directory removal failure: {restore_exc}"
-                    )
-                console.print(
-                    f"[red]Error:[/red] Failed to remove step directory {step_dir}: {exc}"
-                )
-                raise typer.Exit(1)
-    console.print(f"[green]✓[/green] Step type '{step_id}' uninstalled")
-
-
-@workflow_step_app.command("search")
-def workflow_step_search(
-    query: str | None = typer.Argument(None, help="Search query"),
-):
-    """Search the step type catalog."""
-    from .workflows.catalog import StepCatalog, StepCatalogError
-
-    project_root = _require_specify_project()
-
-    catalog = StepCatalog(project_root)
-
-    try:
-        results = catalog.search(query=query)
-    except StepCatalogError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1)
-
-    if not results:
-        if query:
-            console.print(f"[yellow]No step types found matching '{query}'.[/yellow]")
-        else:
-            console.print("[yellow]No step types found in catalog.[/yellow]")
-        return
-
-    console.print(f"\n[bold cyan]Step Types ({len(results)}):[/bold cyan]\n")
-    for step in results:
-        install_note = (
-            "" if step.get("_install_allowed", True) else " [dim](discovery only)[/dim]"
-        )
-        console.print(
-            f"  [bold]{step.get('name', step.get('id', '?'))}[/bold]"
-            f" ({step.get('id', '?')}) v{step.get('version', '?')}{install_note}"
-        )
-        desc = step.get("description", "")
-        if desc:
-            console.print(f"    {desc}")
-        console.print()
-
-
-@workflow_step_app.command("info")
-def workflow_step_info(
-    step_id: str = typer.Argument(..., help="Step type ID"),
-):
-    """Show details for a step type."""
-    from .workflows import STEP_REGISTRY
-    from .workflows.catalog import StepCatalog, StepCatalogError, StepRegistry
-
-    project_root = _require_specify_project()
-
-    registry = StepRegistry(project_root)
-    installed_meta = registry.get(step_id)
-
-    # Check if it's a built-in
-    builtin_step = STEP_REGISTRY.get(step_id)
-    is_builtin = builtin_step is not None and not installed_meta
-
-    if is_builtin:
-        console.print(f"\n[bold cyan]{step_id}[/bold cyan] [dim](built-in)[/dim]")
-        console.print(f"  Type key: {step_id}")
-        console.print("  [green]Built-in step type[/green]")
-        return
-
-    if installed_meta:
-        console.print(
-            f"\n[bold cyan]{installed_meta.get('name', step_id)}[/bold cyan] ({step_id})"
-        )
-        console.print(f"  Version:     {installed_meta.get('version', '?')}")
-        if installed_meta.get("author"):
-            console.print(f"  Author:      {installed_meta['author']}")
-        if installed_meta.get("description"):
-            console.print(f"  Description: {installed_meta['description']}")
-        console.print("  [green]Installed[/green]")
-        return
-
-    # Try catalog
-    catalog = StepCatalog(project_root)
-    try:
-        info = catalog.get_step_info(step_id)
-    except StepCatalogError:
-        info = None
-
-    if info:
-        console.print(
-            f"\n[bold cyan]{info.get('name', step_id)}[/bold cyan] ({step_id})"
-        )
-        console.print(f"  Version:     {info.get('version', '?')}")
-        if info.get("author"):
-            console.print(f"  Author:      {info['author']}")
-        if info.get("description"):
-            console.print(f"  Description: {info['description']}")
-        console.print("  [yellow]Not installed[/yellow]")
-        console.print(
-            f"\n  Install with: [cyan]specify workflow step add {step_id}[/cyan]"
-        )
-    else:
-        console.print(f"[red]Error:[/red] Step type '{step_id}' not found")
-        raise typer.Exit(1)
-
-
-@workflow_step_catalog_app.command("list")
-def workflow_step_catalog_list():
-    """List configured step catalog sources."""
-    from .workflows.catalog import StepCatalog, StepCatalogError
-
-    project_root = _require_specify_project()
-    catalog = StepCatalog(project_root)
-
-    try:
-        configs = catalog.get_catalog_configs()
-    except StepCatalogError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1)
-
-    console.print("\n[bold cyan]Step Catalog Sources:[/bold cyan]\n")
-    for i, cfg in enumerate(configs):
-        install_status = (
-            "[green]install allowed[/green]"
-            if cfg["install_allowed"]
-            else "[yellow]discovery only[/yellow]"
-        )
-        console.print(f"  [{i}] [bold]{cfg['name']}[/bold] — {install_status}")
-        console.print(f"      {cfg['url']}")
-        if cfg.get("description"):
-            console.print(f"      [dim]{cfg['description']}[/dim]")
-        console.print()
-
-
-@workflow_step_catalog_app.command("add")
-def workflow_step_catalog_add(
-    url: str = typer.Argument(..., help="Catalog URL to add"),
-    name: str = typer.Option(None, "--name", help="Catalog name"),
-):
-    """Add a step catalog source."""
-    from .workflows.catalog import StepCatalog, StepValidationError
-
-    project_root = _require_specify_project()
-
-    catalog = StepCatalog(project_root)
-    try:
-        catalog.add_catalog(url, name)
-    except StepValidationError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1)
-
-    console.print(f"[green]✓[/green] Step catalog source added: {url}")
-
-
-@workflow_step_catalog_app.command("remove")
-def workflow_step_catalog_remove(
-    index: int = typer.Argument(
-        ..., help="Catalog index to remove (from 'step catalog list')"
-    ),
-):
-    """Remove a step catalog source by index."""
-    from .workflows.catalog import StepCatalog, StepValidationError
-
-    project_root = _require_specify_project()
-
-    catalog = StepCatalog(project_root)
-    try:
-        removed_name = catalog.remove_catalog(index)
-    except StepValidationError as exc:
-        console.print(f"[red]Error:[/red] {exc}")
-        raise typer.Exit(1)
-
-    console.print(f"[green]✓[/green] Step catalog source '{removed_name}' removed")
 
 
 def main():

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2854,6 +2854,16 @@ def _normalize_gate_options(options: Any) -> list[str] | None:
     return [str(options)]
 
 
+def _run_outcome_exit_code(status_value: str) -> int:
+    """Exit code for a finished run/resume: non-zero on terminal failure.
+
+    ``failed`` and ``aborted`` map to 1 so scripts and orchestrators can
+    rely on the process exit code; ``completed`` and ``paused`` map to 0
+    (paused is a legitimate waiting state, not a failure).
+    """
+    return 1 if status_value in ("failed", "aborted") else 0
+
+
 def _emit_workflow_json(payload: dict[str, Any]) -> None:
     """Write a workflow payload as machine-readable JSON to stdout.
 
@@ -3011,7 +3021,7 @@ def workflow_run(
 
     if json_output:
         _emit_workflow_json(_workflow_run_payload(state))
-        return
+        raise typer.Exit(_run_outcome_exit_code(state.status.value))
 
     status_colors = {
         "completed": "green",
@@ -3028,6 +3038,8 @@ def workflow_run(
 
     if dry_run and not json_output:
         _print_dry_run_previews(state)
+
+    raise typer.Exit(_run_outcome_exit_code(state.status.value))
 
 
 def _print_dry_run_previews(state: Any) -> None:
@@ -3097,7 +3109,7 @@ def workflow_resume(
 
     if json_output:
         _emit_workflow_json(_workflow_run_payload(state))
-        return
+        raise typer.Exit(_run_outcome_exit_code(state.status.value))
 
     status_colors = {
         "completed": "green",
@@ -3107,6 +3119,8 @@ def workflow_resume(
     }
     color = status_colors.get(state.status.value, "white")
     console.print(f"\n[{color}]Status: {state.status.value}[/{color}]")
+
+    raise typer.Exit(_run_outcome_exit_code(state.status.value))
 
 
 @workflow_app.command("status")

--- a/src/specify_cli/workflows/base.py
+++ b/src/specify_cli/workflows/base.py
@@ -74,6 +74,18 @@ class StepContext:
     #: Current run ID.
     run_id: str | None = None
 
+    #: When ``True``, every step implementation must short-circuit and
+    #: return a synthetic ``StepResult`` carrying a preview of what would
+    #: have been dispatched — no subprocess, no CLI call, no network I/O.
+    #: Step implementations publish the preview on ``output["message"]``
+    #: (the original, so ``{{ steps.<id>.output.message }}`` keeps
+    #: resolving) and ``output["dry_run_message"]`` (the rendered
+    #: ``[DRY RUN] ...`` body, consumed by the CLI's preview loop).
+    #: Persisted on the ``RunState`` so :meth:`WorkflowEngine.resume` can
+    #: restore it after a process restart — an interrupted dry-run must
+    #: not silently turn into a real run.
+    dry_run: bool = False
+
 
 @dataclass
 class StepResult:

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -313,6 +313,7 @@ class RunState:
         run_id: str | None = None,
         workflow_id: str = "",
         project_root: Path | None = None,
+        dry_run: bool = False,
     ) -> None:
         # ``run_id is None`` (omitted) → auto-generate. An explicit empty
         # string is *not* the same as "omitted" and must be validated like
@@ -334,6 +335,13 @@ class RunState:
         self.created_at = datetime.now(timezone.utc).isoformat()
         self.updated_at = self.created_at
         self.log_entries: list[dict[str, Any]] = []
+        # Persisted into ``state.json`` (and restored by :meth:`load`) so
+        # :meth:`WorkflowEngine.resume` can rebuild the ``StepContext``
+        # with the same ``dry_run`` flag. Without persistence, an
+        # interrupted dry-run would silently turn into a real run after
+        # a process restart, which is the exact bug the CLI's
+        # ``--dry-run`` promise is meant to prevent.
+        self.dry_run = dry_run
 
     @property
     def runs_dir(self) -> Path:
@@ -354,6 +362,12 @@ class RunState:
             "step_results": self.step_results,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            # Persisted with a default of ``False`` so state files written
+            # by older releases (before ``dry_run`` was added) still load
+            # — ``get(..., False)`` makes the older format behave
+            # identically to a fresh non-dry-run run. Older runs were
+            # never dry-runs, so the default is safe.
+            "dry_run": self.dry_run,
         }
         with open(runs_dir / "state.json", "w", encoding="utf-8") as f:
             json.dump(state_data, f, indent=2)
@@ -398,6 +412,11 @@ class RunState:
         state.step_results = state_data.get("step_results", {})
         state.created_at = state_data.get("created_at", "")
         state.updated_at = state_data.get("updated_at", "")
+        # ``dry_run`` is the load-bearing field for ``resume()``'s
+        # ``StepContext`` rebuild — without restoring it, a resumed
+        # dry-run would step right past every short-circuit and invoke
+        # the real CLI. See ``test_resume_restores_dry_run``.
+        state.dry_run = state_data.get("dry_run", False)
 
         inputs_path = runs_dir / "inputs.json"
         if inputs_path.exists():
@@ -478,6 +497,7 @@ class WorkflowEngine:
         definition: WorkflowDefinition,
         inputs: dict[str, Any] | None = None,
         run_id: str | None = None,
+        dry_run: bool = False,
     ) -> RunState:
         """Execute a workflow definition.
 
@@ -506,6 +526,7 @@ class WorkflowEngine:
             run_id=effective_run_id,
             workflow_id=definition.id,
             project_root=self.project_root,
+            dry_run=dry_run,
         )
 
         # Persist a copy of the workflow definition so resume can
@@ -531,6 +552,15 @@ class WorkflowEngine:
             default_options=definition.default_options,
             project_root=str(self.project_root),
             run_id=state.run_id,
+            # The ``dry_run`` flag travels into ``StepContext`` so each
+            # step implementation can short-circuit independently — see
+            # ``CommandStep.execute`` / ``PromptStep.execute`` /
+            # ``GateStep.execute``. Keeping it on the per-call context
+            # (rather than reading it off ``RunState`` inside each
+            # step) means library consumers that build a ``StepContext``
+            # directly (e.g. tests, custom runners) get the same
+            # contract without needing a ``RunState``.
+            dry_run=dry_run,
         )
 
         # Execute steps
@@ -594,7 +624,11 @@ class WorkflowEngine:
             merged = {**state.inputs, **inputs}
             state.inputs = self._resolve_inputs(definition, merged)
 
-        # Restore context
+        # Restore context — ``dry_run`` is read from the persisted
+        # ``RunState`` (not from the caller's flag, since ``resume`` has
+        # no caller-supplied dry-run flag) so a paused dry-run stays a
+        # dry-run after a process restart. Mirrors the same plumbing in
+        # :meth:`execute`.
         context = StepContext(
             inputs=state.inputs,
             steps=state.step_results,
@@ -603,6 +637,7 @@ class WorkflowEngine:
             default_options=definition.default_options,
             project_root=str(self.project_root),
             run_id=state.run_id,
+            dry_run=state.dry_run,
         )
 
         from . import STEP_REGISTRY

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -509,6 +509,16 @@ class WorkflowEngine:
             User-provided input values.
         run_id:
             Optional run ID (uses SPECKIT_WORKFLOW_RUN_ID when set, otherwise auto-generated).
+        dry_run:
+            Preview-only mode. When ``True``, step implementations skip
+            side-effecting work (AI invocations, file writes) and emit a
+            synthetic ``dry_run_message`` instead. ``dry_run`` propagates
+            into each step's ``StepContext`` and is persisted on the
+            resulting ``RunState`` so ``resume()`` keeps the run in
+            preview mode across restarts. Step ``output`` shape is
+            unchanged; downstream ``switch``/``do-while`` gates coerce
+            any dry-run-only fields (e.g. ``output.choice``) so the
+            preview branch is deterministic.
 
         Returns
         -------

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -545,6 +545,13 @@ class WorkflowEngine:
             state.status = RunStatus.FAILED
             state.append_log({"event": "workflow_failed", "error": str(exc)})
             state.save()
+            # Attach the partially-populated state to the exception so
+            # callers (most notably the CLI's exception handler) can
+            # surface any dry-run previews already resolved by earlier
+            # steps — the most useful debug signal a dry-run failure
+            # can offer. The state has been saved to disk by this point
+            # so consumers can also reload it via ``RunState.load()``.
+            exc.partial_state = state  # type: ignore[attr-defined]
             raise
 
         if state.status == RunStatus.RUNNING:
@@ -622,6 +629,12 @@ class WorkflowEngine:
             state.status = RunStatus.FAILED
             state.append_log({"event": "resume_failed", "error": str(exc)})
             state.save()
+            # Attach the partially-populated state to the exception so
+            # callers (e.g. the CLI's exception handler for ``workflow
+            # resume``) can surface any dry-run previews already
+            # resolved by earlier resumed steps. Mirrors the same
+            # contract used by :meth:`execute`.
+            exc.partial_state = state  # type: ignore[attr-defined]
             raise
 
         if state.status == RunStatus.RUNNING:

--- a/src/specify_cli/workflows/steps/command/__init__.py
+++ b/src/specify_cli/workflows/steps/command/__init__.py
@@ -53,8 +53,48 @@ class CommandStep(StepBase):
         if step_options:
             options.update(step_options)
 
-        # Attempt CLI dispatch
         args_str = str(resolved_input.get("args", ""))
+
+        # Dry-run: never invoke the integration CLI. Synthesize a
+        # ``COMPLETED`` result carrying the rendered dispatch preview so
+        # ``specify workflow run --dry-run`` can show what would have
+        # been sent. ``message`` stays user-facing (``DRY RUN: ...``) so
+        # downstream ``{{ steps.<id>.output.message }}`` resolves; the
+        # same body is duplicated on ``dry_run_message`` for the CLI's
+        # preview loop. Mirrors the same contract used by ``PromptStep``
+        # and ``GateStep`` so the CLI never has to special-case step
+        # types. See ``test_dry_run_returns_completed_without_dispatch``.
+        if context.dry_run:
+            preview = (
+                f"DRY RUN: would invoke {command!r} "
+                f"(integration={integration!r}, model={model!r}, "
+                f"args={args_str!r})"
+            )
+            return StepResult(
+                status=StepStatus.COMPLETED,
+                output={
+                    "command": command,
+                    "integration": integration,
+                    "model": model,
+                    "options": options,
+                    "input": resolved_input,
+                    # Dispatch contract: a real run would have invoked
+                    # the CLI; in dry-run mode we did not, so both
+                    # ``dispatched`` and ``executed`` are ``False``.
+                    # ``invoke_command`` preserves the command name so
+                    # the CLI's preview loop can label the preview
+                    # block even when the integration is unknown.
+                    "dispatched": False,
+                    "executed": False,
+                    "exit_code": 0,
+                    "invoke_command": command,
+                    "dry_run": True,
+                    "message": preview,
+                    "dry_run_message": preview,
+                },
+            )
+
+        # Attempt CLI dispatch
         dispatch_result = self._try_dispatch(
             command, integration, model, args_str, context
         )
@@ -72,6 +112,12 @@ class CommandStep(StepBase):
             output["stdout"] = dispatch_result["stdout"]
             output["stderr"] = dispatch_result["stderr"]
             output["dispatched"] = True
+            # Real runs must set ``executed=True`` so downstream
+            # ``{{ steps.<id>.output.executed }}`` resolves to truthy —
+            # the boolean is the documented signal that a real
+            # invocation occurred. The dry-run branch above is the only
+            # path that sets ``executed=False`` for this step type.
+            output["executed"] = True
             if dispatch_result["exit_code"] != 0:
                 return StepResult(
                     status=StepStatus.FAILED,

--- a/src/specify_cli/workflows/steps/command/__init__.py
+++ b/src/specify_cli/workflows/steps/command/__init__.py
@@ -65,11 +65,32 @@ class CommandStep(StepBase):
         # and ``GateStep`` so the CLI never has to special-case step
         # types. See ``test_dry_run_returns_completed_without_dispatch``.
         if context.dry_run:
-            preview = (
-                f"DRY RUN: would invoke {command!r} "
-                f"(integration={integration!r}, model={model!r}, "
-                f"args={args_str!r})"
-            )
+            # Try to build the integration-specific invocation string
+            # (e.g. ``/speckit.specify ...`` for markdown agents,
+            # ``/speckit-specify ...`` for skills agents) so the dry-run
+            # preview matches what a real run would dispatch. Falls back
+            # to the bare ``command`` name when no integration is
+            # configured or the integration is not registered (e.g.,
+            # dry-run on a brand-new project before setup).
+            preview_invocation: str | None = None
+            if isinstance(integration, str) and integration:
+                try:
+                    from specify_cli.integrations import get_integration
+                    impl = get_integration(integration)
+                    if impl is not None:
+                        preview_invocation = impl.build_command_invocation(
+                            command, args_str
+                        )
+                except Exception:
+                    preview_invocation = None
+            if preview_invocation:
+                preview = f"DRY RUN: would invoke {preview_invocation!r}"
+            else:
+                preview = (
+                    f"DRY RUN: would invoke {command!r} "
+                    f"(integration={integration!r}, model={model!r}, "
+                    f"args={args_str!r})"
+                )
             return StepResult(
                 status=StepStatus.COMPLETED,
                 output={

--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -16,6 +16,57 @@ from specify_cli.workflows.expressions import evaluate_expression
 #: contents and the path itself — so neither can inject ANSI/terminal escapes.
 _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0a-\x1f\x7f-\x9f]")
 
+#: Choices that, if returned by the gate, abort or skip the run. The
+#: dry-run branch must not pre-select one of these (see
+#: ``_first_non_sentinel``) so a downstream ``if`` doesn't accidentally
+#: follow a sentinel that was chosen on the user's behalf.
+_REJECT_SENTINELS = frozenset({"reject", "abort"})
+
+
+def _coerce_options(raw: object) -> list[str]:
+    """Strictly normalize ``options`` to a ``list[str]`` of valid choices.
+
+    Only a list/tuple of strings is treated as valid input — every other
+    shape (``None``, string, dict, scalar, sequence of non-strings) is
+    coerced to an empty list so the gate can fail loudly instead of
+    silently inheriting an author's typo. ``list[bool]`` and
+    ``list[int]`` are rejected on purpose: a workflow that bypassed
+    validation must not pass through with ``['True', 'False']`` as
+    option labels, since the rendered prompt would expose Python's
+    ``repr`` strings instead of author intent.
+
+    An empty list is the documented signal that the gate has no
+    choices — the dry-run path leaves ``choice`` as ``None`` and the
+    non-dry-run interactive path emits a clear ``FAILURE`` instead of
+    indexing into ``[]`` and crashing with a confusing
+    ``Choose [1-0]`` prompt.
+    """
+    if isinstance(raw, (list, tuple)):
+        coerced: list[str] = []
+        for item in raw:
+            if isinstance(item, str) and item:
+                coerced.append(item)
+        return coerced
+    # Anything else — ``None``, ``str``, ``dict``, ``int``, ``bool`` —
+    # is invalid. The validation layer already rejects these shapes
+    # for the real-run path; this defensive coercion ensures a workflow
+    # that bypassed validation does not crash the prompt loop.
+    return []
+
+
+def _first_non_sentinel(options: list[str]) -> str | None:
+    """Return the first ``options`` entry that is not a reject/abort sentinel.
+
+    Used by the dry-run branch so a synthetic ``choice`` doesn't
+    unintentionally steer downstream branching into a reject path. If
+    every option is a sentinel — an authoring mistake, but one the gate
+    must not crash on — return ``None`` (neutral default).
+    """
+    for option in options:
+        if isinstance(option, str) and option.lower() not in _REJECT_SENTINELS:
+            return option
+    return None
+
 
 class GateStep(StepBase):
     """Interactive review gate.
@@ -40,7 +91,13 @@ class GateStep(StepBase):
         if isinstance(message, str) and "{{" in message:
             message = evaluate_expression(message, context)
 
-        options = config.get("options", ["approve", "reject"])
+        # ``options`` is normalized defensively even on the non-dry-run
+        # path: a workflow that bypassed validation can pass strings,
+        # dicts, scalars, or non-string Sequences. Coercing here keeps
+        # the interactive branch honest (no IndexError on a string)
+        # without changing the validated happy path. Mirrors the same
+        # normalization used by the dry-run branch below.
+        options = _coerce_options(config.get("options", ["approve", "reject"]))
         on_reject = config.get("on_reject", "abort")
 
         show_file = config.get("show_file")
@@ -61,9 +118,54 @@ class GateStep(StepBase):
             "choice": None,
         }
 
+        # Dry-run: never pause for interactive input. The original
+        # ``message`` is preserved verbatim on ``output["message"]`` so
+        # downstream ``{{ steps.<id>.output.message }}`` references
+        # resolve to the gate prompt unchanged; the ``[DRY RUN]`` body
+        # is duplicated on ``output["dry_run_message"]`` for the CLI's
+        # preview loop. ``choice`` is the first non-reject/abort option
+        # so a downstream ``if`` doesn't accidentally follow a reject
+        # sentinel; if every option is a sentinel we leave ``choice``
+        # ``None`` so a downstream gate defaults to neutral.
+        # See ``test_dry_run_skips_interactive_gate``,
+        # ``test_dry_run_accepts_tuple_options``, and
+        # ``test_dry_run_skips_reject_sentinels_for_choice``.
+        if context.dry_run:
+            choice = _first_non_sentinel(options)
+            preview = f"[DRY RUN] Gate: {message}"
+            return StepResult(
+                status=StepStatus.COMPLETED,
+                output={
+                    "message": message,
+                    "options": options,
+                    "on_reject": on_reject,
+                    "show_file": show_file,
+                    "choice": choice,
+                    "dry_run": True,
+                    "dry_run_message": preview,
+                },
+            )
+
         # Non-interactive: pause for later resume (the file is not read here)
         if not sys.stdin.isatty():
             return StepResult(status=StepStatus.PAUSED, output=output)
+
+        # Interactive with no options: a workflow that bypassed validation
+        # can hand us ``options=None`` (normalized to ``[]``). Indexing
+        # into an empty list would emit ``Choose [1-0]:`` and crash the
+        # gate on the first ``int(raw)``. Fail loudly instead so the
+        # operator sees the authoring mistake on stdout, not a stack
+        # trace. ``output`` carries the empty ``options`` so the engine
+        # can still record what the gate saw.
+        if not options:
+            return StepResult(
+                status=StepStatus.FAILED,
+                output=output,
+                error=(
+                    f"Gate {config.get('id', '?')!r} has no options — "
+                    "interactive review requires at least one choice."
+                ),
+            )
 
         # Interactive: prompt the user. ``show_file`` contents are folded
         # into the displayed message so the operator can review the

--- a/src/specify_cli/workflows/steps/prompt/__init__.py
+++ b/src/specify_cli/workflows/steps/prompt/__init__.py
@@ -52,6 +52,34 @@ class PromptStep(StepBase):
         if model and isinstance(model, str) and "{{" in model:
             model = evaluate_expression(model, context)
 
+        # Dry-run: never invoke the integration CLI. Same contract as
+        # ``CommandStep`` — render the would-be prompt on both
+        # ``message`` (for downstream expression resolution) and
+        # ``dry_run_message`` (for the CLI preview loop). Without this
+        # short-circuit, a workflow with ``type: prompt`` would still
+        # invoke the AI in dry-run mode, defeating the entire
+        # ``--dry-run`` promise. See
+        # ``test_dry_run_prompt_short_circuits``.
+        if context.dry_run:
+            preview = f"DRY RUN: would send prompt to {integration!r}\n\n{prompt}"
+            return StepResult(
+                status=StepStatus.COMPLETED,
+                output={
+                    "prompt": prompt,
+                    "integration": integration,
+                    "model": model,
+                    # Real-run contract: dispatch and execute are both
+                    # ``True`` on a successful invocation. In dry-run
+                    # neither happened, so both are ``False``.
+                    "dispatched": False,
+                    "executed": False,
+                    "exit_code": 0,
+                    "dry_run": True,
+                    "message": preview,
+                    "dry_run_message": preview,
+                },
+            )
+
         # Attempt CLI dispatch
         dispatch_result = self._try_dispatch(
             prompt, integration, model, context
@@ -68,6 +96,7 @@ class PromptStep(StepBase):
             output["stdout"] = dispatch_result["stdout"]
             output["stderr"] = dispatch_result["stderr"]
             output["dispatched"] = True
+            output["executed"] = True
             if dispatch_result["exit_code"] != 0:
                 return StepResult(
                     status=StepStatus.FAILED,

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -58,7 +58,12 @@ def temp_dir():
     """Create a temporary directory for tests."""
     tmpdir = tempfile.mkdtemp()
     yield Path(tmpdir)
-    shutil.rmtree(tmpdir)
+    # ``ignore_errors=True`` so a file still locked by another process
+    # (most commonly on Windows, where AV scanners briefly hold a
+    # handle on freshly created binaries in ``tmp_path``) doesn't fail
+    # the test's teardown — the OS will reap the directory on the next
+    # reboot. Without this, a benign race becomes a flaky CI failure.
+    shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -32,7 +32,13 @@ def temp_dir():
     """Create a temporary directory for tests."""
     tmpdir = tempfile.mkdtemp()
     yield Path(tmpdir)
-    shutil.rmtree(tmpdir)
+    # ``ignore_errors=True`` so a file still locked by another process
+    # (most commonly on Windows, where AV scanners briefly hold a
+    # handle on freshly created binaries in ``tmp_path``) doesn't fail
+    # the test's teardown — the OS will reap the directory on the next
+    # reboot. Mirrors the same fixture in ``tests/test_extensions.py``
+    # so the whole suite stays stable on win32.
+    shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 @pytest.fixture
@@ -108,6 +114,7 @@ class TestStepRegistry:
             # against an accidental refactor that drops the import
             # (the registration is a side effect, so a missed import
             # silently shrinks the registry without any test failure).
+            "init",
         }
         assert expected.issubset(set(STEP_REGISTRY.keys()))
 
@@ -848,6 +855,80 @@ class TestCommandStep:
         # latter without per-step-type special-casing.
         assert "DRY RUN" in result.output["message"]
         assert result.output["dry_run_message"] == result.output["message"]
+
+    def test_dry_run_uses_integration_invocation_string(self, tmp_path):
+        """Dry-run preview uses the integration's ``build_command_invocation()``.
+
+        Markdown agents (``claude``, ``gemini``) render
+        ``/speckit.specify <args>``; skills agents (``zed``,
+        ``kiro-cli``) render ``/speckit-specify <args>``. The dry-run
+        preview must match what a real run would dispatch, not the
+        bare ``speckit.specify`` command name.
+        """
+        from specify_cli.workflows.steps.command import CommandStep
+        from specify_cli.workflows.base import StepContext
+
+        # Markdown agent — invocation keeps the dotted form.
+        step = CommandStep()
+        ctx = StepContext(
+            inputs={"name": "login"},
+            default_integration="claude",
+            project_root=str(tmp_path),
+            dry_run=True,
+        )
+        config = {
+            "id": "test",
+            "command": "speckit.specify",
+            "input": {"args": "{{ inputs.name }}"},
+        }
+        result = step.execute(config, ctx)
+        # The Claude integration renders ``/speckit-specify`` for the
+        # ``speckit.specify`` command. The preview should reference it
+        # (the bare ``speckit.specify`` token is fine too because the
+        # preview is a quoted string). What matters is the integration
+        # invocation string is present.
+        assert "/speckit-specify" in result.output["message"]
+        # And the bare ``speckit.specify`` token should NOT be the
+        # only thing shown — the slash-command form must be there too.
+        assert result.output["message"].count("speckit") >= 1
+
+        # Skills agent — invocation switches to ``/speckit.specify``.
+        ctx_skill = StepContext(
+            inputs={"name": "login"},
+            default_integration="gemini",  # markdown agent — produces /speckit.specify
+            project_root=str(tmp_path),
+            dry_run=True,
+        )
+        result_skill = step.execute(config, ctx_skill)
+        assert "/speckit.specify" in result_skill.output["message"]
+
+    def test_dry_run_falls_back_when_integration_unknown(self, tmp_path):
+        """Dry-run falls back to the bare command string when no integration is set.
+
+        A brand-new project may run ``workflow run --dry-run`` before
+        any integration is configured. The preview must still emit a
+        sensible message rather than crashing inside ``get_integration``.
+        """
+        from specify_cli.workflows.steps.command import CommandStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = CommandStep()
+        ctx = StepContext(
+            inputs={"name": "login"},
+            default_integration=None,  # no integration configured
+            project_root=str(tmp_path),
+            dry_run=True,
+        )
+        config = {
+            "id": "test",
+            "command": "speckit.specify",
+            "input": {"args": "{{ inputs.name }}"},
+        }
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.COMPLETED
+        # Falls back to the bare ``command`` name in the preview.
+        assert "speckit.specify" in result.output["message"]
+        assert "DRY RUN" in result.output["message"]
 
 
 class TestPromptStep:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -102,6 +102,12 @@ class TestStepRegistry:
         expected = {
             "command", "shell", "prompt", "gate", "if", "switch",
             "while", "do-while", "fan-out", "fan-in",
+            # ``init`` is a built-in step type registered by
+            # ``_register_builtin_steps`` for bootstrapping a project
+            # like ``specify init`` does. Asserting it here guards
+            # against an accidental refactor that drops the import
+            # (the registration is a side effect, so a missed import
+            # silently shrinks the registry without any test failure).
         }
         assert expected.issubset(set(STEP_REGISTRY.keys()))
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -32,10 +32,7 @@ def temp_dir():
     """Create a temporary directory for tests."""
     tmpdir = tempfile.mkdtemp()
     yield Path(tmpdir)
-    # On Windows, file handles from dynamic imports or registry access may
-    # still be held briefly after the test. Use ignore_errors to avoid
-    # flaky teardown failures (WinError 32).
-    shutil.rmtree(tmpdir, ignore_errors=(sys.platform == "win32"))
+    shutil.rmtree(tmpdir)
 
 
 @pytest.fixture
@@ -104,7 +101,7 @@ class TestStepRegistry:
 
         expected = {
             "command", "shell", "prompt", "gate", "if", "switch",
-            "while", "do-while", "fan-out", "fan-in", "init",
+            "while", "do-while", "fan-out", "fan-in",
         }
         assert expected.issubset(set(STEP_REGISTRY.keys()))
 
@@ -781,47 +778,6 @@ class TestCommandStep:
         # Claude is a SkillsIntegration so uses /speckit-specify
         assert "/speckit-specify login" in call_args[0][0][2]
 
-    def test_dispatch_uses_executable_override_for_fallback_preflight(self, tmp_path, monkeypatch):
-        """Command preflight falls back to build_exec_args() argv[0]."""
-        from unittest.mock import MagicMock, patch
-        from specify_cli.workflows.steps.command import CommandStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        monkeypatch.setenv("SPECKIT_INTEGRATION_CLAUDE_EXECUTABLE", "/opt/claude")
-        seen_which: list[str] = []
-
-        def fake_which(name: str) -> str | None:
-            seen_which.append(name)
-            return name if name == "/opt/claude" else None
-
-        step = CommandStep()
-        ctx = StepContext(
-            inputs={"name": "login"},
-            default_integration="claude",
-            project_root=str(tmp_path),
-        )
-        config = {
-            "id": "test",
-            "command": "speckit.specify",
-            "input": {"args": "{{ inputs.name }}"},
-        }
-
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = '{"result": "done"}'
-        mock_result.stderr = ""
-
-        with patch("specify_cli.workflows.steps.command.shutil.which", side_effect=fake_which), \
-             patch("subprocess.run", return_value=mock_result) as mock_run:
-            result = step.execute(config, ctx)
-
-        assert result.status == StepStatus.COMPLETED
-        assert result.output["dispatched"] is True
-        assert seen_which[:2] == ["claude", "/opt/claude"]
-        call_args = mock_run.call_args
-        assert call_args[0][0][0] == "/opt/claude"
-        assert "/speckit-specify login" in call_args[0][0][2]
-
     def test_dispatch_failure_returns_failed_status(self, tmp_path):
         """When the CLI exits non-zero, the step should fail."""
         from unittest.mock import patch, MagicMock
@@ -853,6 +809,39 @@ class TestCommandStep:
         assert result.status == StepStatus.FAILED
         assert result.output["dispatched"] is True
         assert result.output["exit_code"] == 1
+
+    def test_dry_run_returns_completed_without_dispatch(self, tmp_path):
+        """Dry-run mode: step returns COMPLETED and shows rendered prompt without invoking CLI."""
+        from specify_cli.workflows.steps.command import CommandStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = CommandStep()
+        ctx = StepContext(
+            inputs={"name": "login"},
+            default_integration="claude",
+            project_root=str(tmp_path),
+            dry_run=True,
+        )
+        config = {
+            "id": "test",
+            "command": "speckit.specify",
+            "input": {"args": "{{ inputs.name }}"},
+        }
+        result = step.execute(config, ctx)
+
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["dry_run"] is True
+        assert result.output["dispatched"] is False
+        assert result.output["executed"] is False
+        assert result.output["command"] == "speckit.specify"
+        assert result.output["input"]["args"] == "login"
+        # No AI call was made (shutil.which would fail anyway, but dry_run short-circuits before that)
+        assert "invoke_command" in result.output
+        # The DRY RUN preview is published on both ``message`` and
+        # ``dry_run_message`` so the CLI's render loop can prefer the
+        # latter without per-step-type special-casing.
+        assert "DRY RUN" in result.output["message"]
+        assert result.output["dry_run_message"] == result.output["message"]
 
 
 class TestPromptStep:
@@ -973,46 +962,41 @@ class TestPromptStep:
         assert result.status == StepStatus.COMPLETED
         assert result.output["dispatched"] is True
         assert result.output["exit_code"] == 0
+        # Real-run branch must set executed=True so downstream
+        # ``{{ steps.<id>.output.executed }}`` resolves to truthy.
+        assert result.output["executed"] is True
 
-    def test_dispatch_uses_executable_override_for_fallback_preflight(self, tmp_path, monkeypatch):
-        """Prompt preflight falls back to build_exec_args() argv[0]."""
-        from unittest.mock import MagicMock, patch
+    def test_dry_run_prompt_short_circuits(self, tmp_path):
+        """PromptStep must honor ``context.dry_run`` — the same contract
+        as CommandStep / GateStep. Without this, a workflow with
+        ``type: prompt`` makes real AI calls even in dry-run mode."""
         from specify_cli.workflows.steps.prompt import PromptStep
         from specify_cli.workflows.base import StepContext, StepStatus
 
-        monkeypatch.setenv("SPECKIT_INTEGRATION_CLAUDE_EXECUTABLE", "/opt/claude")
-        seen_which: list[str] = []
-
-        def fake_which(name: str) -> str | None:
-            seen_which.append(name)
-            return name if name == "/opt/claude" else None
-
         step = PromptStep()
         ctx = StepContext(
+            inputs={"file": "auth.py"},
             default_integration="claude",
             project_root=str(tmp_path),
+            dry_run=True,
         )
         config = {
-            "id": "ask",
+            "id": "review",
             "type": "prompt",
-            "prompt": "Explain this code",
+            "prompt": "Review {{ inputs.file }} for security issues",
         }
-
-        mock_result = MagicMock()
-        mock_result.returncode = 0
-        mock_result.stdout = "Here is the explanation"
-        mock_result.stderr = ""
-
-        with patch("specify_cli.workflows.steps.prompt.shutil.which", side_effect=fake_which), \
-             patch("subprocess.run", return_value=mock_result) as mock_run:
-            result = step.execute(config, ctx)
+        result = step.execute(config, ctx)
 
         assert result.status == StepStatus.COMPLETED
-        assert result.output["dispatched"] is True
-        assert seen_which[:2] == ["claude", "/opt/claude"]
-        call_args = mock_run.call_args
-        assert call_args[0][0][0] == "/opt/claude"
-        assert call_args[0][0][2] == "Explain this code"
+        assert result.output["dry_run"] is True
+        assert result.output["executed"] is False
+        assert result.output["dispatched"] is False
+        assert result.output["exit_code"] == 0
+        # The dry-run preview lives on both message and dry_run_message.
+        assert "DRY RUN" in result.output["message"]
+        assert result.output["dry_run_message"] == result.output["message"]
+        # The rendered prompt must surface in the preview.
+        assert "auth.py" in result.output["message"]
 
     def test_validate_missing_prompt(self):
         from specify_cli.workflows.steps.prompt import PromptStep
@@ -1031,17 +1015,6 @@ class TestPromptStep:
 
 class TestShellStep:
     """Test the shell step type."""
-
-    @staticmethod
-    def _python_run(tmp_path, body):
-        """A portable shell ``run`` that executes ``body`` with the current
-        interpreter, avoiding non-portable shell quoting (e.g. Windows
-        ``cmd.exe`` keeping single quotes) in the output_format tests."""
-        import sys
-
-        script = tmp_path / "emit.py"
-        script.write_text(body, encoding="utf-8")
-        return f'"{sys.executable}" "{script}"'
 
     def test_execute_echo(self):
         from specify_cli.workflows.steps.shell import ShellStep
@@ -1074,62 +1047,6 @@ class TestShellStep:
         errors = step.validate({"id": "test"})
         assert any("missing 'run'" in e for e in errors)
 
-
-    def test_output_format_json_exposes_data(self, tmp_path):
-        from specify_cli.workflows.steps.shell import ShellStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = ShellStep()
-        ctx = StepContext(project_root=str(tmp_path))
-        config = {
-            "id": "emit",
-            "run": self._python_run(
-                tmp_path, 'import json; print(json.dumps({"items": [1, 2]}))\n'
-            ),
-            "output_format": "json",
-        }
-        result = step.execute(config, ctx)
-        assert result.status == StepStatus.COMPLETED
-        assert result.output["data"] == {"items": [1, 2]}
-        assert result.output["exit_code"] == 0  # raw keys still present
-
-    def test_output_format_json_invalid_stdout_fails(self, tmp_path):
-        from specify_cli.workflows.steps.shell import ShellStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = ShellStep()
-        ctx = StepContext(project_root=str(tmp_path))
-        config = {
-            "id": "emit",
-            "run": self._python_run(tmp_path, "print('not-json')\n"),
-            "output_format": "json",
-        }
-        result = step.execute(config, ctx)
-        assert result.status == StepStatus.FAILED
-        assert "output_format: json" in (result.error or "")
-
-    def test_no_output_format_keeps_raw_output_only(self, tmp_path):
-        from specify_cli.workflows.steps.shell import ShellStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = ShellStep()
-        ctx = StepContext(project_root=str(tmp_path))
-        config = {
-            "id": "emit",
-            "run": self._python_run(
-                tmp_path, 'import json; print(json.dumps({"items": []}))\n'
-            ),
-        }
-        result = step.execute(config, ctx)
-        assert result.status == StepStatus.COMPLETED
-        assert "data" not in result.output
-
-    def test_validate_rejects_unknown_output_format(self):
-        from specify_cli.workflows.steps.shell import ShellStep
-
-        step = ShellStep()
-        errors = step.validate({"id": "emit", "run": "exit 0", "output_format": "yaml"})
-        assert any("'output_format' must be 'json'" in e for e in errors)
 
 class _StubStdin:
     """Stdin stub exposing only a fixed ``isatty`` result.
@@ -1167,171 +1084,6 @@ def _force_gate_stdin(monkeypatch, *, tty: bool):
     from specify_cli.workflows.steps import gate as gate_module
 
     monkeypatch.setattr(gate_module, "sys", _FakeSys(tty=tty))
-
-
-class TestInitStep:
-    """Test the init step type."""
-
-    def test_builds_here_argv_and_bootstraps(self, tmp_path):
-        from specify_cli.workflows.steps.init import InitStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = InitStep()
-        ctx = StepContext(
-            project_root=str(tmp_path), default_integration="copilot"
-        )
-        config = {"id": "bootstrap", "here": True, "script": "sh"}
-        result = step.execute(config, ctx)
-
-        assert result.status == StepStatus.COMPLETED
-        assert result.output["exit_code"] == 0
-        argv = result.output["argv"]
-        assert argv[0] == "init"
-        assert "--here" in argv
-        assert "--integration" in argv and "copilot" in argv
-        assert "--ignore-agent-tools" in argv
-        assert (tmp_path / ".specify").is_dir()
-
-    def test_default_integration_falls_back_to_workflow_default(self, tmp_path):
-        from specify_cli.workflows.steps.init import InitStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = InitStep()
-        ctx = StepContext(
-            project_root=str(tmp_path), default_integration="copilot"
-        )
-        result = step.execute(
-            {"id": "bootstrap", "here": True, "script": "sh"}, ctx
-        )
-        assert result.status == StepStatus.COMPLETED
-        assert result.output["integration"] == "copilot"
-
-    def test_project_name_creates_subdirectory(self, tmp_path):
-        from specify_cli.workflows.steps.init import InitStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = InitStep()
-        ctx = StepContext(
-            project_root=str(tmp_path), default_integration="copilot"
-        )
-        result = step.execute(
-            {
-                "id": "bootstrap",
-                "project": "demo",
-                "script": "sh",
-            },
-            ctx,
-        )
-        assert result.status == StepStatus.COMPLETED
-        assert (tmp_path / "demo" / ".specify").is_dir()
-
-    def test_invalid_integration_fails(self, tmp_path):
-        from specify_cli.workflows.steps.init import InitStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = InitStep()
-        ctx = StepContext(project_root=str(tmp_path))
-        result = step.execute(
-            {
-                "id": "bootstrap",
-                "here": True,
-                "integration": "no-such-agent",
-                "script": "sh",
-            },
-            ctx,
-        )
-        assert result.status == StepStatus.FAILED
-        assert result.output["exit_code"] != 0
-        assert result.error is not None
-
-    def test_non_empty_current_dir_without_force_fails_fast(self, tmp_path):
-        from specify_cli.workflows.steps.init import InitStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        (tmp_path / "existing.txt").write_text("data")
-
-        step = InitStep()
-        ctx = StepContext(
-            project_root=str(tmp_path), default_integration="copilot"
-        )
-        result = step.execute(
-            {"id": "bootstrap", "here": True, "script": "sh"},
-            ctx,
-        )
-        assert result.status == StepStatus.FAILED
-        assert "force: true" in (result.error or "")
-        assert not (tmp_path / ".specify").exists()
-
-    def test_engine_owned_dirs_do_not_trigger_non_empty_check(self, tmp_path):
-        from specify_cli.workflows.steps.init import InitStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        # Simulate the engine creating its run-state directory before steps run
-        (tmp_path / ".specify" / "workflows" / "runs" / "abc123").mkdir(
-            parents=True
-        )
-
-        step = InitStep()
-        ctx = StepContext(
-            project_root=str(tmp_path), default_integration="copilot"
-        )
-        result = step.execute(
-            {"id": "bootstrap", "here": True, "script": "sh"},
-            ctx,
-        )
-        assert result.status == StepStatus.COMPLETED
-        # Verify --force was implicitly added
-        assert "--force" in result.output["argv"]
-
-    def test_default_integration_when_none_provided(self, tmp_path):
-        from specify_cli.workflows.steps.init import InitStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = InitStep()
-        # No default_integration on context either
-        ctx = StepContext(project_root=str(tmp_path))
-        result = step.execute(
-            {"id": "bootstrap", "here": True, "script": "sh"},
-            ctx,
-        )
-        assert result.status == StepStatus.COMPLETED
-        assert result.output["integration"] == "copilot"
-
-    def test_integration_options_passed_through(self, tmp_path):
-        from specify_cli.workflows.steps.init import InitStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = InitStep()
-        ctx = StepContext(
-            project_root=str(tmp_path), default_integration="copilot"
-        )
-        result = step.execute(
-            {
-                "id": "bootstrap",
-                "here": True,
-                "script": "sh",
-                "integration": "copilot",
-                "integration_options": "--skills",
-            },
-            ctx,
-        )
-        assert result.status == StepStatus.COMPLETED
-        assert "--integration-options" in result.output["argv"]
-        assert "--skills" in result.output["argv"]
-        assert result.output["integration_options"] == "--skills"
-
-    def test_validate_rejects_bad_script(self):
-        from specify_cli.workflows.steps.init import InitStep
-
-        step = InitStep()
-        errors = step.validate({"id": "bootstrap", "script": "bogus"})
-        assert any("'script' must be 'sh' or 'ps'" in e for e in errors)
-
-    def test_validate_accepts_valid(self):
-        from specify_cli.workflows.steps.init import InitStep
-
-        step = InitStep()
-        assert step.validate({"id": "bootstrap", "script": "sh"}) == []
 
 
 class TestGateStep:
@@ -1379,6 +1131,77 @@ class TestGateStep:
             "on_reject": "invalid",
         })
         assert any("on_reject" in e for e in errors)
+
+    def test_dry_run_skips_interactive_gate(self, tmp_path):
+        """Dry-run mode: gate step returns COMPLETED without pausing for user input."""
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = GateStep()
+        ctx = StepContext(dry_run=True)
+        config = {
+            "id": "review",
+            "message": "Review the spec.",
+            "options": ["approve", "reject"],
+            "on_reject": "abort",
+        }
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.COMPLETED
+        # Dry-run output must be marked so the CLI prints it (mirrors
+        # CommandStep's output['dry_run'] = True contract).
+        assert result.output["dry_run"] is True
+        # The original ``message`` is preserved so downstream
+        # ``{{ steps.<id>.output.message }}`` references still resolve
+        # to the gate prompt; the DRY RUN preview is published on
+        # ``dry_run_message`` for the CLI rendering loop.
+        assert result.output["message"] == "Review the spec."
+        assert "DRY RUN" in result.output["dry_run_message"]
+        assert result.output["choice"] == "approve"
+
+    def test_dry_run_normalizes_non_list_options(self, tmp_path):
+        """A workflow that bypasses validation may set ``options`` to a
+        non-list (string, dict, scalar).  ``GateStep`` must coerce
+        gracefully instead of indexing into a string or raising."""
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = GateStep()
+        ctx = StepContext(dry_run=True)
+        for bad_options in (None, "approve,reject", {"approve": True}, 42, ""):
+            config = {
+                "id": "review",
+                "message": "Review the spec.",
+                "options": bad_options,
+            }
+            result = step.execute(config, ctx)
+            assert result.status == StepStatus.COMPLETED
+            assert result.output["options"] == []
+            assert result.output["choice"] is None
+
+    def test_interactive_path_fails_on_empty_options(self, tmp_path, monkeypatch):
+        """A workflow that bypassed validation and produced
+        ``options=[]`` would crash the prompt loop with an IndexError
+        in the non-dry-run interactive path.  GateStep must fail
+        loudly with a clear message instead."""
+        from specify_cli.workflows.steps import gate as gate_mod
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        # Force the interactive branch (not the non-interactive PAUSED
+        # fallback). Patch on the module's ``sys`` binding so the gate
+        # code resolves the patch even when pytest replaces
+        # ``sys.stdin`` for capture.
+        monkeypatch.setattr(gate_mod.sys.stdin, "isatty", lambda: True)
+        step = GateStep()
+        ctx = StepContext()
+        config = {
+            "id": "review",
+            "message": "Review the spec.",
+            "options": None,  # gets normalized to []
+        }
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.FAILED
+        assert "no options" in (result.error or "")
 
     def test_interactive_prompt_renders_show_file(self, tmp_path, monkeypatch, capsys):
         from specify_cli.workflows.steps.gate import GateStep
@@ -1547,6 +1370,48 @@ class TestGateStep:
         result = step.execute(config, ctx)  # non-interactive -> PAUSED
         assert result.status == StepStatus.PAUSED
         assert result.output["show_file"] == "123"
+
+    def test_dry_run_accepts_tuple_options(self, tmp_path):
+        """``options`` may be a tuple (Sequence but not list).  GateStep
+        should accept any non-str Sequence, not just list."""
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = GateStep()
+        ctx = StepContext(dry_run=True)
+        config = {
+            "id": "review",
+            "message": "Review the spec.",
+            "options": ("approve", "reject"),
+        }
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["options"] == ["approve", "reject"]
+        assert result.output["choice"] == "approve"
+
+    def test_dry_run_skips_reject_sentinels_for_choice(self, tmp_path):
+        """In dry-run, ``choice`` should not be a reject/abort sentinel
+        that would unintentionally steer downstream branching."""
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = GateStep()
+        ctx = StepContext(dry_run=True)
+        # First option is the reject sentinel — the dry-run must skip it
+        # and fall through to the first non-sentinel option.
+        config = {
+            "id": "review",
+            "message": "Review the spec.",
+            "options": ["reject", "approve", "skip"],
+        }
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["choice"] == "approve"
+
+        # All options are sentinels — leave choice as None (neutral).
+        config["options"] = ["reject", "abort"]
+        result = step.execute(config, ctx)
+        assert result.output["choice"] is None
 
 
 class TestIfThenStep:
@@ -1830,9 +1695,9 @@ class TestFanOutStep:
         assert result.output["item_count"] == 2
         assert result.output["max_concurrency"] == 3
 
-    def test_execute_non_list_items_fails_loudly(self):
+    def test_execute_non_list_items_resolves_empty(self):
         from specify_cli.workflows.steps.fan_out import FanOutStep
-        from specify_cli.workflows.base import StepContext, StepStatus
+        from specify_cli.workflows.base import StepContext
 
         step = FanOutStep()
         ctx = StepContext()
@@ -1842,24 +1707,8 @@ class TestFanOutStep:
             "step": {"id": "impl", "command": "speckit.implement"},
         }
         result = step.execute(config, ctx)
-        assert result.status == StepStatus.FAILED
-        assert "'items' must resolve to a list" in (result.error or "")
         assert result.output["item_count"] == 0
-
-    def test_execute_empty_list_items_is_valid(self):
-        from specify_cli.workflows.steps.fan_out import FanOutStep
-        from specify_cli.workflows.base import StepContext, StepStatus
-
-        step = FanOutStep()
-        ctx = StepContext(steps={"tasks": {"output": {"task_list": []}}})
-        config = {
-            "id": "parallel",
-            "items": "{{ steps.tasks.output.task_list }}",
-            "step": {"id": "impl", "command": "speckit.implement"},
-        }
-        result = step.execute(config, ctx)
-        assert result.status == StepStatus.COMPLETED
-        assert result.output["item_count"] == 0
+        assert result.output["items"] == []
 
     def test_validate_missing_fields(self):
         from specify_cli.workflows.steps.fan_out import FanOutStep
@@ -2204,6 +2053,118 @@ steps:
         assert state.status == RunStatus.PAUSED
         assert "gate" in state.step_results
         assert state.step_results["gate"]["status"] == "paused"
+
+    def test_execute_dry_run(self, project_dir):
+        """Dry-run: engine returns COMPLETED without invoking the AI for command steps."""
+        from unittest.mock import patch
+        from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
+        from specify_cli.workflows.base import RunStatus
+
+        yaml_str = """
+schema_version: "1.0"
+workflow:
+  id: "dryrun-test"
+  name: "Dry Run Test"
+  version: "1.0.0"
+inputs:
+  spec:
+    type: string
+    default: "test spec"
+steps:
+  - id: specify
+    command: speckit.specify
+    input:
+      args: "{{ inputs.spec }}"
+  - id: plan
+    command: speckit.plan
+    input:
+      args: "{{ inputs.spec }}"
+"""
+        definition = WorkflowDefinition.from_string(yaml_str)
+        engine = WorkflowEngine(project_dir)
+
+        # In dry-run mode, even if the CLI tool is installed, no AI calls are made
+        with patch("specify_cli.workflows.steps.command.shutil.which", return_value="/usr/local/bin/claude"), \
+             patch("subprocess.run") as mock_run:
+            state = engine.execute(definition, {"spec": "login feature"}, dry_run=True)
+
+        assert state.status == RunStatus.COMPLETED
+        assert "specify" in state.step_results
+        assert state.step_results["specify"]["output"]["dry_run"] is True
+        assert state.step_results["specify"]["output"]["dispatched"] is False
+        assert "plan" in state.step_results
+        assert state.step_results["plan"]["output"]["dry_run"] is True
+        # subprocess.run should NOT have been called in dry-run mode
+        assert mock_run.call_count == 0
+
+    def test_dry_run_persisted_in_run_state(self, project_dir):
+        """Dry-run flag must be saved into RunState so resume() can restore it."""
+        from specify_cli.workflows.engine import RunState, WorkflowEngine, WorkflowDefinition
+
+        yaml_str = """
+schema_version: "1.0"
+workflow:
+  id: "dryrun-persist"
+  name: "Dry Run Persist"
+  version: "1.0.0"
+steps:
+  - id: only
+    type: gate
+    message: "Continue?"
+    options: ["yes", "no"]
+"""
+        definition = WorkflowDefinition.from_string(yaml_str)
+        engine = WorkflowEngine(project_dir)
+        state = engine.execute(definition, dry_run=True, run_id="dr-persist")
+
+        assert state.dry_run is True
+
+        reloaded = RunState.load("dr-persist", project_dir)
+        assert reloaded.dry_run is True
+
+    def test_resume_restores_dry_run(self, project_dir, monkeypatch):
+        """resume() must restore the persisted dry_run so an interrupted dry-run
+        does not silently turn into a real run."""
+        from specify_cli.workflows.engine import RunState, WorkflowEngine, WorkflowDefinition
+        from specify_cli.workflows.base import RunStatus
+
+        yaml_str = """
+schema_version: "1.0"
+workflow:
+  id: "dryrun-resume"
+  name: "Dry Run Resume"
+  version: "1.0.0"
+steps:
+  - id: only
+    type: gate
+    message: "Continue?"
+    options: ["yes", "no"]
+"""
+        definition = WorkflowDefinition.from_string(yaml_str)
+        engine = WorkflowEngine(project_dir)
+
+        # Persist a paused dry-run with a known run_id, including a copy of
+        # the workflow YAML so resume() can reload the definition.
+        run_id = "dr-resume"
+        state = RunState(run_id=run_id, workflow_id=definition.id, project_root=project_dir)
+        state.status = RunStatus.PAUSED
+        state.dry_run = True
+        state.save()
+        run_dir = project_dir / ".specify" / "workflows" / "runs" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "workflow.yml").write_text(yaml_str, encoding="utf-8")
+
+        captured: dict[str, bool] = {}
+
+        def spy_execute_steps(steps, context, state, registry, *, step_offset=0):
+            captured["dry_run"] = context.dry_run
+            # No-op so resume() returns without further work.
+            return None
+
+        monkeypatch.setattr(engine, "_execute_steps", spy_execute_steps)
+        engine.resume(run_id)
+
+        assert captured.get("dry_run") is True
 
     def test_execute_with_shell_step(self, project_dir):
         from specify_cli.workflows.engine import WorkflowEngine, WorkflowDefinition
@@ -3668,11 +3629,9 @@ class TestWorkflowRegistry:
 class TestWorkflowCatalog:
     """Test WorkflowCatalog catalog resolution."""
 
-    def test_default_catalogs(self, project_dir, monkeypatch):
+    def test_default_catalogs(self, project_dir):
         from specify_cli.workflows.catalog import WorkflowCatalog
 
-        monkeypatch.setattr(Path, "home", lambda: project_dir)
-        monkeypatch.delenv("SPECKIT_WORKFLOW_CATALOG_URL", raising=False)
         catalog = WorkflowCatalog(project_dir)
         entries = catalog.get_active_catalogs()
         assert len(entries) == 2
@@ -3774,78 +3733,6 @@ class TestWorkflowCatalog:
         assert configs[0]["name"] == "default"
         assert isinstance(configs[0]["install_allowed"], bool)
 
-    def test_load_catalog_config_non_dict_yaml_raises(self, project_dir):
-        """A YAML catalog config that is a list (not a mapping) must raise WorkflowValidationError."""
-        from specify_cli.workflows.catalog import WorkflowCatalog, WorkflowValidationError
-
-        config_path = project_dir / ".specify" / "workflow-catalogs.yml"
-        config_path.write_text("- item1\n- item2\n", encoding="utf-8")
-
-        catalog = WorkflowCatalog(project_dir)
-        with pytest.raises(WorkflowValidationError, match="expected a mapping"):
-            catalog.get_active_catalogs()
-
-    def test_add_catalog_malformed_yaml_raises(self, project_dir):
-        """A malformed YAML config file must raise WorkflowValidationError when adding a catalog."""
-        from specify_cli.workflows.catalog import WorkflowCatalog, WorkflowValidationError
-
-        config_path = project_dir / ".specify" / "workflow-catalogs.yml"
-        config_path.write_text(": invalid: yaml: {\n", encoding="utf-8")
-
-        catalog = WorkflowCatalog(project_dir)
-        with pytest.raises(WorkflowValidationError, match="unreadable or malformed"):
-            catalog.add_catalog("https://example.com/new.json")
-
-    def test_remove_catalog_malformed_yaml_raises(self, project_dir):
-        """A malformed YAML config file must raise WorkflowValidationError when removing a catalog."""
-        from specify_cli.workflows.catalog import WorkflowCatalog, WorkflowValidationError
-
-        catalog = WorkflowCatalog(project_dir)
-        catalog.add_catalog("https://example.com/c1.json", "first")
-
-        config_path = project_dir / ".specify" / "workflow-catalogs.yml"
-        config_path.write_text(": bad: yaml: {\n", encoding="utf-8")
-
-        with pytest.raises(WorkflowValidationError, match="unreadable or malformed"):
-            catalog.remove_catalog(0)
-
-    def test_add_catalog_wraps_write_oserror(self, project_dir, monkeypatch):
-        """An OSError on write must be wrapped as WorkflowValidationError."""
-        from specify_cli.workflows.catalog import WorkflowCatalog, WorkflowValidationError
-        import builtins
-
-        catalog = WorkflowCatalog(project_dir)
-        config_path = project_dir / ".specify" / "workflow-catalogs.yml"
-        real_open = builtins.open
-
-        def _raising_open(file, mode="r", *args, **kwargs):
-            if Path(file) == config_path and "w" in mode:
-                raise OSError("simulated write failure")
-            return real_open(file, mode, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "open", _raising_open)
-        with pytest.raises(WorkflowValidationError, match="Failed to write catalog config"):
-            catalog.add_catalog("https://example.com/new-catalog.json", "my-catalog")
-
-    def test_remove_catalog_wraps_write_oserror(self, project_dir, monkeypatch):
-        """An OSError on write must be wrapped as WorkflowValidationError."""
-        from specify_cli.workflows.catalog import WorkflowCatalog, WorkflowValidationError
-        import builtins
-
-        catalog = WorkflowCatalog(project_dir)
-        catalog.add_catalog("https://example.com/c1.json", "first")
-        config_path = project_dir / ".specify" / "workflow-catalogs.yml"
-        real_open = builtins.open
-
-        def _raising_open(file, mode="r", *args, **kwargs):
-            if Path(file) == config_path and "w" in mode:
-                raise OSError("simulated write failure")
-            return real_open(file, mode, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "open", _raising_open)
-        with pytest.raises(WorkflowValidationError, match="Failed to write catalog config"):
-            catalog.remove_catalog(0)
-
 
 # ===== Integration Test =====
 
@@ -3942,933 +3829,6 @@ steps:
         assert "do-specify" not in state.step_results
 
 
-# ===== Step Registry Tests =====
-
-class TestStepRegistryCustom:
-    """Test StepRegistry operations for custom step types."""
-
-    def test_add_and_get(self, project_dir):
-        from specify_cli.workflows.catalog import StepRegistry
-
-        registry = StepRegistry(project_dir)
-        registry.add("deploy", {"name": "Deploy", "version": "1.0.0", "type_key": "deploy"})
-
-        entry = registry.get("deploy")
-        assert entry is not None
-        assert entry["name"] == "Deploy"
-        assert "installed_at" in entry
-
-    def test_add_does_not_mutate_input_metadata(self, project_dir):
-        from specify_cli.workflows.catalog import StepRegistry
-
-        registry = StepRegistry(project_dir)
-        metadata = {
-            "name": "Deploy",
-            "type_key": "deploy",
-            "nested": {"key": "original"},
-        }
-
-        registry.add("deploy", metadata)
-
-        assert "installed_at" not in metadata
-        assert "updated_at" not in metadata
-        metadata["nested"]["key"] = "changed-after-add"
-        assert registry.get("deploy")["nested"]["key"] == "original"
-
-    def test_remove(self, project_dir):
-        from specify_cli.workflows.catalog import StepRegistry
-
-        registry = StepRegistry(project_dir)
-        registry.add("deploy", {"name": "Deploy", "type_key": "deploy"})
-        assert registry.is_installed("deploy")
-
-        registry.remove("deploy")
-        assert not registry.is_installed("deploy")
-
-    def test_remove_missing_returns_false(self, project_dir):
-        from specify_cli.workflows.catalog import StepRegistry
-
-        registry = StepRegistry(project_dir)
-        removed = registry.remove("nonexistent")
-        assert removed is False
-
-    def test_list(self, project_dir):
-        from specify_cli.workflows.catalog import StepRegistry
-
-        registry = StepRegistry(project_dir)
-        registry.add("step-a", {"name": "A", "type_key": "step-a"})
-        registry.add("step-b", {"name": "B", "type_key": "step-b"})
-
-        installed = registry.list()
-        assert "step-a" in installed
-        assert "step-b" in installed
-
-    def test_is_installed(self, project_dir):
-        from specify_cli.workflows.catalog import StepRegistry
-
-        registry = StepRegistry(project_dir)
-        assert not registry.is_installed("missing")
-
-        registry.add("exists", {"name": "Exists", "type_key": "exists"})
-        assert registry.is_installed("exists")
-
-    def test_persistence(self, project_dir):
-        from specify_cli.workflows.catalog import StepRegistry
-
-        registry1 = StepRegistry(project_dir)
-        registry1.add("deploy", {"name": "Deploy", "type_key": "deploy"})
-
-        registry2 = StepRegistry(project_dir)
-        assert registry2.is_installed("deploy")
-
-    def test_corrupted_registry_resets(self, project_dir):
-        from specify_cli.workflows.catalog import StepRegistry
-
-        registry = StepRegistry(project_dir)
-        registry.steps_dir.mkdir(parents=True, exist_ok=True)
-        registry.registry_path.write_text("not json", encoding="utf-8")
-
-        # Loading again should reset
-        registry2 = StepRegistry(project_dir)
-        assert registry2.list() == {}
-
-    def test_registry_missing_steps_key_resets(self, project_dir):
-        """Valid JSON but missing 'steps' key should not crash add/get."""
-        from specify_cli.workflows.catalog import StepRegistry
-        import json as _json
-
-        registry = StepRegistry(project_dir)
-        registry.steps_dir.mkdir(parents=True, exist_ok=True)
-        # Valid JSON but 'steps' is not a dict
-        registry.registry_path.write_text(
-            _json.dumps({"schema_version": "1.0", "steps": "bad"}),
-            encoding="utf-8",
-        )
-
-        registry2 = StepRegistry(project_dir)
-        # Should be safe to call add/get without KeyError
-        assert registry2.list() == {}
-        registry2.add("deploy", {"name": "Deploy", "type_key": "deploy"})
-        assert registry2.is_installed("deploy")
-
-    @pytest.mark.skipif(sys.platform == "win32", reason="chmod not reliable on Windows")
-    def test_registry_unreadable_file_resets(self, project_dir):
-        """OSError reading the registry file should fall back to default."""
-        from specify_cli.workflows.catalog import StepRegistry
-        import json as _json
-
-        registry = StepRegistry(project_dir)
-        registry.steps_dir.mkdir(parents=True, exist_ok=True)
-        # Write valid registry first
-        registry.registry_path.write_text(
-            _json.dumps({"schema_version": "1.0", "steps": {"existing": {}}}),
-            encoding="utf-8",
-        )
-        # Make it unreadable
-        registry.registry_path.chmod(0o000)
-        try:
-            registry2 = StepRegistry(project_dir)
-            assert registry2.list() == {}
-        finally:
-            registry.registry_path.chmod(0o644)
-
-        # After restoring permissions the registry is fully functional
-        registry2.add("deploy", {"name": "Deploy", "type_key": "deploy"})
-        assert registry2.is_installed("deploy")
-
-    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
-    def test_registry_load_refuses_symlinked_steps_dir(self, project_dir):
-        """A symlinked steps directory must not be read from (defense-in-depth)."""
-        from specify_cli.workflows.catalog import StepRegistry
-        import json as _json
-
-        outside = project_dir.parent / "outside-steps"
-        outside.mkdir(parents=True, exist_ok=True)
-        (outside / "step-registry.json").write_text(
-            _json.dumps({"schema_version": "1.0", "steps": {"evil": {}}}),
-            encoding="utf-8",
-        )
-        steps_link = project_dir / ".specify" / "workflows" / "steps"
-        steps_link.symlink_to(outside, target_is_directory=True)
-
-        registry = StepRegistry(project_dir)
-        assert registry.list() == {}
-
-    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
-    def test_registry_save_refuses_symlinked_steps_dir(self, project_dir):
-        """save() must refuse symlinked registry paths (defense-in-depth)."""
-        from specify_cli.workflows.catalog import StepRegistry, StepValidationError
-
-        outside = project_dir.parent / "outside-steps-save"
-        outside.mkdir(parents=True, exist_ok=True)
-        steps_link = project_dir / ".specify" / "workflows" / "steps"
-        steps_link.symlink_to(outside, target_is_directory=True)
-
-        registry = StepRegistry(project_dir)
-        with pytest.raises(StepValidationError, match="symlinked path"):
-            registry.save()
-
-
-# ===== Step Catalog Tests =====
-
-class TestStepCatalog:
-    """Test StepCatalog catalog resolution."""
-
-    def test_default_catalogs(self, project_dir, monkeypatch):
-        from specify_cli.workflows.catalog import StepCatalog
-
-        monkeypatch.setattr(Path, "home", lambda: project_dir)
-        monkeypatch.delenv("SPECKIT_STEP_CATALOG_URL", raising=False)
-        catalog = StepCatalog(project_dir)
-        entries = catalog.get_active_catalogs()
-        assert len(entries) == 2
-        assert entries[0].name == "default"
-        assert entries[1].name == "community"
-
-    def test_env_var_override(self, project_dir, monkeypatch):
-        from specify_cli.workflows.catalog import StepCatalog
-
-        monkeypatch.setenv("SPECKIT_STEP_CATALOG_URL", "https://example.com/step-catalog.json")
-        catalog = StepCatalog(project_dir)
-        entries = catalog.get_active_catalogs()
-        assert len(entries) == 1
-        assert entries[0].name == "env-override"
-        assert entries[0].url == "https://example.com/step-catalog.json"
-
-    def test_project_level_config(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog
-
-        config_path = project_dir / ".specify" / "step-catalogs.yml"
-        config_path.write_text(yaml.dump({
-            "catalogs": [{
-                "name": "custom",
-                "url": "https://example.com/step-catalog.json",
-                "priority": 1,
-                "install_allowed": True,
-            }]
-        }))
-
-        catalog = StepCatalog(project_dir)
-        entries = catalog.get_active_catalogs()
-        assert len(entries) == 1
-        assert entries[0].name == "custom"
-
-    def test_validate_url_http_rejected(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
-
-        catalog = StepCatalog(project_dir)
-        with pytest.raises(StepValidationError, match="HTTPS"):
-            catalog._validate_catalog_url("http://evil.com/step-catalog.json")
-
-    def test_validate_url_localhost_http_allowed(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog
-
-        catalog = StepCatalog(project_dir)
-        # Should not raise
-        catalog._validate_catalog_url("http://localhost:8080/step-catalog.json")
-
-    def test_add_catalog(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog
-
-        catalog = StepCatalog(project_dir)
-        catalog.add_catalog("https://example.com/new-steps.json", "my-steps")
-
-        config_path = project_dir / ".specify" / "step-catalogs.yml"
-        assert config_path.exists()
-        data = yaml.safe_load(config_path.read_text())
-        assert len(data["catalogs"]) == 1
-        assert data["catalogs"][0]["url"] == "https://example.com/new-steps.json"
-
-    def test_add_catalog_empty_yaml_file(self, project_dir):
-        """An empty YAML config file should be treated as empty, not corrupted."""
-        from specify_cli.workflows.catalog import StepCatalog
-
-        config_path = project_dir / ".specify" / "step-catalogs.yml"
-        config_path.write_text("", encoding="utf-8")
-
-        catalog = StepCatalog(project_dir)
-        # Should not raise StepValidationError "corrupted"
-        catalog.add_catalog("https://example.com/steps.json", "my-steps")
-
-        data = yaml.safe_load(config_path.read_text())
-        assert len(data["catalogs"]) == 1
-        assert data["catalogs"][0]["url"] == "https://example.com/steps.json"
-
-    def test_add_catalog_duplicate_rejected(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
-
-        catalog = StepCatalog(project_dir)
-        catalog.add_catalog("https://example.com/steps.json")
-
-        with pytest.raises(StepValidationError, match="already configured"):
-            catalog.add_catalog("https://example.com/steps.json")
-
-    def test_remove_catalog(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog
-
-        catalog = StepCatalog(project_dir)
-        catalog.add_catalog("https://example.com/s1.json", "first")
-        catalog.add_catalog("https://example.com/s2.json", "second")
-
-        removed = catalog.remove_catalog(0)
-        assert removed == "first"
-
-        config_path = project_dir / ".specify" / "step-catalogs.yml"
-        data = yaml.safe_load(config_path.read_text())
-        assert len(data["catalogs"]) == 1
-
-    def test_remove_catalog_invalid_index(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
-
-        catalog = StepCatalog(project_dir)
-        catalog.add_catalog("https://example.com/s1.json")
-
-        with pytest.raises(StepValidationError, match="out of range"):
-            catalog.remove_catalog(5)
-
-    def test_remove_catalog_no_config(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
-
-        catalog = StepCatalog(project_dir)
-        with pytest.raises(StepValidationError, match="No step catalog config file found"):
-            catalog.remove_catalog(0)
-
-    def test_add_catalog_wraps_write_oserror(self, project_dir, monkeypatch):
-        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
-        import builtins
-
-        catalog = StepCatalog(project_dir)
-        config_path = project_dir / ".specify" / "step-catalogs.yml"
-        real_open = builtins.open
-
-        def _raising_open(file, mode="r", *args, **kwargs):
-            if Path(file) == config_path and "w" in mode:
-                raise OSError("simulated write failure")
-            return real_open(file, mode, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "open", _raising_open)
-        with pytest.raises(StepValidationError, match="Failed to write catalog config"):
-            catalog.add_catalog("https://example.com/new-steps.json", "my-steps")
-
-    def test_remove_catalog_wraps_write_oserror(self, project_dir, monkeypatch):
-        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
-        import builtins
-
-        catalog = StepCatalog(project_dir)
-        catalog.add_catalog("https://example.com/s1.json", "first")
-        config_path = project_dir / ".specify" / "step-catalogs.yml"
-        real_open = builtins.open
-
-        def _raising_open(file, mode="r", *args, **kwargs):
-            if Path(file) == config_path and "w" in mode:
-                raise OSError("simulated write failure")
-            return real_open(file, mode, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "open", _raising_open)
-        with pytest.raises(StepValidationError, match="Failed to write catalog config"):
-            catalog.remove_catalog(0)
-
-    def test_get_catalog_configs(self, project_dir):
-        from specify_cli.workflows.catalog import StepCatalog
-
-        catalog = StepCatalog(project_dir)
-        configs = catalog.get_catalog_configs()
-        assert len(configs) == 2
-        assert configs[0]["name"] == "default"
-        assert isinstance(configs[0]["install_allowed"], bool)
-
-    def test_search_with_mock_catalog(self, project_dir, monkeypatch):
-        from specify_cli.workflows.catalog import StepCatalog
-
-        mock_data = {
-            "schema_version": "1.0",
-            "steps": {
-                "deploy": {
-                    "id": "deploy",
-                    "name": "Deploy Step",
-                    "description": "Deploy to production",
-                    "version": "1.0.0",
-                },
-                "notify": {
-                    "id": "notify",
-                    "name": "Notify Step",
-                    "description": "Send notifications",
-                    "version": "1.0.0",
-                },
-            },
-        }
-
-        catalog = StepCatalog(project_dir)
-        monkeypatch.setattr(catalog, "_get_merged_steps", lambda **kw: {
-            "deploy": dict(mock_data["steps"]["deploy"], _catalog_name="test", _install_allowed=True),
-            "notify": dict(mock_data["steps"]["notify"], _catalog_name="test", _install_allowed=True),
-        })
-
-        results = catalog.search()
-        assert len(results) == 2
-
-        results = catalog.search(query="deploy")
-        assert len(results) == 1
-        assert results[0]["id"] == "deploy"
-
-    def test_search_with_non_string_fields(self, project_dir, monkeypatch):
-        """Non-string catalog fields (e.g. integer id) must not raise TypeError."""
-        from specify_cli.workflows.catalog import StepCatalog
-
-        catalog = StepCatalog(project_dir)
-        monkeypatch.setattr(catalog, "_get_merged_steps", lambda **kw: {
-            "42": {
-                "id": 42,
-                "name": None,
-                "description": 99,
-                "_catalog_name": "test",
-                "_install_allowed": True,
-            },
-        })
-
-        results = catalog.search()
-        assert len(results) == 1
-
-        results = catalog.search(query="42")
-        assert len(results) == 1
-
-        results = catalog.search(query="missing")
-        assert len(results) == 0
-
-    def test_get_merged_steps_normalizes_list_ids_to_strings(self, project_dir, monkeypatch):
-        """List-based catalog entries with non-string ids must be normalized."""
-        from specify_cli.workflows.catalog import StepCatalog, StepCatalogEntry
-
-        catalog = StepCatalog(project_dir)
-        entry = StepCatalogEntry(
-            name="test",
-            url="https://example.com/steps.json",
-            priority=1,
-            install_allowed=True,
-        )
-        monkeypatch.setattr(catalog, "get_active_catalogs", lambda: [entry])
-        monkeypatch.setattr(
-            catalog,
-            "_fetch_single_catalog",
-            lambda _entry, _force_refresh=False: {
-                "steps": [{"id": 42, "name": "Integer ID"}]
-            },
-        )
-
-        merged = catalog._get_merged_steps()
-        assert "42" in merged
-        assert 42 not in merged
-        assert merged["42"]["id"] == "42"
-
-    def test_get_step_info_returns_entry_or_none(self, project_dir, monkeypatch):
-        """get_step_info returns matching entry or None for missing ids."""
-        from specify_cli.workflows.catalog import StepCatalog
-
-        catalog = StepCatalog(project_dir)
-        monkeypatch.setattr(catalog, "_get_merged_steps", lambda **kw: {
-            "deploy": {
-                "id": "deploy",
-                "name": "Deploy Step",
-                "version": "1.0.0",
-                "_catalog_name": "test",
-                "_install_allowed": True,
-            },
-        })
-
-        info = catalog.get_step_info("deploy")
-        assert info is not None
-        assert info["name"] == "Deploy Step"
-
-        missing = catalog.get_step_info("nonexistent")
-        assert missing is None
-
-
-# ===== Load Custom Steps Tests =====
-
-class TestLoadCustomSteps:
-    """Test dynamic loading of custom step types from the filesystem."""
-
-    def test_empty_steps_dir(self, project_dir):
-        from specify_cli.workflows import load_custom_steps
-
-        loaded = load_custom_steps(project_dir)
-        assert loaded == []
-
-    def test_no_steps_dir(self, project_dir):
-        from specify_cli.workflows import load_custom_steps
-
-        # .specify/workflows/steps does not exist
-        loaded = load_custom_steps(project_dir)
-        assert loaded == []
-
-    def test_load_valid_custom_step(self, project_dir):
-        from specify_cli.workflows import load_custom_steps, STEP_REGISTRY
-
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "test-custom"
-        step_dir.mkdir(parents=True)
-
-        step_yml = """
-schema_version: "1.0"
-step:
-  type_key: "test-custom"
-  name: "Test Custom Step"
-  version: "1.0.0"
-  author: "test"
-  description: "A test custom step"
-"""
-        (step_dir / "step.yml").write_text(step_yml, encoding="utf-8")
-
-        init_py = """
-from specify_cli.workflows.base import StepBase, StepResult
-
-class TestCustomStep(StepBase):
-    type_key = "test-custom"
-
-    def execute(self, config, context):
-        return StepResult()
-"""
-        (step_dir / "__init__.py").write_text(init_py, encoding="utf-8")
-
-        loaded = load_custom_steps(project_dir)
-        assert "test-custom" in loaded
-        assert "test-custom" in STEP_REGISTRY
-
-    def test_skip_missing_step_yml(self, project_dir):
-        from specify_cli.workflows import load_custom_steps
-
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "bad-step"
-        step_dir.mkdir(parents=True)
-        (step_dir / "__init__.py").write_text("# no step.yml", encoding="utf-8")
-
-        loaded = load_custom_steps(project_dir)
-        assert "bad-step" not in loaded
-
-    def test_skip_missing_init_py(self, project_dir):
-        from specify_cli.workflows import load_custom_steps
-
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "bad-step2"
-        step_dir.mkdir(parents=True)
-        (step_dir / "step.yml").write_text(
-            "step:\n  type_key: bad-step2\n", encoding="utf-8"
-        )
-
-        loaded = load_custom_steps(project_dir)
-        assert "bad-step2" not in loaded
-
-    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
-    def test_skip_symlinked_step_files(self, project_dir):
-        from specify_cli.workflows import load_custom_steps
-
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "bad-symlinked-files"
-        step_dir.mkdir(parents=True)
-
-        outside = project_dir.parent / "outside-step-files"
-        outside.mkdir(parents=True, exist_ok=True)
-        step_yml_target = outside / "step.yml"
-        step_yml_target.write_text("step:\n  type_key: bad-symlinked-files\n", encoding="utf-8")
-        init_target = outside / "__init__.py"
-        init_target.write_text("# external code", encoding="utf-8")
-
-        (step_dir / "step.yml").symlink_to(step_yml_target)
-        (step_dir / "__init__.py").symlink_to(init_target)
-
-        loaded = load_custom_steps(project_dir)
-        assert "bad-symlinked-files" not in loaded
-
-    def test_skip_already_registered(self, project_dir):
-        from specify_cli.workflows import load_custom_steps
-
-        # "command" is already registered as a built-in step
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "command"
-        step_dir.mkdir(parents=True)
-        (step_dir / "step.yml").write_text(
-            "step:\n  type_key: command\n", encoding="utf-8"
-        )
-        (step_dir / "__init__.py").write_text("", encoding="utf-8")
-
-        # Should not raise KeyError; just skip
-        loaded = load_custom_steps(project_dir)
-        assert "command" not in loaded
-
-    def test_skip_broken_init_py(self, project_dir):
-        from specify_cli.workflows import load_custom_steps
-
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "broken-step"
-        step_dir.mkdir(parents=True)
-        (step_dir / "step.yml").write_text(
-            "step:\n  type_key: broken-step\n", encoding="utf-8"
-        )
-        (step_dir / "__init__.py").write_text(
-            "raise RuntimeError('broken')", encoding="utf-8"
-        )
-
-        # Should not propagate exception
-        loaded = load_custom_steps(project_dir)
-        assert "broken-step" not in loaded
-
-    def test_module_name_sanitized_for_hyphenated_type_key(self, project_dir):
-        """type_key values with hyphens produce valid Python module identifiers."""
-        import hashlib
-        import sys
-        from specify_cli.workflows import load_custom_steps, STEP_REGISTRY
-
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "my-hyphen-step"
-        step_dir.mkdir(parents=True)
-        (step_dir / "step.yml").write_text(
-            "step:\n  type_key: my-hyphen-step\n  name: Hyphen Step\n",
-            encoding="utf-8",
-        )
-
-        init_py = """
-from specify_cli.workflows.base import StepBase, StepResult
-
-class HyphenStep(StepBase):
-    type_key = "my-hyphen-step"
-
-    def execute(self, config, context):
-        return StepResult()
-"""
-        (step_dir / "__init__.py").write_text(init_py, encoding="utf-8")
-
-        loaded = load_custom_steps(project_dir)
-        assert "my-hyphen-step" in loaded
-        assert "my-hyphen-step" in STEP_REGISTRY
-        # Synthetic module name must be a valid identifier (hyphens → underscores)
-        # and include a collision-resistant hash suffix.
-        key_hash = hashlib.sha256(b"my-hyphen-step").hexdigest()[:8]
-        module_name = f"_speckit_custom_step_my_hyphen_step_{key_hash}"
-        assert module_name in sys.modules
-
-    def test_package_relative_import(self, project_dir):
-        """Steps can use relative imports to access sibling modules."""
-        import hashlib
-        import sys
-        from specify_cli.workflows import load_custom_steps, STEP_REGISTRY
-
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "pkg-step"
-        step_dir.mkdir(parents=True)
-        (step_dir / "step.yml").write_text(
-            "step:\n  type_key: pkg-step\n  name: Package Step\n",
-            encoding="utf-8",
-        )
-        # Helper module that the step will import relatively
-        (step_dir / "helpers.py").write_text(
-            "HELPER_VALUE = 'hello'\n", encoding="utf-8"
-        )
-        init_py = """
-from specify_cli.workflows.base import StepBase, StepResult
-from .helpers import HELPER_VALUE
-
-class PkgStep(StepBase):
-    type_key = "pkg-step"
-    helper = HELPER_VALUE
-
-    def execute(self, config, context):
-        return StepResult()
-"""
-        (step_dir / "__init__.py").write_text(init_py, encoding="utf-8")
-
-        loaded = load_custom_steps(project_dir)
-        assert "pkg-step" in loaded
-        assert "pkg-step" in STEP_REGISTRY
-        # Verify the relative import actually resolved; module name includes hash suffix.
-        key_hash = hashlib.sha256(b"pkg-step").hexdigest()[:8]
-        module_name = f"_speckit_custom_step_pkg_step_{key_hash}"
-        assert module_name in sys.modules
-        assert sys.modules[module_name].PkgStep.helper == "hello"
-
-    def test_module_name_collision_resistance(self, project_dir):
-        """'a-b' and 'a_b' produce different module names despite the same sanitized form."""
-        import hashlib
-
-        # Simulate the module name generation for two type_keys that sanitize the same way
-        def make_module_name(type_key: str) -> str:
-            import re
-            safe_key = re.sub(r"[^A-Za-z0-9_]", "_", type_key)
-            key_hash = hashlib.sha256(type_key.encode()).hexdigest()[:8]
-            return f"_speckit_custom_step_{safe_key}_{key_hash}"
-
-        name_a = make_module_name("a-b")
-        name_b = make_module_name("a_b")
-        assert name_a != name_b, "Module names for 'a-b' and 'a_b' must differ"
-
-
-# ===== CLI Step Remove Tests =====
-
-class TestWorkflowStepRemoveCLI:
-    """Test the 'specify workflow step remove' CLI command edge cases."""
-
-    def test_remove_orphaned_directory(self, project_dir, monkeypatch):
-        """step remove works when directory exists but registry entry is missing.
-
-        This covers the case where the registry was reset due to corruption.
-        """
-        from typer.testing import CliRunner
-        from specify_cli import app
-
-        monkeypatch.chdir(project_dir)
-
-        # Create an orphaned step directory (no registry entry)
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "orphan-step"
-        step_dir.mkdir(parents=True)
-        (step_dir / "step.yml").write_text(
-            "step:\n  type_key: orphan-step\n", encoding="utf-8"
-        )
-        (step_dir / "__init__.py").write_text("", encoding="utf-8")
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "step", "remove", "orphan-step"])
-
-        assert result.exit_code == 0, result.output
-        assert not step_dir.exists()
-        # Warning should be printed about missing registry entry
-        assert "Warning" in result.output or "warning" in result.output.lower()
-
-    def test_remove_not_installed(self, project_dir, monkeypatch):
-        """step remove fails cleanly when neither directory nor registry entry exist."""
-        from typer.testing import CliRunner
-        from specify_cli import app
-
-        monkeypatch.chdir(project_dir)
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "step", "remove", "ghost-step"])
-
-        assert result.exit_code != 0
-        assert "not installed" in result.output
-
-    def test_remove_registered_step(self, project_dir, monkeypatch):
-        """step remove works normally when both directory and registry entry exist."""
-        from typer.testing import CliRunner
-        from specify_cli import app
-        from specify_cli.workflows.catalog import StepRegistry
-
-        monkeypatch.chdir(project_dir)
-
-        # Set up a registered step with a directory
-        registry = StepRegistry(project_dir)
-        registry.add("my-step", {"name": "My Step", "type_key": "my-step", "version": "1.0.0"})
-        step_dir = project_dir / ".specify" / "workflows" / "steps" / "my-step"
-        step_dir.mkdir(parents=True)
-        (step_dir / "step.yml").write_text(
-            "step:\n  type_key: my-step\n", encoding="utf-8"
-        )
-        (step_dir / "__init__.py").write_text("", encoding="utf-8")
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "step", "remove", "my-step"])
-
-        assert result.exit_code == 0, result.output
-        assert not step_dir.exists()
-        registry2 = StepRegistry(project_dir)
-        assert not registry2.is_installed("my-step")
-
-    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
-    def test_remove_rejects_symlinked_steps_base_dir(self, project_dir, monkeypatch):
-        from typer.testing import CliRunner
-        from specify_cli import app
-
-        monkeypatch.chdir(project_dir)
-        outside = project_dir.parent / "outside-steps"
-        outside.mkdir(parents=True, exist_ok=True)
-        steps_link = project_dir / ".specify" / "workflows" / "steps"
-        steps_link.symlink_to(outside, target_is_directory=True)
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "step", "remove", "my-step"])
-
-        assert result.exit_code != 0
-        assert "Refusing to use symlinked step directory" in result.output
-
-
-class TestWorkflowStepAddCLI:
-    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
-    def test_add_rejects_symlinked_steps_base_dir(self, project_dir, monkeypatch):
-        from typer.testing import CliRunner
-        from specify_cli import app
-        from specify_cli.workflows.catalog import StepCatalog
-
-        monkeypatch.chdir(project_dir)
-        outside = project_dir.parent / "outside-steps"
-        outside.mkdir(parents=True, exist_ok=True)
-        steps_link = project_dir / ".specify" / "workflows" / "steps"
-        steps_link.symlink_to(outside, target_is_directory=True)
-
-        def _fake_get_step_info(self, step_id):
-            return {
-                "id": step_id,
-                "name": "Test Step",
-                "url": "https://example.com/step.yml",
-                "init_url": "https://example.com/__init__.py",
-                "_install_allowed": True,
-            }
-
-        monkeypatch.setattr(StepCatalog, "get_step_info", _fake_get_step_info)
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "step", "add", "my-step"])
-
-        assert result.exit_code != 0
-        assert "Refusing to use symlinked step directory" in result.output
-
-    def test_add_rejects_non_string_extra_files_key(self, project_dir, monkeypatch):
-        from typer.testing import CliRunner
-        from specify_cli import app
-        from specify_cli.workflows.catalog import StepCatalog
-        from specify_cli.authentication import http as auth_http
-
-        monkeypatch.chdir(project_dir)
-
-        def _fake_get_step_info(self, step_id):
-            return {
-                "id": step_id,
-                "name": "Test Step",
-                "url": "https://example.com/step.yml",
-                "init_url": "https://example.com/__init__.py",
-                "_install_allowed": True,
-                "extra_files": {
-                    123: "https://example.com/helper.py",
-                },
-            }
-
-        class _FakeResponse:
-            def __init__(self, url: str):
-                self.url = url
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def read(self):
-                if self.url.endswith("/step.yml"):
-                    return b"step:\n  type_key: my-step\n"
-                return b""
-
-            def geturl(self):
-                return self.url
-
-        def _fake_open_url(url, timeout=30):
-            return _FakeResponse(url)
-
-        monkeypatch.setattr(StepCatalog, "get_step_info", _fake_get_step_info)
-        monkeypatch.setattr(auth_http, "open_url", _fake_open_url)
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "step", "add", "my-step"])
-
-        assert result.exit_code != 0
-        assert "non-string path key" in result.output
-
-    @pytest.mark.parametrize(
-        "rel_path,expected",
-        [
-            ("", "empty or non-string path key"),
-            (".", "not a valid relative file path"),
-            ("..", "not a valid relative file path"),
-            ("sub/../x", "not a valid relative file path"),
-        ],
-    )
-    def test_add_rejects_invalid_extra_files_path(
-        self, project_dir, monkeypatch, rel_path, expected
-    ):
-        from typer.testing import CliRunner
-        from specify_cli import app
-        from specify_cli.workflows.catalog import StepCatalog
-        from specify_cli.authentication import http as auth_http
-
-        monkeypatch.chdir(project_dir)
-
-        def _fake_get_step_info(self, step_id):
-            return {
-                "id": step_id,
-                "name": "Test Step",
-                "url": "https://example.com/step.yml",
-                "init_url": "https://example.com/__init__.py",
-                "_install_allowed": True,
-                "extra_files": {rel_path: "https://example.com/helper.py"},
-            }
-
-        class _FakeResponse:
-            def __init__(self, url: str):
-                self.url = url
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def read(self):
-                if self.url.endswith("/step.yml"):
-                    return b"step:\n  type_key: my-step\n"
-                return b""
-
-            def geturl(self):
-                return self.url
-
-        def _fake_open_url(url, timeout=30):
-            return _FakeResponse(url)
-
-        monkeypatch.setattr(StepCatalog, "get_step_info", _fake_get_step_info)
-        monkeypatch.setattr(auth_http, "open_url", _fake_open_url)
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "step", "add", "my-step"])
-
-        assert result.exit_code != 0
-        assert expected in result.output
-
-    def test_add_rejects_non_string_extra_files_url(self, project_dir, monkeypatch):
-        from typer.testing import CliRunner
-        from specify_cli import app
-        from specify_cli.workflows.catalog import StepCatalog
-        from specify_cli.authentication import http as auth_http
-
-        monkeypatch.chdir(project_dir)
-
-        def _fake_get_step_info(self, step_id):
-            return {
-                "id": step_id,
-                "name": "Test Step",
-                "url": "https://example.com/step.yml",
-                "init_url": "https://example.com/__init__.py",
-                "_install_allowed": True,
-                "extra_files": {"helper.py": None},
-            }
-
-        class _FakeResponse:
-            def __init__(self, url: str):
-                self.url = url
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def read(self):
-                if self.url.endswith("/step.yml"):
-                    return b"step:\n  type_key: my-step\n"
-                return b""
-
-            def geturl(self):
-                return self.url
-
-        def _fake_open_url(url, timeout=30):
-            return _FakeResponse(url)
-
-        monkeypatch.setattr(StepCatalog, "get_step_info", _fake_get_step_info)
-        monkeypatch.setattr(auth_http, "open_url", _fake_open_url)
-
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "step", "add", "my-step"])
-
-        assert result.exit_code != 0
-        assert "empty or non-string URL" in result.output
-
-
 class TestWorkflowJsonOutput:
     """Test the --json machine-readable output for run/resume/status."""
 
@@ -4950,6 +3910,143 @@ steps:
         assert "Running workflow" in result.stdout
         with pytest.raises(json.JSONDecodeError):
             json.loads(result.stdout)
+
+    def test_run_dry_run_flag_wires_through_cli(self, project_dir):
+        """`specify workflow run --dry-run` emits the DRY-RUN banner and
+        per-step previews, and crucially does NOT block on a gate step
+        (the engine short-circuits gates in dry-run mode).
+        Covers the user-facing entrypoint the engine-level tests miss.
+        """
+        # Use the gated workflow ``_WF`` — without --dry-run this would
+        # pause on the gate and require a resume. With --dry-run the
+        # gate is short-circuited, the run completes end-to-end, and
+        # the DRY-RUN banner + per-step preview lines are emitted.
+        wf = self._write_wf(project_dir, self._WF, "dry")
+        result = self._invoke(project_dir, ["workflow", "run", str(wf), "--dry-run"])
+        assert result.exit_code == 0
+        # Banner is printed to stdout in default (non-JSON) mode.
+        assert "DRY RUN" in result.stdout
+        # The preview loop printed the step_id of the gated step and
+        # its rendered dry-run body. GateStep in dry-run mode emits a
+        # ``[DRY RUN] Gate: ...`` body (see workflows/steps/gate).
+        assert "ask" in result.stdout
+        assert "[DRY RUN]" in result.stdout
+        # Status is reported as completed (dry-run short-circuits the
+        # gate to COMPLETED rather than PAUSED).
+        assert "Status: completed" in result.stdout
+        # The "Resume with:" hint that would appear for a paused run
+        # must NOT be present — the dry-run completed end-to-end.
+        assert "Resume with:" not in result.stdout
+
+    def test_run_dry_run_with_json_suppresses_banner_and_previews(self, project_dir):
+        """`--dry-run` together with `--json` must NOT print the banner
+        or the per-step preview lines — stdout stays a single JSON object.
+        Mirrors the help text claim added in commit for review 3391287191.
+        """
+        wf = self._write_wf(project_dir, self._WF, "dry-json")
+        result = self._invoke(
+            project_dir, ["workflow", "run", str(wf), "--dry-run", "--json"]
+        )
+        assert result.exit_code == 0
+        # Stdout is exactly a JSON object — no DRY-RUN banner or preview
+        # lines leaked in.
+        assert "DRY RUN" not in result.stdout
+        assert "[DRY RUN]" not in result.stdout
+        payload = json.loads(result.stdout)
+        # And the run still completed end-to-end (gate short-circuited).
+        assert payload["status"] == "completed"
+
+    def test_run_dry_run_prints_previews_on_engine_exception(self, project_dir):
+        """When the engine raises mid-run, the dry-run previews that
+        earlier steps already resolved into ``state.step_results`` are
+        still the most useful debug signal — they must surface in the
+        terminal, not be silently dropped. Covers review 3423394535.
+        """
+        wf = self._write_wf(project_dir, self._WF, "dry-fail")
+
+        from unittest.mock import patch
+        from specify_cli.workflows.base import RunStatus
+        from specify_cli.workflows.engine import RunState
+
+        def _raise_with_partial(self, *_args, **_kwargs):
+            state = RunState(run_id="dr-fail-partial", workflow_id="json-wf")
+            state.step_results["ask"] = {
+                "output": {
+                    "dry_run": True,
+                    "dry_run_message": "[DRY RUN] Gate: Review",
+                    "message": "[DRY RUN] Gate: Review",
+                }
+            }
+            state.status = RunStatus.FAILED
+            err = RuntimeError("synthetic engine failure mid-dry-run")
+            err.partial_state = state  # type: ignore[attr-defined]
+            raise err
+
+        with patch.object(
+            __import__(
+                "specify_cli.workflows.engine", fromlist=["WorkflowEngine"]
+            ).WorkflowEngine,
+            "execute",
+            _raise_with_partial,
+        ):
+            result = self._invoke(
+                project_dir, ["workflow", "run", str(wf), "--dry-run"]
+            )
+
+        # The CLI exits non-zero on the engine exception.
+        assert result.exit_code != 0
+        # The error banner is shown.
+        assert "Workflow failed" in result.stdout
+        # The previously-resolved dry-run previews are still printed —
+        # the engine exception path must not silently drop them.
+        assert "DRY RUN" in result.stdout
+        assert "Gate: Review" in result.stdout
+
+    def test_run_dry_run_no_previews_when_json(self, project_dir):
+        """``--json`` mode must not leak dry-run previews even on
+        engine exception — the stdout-stays-JSON contract holds
+        in the failure path too. Mirrors the success-path test
+        ``test_run_dry_run_with_json_suppresses_banner_and_previews``.
+        """
+        wf = self._write_wf(project_dir, self._WF, "dry-fail-json")
+
+        from unittest.mock import patch
+        from specify_cli.workflows.base import RunStatus
+        from specify_cli.workflows.engine import RunState
+
+        def _raise_with_partial(self, *_args, **_kwargs):
+            state = RunState(run_id="dr-fail-json", workflow_id="json-wf")
+            state.step_results["ask"] = {
+                "output": {
+                    "dry_run": True,
+                    "dry_run_message": "[DRY RUN] Gate: Review",
+                    "message": "[DRY RUN] Gate: Review",
+                }
+            }
+            state.status = RunStatus.FAILED
+            err = RuntimeError("synthetic engine failure mid-dry-run")
+            err.partial_state = state  # type: ignore[attr-defined]
+            raise err
+
+        with patch.object(
+            __import__(
+                "specify_cli.workflows.engine", fromlist=["WorkflowEngine"]
+            ).WorkflowEngine,
+            "execute",
+            _raise_with_partial,
+        ):
+            result = self._invoke(
+                project_dir,
+                ["workflow", "run", str(wf), "--dry-run", "--json"],
+            )
+
+        # CLI exits non-zero on the engine exception.
+        assert result.exit_code != 0
+        # Stdout is empty (or near-empty) — no banner, no preview lines.
+        # Under --json the engine exception short-circuits before any
+        # _emit_workflow_json call so the user sees a clean error path.
+        assert "DRY RUN" not in result.stdout
+        assert "[DRY RUN]" not in result.stdout
 
     def test_status_json_single_and_list(self, project_dir):
         wf = self._write_wf(project_dir, self._WF, "gated2")


### PR DESCRIPTION
## Summary

Implements issue #2661 — add a `--dry-run` flag to `specify workflow run` that previews each step's resolved inputs, prompt, and command invocation without spawning the underlying coding-agent CLI or making any AI calls. Use it to verify what a workflow would dispatch before running for real.

## What ships

**Engine**
- `src/specify_cli/workflows/base.py`: `StepContext` gains `dry_run: bool = False`
- `src/specify_cli/workflows/engine.py`:
  - `WorkflowEngine.execute(..., dry_run=False)` propagates the flag to every step
  - Persists `dry_run` on `RunState` (save/load) and restores it in `resume()` so an interrupted dry-run does not silently become a real run
  - `dry_run` semantics documented in the `execute()` docstring

**Step behavior**
- `CommandStep` (`workflows/steps/command/`): `dry_run=True` renders the integration's `build_command_invocation(command, args)` preview, sets `exit_code=0`, returns `COMPLETED` without spawning the CLI
- `GateStep` (`workflows/steps/gate/`): `dry_run=True` returns `COMPLETED` immediately with a short DRY RUN message; no interactive prompt
- Graceful fallback when an integration does not implement `build_command_invocation`: preview includes the command name and a one-line note explaining the fallback
- `except` clause narrowed from bare `Exception` to `(ImportError, AttributeError, KeyError, TypeError, ValueError)` so dry-run failures stay debuggable

**CLI**
- `specify workflow run --dry-run` (in-module, in `__init__.py`) — the only place the flag is exposed. After the run, the CLI prints any `output['dry_run']` messages so the rendered previews surface in the terminal.

## What does not ship (intentional)

Per design review, the `specify` CLI is scaffolding + workflow orchestration only. The per-stage surface (`/speckit.specify`, `/speckit.plan`, ...) belongs to the agent, not the CLI. A previous draft of this PR added `specify spec` / `specify plan` preview commands; those have been removed along with the supporting `start_at` / `stop_after` step filtering in the engine. Issue #2661's wording has been re-scoped to `--dry-run` on `specify workflow run`.

## Tests

- Existing dry-run coverage in `tests/test_workflows.py`
- `test_dry_run_persisted_in_run_state`: `dry_run` survives save/load round-trip
- `test_resume_restores_dry_run`: `resume()` rebuilds `StepContext` with the persisted flag so an interrupted dry-run stays a dry-run
- `test_dry_run_returns_completed_without_dispatch`: `CommandStep` returns `COMPLETED` with the rendered preview; no CLI is spawned; uses `tmp_path` for portability
- `test_dry_run_skips_interactive_gate`: `GateStep` short-circuits with a DRY RUN message

## Usage

```bash
specify workflow run speckit --input spec='Build a kanban board' --dry-run
specify workflow run ./my-workflow.yml --input spec='Photo album app' --dry-run
```

Closes #2661