### PR TITLE
Re-validate spec quality checklist after clarify updates spec

### DIFF
--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -203,12 +203,18 @@ Execution steps:
    - If it exists:
      1. Read the checklist file.
      2. Identify all GitHub task-list checkbox lines — lines matching `- [ ]`, `- [x]`, or `- [X]` (case-insensitive, tolerant of leading whitespace for nested items) outside of code fences. Ignore all other content (headings, notes, non-checkbox bullets, metadata).
-     3. Re-evaluate each checkbox item against the **updated** spec (the version just saved in step 7).
-     4. For each checkbox item, set its marker based solely on whether it passes against the current spec — prior state does not matter:
-        - If the item passes: set to `- [x]`.
-        - If the item does not pass: set to `- [ ]` (even if it was previously `- [x]` — spec edits can cause regressions).
-     5. Save the updated checklist file. **Only toggle the `[ ]`/`[x]` marker portion of checkbox lines.** All other file content — headings, metadata, notes, line ordering, whitespace — must remain unchanged to avoid noisy diffs.
-     6. Record the before/after pass counts as checked/total checkbox items for the Completion Report (e.g., "12/16 → 15/16 items passing").
+     3. For each checkbox line, record its current marker state (checked or unchecked) and item text into a before-snapshot list.
+     4. Re-evaluate each checkbox item against the **updated** spec (the version just saved in step 7).
+     5. For each checkbox item, update only if the checked/unchecked state actually changes:
+        - If the item now passes and was unchecked: change `[ ]` to `[x]`.
+        - If the item now fails and was checked: change `[x]`/`[X]` to `[ ]`.
+        - If the state is unchanged: leave the marker as-is (preserve existing case to avoid cosmetic diffs).
+     6. Save the updated checklist file. **Only toggle the `[ ]`/`[x]` marker portion of checkbox lines whose state changed.** All other file content — headings, metadata, notes, line ordering, whitespace — must remain unchanged to avoid noisy diffs.
+     7. Compare the before-snapshot with the current state to compute three lists for the Completion Report:
+        - **Newly passing**: items that changed from unchecked to checked.
+        - **Regressions**: items that changed from checked to unchecked.
+        - **Still unchecked**: items that remain unchecked.
+     8. Record the before/after pass counts as checked/total checkbox items (e.g., "12/16 → 15/16 items passing").
 
 Behavior rules:
 

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -197,6 +197,19 @@ Execution steps:
 
 7. Write the updated spec back to `FEATURE_SPEC`.
 
+8. **Re-validate Spec Quality Checklist** (if it exists):
+   - Check if `FEATURE_DIR/checklists/requirements.md` exists.
+   - If it does NOT exist, skip this step silently.
+   - If it exists:
+     1. Read the checklist file.
+     2. Re-evaluate each checklist item against the **updated** spec (the version just saved in step 7).
+     3. For each item:
+        - If the item now passes (e.g., a `[NEEDS CLARIFICATION]` marker was resolved, a requirement was made unambiguous, an edge case was added), update the marker from `- [ ]` to `- [x]`.
+        - If the item previously passed and still passes, leave it as `- [x]`.
+        - If the item does not pass, leave it as `- [ ]`.
+     4. Save the updated checklist file.
+     5. Record the before/after pass counts for the Completion Report (e.g., "12/16 → 15/16 items passing").
+
 Behavior rules:
 
 - If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
@@ -248,6 +261,7 @@ Report completion (after questioning loop ends or early termination):
 - Number of questions asked & answered.
 - Path to updated spec.
 - Sections touched (list names).
+- Spec quality checklist status (if `FEATURE_DIR/checklists/requirements.md` was re-validated): show before/after pass counts (e.g., "Spec Quality Checklist: 12/16 → 15/16 items passing") and list any items that changed from unchecked to checked. If any items remain unchecked, list them as areas needing attention.
 - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
 - If any Outstanding or Deferred remain, recommend whether to proceed to `__SPECKIT_COMMAND_PLAN__` or run `__SPECKIT_COMMAND_CLARIFY__` again later post-plan.
 - Suggested next command.
@@ -255,5 +269,6 @@ Report completion (after questioning loop ends or early termination):
 ## Done When
 
 - [ ] Spec ambiguities identified and clarifications integrated into spec file
