### PR TITLE
fix: resolve __SPECKIT_COMMAND_*__ refs in preset skill rendering (#2717)

### DIFF
--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -28,6 +28,7 @@ from packaging import version as pkg_version
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
 
 from .extensions import REINSTALL_COMMAND, ExtensionRegistry, normalize_priority
+from .integrations.base import IntegrationBase
 
 
 def _substitute_core_template(
@@ -1058,6 +1059,9 @@ class PresetManager:
                         body = registrar.resolve_skill_placeholders(
                             selected_ai, fm, body, self.project_root
                         )
+                        body = self._resolve_skill_command_refs(
+                            body, registrar, selected_ai
+                        )
                     fm_data = registrar.build_skill_frontmatter(
                         selected_ai if isinstance(selected_ai, str) else "",
                         skill_name, desc,
@@ -1133,6 +1137,23 @@ class PresetManager:
         if title_name.startswith("speckit."):
             title_name = title_name[len("speckit."):]
         return title_name.replace(".", " ").replace("-", " ").title()
+
+    @staticmethod
+    def _resolve_skill_command_refs(
+        body: str, registrar: "CommandRegistrar", selected_ai: str
+    ) -> str:
+        """Render ``__SPECKIT_COMMAND_*__`` tokens in a skill body as invocations.
+
+        Looks up the agent's invoke separator and rewrites each
+        ``__SPECKIT_COMMAND_<NAME>__`` placeholder into the matching
+        slash-command invocation — ``/speckit-<cmd>`` for a ``-`` separator,
+        ``/speckit.<cmd>`` for ``.`` — the same rendering the command layer
+        applies via ``CommandRegistrar.register_commands()``.
+        """
+        separator = registrar.AGENT_CONFIGS.get(selected_ai, {}).get(
+            "invoke_separator", "."
+        )
+        return IntegrationBase.resolve_command_refs(body, separator)
 
     def _build_extension_skill_restore_index(self) -> Dict[str, Dict[str, Any]]:
         """Index extension-backed skill restore data by skill directory name."""
@@ -1310,6 +1331,7 @@ class PresetManager:
             body = registrar.resolve_skill_placeholders(
                 selected_ai, frontmatter, body, self.project_root
             )
+            body = self._resolve_skill_command_refs(body, registrar, selected_ai)
 
             for target_skill_name in target_skill_names:
                 skill_subdir = skills_dir / target_skill_name
@@ -1402,6 +1424,9 @@ class PresetManager:
                     body = registrar.resolve_skill_placeholders(
                         selected_ai, frontmatter, body, self.project_root
                     )
+                    body = self._resolve_skill_command_refs(
+                        body, registrar, selected_ai
+                    )
 
                 original_desc = frontmatter.get("description", "")
                 enhanced_desc = original_desc or SKILL_DESCRIPTIONS.get(
@@ -1438,6 +1463,9 @@ class PresetManager:
                 if isinstance(selected_ai, str):
                     body = registrar.resolve_skill_placeholders(
                         selected_ai, frontmatter, body, self.project_root
+                    )
+                    body = self._resolve_skill_command_refs(
+                        body, registrar, selected_ai
                     )
 
                 command_name = extension_restore["command_name"]

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -2402,6 +2402,98 @@ class TestPresetSkills:
         assert "__SPECKIT_COMMAND_" not in content, "raw command token leaked on restore"
         assert "/speckit-plan" in content
 
+    def test_reconcile_override_skill_resolves_command_refs(self, project_dir, temp_dir):
+        """Reconcile's project-override restore must resolve command tokens (issue #2717).
+
+        When a preset that overrode a command is removed and a project override
+        becomes the winning layer, ``_reconcile_skills`` rewrites the skill from
+        the override body — which must also render ``__SPECKIT_COMMAND_*__`` tokens.
+        """
+        self._write_init_options(project_dir, ai="claude")
+        skills_dir = project_dir / ".claude" / "skills"
+        self._create_skill(skills_dir, "speckit-specify")
+
+        # Project override wins once the preset is removed; its body carries a
+        # command cross-reference token. No core template exists for "specify",
+        # so the skill is restored exclusively via the reconcile override branch.
+        overrides_dir = project_dir / ".specify" / "templates" / "overrides"
+        overrides_dir.mkdir(parents=True, exist_ok=True)
+        (overrides_dir / "speckit.specify.md").write_text(
+            "---\ndescription: Override specify\n---\n\n"
+            "Then run `__SPECKIT_COMMAND_PLAN__`.\n"
+        )
+
+        preset_dir = self._create_command_preset(
+            temp_dir,
+            "cmdref-reconcile",
+            "speckit.specify",
+            "Preset specify",
+            "Preset body\n",
+        )
+        manager = PresetManager(project_dir)
+        manager.install_from_directory(preset_dir, "0.1.5")
+        manager.remove("cmdref-reconcile")
+
+        content = (skills_dir / "speckit-specify" / "SKILL.md").read_text()
+        assert "override:speckit.specify" in content, "skill should be restored from the project override"
+        assert "__SPECKIT_COMMAND_" not in content, "raw command token leaked on reconcile"
+        assert "/speckit-plan" in content
+
+    def test_extension_restore_resolves_command_refs(self, project_dir, temp_dir):
+        """Extension-backed skill restore must resolve command tokens (issue #2717).
+
+        When a preset override is removed and the skill is restored from an
+        extension command body, ``__SPECKIT_COMMAND_*__`` tokens in that body
+        must render as slash-command invocations like the core-template path.
+        """
+        self._write_init_options(project_dir, ai="claude")
+        skills_dir = project_dir / ".claude" / "skills"
+        self._create_skill(skills_dir, "speckit-fakeext-cmd", body="original extension skill")
+
+        extension_dir = project_dir / ".specify" / "extensions" / "fakeext"
+        (extension_dir / "commands").mkdir(parents=True, exist_ok=True)
+        (extension_dir / "commands" / "cmd.md").write_text(
+            "---\ndescription: Extension fakeext cmd\n---\n\n"
+            "Then run `__SPECKIT_COMMAND_PLAN__`.\n"
+        )
+        extension_manifest = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "fakeext",
+                "name": "Fake Extension",
+                "version": "1.0.0",
+                "description": "Test",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "commands": [
+                    {
+                        "name": "speckit.fakeext.cmd",
+                        "file": "commands/cmd.md",
+                        "description": "Fake extension command",
+                    }
+                ]
+            },
+        }
+        with open(extension_dir / "extension.yml", "w") as f:
+            yaml.dump(extension_manifest, f)
+
+        preset_dir = self._create_command_preset(
+            temp_dir,
+            "cmdref-ext-restore",
+            "speckit.fakeext.cmd",
+            "Override fakeext cmd",
+            "Override body\n",
+        )
+        manager = PresetManager(project_dir)
+        manager.install_from_directory(preset_dir, "0.1.5")
+        manager.remove("cmdref-ext-restore")
+
+        content = (skills_dir / "speckit-fakeext-cmd" / "SKILL.md").read_text()
+        assert "source: extension:fakeext" in content, "skill should be restored from the extension"
+        assert "__SPECKIT_COMMAND_" not in content, "raw command token leaked on extension restore"
+        assert "/speckit-plan" in content
+
     def test_core_command_override_skill_uses_preset_command_description(self, project_dir, temp_dir):
         """Preset skill overrides for core commands should keep preset frontmatter descriptions."""
         self._write_init_options(project_dir, ai="claude")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -2346,6 +2346,62 @@ class TestPresetSkills:
         metadata = manager.registry.get("self-test")
         assert "speckit-specify" in metadata.get("registered_skills", [])
 
+    def test_register_skills_resolves_command_refs(self, project_dir, temp_dir):
+        """Preset skill overrides must resolve __SPECKIT_COMMAND_*__ tokens (issue #2717).
+
+        ``_register_skills()`` previously ran only ``resolve_skill_placeholders()``,
+        so command cross-references leaked into SKILL.md as raw placeholders
+        instead of rendering as ``/speckit-<cmd>`` like the command layer.
+        """
+        self._write_init_options(project_dir, ai="claude")
+        skills_dir = project_dir / ".claude" / "skills"
+        self._create_skill(skills_dir, "speckit-specify")
+
+        preset_dir = self._create_command_preset(
+            temp_dir,
+            "cmdref-install",
+            "speckit.specify",
+            "Override specify",
+            "Run `__SPECKIT_COMMAND_SPECIFY__` then `__SPECKIT_COMMAND_PLAN__`.\n",
+        )
+
+        manager = PresetManager(project_dir)
+        manager.install_from_directory(preset_dir, "0.1.5")
+
+        content = (skills_dir / "speckit-specify" / "SKILL.md").read_text()
+        assert "__SPECKIT_COMMAND_" not in content, "raw command token leaked into SKILL.md"
+        # Claude's invoke_separator is "-", so tokens render as /speckit-<cmd>.
+        assert "/speckit-specify" in content
+        assert "/speckit-plan" in content
+
+    def test_restore_skill_resolves_command_refs(self, project_dir, temp_dir):
+        """Skill restore on preset removal must also resolve command tokens (issue #2717)."""
+        self._write_init_options(project_dir, ai="claude")
+        skills_dir = project_dir / ".claude" / "skills"
+        self._create_skill(skills_dir, "speckit-specify")
+
+        core_cmds = project_dir / ".specify" / "templates" / "commands"
+        core_cmds.mkdir(parents=True, exist_ok=True)
+        (core_cmds / "specify.md").write_text(
+            "---\ndescription: Core specify\n---\n\n"
+            "Then run `__SPECKIT_COMMAND_PLAN__`.\n"
+        )
+
+        preset_dir = self._create_command_preset(
+            temp_dir,
+            "cmdref-restore",
+            "speckit.specify",
+            "Override specify",
+            "Override body\n",
+        )
+        manager = PresetManager(project_dir)
+        manager.install_from_directory(preset_dir, "0.1.5")
+        manager.remove("cmdref-restore")
+
+        content = (skills_dir / "speckit-specify" / "SKILL.md").read_text()
+        assert "__SPECKIT_COMMAND_" not in content, "raw command token leaked on restore"
+        assert "/speckit-plan" in content
+
     def test_core_command_override_skill_uses_preset_command_description(self, project_dir, temp_dir):
         """Preset skill overrides for core commands should keep preset frontmatter descriptions."""
         self._write_init_options(project_dir, ai="claude")


### PR DESCRIPTION
## Description

Presets that override core commands under the agent **skill** layer (e.g. Claude with `--ai-skills`) were leaking raw `__SPECKIT_COMMAND_*__` placeholders into the generated `SKILL.md` instead of rendering them as slash-command invocations like `/speckit-plan`.

**Root cause:** the preset skill-rendering paths in `src/specify_cli/presets.py` ran only `resolve_skill_placeholders()`, whereas the command layer (`CommandRegistrar.register_commands()`) additionally calls `IntegrationBase.resolve_command_refs()`. The skill paths never resolved the command-reference tokens — `{ARGS}` → `$ARGUMENTS` resolved correctly, so only the command tokens leaked, matching the report.

Fixes #2717. This is a concrete instance of the path divergence tracked in #1976.

**Change:** added a small shared helper `PresetManager._resolve_skill_command_refs()` that maps the agent's invoke separator to `resolve_command_refs()`, and called it right after `resolve_skill_placeholders()` in every preset skill-rendering path:

- `_register_skills()` — preset install (the path reported in the issue)
- `_reconcile_skills()` — override-restoration block
- `_unregister_skills()` — both restore paths (core + extension templates)

The issue's proposed patch covered only `_register_skills()`; I extended the same one-line fix to the sibling restore/reconcile paths because they share the identical omission and would otherwise still leak tokens on preset **removal** / reconciliation. `extensions.py` is intentionally left out of scope (separate concern).

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` — **2988 passed, 35 skipped**
- [x] Tested with a sample project (Claude `--ai-skills`: `preset add --dev` + `preset remove`)

> ⚠️ **Note for reviewers:** `uv run specify` served a **stale cached wheel** (project version `0.8.15.dev0` unchanged → uv build-cache hit), so it kept showing the pre-fix behavior even after `uv pip install -e .`. I verified working-tree behavior by invoking `.venv/bin/specify` directly. Worth flagging since the documented `uv run specify` flow can silently exercise old code when the dev version string is unchanged.

### Manual test results

**Agent**: Claude Code (CLI)  |  **OS/Shell**: macOS / zsh

Repro: scaffold a Claude `--ai-skills` project, install a local preset overriding `speckit.specify` whose body references `__SPECKIT_COMMAND_PLAN__` / `__SPECKIT_COMMAND_TASKS__`, then remove it (restoring from a core template that also carries the tokens). Inspected `.claude/skills/speckit-specify/SKILL.md`.

| Command tested | Notes |
|----------------|-------|
| `specify init --integration claude` | Skills installed to `.claude/skills`; `speckit-specify` present |
| `specify preset add --dev <preset>` | `SKILL.md` renders `/speckit-plan`, `/speckit-tasks`; **0** raw `__SPECKIT_COMMAND_*__` (was **2** before the fix) |
| `specify preset remove <preset>` | Restored `SKILL.md` renders `/speckit-plan`; **0** raw tokens (was **1** before the fix) |

### Test selection reasoning

| Changed file | Affects | Test | Why |
|---|---|---|---|
| `src/specify_cli/presets.py` | `specify preset add` / `remove`, preset skill overrides | T1–T3 | Rule: `src/specify_cli/*.py` → CLI preset commands; preset command overrides mirror into the skill layer |

**Required tests** (prerequisites first):

- T1: `specify init --integration claude` — scaffold the skills layer (prerequisite for T2/T3)
- T2: `specify preset add --dev` — install path (`_register_skills`)
- T3: `specify preset remove` — restore path (`_unregister_skills`); requires T2

New automated regression tests added in `tests/test_presets.py`: `test_register_skills_resolves_command_refs` (install) and `test_restore_skill_resolves_command_refs` (restore). Both **fail on `main`** and **pass with the fix**.

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->

- [x] I **did** use AI assistance (describe below)

This PR was developed with **Claude Code** (Anthropic): issue analysis, the patch, and the regression tests were AI-generated. The full `pytest` suite and the manual CLI install/remove cycle reported above were run as part of development, and the change was reviewed (including a follow-up pass to remove a lint-suppression `# noqa` in favor of a top-level import and to make the helper docstring describe behavior) before submission.