+- [ ] Spec quality checklist re-validated against updated spec (if `checklists/requirements.md` exists)
 - [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
-- [ ] Completion reported to user with questions answered, sections touched, and coverage summary
+- [ ] Completion reported to user with questions answered, sections touched, checklist status, and coverage summary

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -204,10 +204,9 @@ Execution steps:
      1. Read the checklist file.
      2. Identify all GitHub task-list checkbox lines — lines matching `- [ ]` or `- [x]` outside of code fences. Ignore all other content (headings, notes, non-checkbox bullets, metadata).
      3. Re-evaluate each checkbox item against the **updated** spec (the version just saved in step 7).
-     4. For each checkbox item:
-        - If the item now passes (e.g., a `[NEEDS CLARIFICATION]` marker was resolved, a requirement was made unambiguous, an edge case was added), update the marker from `- [ ]` to `- [x]`.
-        - If the item previously passed and still passes, leave it as `- [x]`.
-        - If the item does not pass, leave it as `- [ ]`.
+     4. For each checkbox item, set its marker based solely on whether it passes against the current spec — prior state does not matter:
+        - If the item passes: set to `- [x]`.
+        - If the item does not pass: set to `- [ ]` (even if it was previously `- [x]` — spec edits can cause regressions).
      5. Save the updated checklist file.
      6. Record the before/after pass counts as checked/total checkbox items for the Completion Report (e.g., "12/16 → 15/16 items passing").
 
@@ -262,7 +261,7 @@ Report completion (after questioning loop ends or early termination):
 - Number of questions asked & answered.
 - Path to updated spec.
 - Sections touched (list names).
-- Spec quality checklist status (if `FEATURE_DIR/checklists/requirements.md` was re-validated): show before/after pass counts (e.g., "Spec Quality Checklist: 12/16 → 15/16 items passing") and list any items that changed from unchecked to checked. If any items remain unchecked, list them as areas needing attention.
+- Spec quality checklist status (if `FEATURE_DIR/checklists/requirements.md` was re-validated): show before/after pass counts (e.g., "Spec Quality Checklist: 12/16 → 15/16 items passing") and list any items that changed state — both newly checked (unchecked → checked) and any regressions (checked → unchecked). If any items remain unchecked, list them as areas needing attention.
 - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
 - If any Outstanding or Deferred remain, recommend whether to proceed to `__SPECKIT_COMMAND_PLAN__` or run `__SPECKIT_COMMAND_CLARIFY__` again later post-plan.
 - Suggested next command.

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -202,12 +202,12 @@ Execution steps:
    - If it does NOT exist, skip this step silently.
    - If it exists:
      1. Read the checklist file.
-     2. Identify all GitHub task-list checkbox lines — lines matching `- [ ]` or `- [x]` outside of code fences. Ignore all other content (headings, notes, non-checkbox bullets, metadata).
+     2. Identify all GitHub task-list checkbox lines — lines matching `- [ ]`, `- [x]`, or `- [X]` (case-insensitive, tolerant of leading whitespace for nested items) outside of code fences. Ignore all other content (headings, notes, non-checkbox bullets, metadata).
      3. Re-evaluate each checkbox item against the **updated** spec (the version just saved in step 7).
      4. For each checkbox item, set its marker based solely on whether it passes against the current spec — prior state does not matter:
         - If the item passes: set to `- [x]`.
         - If the item does not pass: set to `- [ ]` (even if it was previously `- [x]` — spec edits can cause regressions).
-     5. Save the updated checklist file.
+     5. Save the updated checklist file. **Only toggle the `[ ]`/`[x]` marker portion of checkbox lines.** All other file content — headings, metadata, notes, line ordering, whitespace — must remain unchanged to avoid noisy diffs.
      6. Record the before/after pass counts as checked/total checkbox items for the Completion Report (e.g., "12/16 → 15/16 items passing").
 
 Behavior rules:

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -202,13 +202,14 @@ Execution steps:
    - If it does NOT exist, skip this step silently.
    - If it exists:
      1. Read the checklist file.
-     2. Re-evaluate each checklist item against the **updated** spec (the version just saved in step 7).
-     3. For each item:
+     2. Identify all GitHub task-list checkbox lines — lines matching `- [ ]` or `- [x]` outside of code fences. Ignore all other content (headings, notes, non-checkbox bullets, metadata).
+     3. Re-evaluate each checkbox item against the **updated** spec (the version just saved in step 7).
+     4. For each checkbox item:
         - If the item now passes (e.g., a `[NEEDS CLARIFICATION]` marker was resolved, a requirement was made unambiguous, an edge case was added), update the marker from `- [ ]` to `- [x]`.
         - If the item previously passed and still passes, leave it as `- [x]`.
         - If the item does not pass, leave it as `- [ ]`.
-     4. Save the updated checklist file.
-     5. Record the before/after pass counts for the Completion Report (e.g., "12/16 → 15/16 items passing").
+     5. Save the updated checklist file.
+     6. Record the before/after pass counts as checked/total checkbox items for the Completion Report (e.g., "12/16 → 15/16 items passing").
 
 Behavior rules:
 
@@ -269,6 +270,6 @@ Report completion (after questioning loop ends or early termination):
 ## Done When
 
 - [ ] Spec ambiguities identified and clarifications integrated into spec file
-- [ ] Spec quality checklist re-validated against updated spec (if `checklists/requirements.md` exists)
+- [ ] Spec quality checklist re-validated against updated spec (if `FEATURE_DIR/checklists/requirements.md` exists)
 - [ ] Extension hooks dispatched or skipped according to the rules in Mandatory Post-Execution Hooks above
 - [ ] Completion reported to user with questions answered, sections touched, checklist status, and coverage summary


### PR DESCRIPTION
## Summary

After `/speckit.clarify` modifies `spec.md`, the existing `checklists/requirements.md` (generated by `/speckit.specify`) can become stale. Items like "No [NEEDS CLARIFICATION] markers remain" may now pass, and newly added requirements aren't reflected in the checklist evaluation.

This adds a re-validation step to the clarify command so the spec quality checklist stays in sync with spec changes.

## Changes

Three modifications to `templates/commands/clarify.md`:

1. **New step 8** — after saving the updated spec, re-validates `checklists/requirements.md` if it exists, updating check marks and recording before/after pass counts
2. **Completion Report** — now includes checklist status with before/after counts and lists items that changed from unchecked to checked. If any items remain unchecked, they are listed as areas needing attention
3. **Done When** — added a checklist re-validation criterion

## Behavior

- If `FEATURE_DIR/checklists/requirements.md` does not exist, the step is skipped silently (no breaking change)
- Items that now pass are checked (`- [x]`), items that still fail remain unchecked (`- [ ]`)
- The completion report shows before/after pass counts (e.g., "12/16 → 15/16 items passing")

## Testing

This is a template-only change (AI agent prompt instructions). It requires no code changes or unit tests. Validation is through running `/speckit.clarify` in a project that has an existing `checklists/requirements.md` and confirming the checklist is updated.

Fixes #2693

cc @yag3l