### PR TITLE
chore: add scripts/dev/test.sh — chunked FIFO local test wrapper (~1.75x faster)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ packages = ["src/specify_cli"]
 test = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "pytest-xdist>=3.5",
 ]
 
 [tool.pytest.ini_options]
@@ -60,6 +61,8 @@ addopts = [
     "-v",
     "--strict-markers",
     "--tb=short",
+    "-n=auto",
+    "--dist=worksteal",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,6 @@ addopts = [
     "-v",
     "--strict-markers",
     "--tb=short",
-    "-n=auto",
-    "--dist=worksteal",
 ]
 
 [tool.coverage.run]

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -147,12 +147,12 @@ mktemp_file() {
 arg_bytes() {
     local total=0
     local arg
-    local bytes
+    local old_lc_all="${LC_ALL:-}"
+    LC_ALL=C
     for arg in "$@"; do
-        bytes="$(LC_ALL=C printf '%s' "$arg" | wc -c | tr -d '[:space:]')"
-        bytes="${bytes:-0}"
-        total=$(( total + bytes + 1 ))
+        total=$(( total + ${#arg} + 1 ))
     done
+    LC_ALL="$old_lc_all"
     printf '%s\n' "$total"
 }
 
@@ -164,11 +164,7 @@ while (( idx < ${#PASSTHROUGH[@]} )); do
     arg="${PASSTHROUGH[$idx]}"
     case "$arg" in
         --collect-only|--co) COLLECT_ONLY_REQUESTED=1 ;;
-        -n|--numprocesses|--dist)
-            err "$arg is managed by this script; remove xdist flags from arguments"
-            exit 1
-            ;;
-        -n*|--numprocesses=*|--dist=*)
+        -n|--numprocesses|--dist|-n*|--numprocesses=*|--dist=*)
             err "$arg is managed by this script; remove xdist flags from arguments"
             exit 1
             ;;

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Spec Kit local test wrapper — chunked FIFO dispatch over pytest-xdist.
+#
+# Design (matches the chunked-task / bounded-memory pattern):
+#   * Collect node ids once: `pytest --collect-only -q`.
+#   * Split the collection into fixed-size chunks (default 200 nodes).
+#   * Dispatch chunks sequentially as a FIFO queue; inside each chunk,
+#     pytest-xdist's `--dist=load` hands tests out one at a time to
+#     workers as they finish — natural FIFO progression with bounded
+#     in-flight memory.
+#   * Persist the cursor (next chunk index) to
+#     `.pytest_cache/fast-test-cursor` after every successful chunk so
+#     `--resume` continues exactly where a crash left off.
+#   * `--reset` clears the cursor; `--bench` reports wall-time only.
+#
+# Usage:
+#   scripts/dev/test.sh                          # full suite, chunked
+#   scripts/dev/test.sh --chunk-size 100
+#   scripts/dev/test.sh --resume                 # continue from cursor
+#   scripts/dev/test.sh --reset                  # clear cursor
+#   scripts/dev/test.sh --bench                  # time only, no -v
+#   scripts/dev/test.sh -- tests/test_merge.py   # pass-through to pytest
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CURSOR_FILE="$REPO_ROOT/.pytest_cache/fast-test-cursor"
+
+CHUNK_SIZE=200
+RESUME=0
+RESET=0
+BENCH=0
+PASSTHROUGH=()
+
+while (( $# )); do
+    case "$1" in
+        --chunk-size) CHUNK_SIZE="$2"; shift 2 ;;
+        --resume)     RESUME=1; shift ;;
+        --reset)      RESET=1;  shift ;;
+        --bench)      BENCH=1;  shift ;;
+        --)           shift; PASSTHROUGH+=("$@"); break ;;
+        -h|--help)    sed -n '2,22p' "$0"; exit 0 ;;
+        *)            PASSTHROUGH+=("$1"); shift ;;
+    esac
+done
+
+if (( RESET )); then
+    rm -f "$CURSOR_FILE"
+    echo "[fast-test] cursor cleared"
+    exit 0
+fi
+
+cd "$REPO_ROOT"
+mkdir -p "$(dirname "$CURSOR_FILE")"
+
+# 1. Collect node ids (override addopts so collection itself is serial/quiet).
+echo "[fast-test] collecting tests ..."
+mapfile -t NODES < <(
+    uv run pytest -o addopts= --collect-only -q "${PASSTHROUGH[@]}" \
+        2>/dev/null | grep -E '::' || true
+)
+TOTAL="${#NODES[@]}"
+if (( TOTAL == 0 )); then
+    echo "[fast-test] no tests collected" >&2
+    exit 1
+fi
+
+# 2. Determine starting cursor.
+START=0
+if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
+    START="$(cat "$CURSOR_FILE")"
+    echo "[fast-test] resuming from chunk cursor: test #$START"
+fi
+
+CHUNKS=$(( (TOTAL - START + CHUNK_SIZE - 1) / CHUNK_SIZE ))
+echo "[fast-test] $TOTAL tests · chunk=$CHUNK_SIZE · $CHUNKS chunk(s) queued · workers=auto"
+
+# 3. FIFO dispatch.
+T_START=$(date +%s)
+i="$START"
+chunk_idx=0
+while (( i < TOTAL )); do
+    end=$(( i + CHUNK_SIZE ))
+    (( end > TOTAL )) && end="$TOTAL"
+    chunk_idx=$(( chunk_idx + 1 ))
+    echo "[fast-test] chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
+
+    PYTEST_FLAGS=(-o addopts= -n auto --dist=load --tb=short)
+    (( BENCH )) && PYTEST_FLAGS+=(-q) || PYTEST_FLAGS+=(--no-header -q)
+
+    if ! uv run pytest "${PYTEST_FLAGS[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
+        echo "[fast-test] chunk failed — cursor preserved at test #$i (use --resume to retry)"
+        echo "$i" > "$CURSOR_FILE"
+        exit 1
+    fi
+
+    i="$end"
+    echo "$i" > "$CURSOR_FILE"
+done
+
+T_END=$(date +%s)
+rm -f "$CURSOR_FILE"
+echo "[fast-test] all $TOTAL tests passed in $((T_END - T_START))s"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -266,7 +266,11 @@ write_cursor() {
         exit 1
     fi
     printf '%s\n' "$1" > "$cursor_tmp"
-    mv "$cursor_tmp" "$CURSOR_FILE"
+    if ! mv "$cursor_tmp" "$CURSOR_FILE"; then
+        err "failed to persist cursor to $CURSOR_FILE"
+        rm -f "$cursor_tmp" 2>/dev/null || true
+        exit 1
+    fi
 }
 
 read_chunk() {
@@ -418,7 +422,7 @@ if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
     ensure_dir_safe "$PYTEST_CACHE_DIR" "pytest cache dir"
     ensure_regular_file_or_missing "$CURSOR_FILE" "cursor path"
     ensure_single_link "$CURSOR_FILE" "cursor path"
-    RAW_START="$(tr -d '[:space:]' < "$CURSOR_FILE")"
+    RAW_START="$(tr -d '[:space:]' < "$CURSOR_FILE" 2>/dev/null || true)"
     if [[ "$RAW_START" =~ ^[0-9]+$ ]]; then
         START="$RAW_START"
         (( START > TOTAL )) && START="$TOTAL"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -126,7 +126,7 @@ if (( XDIST_IGNORED )); then
 fi
 
 cleanup() {
-    exec 3<&- 2>/dev/null || true
+    { exec 3<&-; } 2>/dev/null || true
     [[ -n "$COLLECT_ERR" && -f "$COLLECT_ERR" ]] && rm -f "$COLLECT_ERR"
     [[ -n "$COLLECT_OUT" && -f "$COLLECT_OUT" ]] && rm -f "$COLLECT_OUT"
     [[ -n "$COLLECT_FILTERED" && -f "$COLLECT_FILTERED" ]] && rm -f "$COLLECT_FILTERED"
@@ -280,7 +280,8 @@ while (( i < TOTAL )); do
     read_chunk
     if (( ${#CHUNK_NODES[@]} == 0 )); then
         echo "[fast-test] no tests read for chunk; stopping" >&2
-        break
+        write_cursor "$i"
+        exit 1
     fi
     end=$(( i + ${#CHUNK_NODES[@]} ))
     echo "[fast-test] chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
@@ -303,7 +304,7 @@ while (( i < TOTAL )); do
 done
 
 T_END=$(date +%s)
-exec 3<&- 2>/dev/null || true
+{ exec 3<&-; } 2>/dev/null || true
 rm -f "$COLLECT_OUT"
 rm -f "$CURSOR_FILE"
 echo "[fast-test] all $TOTAL tests passed in $((T_END - T_START))s"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -32,6 +32,7 @@ RESET=0
 BENCH=0
 PASSTHROUGH=()
 RUNTIME_PASSTHROUGH=()
+PYTEST_CMD=()
 LOCK_DIR="$REPO_ROOT/.pytest_cache/fast-test.lock"
 LOCK_HELD=0
 CURSOR_TMP="$CURSOR_FILE.tmp"
@@ -62,11 +63,32 @@ if ! [[ "$CHUNK_SIZE" =~ ^[1-9][0-9]*$ ]]; then
     exit 1
 fi
 
+mktemp_file() {
+    local tmp
+    if tmp="$(mktemp -t fast-test.XXXXXX 2>/dev/null)"; then
+        printf '%s\n' "$tmp"
+        return 0
+    fi
+    if tmp="$(mktemp "${TMPDIR:-/tmp}/fast-test.XXXXXX" 2>/dev/null)"; then
+        printf '%s\n' "$tmp"
+        return 0
+    fi
+    mktemp
+}
+
 # Collection and execution do not share every pytest flag. Keep runtime
-# passthrough aligned with user intent while stripping collect-only toggles.
+# passthrough aligned with user intent while stripping collect-only toggles
+# and xdist-specific options that this script owns.
+skip_next=0
 for arg in "${PASSTHROUGH[@]}"; do
+    if (( skip_next )); then
+        skip_next=0
+        continue
+    fi
     case "$arg" in
         --collect-only|--co) ;;
+        -n|--numprocesses|--dist) skip_next=1 ;;
+        -n*|--numprocesses=*|--dist=*) ;;
         *) RUNTIME_PASSTHROUGH+=("$arg") ;;
     esac
 done
@@ -90,6 +112,18 @@ write_cursor() {
 cd "$REPO_ROOT"
 mkdir -p "$(dirname "$CURSOR_FILE")"
 
+if [[ -d "$LOCK_DIR" ]]; then
+    if [[ -f "$LOCK_DIR/pid" ]]; then
+        PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
+        if [[ "$PID_CONTENTS" =~ ^[0-9]+$ ]] && kill -0 "$PID_CONTENTS" 2>/dev/null; then
+            echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
+            exit 1
+        fi
+        echo "[fast-test] removing stale lock (pid: ${PID_CONTENTS:-unknown})" >&2
+    fi
+    rm -f "$LOCK_DIR/pid"
+    rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+fi
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
     echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
     exit 1
@@ -104,10 +138,19 @@ if (( RESET )); then
 fi
 
 # 1. Collect node ids.
+if command -v uv >/dev/null 2>&1; then
+    PYTEST_CMD=(uv run pytest)
+elif command -v python >/dev/null 2>&1; then
+    PYTEST_CMD=(python -m pytest)
+else
+    echo "[fast-test] pytest runner not found (install uv or ensure python is on PATH)" >&2
+    exit 1
+fi
+
 echo "[fast-test] collecting tests ..."
-COLLECT_ERR="$(mktemp)"
-COLLECT_OUT="$(mktemp)"
-if ! uv run pytest --collect-only -q "${PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
+COLLECT_ERR="$(mktemp_file)"
+COLLECT_OUT="$(mktemp_file)"
+if ! "${PYTEST_CMD[@]}" --collect-only -q "${PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
     echo "[fast-test] test collection failed" >&2
     [[ -s "$COLLECT_ERR" ]] && { echo "--- collection stderr ---"; cat "$COLLECT_ERR"; } >&2
     rm -f "$COLLECT_ERR" "$COLLECT_OUT"
@@ -115,8 +158,8 @@ if ! uv run pytest --collect-only -q "${PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COL
 fi
 NODES=()
 while IFS= read -r node; do
-    NODES+=("$node")
-done < <(grep -E '::' "$COLLECT_OUT" || true)
+    [[ -n "$node" ]] && NODES+=("$node")
+done < "$COLLECT_OUT"
 rm -f "$COLLECT_ERR" "$COLLECT_OUT"
 TOTAL="${#NODES[@]}"
 if (( TOTAL == 0 )); then
@@ -159,7 +202,7 @@ while (( i < TOTAL )); do
     PYTEST_FLAGS=(-n auto --dist=load)
     (( BENCH )) && PYTEST_FLAGS+=(-q) || PYTEST_FLAGS+=(--no-header -q)
 
-    if ! uv run pytest "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
+    if ! "${PYTEST_CMD[@]}" "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
         echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)"
         write_cursor "$i"
         exit 1

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -134,10 +134,14 @@ cleanup() {
     if [[ "$LOCK_MODE" == "flock" ]]; then
         flock -u 9 2>/dev/null || true
         exec 9>&- || true
-        rm -f "$LOCK_FILE"
-    elif (( LOCK_HELD )); then
-        rm -f "$LOCK_DIR/pid"
-        rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+    elif [[ "$LOCK_MODE" == "dir" ]] && (( LOCK_HELD )); then
+        if [[ -f "$LOCK_DIR/pid" ]]; then
+            PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
+            if [[ "$PID_CONTENTS" == "$$" ]]; then
+                rm -f "$LOCK_DIR/pid"
+                rmdir "$LOCK_DIR" 2>/dev/null || true
+            fi
+        fi
     fi
 }
 
@@ -208,6 +212,12 @@ elif command -v python >/dev/null 2>&1; then
     PYTEST_CMD=(python -m pytest)
 else
     echo "[fast-test] pytest runner not found (install uv or ensure python is on PATH)" >&2
+    exit 1
+fi
+
+if ! "${PYTEST_CMD[@]}" --help 2>/dev/null | grep -Eq '(-n[[:space:]]|--numprocesses)'; then
+    echo "[fast-test] pytest-xdist is required for this wrapper (missing -n/--numprocesses)." >&2
+    echo "[fast-test] install test extras, e.g. 'uv pip install -e .[test]'" >&2
     exit 1
 fi
 

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -53,6 +53,10 @@ CHUNK_NODES=()
 XDIST_IGNORED=0
 COLLECT_ONLY_REQUESTED=0
 
+log() {
+    echo "$*" >&2
+}
+
 print_help() {
     awk '
         /^# Usage:/ {printing=1}
@@ -89,7 +93,7 @@ if ! [[ "$CHUNK_SIZE" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 if (( CHUNK_SIZE > 1000 )); then
-    echo "[fast-test] warning: large --chunk-size may exceed OS argument limits" >&2
+    log "[fast-test] warning: large --chunk-size may exceed OS argument limits"
 fi
 
 mktemp_file() {
@@ -138,7 +142,7 @@ if (( COLLECT_ONLY_REQUESTED )); then
 fi
 
 if (( XDIST_IGNORED )); then
-    echo "[fast-test] ignoring xdist flags (-n/--numprocesses/--dist); this script manages them" >&2
+    log "[fast-test] ignoring xdist flags (-n/--numprocesses/--dist); this script manages them"
 fi
 
 cleanup() {
@@ -170,6 +174,7 @@ write_cursor() {
 
 read_chunk() {
     local count=0
+    local node
     CHUNK_NODES=()
     while (( count < CHUNK_SIZE )); do
         if ! IFS= read -r node <&3; then
@@ -215,7 +220,7 @@ fi
 
 if (( RESET )); then
     rm -f "$CURSOR_FILE" "$CURSOR_TMP"
-    echo "[fast-test] cursor cleared"
+    log "[fast-test] cursor cleared"
     exit 0
 fi
 
@@ -237,7 +242,7 @@ if ! "${PYTEST_CMD[@]}" --help 2>/dev/null | grep -Eq '(-n[[:space:]]|--numproce
     exit 1
 fi
 
-echo "[fast-test] collecting tests ..."
+log "[fast-test] collecting tests ..."
 COLLECT_ERR="$(mktemp_file)"
 COLLECT_OUT="$(mktemp_file)"
 if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
@@ -263,20 +268,21 @@ if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
     if [[ "$RAW_START" =~ ^[0-9]+$ ]]; then
         START="$RAW_START"
         (( START > TOTAL )) && START="$TOTAL"
-        echo "[fast-test] resuming from next test index: $START"
+        log "[fast-test] resuming from next test index: $START"
     else
         echo "[fast-test] cursor file is invalid ('$RAW_START'); starting from 0" >&2
+        rm -f "$CURSOR_FILE"
     fi
 fi
 
 if (( START >= TOTAL )); then
-    echo "[fast-test] nothing to resume (cursor at end: $START/$TOTAL)"
+    log "[fast-test] nothing to resume (cursor at end: $START/$TOTAL)"
     rm -f "$CURSOR_FILE"
     exit 0
 fi
 
 CHUNKS=$(( (TOTAL - START + CHUNK_SIZE - 1) / CHUNK_SIZE ))
-echo "[fast-test] $TOTAL tests · chunk=$CHUNK_SIZE · $CHUNKS chunk(s) queued · workers=auto"
+log "[fast-test] $TOTAL tests · chunk=$CHUNK_SIZE · $CHUNKS chunk(s) queued · workers=auto"
 
 exec 3< "$COLLECT_OUT"
 skip_count=0
@@ -302,7 +308,7 @@ while (( i < TOTAL )); do
         exit 1
     fi
     end=$(( i + ${#CHUNK_NODES[@]} ))
-    echo "[fast-test] chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
+    log "[fast-test] chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
 
     PYTEST_FLAGS=(-n auto --dist=load)
     if (( BENCH )); then
@@ -325,4 +331,4 @@ T_END=$(date +%s)
 { exec 3<&-; } 2>/dev/null || true
 rm -f "$COLLECT_OUT"
 rm -f "$CURSOR_FILE"
-echo "[fast-test] all $TOTAL tests passed in $((T_END - T_START))s"
+log "[fast-test] all $TOTAL tests passed in $((T_END - T_START))s"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -54,12 +54,10 @@ LOCK_FILE="$PYTEST_CACHE_DIR/${SCRIPT_STEM}.lock"
 LOCK_DIR="$PYTEST_CACHE_DIR/${SCRIPT_STEM}.lockdir"
 LOCK_MODE=""
 LOCK_HELD=0
-CURSOR_TMP="$CURSOR_FILE.tmp"
 COLLECT_ERR=""
 COLLECT_OUT=""
 COLLECT_FILTERED=""
 CHUNK_NODES=()
-XDIST_IGNORED=0
 COLLECT_ONLY_REQUESTED=0
 FD3_OPEN=0
 
@@ -160,7 +158,7 @@ arg_bytes() {
 
 # Collection and execution do not share every pytest flag. Keep runtime
 # passthrough aligned with user intent while stripping collect-only toggles
-# and xdist-specific options that this script owns.
+# and failing fast on xdist-specific options owned by this script.
 idx=0
 while (( idx < ${#PASSTHROUGH[@]} )); do
     arg="${PASSTHROUGH[$idx]}"
@@ -187,10 +185,6 @@ if (( COLLECT_ONLY_REQUESTED )); then
     exit 1
 fi
 
-if (( XDIST_IGNORED )); then
-    log "ignoring xdist flags (-n/--numprocesses/--dist); this script manages them"
-fi
-
 cleanup() {
     if (( FD3_OPEN )); then
         { exec 3<&-; } 2>/dev/null || true
@@ -199,7 +193,6 @@ cleanup() {
     [[ -n "$COLLECT_ERR" && -f "$COLLECT_ERR" ]] && rm -f "$COLLECT_ERR"
     [[ -n "$COLLECT_OUT" && -f "$COLLECT_OUT" ]] && rm -f "$COLLECT_OUT"
     [[ -n "$COLLECT_FILTERED" && -f "$COLLECT_FILTERED" ]] && rm -f "$COLLECT_FILTERED"
-    [[ -n "$CURSOR_TMP" && -f "$CURSOR_TMP" ]] && rm -f "$CURSOR_TMP"
     if [[ "$LOCK_MODE" == "flock" ]]; then
         flock -u 9 2>/dev/null || true
         exec 9>&- || true
@@ -220,8 +213,15 @@ trap cleanup EXIT
 write_cursor() {
     ensure_dir_safe "$PYTEST_CACHE_DIR" "pytest cache dir"
     ensure_regular_file_or_missing "$CURSOR_FILE" "cursor path"
-    printf '%s\n' "$1" > "$CURSOR_TMP"
-    mv "$CURSOR_TMP" "$CURSOR_FILE"
+    local cursor_tmp
+    cursor_tmp="$(mktemp "${PYTEST_CACHE_DIR}/${SCRIPT_STEM}.cursor.XXXXXX")" || exit 1
+    if [[ -L "$cursor_tmp" || ! -f "$cursor_tmp" ]]; then
+        err "cursor temp path is unsafe; refusing to write $cursor_tmp"
+        rm -f "$cursor_tmp" 2>/dev/null || true
+        exit 1
+    fi
+    printf '%s\n' "$1" > "$cursor_tmp"
+    mv "$cursor_tmp" "$CURSOR_FILE"
 }
 
 read_chunk() {
@@ -277,7 +277,7 @@ else
 fi
 
 if (( RESET )); then
-    rm -f "$CURSOR_FILE" "$CURSOR_TMP"
+    rm -f "$CURSOR_FILE"
     log "cursor cleared"
     exit 0
 fi

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -60,7 +60,7 @@ while (( $# )); do
         --reset)      RESET=1;  shift ;;
         --bench)      BENCH=1;  shift ;;
         --)           shift; PASSTHROUGH+=("$@"); break ;;
-        -h|--help)    sed -n '2,22p' "$0"; exit 0 ;;
+        -h|--help)    print_help; exit 0 ;;
         *)            PASSTHROUGH+=("$1"); shift ;;
     esac
 done
@@ -82,6 +82,17 @@ mktemp_file() {
     fi
     echo "[fast-test] mktemp failed; set TMPDIR or install a compatible mktemp" >&2
     return 1
+}
+
+print_help() {
+    awk '
+        /^# Usage:/ {printing=1}
+        printing {
+            if ($0 !~ /^#/) {exit}
+            sub(/^# ?/, "", $0)
+            print
+        }
+    ' "$0"
 }
 
 # Collection and execution do not share every pytest flag. Keep runtime
@@ -115,6 +126,7 @@ if (( XDIST_IGNORED )); then
 fi
 
 cleanup() {
+    exec 3<&- 2>/dev/null || true
     [[ -n "$COLLECT_ERR" && -f "$COLLECT_ERR" ]] && rm -f "$COLLECT_ERR"
     [[ -n "$COLLECT_OUT" && -f "$COLLECT_OUT" ]] && rm -f "$COLLECT_OUT"
     [[ -n "$COLLECT_FILTERED" && -f "$COLLECT_FILTERED" ]] && rm -f "$COLLECT_FILTERED"
@@ -136,16 +148,16 @@ write_cursor() {
     mv "$CURSOR_TMP" "$CURSOR_FILE"
 }
 
-load_chunk_nodes() {
-    local start_index="$1"
-    local end_index="$2"
-    local start_line=$(( start_index + 1 ))
-    local end_line="$end_index"
-
+read_chunk() {
+    local count=0
     CHUNK_NODES=()
-    while IFS= read -r node; do
-        [[ -n "$node" ]] && CHUNK_NODES+=("$node")
-    done < <(awk -v start="$start_line" -v end="$end_line" 'NR < start {next} NR > end {exit} {print}' "$COLLECT_OUT")
+    while (( count < CHUNK_SIZE )); do
+        if ! IFS= read -r node <&3; then
+            break
+        fi
+        CHUNK_NODES+=("$node")
+        count=$((count + 1))
+    done
 }
 
 cd "$REPO_ROOT"
@@ -248,6 +260,15 @@ fi
 CHUNKS=$(( (TOTAL - START + CHUNK_SIZE - 1) / CHUNK_SIZE ))
 echo "[fast-test] $TOTAL tests · chunk=$CHUNK_SIZE · $CHUNKS chunk(s) queued · workers=auto"
 
+exec 3< "$COLLECT_OUT"
+skip_count=0
+while (( skip_count < START )); do
+    if ! IFS= read -r _ <&3; then
+        break
+    fi
+    skip_count=$((skip_count + 1))
+done
+
 # 3. FIFO dispatch.
 T_START=$(date +%s)
 i="$START"
@@ -256,6 +277,12 @@ while (( i < TOTAL )); do
     end=$(( i + CHUNK_SIZE ))
     (( end > TOTAL )) && end="$TOTAL"
     chunk_idx=$(( chunk_idx + 1 ))
+    read_chunk
+    if (( ${#CHUNK_NODES[@]} == 0 )); then
+        echo "[fast-test] no tests read for chunk; stopping" >&2
+        break
+    fi
+    end=$(( i + ${#CHUNK_NODES[@]} ))
     echo "[fast-test] chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
 
     PYTEST_FLAGS=(-n auto --dist=load)
@@ -265,9 +292,8 @@ while (( i < TOTAL )); do
         PYTEST_FLAGS+=(--no-header)
     fi
 
-    load_chunk_nodes "$i" "$end"
     if ! "${PYTEST_CMD[@]}" "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${CHUNK_NODES[@]}"; then
-        echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)"
+        echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)" >&2
         write_cursor "$i"
         exit 1
     fi
@@ -277,6 +303,7 @@ while (( i < TOTAL )); do
 done
 
 T_END=$(date +%s)
+exec 3<&- 2>/dev/null || true
 rm -f "$COLLECT_OUT"
 rm -f "$CURSOR_FILE"
 echo "[fast-test] all $TOTAL tests passed in $((T_END - T_START))s"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -213,6 +213,10 @@ cd "$REPO_ROOT"
 mkdir -p "$(dirname "$CURSOR_FILE")"
 
 if command -v flock >/dev/null 2>&1; then
+    if [[ -L "$LOCK_FILE" ]]; then
+        err "lock path is a symlink; refusing to use $LOCK_FILE"
+        exit 1
+    fi
     exec 9>"$LOCK_FILE" || { err "unable to open lock file: $LOCK_FILE"; exit 1; }
     if ! flock -n 9; then
         err "another run is active (lock: $LOCK_FILE)"
@@ -274,8 +278,8 @@ if ! "${PYTEST_CMD[@]}" --help 2>/dev/null | grep -Eq '(-n[[:space:]]|--numproce
 fi
 
 log "collecting tests ..."
-COLLECT_ERR="$(mktemp_file)"
-COLLECT_OUT="$(mktemp_file)"
+COLLECT_ERR="$(mktemp_file)" || exit 1
+COLLECT_OUT="$(mktemp_file)" || exit 1
 if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
     err "test collection failed"
     [[ -s "$COLLECT_ERR" ]] && { echo "--- collection stderr ---"; cat "$COLLECT_ERR"; } >&2
@@ -283,7 +287,7 @@ if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT
     exit 1
 fi
 rm -f "$COLLECT_ERR"
-COLLECT_FILTERED="$(mktemp_file)"
+COLLECT_FILTERED="$(mktemp_file)" || exit 1
 awk 'NF' "$COLLECT_OUT" > "$COLLECT_FILTERED"
 mv "$COLLECT_FILTERED" "$COLLECT_OUT"
 TOTAL="$(wc -l < "$COLLECT_OUT" | tr -d '[:space:]')"
@@ -305,7 +309,10 @@ if [[ "$ARG_MAX" =~ ^[0-9]+$ ]]; then
     BASE_ARGS_SIZE="$(arg_bytes "${PYTEST_CMD[@]}" "${BASE_PYTEST_ARGS[@]}" "${RUNTIME_PASSTHROUGH[@]}")"
     SAFETY_MARGIN=2048
     AVAILABLE=$(( ARG_MAX - BASE_ARGS_SIZE - SAFETY_MARGIN ))
-    (( AVAILABLE < 0 )) && AVAILABLE=0
+    if (( AVAILABLE <= 0 )); then
+        err "base pytest invocation exceeds ARG_MAX; reduce passthrough args"
+        exit 1
+    fi
     PER_NODE=$(( MAX_NODE_LEN + 1 ))
     if (( PER_NODE > 0 )); then
         MAX_SAFE=$(( AVAILABLE / PER_NODE ))

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -292,6 +292,7 @@ mkdir -p "$PYTEST_CACHE_DIR"
 
 if command -v flock >/dev/null 2>&1; then
     ensure_regular_file_or_missing "$LOCK_FILE" "lock file"
+    ensure_single_link "$LOCK_FILE" "lock file"
     exec 9>>"$LOCK_FILE" || { err "unable to open lock file: $LOCK_FILE"; exit 1; }
     if ! flock -n 9; then
         err "another run is active (lock: $LOCK_FILE)"
@@ -303,6 +304,9 @@ else
     ensure_dir_safe "$LOCK_DIR" "lock dir"
     if [[ -d "$LOCK_DIR" ]]; then
         if [[ -f "$LOCK_DIR/pid" ]]; then
+            local PID_CONTENTS
+            ensure_regular_file_or_missing "$LOCK_DIR/pid" "lock pid file"
+            ensure_single_link "$LOCK_DIR/pid" "lock pid file"
             PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
             if [[ "$PID_CONTENTS" =~ ^[0-9]+$ ]] && kill -0 "$PID_CONTENTS" 2>/dev/null; then
                 err "another run is active (lock: $LOCK_DIR)"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -74,10 +74,6 @@ mktemp_file() {
         printf '%s\n' "$tmp"
         return 0
     fi
-    if tmp="$(mktemp "${TMPDIR:-/tmp}/fast-test.XXXXXX" 2>/dev/null)"; then
-        printf '%s\n' "$tmp"
-        return 0
-    fi
     echo "[fast-test] mktemp failed; set TMPDIR or install a compatible mktemp" >&2
     return 1
 }
@@ -209,7 +205,11 @@ while (( i < TOTAL )); do
     echo "[fast-test] chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
 
     PYTEST_FLAGS=(-n auto --dist=load)
-    (( BENCH )) && PYTEST_FLAGS+=(-q) || PYTEST_FLAGS+=(--no-header -q)
+    if (( BENCH )); then
+        PYTEST_FLAGS+=(--no-header -q)
+    else
+        PYTEST_FLAGS+=(--no-header)
+    fi
 
     if ! "${PYTEST_CMD[@]}" "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
         echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -11,6 +11,8 @@
 #   * Persist the cursor (next test index / chunk boundary) to
 #     `.pytest_cache/fast-test-cursor` after every successful chunk so
 #     `--resume` continues from the last completed chunk.
+#   * Resume is tied to the current collection order; changing selection
+#     or order can skip or re-run tests.
 #   * `--reset` clears the cursor; `--bench` reduces pytest output (progress still prints).
 #
 # Usage:
@@ -20,6 +22,10 @@
 #   scripts/dev/test.sh --reset                  # clear cursor
 #   scripts/dev/test.sh --bench                  # quieter pytest output
 #   scripts/dev/test.sh -- tests/test_merge.py   # pass-through to pytest
+#
+# Notes:
+#   --resume assumes the same collection order; changing selection/order
+#   can skip or re-run tests.
 
 set -euo pipefail
 
@@ -45,6 +51,7 @@ COLLECT_OUT=""
 COLLECT_FILTERED=""
 CHUNK_NODES=()
 XDIST_IGNORED=0
+COLLECT_ONLY_REQUESTED=0
 
 print_help() {
     awk '
@@ -81,6 +88,10 @@ if ! [[ "$CHUNK_SIZE" =~ ^[1-9][0-9]*$ ]]; then
     exit 1
 fi
 
+if (( CHUNK_SIZE > 1000 )); then
+    echo "[fast-test] warning: large --chunk-size may exceed OS argument limits" >&2
+fi
+
 mktemp_file() {
     local tmp
     if tmp="$(mktemp -t fast-test.XXXXXX 2>/dev/null)"; then
@@ -102,7 +113,7 @@ idx=0
 while (( idx < ${#PASSTHROUGH[@]} )); do
     arg="${PASSTHROUGH[$idx]}"
     case "$arg" in
-        --collect-only|--co) ;;
+        --collect-only|--co) COLLECT_ONLY_REQUESTED=1 ;;
         -n|--numprocesses|--dist)
             next="${PASSTHROUGH[$((idx + 1))]:-}"
             if [[ -z "$next" || "$next" == -* ]]; then
@@ -120,6 +131,11 @@ while (( idx < ${#PASSTHROUGH[@]} )); do
     esac
     idx=$((idx + 1))
 done
+
+if (( COLLECT_ONLY_REQUESTED )); then
+    echo "[fast-test] --collect-only is not supported; run pytest --collect-only directly" >&2
+    exit 1
+fi
 
 if (( XDIST_IGNORED )); then
     echo "[fast-test] ignoring xdist flags (-n/--numprocesses/--dist); this script manages them" >&2

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -304,7 +304,7 @@ fi
 log "collecting tests ..."
 COLLECT_ERR="$(mktemp_file)" || exit 1
 COLLECT_OUT="$(mktemp_file)" || exit 1
-if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
+if ! "${PYTEST_CMD[@]}" --collect-only -q --no-header --no-summary "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
     err "test collection failed"
     [[ -s "$COLLECT_ERR" ]] && { echo "--- collection stderr ---"; cat "$COLLECT_ERR"; } >&2
     rm -f "$COLLECT_ERR" "$COLLECT_OUT"
@@ -324,7 +324,7 @@ if (( TOTAL == 0 )); then
     exit 1
 fi
 
-BASE_PYTEST_FLAGS=(-n auto --dist=load --no-header)
+BASE_PYTEST_FLAGS=(-p xdist -n auto --dist=load --no-header)
 if (( BENCH )); then
     BASE_PYTEST_FLAGS+=(-q)
 fi

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -53,12 +53,18 @@ fi
 cd "$REPO_ROOT"
 mkdir -p "$(dirname "$CURSOR_FILE")"
 
-# 1. Collect node ids (override addopts so collection itself is serial/quiet).
+# 1. Collect node ids.
 echo "[fast-test] collecting tests ..."
-mapfile -t NODES < <(
-    uv run pytest -o addopts= --collect-only -q "${PASSTHROUGH[@]}" \
-        2>/dev/null | grep -E '::' || true
-)
+COLLECT_ERR="$(mktemp)"
+COLLECT_OUT="$(mktemp)"
+if ! uv run pytest --collect-only -qq "${PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
+    echo "[fast-test] test collection failed" >&2
+    [[ -s "$COLLECT_ERR" ]] && { echo "--- collection stderr ---"; cat "$COLLECT_ERR"; } >&2
+    rm -f "$COLLECT_ERR" "$COLLECT_OUT"
+    exit 1
+fi
+mapfile -t NODES < <(grep -E '::' "$COLLECT_OUT" || true)
+rm -f "$COLLECT_ERR" "$COLLECT_OUT"
 TOTAL="${#NODES[@]}"
 if (( TOTAL == 0 )); then
     echo "[fast-test] no tests collected" >&2
@@ -69,7 +75,7 @@ fi
 START=0
 if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
     START="$(cat "$CURSOR_FILE")"
-    echo "[fast-test] resuming from chunk cursor: test #$START"
+    echo "[fast-test] resuming from next test index: $START"
 fi
 
 CHUNKS=$(( (TOTAL - START + CHUNK_SIZE - 1) / CHUNK_SIZE ))
@@ -85,11 +91,11 @@ while (( i < TOTAL )); do
     chunk_idx=$(( chunk_idx + 1 ))
     echo "[fast-test] chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
 
-    PYTEST_FLAGS=(-o addopts= -n auto --dist=load --tb=short)
+    PYTEST_FLAGS=(-n auto --dist=load)
     (( BENCH )) && PYTEST_FLAGS+=(-q) || PYTEST_FLAGS+=(--no-header -q)
 
     if ! uv run pytest "${PYTEST_FLAGS[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
-        echo "[fast-test] chunk failed — cursor preserved at test #$i (use --resume to retry)"
+        echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)"
         echo "$i" > "$CURSOR_FILE"
         exit 1
     fi

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -35,7 +35,14 @@ RUNTIME_PASSTHROUGH=()
 
 while (( $# )); do
     case "$1" in
-        --chunk-size) CHUNK_SIZE="$2"; shift 2 ;;
+        --chunk-size)
+            if (( $# < 2 )); then
+                echo "[fast-test] --chunk-size requires a value" >&2
+                exit 1
+            fi
+            CHUNK_SIZE="$2"
+            shift 2
+            ;;
         --resume)     RESUME=1; shift ;;
         --reset)      RESET=1;  shift ;;
         --bench)      BENCH=1;  shift ;;
@@ -44,6 +51,11 @@ while (( $# )); do
         *)            PASSTHROUGH+=("$1"); shift ;;
     esac
 done
+
+if ! [[ "$CHUNK_SIZE" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[fast-test] --chunk-size must be a positive integer (got '$CHUNK_SIZE')" >&2
+    exit 1
+fi
 
 # Collection and execution do not share every pytest flag. Keep runtime
 # passthrough aligned with user intent while stripping collect-only toggles.
@@ -73,7 +85,10 @@ if ! uv run pytest --collect-only -qq "${PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$CO
     rm -f "$COLLECT_ERR" "$COLLECT_OUT"
     exit 1
 fi
-mapfile -t NODES < <(grep -E '::' "$COLLECT_OUT" || true)
+NODES=()
+while IFS= read -r node; do
+    NODES+=("$node")
+done < <(grep -E '::' "$COLLECT_OUT" || true)
 rm -f "$COLLECT_ERR" "$COLLECT_OUT"
 TOTAL="${#NODES[@]}"
 if (( TOTAL == 0 )); then
@@ -92,6 +107,12 @@ if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
     else
         echo "[fast-test] cursor file is invalid ('$RAW_START'); starting from 0" >&2
     fi
+fi
+
+if (( START >= TOTAL )); then
+    echo "[fast-test] nothing to resume (cursor at end: $START/$TOTAL)"
+    rm -f "$CURSOR_FILE"
+    exit 0
 fi
 
 CHUNKS=$(( (TOTAL - START + CHUNK_SIZE - 1) / CHUNK_SIZE ))

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -115,6 +115,13 @@ ensure_single_link() {
     fi
 }
 
+remove_cursor_safe() {
+    ensure_dir_safe "$PYTEST_CACHE_DIR" "pytest cache dir"
+    ensure_regular_file_or_missing "$CURSOR_FILE" "cursor path"
+    ensure_single_link "$CURSOR_FILE" "cursor path"
+    rm -f "$CURSOR_FILE"
+}
+
 print_help() {
     awk '
         /^# Usage:/ {printing=1}
@@ -180,12 +187,20 @@ mktemp_file() {
 arg_bytes() {
     local total=0
     local arg
-    local old_lc_all="${LC_ALL:-}"
+    local old_lc_all="${LC_ALL-}"
+    local had_lc_all=0
+    if [[ ${LC_ALL+x} ]]; then
+        had_lc_all=1
+    fi
     LC_ALL=C
     for arg in "$@"; do
         total=$(( total + ${#arg} + 1 ))
     done
-    LC_ALL="$old_lc_all"
+    if (( had_lc_all )); then
+        LC_ALL="$old_lc_all"
+    else
+        unset LC_ALL
+    fi
     printf '%s\n' "$total"
 }
 
@@ -306,12 +321,16 @@ else
         exit 1
     fi
     LOCK_MODE="dir"
+    printf '%s\n' "$$" > "$LOCK_DIR/pid" || {
+        err "failed to write lock pid file: $LOCK_DIR/pid"
+        rmdir "$LOCK_DIR" 2>/dev/null || true
+        exit 1
+    }
     LOCK_HELD=1
-    printf '%s\n' "$$" > "$LOCK_DIR/pid"
 fi
 
 if (( RESET )); then
-    rm -f "$CURSOR_FILE"
+    remove_cursor_safe
     log "cursor cleared"
     exit 0
 fi
@@ -459,5 +478,5 @@ if (( FD3_OPEN )); then
     FD3_OPEN=0
 fi
 rm -f "$COLLECT_OUT"
-rm -f "$CURSOR_FILE"
+remove_cursor_safe
 log "all $TOTAL tests passed in $((T_END - T_START))s"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -311,9 +311,13 @@ if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT
     rm -f "$COLLECT_ERR" "$COLLECT_OUT"
     exit 1
 fi
+if [[ -s "$COLLECT_ERR" ]] && (( ! BENCH )); then
+    log "collection warnings:"
+    cat "$COLLECT_ERR" >&2
+fi
 rm -f "$COLLECT_ERR"
 COLLECT_FILTERED="$(mktemp_file)" || exit 1
-LC_ALL=C awk 'match($0, /\.py($|::)/) { print }' "$COLLECT_OUT" > "$COLLECT_FILTERED"
+LC_ALL=C awk 'NF { print }' "$COLLECT_OUT" > "$COLLECT_FILTERED"
 mv "$COLLECT_FILTERED" "$COLLECT_OUT"
 TOTAL="$(wc -l < "$COLLECT_OUT" | tr -d '[:space:]')"
 if (( TOTAL == 0 )); then
@@ -407,9 +411,7 @@ while (( i < TOTAL )); do
     end=$(( i + ${#CHUNK_NODES[@]} ))
     log "chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
 
-    PYTEST_FLAGS=("${BASE_PYTEST_FLAGS[@]}")
-
-    if ! "${PYTEST_CMD[@]}" "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${CHUNK_NODES[@]}"; then
+    if ! "${PYTEST_CMD[@]}" "${BASE_PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${CHUNK_NODES[@]}"; then
         err "chunk failed — cursor preserved at next test index $i (use --resume to retry)"
         write_cursor "$i"
         exit 1

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -415,6 +415,9 @@ fi
 # 2. Determine starting cursor.
 START=0
 if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
+    ensure_dir_safe "$PYTEST_CACHE_DIR" "pytest cache dir"
+    ensure_regular_file_or_missing "$CURSOR_FILE" "cursor path"
+    ensure_single_link "$CURSOR_FILE" "cursor path"
     RAW_START="$(tr -d '[:space:]' < "$CURSOR_FILE")"
     if [[ "$RAW_START" =~ ^[0-9]+$ ]]; then
         START="$RAW_START"
@@ -422,13 +425,13 @@ if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
         log "resuming from next test index: $START"
     else
         err "cursor file is invalid ('$RAW_START'); starting from 0"
-        rm -f "$CURSOR_FILE"
+        remove_cursor_safe
     fi
 fi
 
 if (( START >= TOTAL )); then
     log "nothing to resume (cursor at end: $START/$TOTAL)"
-    rm -f "$CURSOR_FILE"
+    remove_cursor_safe
     exit 0
 fi
 

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -32,6 +32,11 @@ RESET=0
 BENCH=0
 PASSTHROUGH=()
 RUNTIME_PASSTHROUGH=()
+LOCK_DIR="$REPO_ROOT/.pytest_cache/fast-test.lock"
+LOCK_HELD=0
+CURSOR_TMP="$CURSOR_FILE.tmp"
+COLLECT_ERR=""
+COLLECT_OUT=""
 
 while (( $# )); do
     case "$1" in
@@ -66,14 +71,37 @@ for arg in "${PASSTHROUGH[@]}"; do
     esac
 done
 
+cleanup() {
+    [[ -n "$COLLECT_ERR" && -f "$COLLECT_ERR" ]] && rm -f "$COLLECT_ERR"
+    [[ -n "$COLLECT_OUT" && -f "$COLLECT_OUT" ]] && rm -f "$COLLECT_OUT"
+    [[ -n "$CURSOR_TMP" && -f "$CURSOR_TMP" ]] && rm -f "$CURSOR_TMP"
+    if (( LOCK_HELD )); then
+        rm -f "$LOCK_DIR/pid"
+        rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+    fi
+}
+
+trap cleanup EXIT
+
+write_cursor() {
+    printf '%s\n' "$1" > "$CURSOR_TMP"
+    mv "$CURSOR_TMP" "$CURSOR_FILE"
+}
+cd "$REPO_ROOT"
+mkdir -p "$(dirname "$CURSOR_FILE")"
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
+    exit 1
+fi
+LOCK_HELD=1
+printf '%s\n' "$$" > "$LOCK_DIR/pid"
+
 if (( RESET )); then
-    rm -f "$CURSOR_FILE"
+    rm -f "$CURSOR_FILE" "$CURSOR_TMP"
     echo "[fast-test] cursor cleared"
     exit 0
 fi
-
-cd "$REPO_ROOT"
-mkdir -p "$(dirname "$CURSOR_FILE")"
 
 # 1. Collect node ids.
 echo "[fast-test] collecting tests ..."
@@ -133,12 +161,12 @@ while (( i < TOTAL )); do
 
     if ! uv run pytest "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
         echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)"
-        echo "$i" > "$CURSOR_FILE"
+        write_cursor "$i"
         exit 1
     fi
 
     i="$end"
-    echo "$i" > "$CURSOR_FILE"
+    write_cursor "$i"
 done
 
 T_END=$(date +%s)

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -95,11 +95,32 @@ ensure_regular_file_or_missing() {
     fi
 }
 
+ensure_single_link() {
+    local path="$1"
+    local label="$2"
+    local links=""
+    if [[ ! -e "$path" ]]; then
+        return 0
+    fi
+    if links="$(stat -c %h "$path" 2>/dev/null)"; then
+        :
+    elif links="$(stat -f %l "$path" 2>/dev/null)"; then
+        :
+    else
+        return 0
+    fi
+    if [[ "$links" =~ ^[0-9]+$ ]] && (( links > 1 )); then
+        err "$label has multiple links ($links); refusing to use $path"
+        exit 1
+    fi
+}
+
 print_help() {
     awk '
         /^# Usage:/ {printing=1}
+    ensure_single_link "$CURSOR_FILE" "cursor path"
         printing {
-            if ($0 !~ /^#/) {exit}
+    cursor_tmp="$(mktemp_file "$PYTEST_CACHE_DIR")" || exit 1
             sub(/^# ?/, "", $0)
             print
         }
@@ -131,7 +152,20 @@ if ! [[ "$CHUNK_SIZE" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 mktemp_file() {
+    local target_dir="${1:-}"
     local tmp
+    if [[ -n "$target_dir" ]]; then
+        if tmp="$(mktemp -p "$target_dir" "${SCRIPT_STEM}.XXXXXX" 2>/dev/null)"; then
+            printf '%s\n' "$tmp"
+            return 0
+        fi
+        if tmp="$(mktemp "$target_dir/${SCRIPT_STEM}.XXXXXX" 2>/dev/null)"; then
+            printf '%s\n' "$tmp"
+            return 0
+        fi
+        err "mktemp failed in $target_dir; check permissions"
+        return 1
+    fi
     if tmp="$(mktemp -t "${SCRIPT_STEM}.XXXXXX" 2>/dev/null)"; then
         printf '%s\n' "$tmp"
         return 0

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -214,7 +214,7 @@ write_cursor() {
     ensure_dir_safe "$PYTEST_CACHE_DIR" "pytest cache dir"
     ensure_regular_file_or_missing "$CURSOR_FILE" "cursor path"
     local cursor_tmp
-    cursor_tmp="$(mktemp "${PYTEST_CACHE_DIR}/${SCRIPT_STEM}.cursor.XXXXXX")" || exit 1
+    cursor_tmp="$(TMPDIR="$PYTEST_CACHE_DIR" mktemp_file)" || exit 1
     if [[ -L "$cursor_tmp" || ! -f "$cursor_tmp" ]]; then
         err "cursor temp path is unsafe; refusing to write $cursor_tmp"
         rm -f "$cursor_tmp" 2>/dev/null || true
@@ -268,7 +268,11 @@ else
         fi
     fi
     if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-        err "another run is active (lock: $LOCK_DIR)"
+        if [[ -d "$LOCK_DIR" ]]; then
+            err "another run is active (lock: $LOCK_DIR)"
+        else
+            err "failed to create lock dir: $LOCK_DIR"
+        fi
         exit 1
     fi
     LOCK_MODE="dir"
@@ -407,7 +411,7 @@ while (( i < TOTAL )); do
         exit 1
     fi
     end=$(( i + ${#CHUNK_NODES[@]} ))
-    log "chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
+    log "chunk $chunk_idx/$CHUNKS tests $((i+1))..$end"
 
     if ! "${PYTEST_CMD[@]}" "${BASE_PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${CHUNK_NODES[@]}"; then
         err "chunk failed — cursor preserved at next test index $i (use --resume to retry)"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -39,7 +39,8 @@ SCRIPT_STEM="${SCRIPT_NAME%.*}"
 LOG_PREFIX="[${SCRIPT_STEM}]"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-CURSOR_FILE="$REPO_ROOT/.pytest_cache/${SCRIPT_STEM}-cursor"
+PYTEST_CACHE_DIR="$REPO_ROOT/.pytest_cache"
+CURSOR_FILE="$PYTEST_CACHE_DIR/${SCRIPT_STEM}-cursor"
 
 CHUNK_SIZE=200
 RESUME=0
@@ -49,8 +50,8 @@ PASSTHROUGH=()
 RUNTIME_PASSTHROUGH=()
 COLLECT_PASSTHROUGH=()
 PYTEST_CMD=()
-LOCK_FILE="$REPO_ROOT/.pytest_cache/${SCRIPT_STEM}.lock"
-LOCK_DIR="$REPO_ROOT/.pytest_cache/${SCRIPT_STEM}.lockdir"
+LOCK_FILE="$PYTEST_CACHE_DIR/${SCRIPT_STEM}.lock"
+LOCK_DIR="$PYTEST_CACHE_DIR/${SCRIPT_STEM}.lockdir"
 LOCK_MODE=""
 LOCK_HELD=0
 CURSOR_TMP="$CURSOR_FILE.tmp"
@@ -192,6 +193,14 @@ cleanup() {
 trap cleanup EXIT
 
 write_cursor() {
+    if [[ -L "$PYTEST_CACHE_DIR" ]]; then
+        err "pytest cache dir is a symlink; refusing to write $CURSOR_FILE"
+        exit 1
+    fi
+    if [[ -e "$PYTEST_CACHE_DIR" && ! -d "$PYTEST_CACHE_DIR" ]]; then
+        err "pytest cache path is not a directory; refusing to write $CURSOR_FILE"
+        exit 1
+    fi
     if [[ -L "$(dirname "$CURSOR_FILE")" ]]; then
         err "cursor directory is a symlink; refusing to write $CURSOR_FILE"
         exit 1
@@ -218,7 +227,15 @@ read_chunk() {
 }
 
 cd "$REPO_ROOT"
-mkdir -p "$(dirname "$CURSOR_FILE")"
+if [[ -L "$PYTEST_CACHE_DIR" ]]; then
+    err "pytest cache dir is a symlink; refusing to use $PYTEST_CACHE_DIR"
+    exit 1
+fi
+if [[ -e "$PYTEST_CACHE_DIR" && ! -d "$PYTEST_CACHE_DIR" ]]; then
+    err "pytest cache path is not a directory; refusing to use $PYTEST_CACHE_DIR"
+    exit 1
+fi
+mkdir -p "$PYTEST_CACHE_DIR"
 
 if command -v flock >/dev/null 2>&1; then
     if [[ -L "$LOCK_FILE" ]]; then
@@ -296,12 +313,17 @@ if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT
 fi
 rm -f "$COLLECT_ERR"
 COLLECT_FILTERED="$(mktemp_file)" || exit 1
-awk 'NF' "$COLLECT_OUT" > "$COLLECT_FILTERED"
+LC_ALL=C awk 'match($0, /\.py($|::)/) { print }' "$COLLECT_OUT" > "$COLLECT_FILTERED"
 mv "$COLLECT_FILTERED" "$COLLECT_OUT"
 TOTAL="$(wc -l < "$COLLECT_OUT" | tr -d '[:space:]')"
 if (( TOTAL == 0 )); then
     err "no tests collected"
     exit 1
+fi
+
+BASE_PYTEST_FLAGS=(-n auto --dist=load --no-header)
+if (( BENCH )); then
+    BASE_PYTEST_FLAGS+=(-q)
 fi
 
 ARG_MAX=""
@@ -310,11 +332,7 @@ if command -v getconf >/dev/null 2>&1; then
 fi
 if [[ "$ARG_MAX" =~ ^[0-9]+$ ]]; then
     MAX_NODE_LEN="$(LC_ALL=C awk 'length > max { max = length } END { print max + 0 }' "$COLLECT_OUT")"
-    BASE_PYTEST_ARGS=(-n auto --dist=load --no-header)
-    if (( BENCH )); then
-        BASE_PYTEST_ARGS+=(-q)
-    fi
-    BASE_ARGS_SIZE="$(arg_bytes "${PYTEST_CMD[@]}" "${BASE_PYTEST_ARGS[@]}" "${RUNTIME_PASSTHROUGH[@]}")"
+    BASE_ARGS_SIZE="$(arg_bytes "${PYTEST_CMD[@]}" "${BASE_PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}")"
     SAFETY_MARGIN=2048
     AVAILABLE=$(( ARG_MAX - BASE_ARGS_SIZE - SAFETY_MARGIN ))
     if (( AVAILABLE <= 0 )); then
@@ -389,12 +407,7 @@ while (( i < TOTAL )); do
     end=$(( i + ${#CHUNK_NODES[@]} ))
     log "chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
 
-    PYTEST_FLAGS=(-n auto --dist=load)
-    if (( BENCH )); then
-        PYTEST_FLAGS+=(--no-header -q)
-    else
-        PYTEST_FLAGS+=(--no-header)
-    fi
+    PYTEST_FLAGS=("${BASE_PYTEST_FLAGS[@]}")
 
     if ! "${PYTEST_CMD[@]}" "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${CHUNK_NODES[@]}"; then
         err "chunk failed — cursor preserved at next test index $i (use --resume to retry)"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -8,10 +8,10 @@
 #     pytest-xdist's `--dist=load` hands tests out one at a time to
 #     workers as they finish — natural FIFO progression with bounded
 #     in-flight memory.
-#   * Persist the cursor (next chunk index) to
+#   * Persist the cursor (next test index / chunk boundary) to
 #     `.pytest_cache/fast-test-cursor` after every successful chunk so
-#     `--resume` continues exactly where a crash left off.
-#   * `--reset` clears the cursor; `--bench` reports wall-time only.
+#     `--resume` continues from the last completed chunk.
+#   * `--reset` clears the cursor; `--bench` reduces pytest output (progress still prints).
 #
 # Usage:
 #   scripts/dev/test.sh                          # full suite, chunked

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -118,9 +118,8 @@ ensure_single_link() {
 print_help() {
     awk '
         /^# Usage:/ {printing=1}
-    ensure_single_link "$CURSOR_FILE" "cursor path"
         printing {
-    cursor_tmp="$(mktemp_file "$PYTEST_CACHE_DIR")" || exit 1
+            if ($0 !~ /^#/) {exit}
             sub(/^# ?/, "", $0)
             print
         }
@@ -243,8 +242,9 @@ trap cleanup EXIT
 write_cursor() {
     ensure_dir_safe "$PYTEST_CACHE_DIR" "pytest cache dir"
     ensure_regular_file_or_missing "$CURSOR_FILE" "cursor path"
+    ensure_single_link "$CURSOR_FILE" "cursor path"
     local cursor_tmp
-    cursor_tmp="$(TMPDIR="$PYTEST_CACHE_DIR" mktemp_file)" || exit 1
+    cursor_tmp="$(mktemp_file "$PYTEST_CACHE_DIR")" || exit 1
     if [[ -L "$cursor_tmp" || ! -f "$cursor_tmp" ]]; then
         err "cursor temp path is unsafe; refusing to write $cursor_tmp"
         rm -f "$cursor_tmp" 2>/dev/null || true

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -34,11 +34,17 @@ PASSTHROUGH=()
 RUNTIME_PASSTHROUGH=()
 COLLECT_PASSTHROUGH=()
 PYTEST_CMD=()
-LOCK_DIR="$REPO_ROOT/.pytest_cache/fast-test.lock"
+LOCK_FILE="$REPO_ROOT/.pytest_cache/fast-test.lock"
+LOCK_DIR="$REPO_ROOT/.pytest_cache/fast-test.lockdir"
+LOCK_MODE=""
 LOCK_HELD=0
+LOCK_NAME="$(basename "$0")"
 CURSOR_TMP="$CURSOR_FILE.tmp"
 COLLECT_ERR=""
 COLLECT_OUT=""
+COLLECT_FILTERED=""
+CHUNK_NODES=()
+XDIST_IGNORED=0
 
 while (( $# )); do
     case "$1" in
@@ -81,28 +87,43 @@ mktemp_file() {
 # Collection and execution do not share every pytest flag. Keep runtime
 # passthrough aligned with user intent while stripping collect-only toggles
 # and xdist-specific options that this script owns.
-skip_next=0
-for arg in "${PASSTHROUGH[@]}"; do
-    if (( skip_next )); then
-        skip_next=0
-        continue
-    fi
+idx=0
+while (( idx < ${#PASSTHROUGH[@]} )); do
+    arg="${PASSTHROUGH[$idx]}"
     case "$arg" in
         --collect-only|--co) ;;
-        -n|--numprocesses|--dist) skip_next=1 ;;
-        -n*|--numprocesses=*|--dist=*) ;;
+        -n|--numprocesses|--dist)
+            next="${PASSTHROUGH[$((idx + 1))]:-}"
+            if [[ -z "$next" || "$next" == -* ]]; then
+                echo "[fast-test] $arg requires a value, but xdist flags are managed by this script" >&2
+                exit 1
+            fi
+            XDIST_IGNORED=1
+            idx=$((idx + 1))
+            ;;
+        -n*|--numprocesses=*|--dist=*) XDIST_IGNORED=1 ;;
         *)
             RUNTIME_PASSTHROUGH+=("$arg")
             COLLECT_PASSTHROUGH+=("$arg")
             ;;
     esac
+    idx=$((idx + 1))
 done
+
+if (( XDIST_IGNORED )); then
+    echo "[fast-test] ignoring xdist flags (-n/--numprocesses/--dist); this script manages them" >&2
+fi
 
 cleanup() {
     [[ -n "$COLLECT_ERR" && -f "$COLLECT_ERR" ]] && rm -f "$COLLECT_ERR"
     [[ -n "$COLLECT_OUT" && -f "$COLLECT_OUT" ]] && rm -f "$COLLECT_OUT"
+    [[ -n "$COLLECT_FILTERED" && -f "$COLLECT_FILTERED" ]] && rm -f "$COLLECT_FILTERED"
     [[ -n "$CURSOR_TMP" && -f "$CURSOR_TMP" ]] && rm -f "$CURSOR_TMP"
-    if (( LOCK_HELD )); then
+    if [[ "$LOCK_MODE" == "flock" ]]; then
+        flock -u 9 2>/dev/null || true
+        exec 9>&- || true
+        rm -f "$LOCK_FILE"
+    elif (( LOCK_HELD )); then
         rm -f "$LOCK_DIR/pid"
         rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
     fi
@@ -114,27 +135,59 @@ write_cursor() {
     printf '%s\n' "$1" > "$CURSOR_TMP"
     mv "$CURSOR_TMP" "$CURSOR_FILE"
 }
+
+load_chunk_nodes() {
+    local start_index="$1"
+    local end_index="$2"
+    local start_line=$(( start_index + 1 ))
+    local end_line="$end_index"
+
+    CHUNK_NODES=()
+    while IFS= read -r node; do
+        [[ -n "$node" ]] && CHUNK_NODES+=("$node")
+    done < <(awk -v start="$start_line" -v end="$end_line" 'NR < start {next} NR > end {exit} {print}' "$COLLECT_OUT")
+}
+
 cd "$REPO_ROOT"
 mkdir -p "$(dirname "$CURSOR_FILE")"
 
-if [[ -d "$LOCK_DIR" ]]; then
-    if [[ -f "$LOCK_DIR/pid" ]]; then
-        PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
-        if [[ "$PID_CONTENTS" =~ ^[0-9]+$ ]] && kill -0 "$PID_CONTENTS" 2>/dev/null; then
-            echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
-            exit 1
-        fi
-        echo "[fast-test] removing stale lock (pid: ${PID_CONTENTS:-unknown})" >&2
+if command -v flock >/dev/null 2>&1; then
+    exec 9>"$LOCK_FILE" || { echo "[fast-test] unable to open lock file: $LOCK_FILE" >&2; exit 1; }
+    if ! flock -n 9; then
+        echo "[fast-test] another run is active (lock: $LOCK_FILE)" >&2
+        exit 1
     fi
-    rm -f "$LOCK_DIR/pid"
-    rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+    LOCK_MODE="flock"
+    LOCK_HELD=1
+else
+    if [[ -d "$LOCK_DIR" ]]; then
+        if [[ -f "$LOCK_DIR/pid" ]]; then
+            PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
+            if [[ "$PID_CONTENTS" =~ ^[0-9]+$ ]] && kill -0 "$PID_CONTENTS" 2>/dev/null; then
+                if command -v ps >/dev/null 2>&1; then
+                    CMDLINE="$(ps -p "$PID_CONTENTS" -o args= 2>/dev/null || true)"
+                    if [[ -z "$CMDLINE" || "$CMDLINE" == *"$LOCK_NAME"* ]]; then
+                        echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
+                        exit 1
+                    fi
+                else
+                    echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
+                    exit 1
+                fi
+            fi
+            echo "[fast-test] removing stale lock (pid: ${PID_CONTENTS:-unknown})" >&2
+        fi
+        rm -f "$LOCK_DIR/pid"
+        rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+    fi
+    if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+        echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
+        exit 1
+    fi
+    LOCK_MODE="dir"
+    LOCK_HELD=1
+    printf '%s\n' "$$" > "$LOCK_DIR/pid"
 fi
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-    echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
-    exit 1
-fi
-LOCK_HELD=1
-printf '%s\n' "$$" > "$LOCK_DIR/pid"
 
 if (( RESET )); then
     rm -f "$CURSOR_FILE" "$CURSOR_TMP"
@@ -145,6 +198,8 @@ fi
 # 1. Collect node ids.
 if command -v uv >/dev/null 2>&1; then
     PYTEST_CMD=(uv run pytest)
+elif command -v python3 >/dev/null 2>&1; then
+    PYTEST_CMD=(python3 -m pytest)
 elif command -v python >/dev/null 2>&1; then
     PYTEST_CMD=(python -m pytest)
 else
@@ -161,12 +216,11 @@ if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT
     rm -f "$COLLECT_ERR" "$COLLECT_OUT"
     exit 1
 fi
-NODES=()
-while IFS= read -r node; do
-    [[ -n "$node" ]] && NODES+=("$node")
-done < "$COLLECT_OUT"
-rm -f "$COLLECT_ERR" "$COLLECT_OUT"
-TOTAL="${#NODES[@]}"
+rm -f "$COLLECT_ERR"
+COLLECT_FILTERED="$(mktemp_file)"
+awk 'NF' "$COLLECT_OUT" > "$COLLECT_FILTERED"
+mv "$COLLECT_FILTERED" "$COLLECT_OUT"
+TOTAL="$(wc -l < "$COLLECT_OUT" | tr -d '[:space:]')"
 if (( TOTAL == 0 )); then
     echo "[fast-test] no tests collected" >&2
     exit 1
@@ -211,7 +265,8 @@ while (( i < TOTAL )); do
         PYTEST_FLAGS+=(--no-header)
     fi
 
-    if ! "${PYTEST_CMD[@]}" "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
+    load_chunk_nodes "$i" "$end"
+    if ! "${PYTEST_CMD[@]}" "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${CHUNK_NODES[@]}"; then
         echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)"
         write_cursor "$i"
         exit 1
@@ -222,5 +277,6 @@ while (( i < TOTAL )); do
 done
 
 T_END=$(date +%s)
+rm -f "$COLLECT_OUT"
 rm -f "$CURSOR_FILE"
 echo "[fast-test] all $TOTAL tests passed in $((T_END - T_START))s"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -9,7 +9,7 @@
 #     workers as they finish — natural FIFO progression with bounded
 #     in-flight memory.
 #   * Persist the cursor (next test index / chunk boundary) to
-#     `.pytest_cache/fast-test-cursor` after every successful chunk so
+#     `.pytest_cache/<script>-cursor` after every successful chunk so
 #     `--resume` continues from the last completed chunk.
 #   * Resume is tied to the current collection order; changing selection
 #     or order can skip or re-run tests.
@@ -27,10 +27,19 @@
 #   --resume assumes the same collection order; changing selection/order
 #   can skip or re-run tests.
 
+if [ -z "${BASH_VERSION:-}" ]; then
+    echo "This script requires bash." >&2
+    exit 1
+fi
+
 set -euo pipefail
 
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_STEM="${SCRIPT_NAME%.*}"
+LOG_PREFIX="[${SCRIPT_STEM}]"
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-CURSOR_FILE="$REPO_ROOT/.pytest_cache/fast-test-cursor"
+CURSOR_FILE="$REPO_ROOT/.pytest_cache/${SCRIPT_STEM}-cursor"
 
 CHUNK_SIZE=200
 RESUME=0
@@ -40,11 +49,10 @@ PASSTHROUGH=()
 RUNTIME_PASSTHROUGH=()
 COLLECT_PASSTHROUGH=()
 PYTEST_CMD=()
-LOCK_FILE="$REPO_ROOT/.pytest_cache/fast-test.lock"
-LOCK_DIR="$REPO_ROOT/.pytest_cache/fast-test.lockdir"
+LOCK_FILE="$REPO_ROOT/.pytest_cache/${SCRIPT_STEM}.lock"
+LOCK_DIR="$REPO_ROOT/.pytest_cache/${SCRIPT_STEM}.lockdir"
 LOCK_MODE=""
 LOCK_HELD=0
-LOCK_NAME="$(basename "$0")"
 CURSOR_TMP="$CURSOR_FILE.tmp"
 COLLECT_ERR=""
 COLLECT_OUT=""
@@ -55,7 +63,11 @@ COLLECT_ONLY_REQUESTED=0
 FD3_OPEN=0
 
 log() {
-    echo "$*" >&2
+    echo "$LOG_PREFIX $*" >&2
+}
+
+err() {
+    echo "$LOG_PREFIX $*" >&2
 }
 
 print_help() {
@@ -73,7 +85,7 @@ while (( $# )); do
     case "$1" in
         --chunk-size)
             if (( $# < 2 )); then
-                echo "[fast-test] --chunk-size requires a value" >&2
+                err "--chunk-size requires a value"
                 exit 1
             fi
             CHUNK_SIZE="$2"
@@ -89,29 +101,32 @@ while (( $# )); do
 done
 
 if ! [[ "$CHUNK_SIZE" =~ ^[1-9][0-9]*$ ]]; then
-    echo "[fast-test] --chunk-size must be a positive integer (got '$CHUNK_SIZE')" >&2
+    err "--chunk-size must be a positive integer (got '$CHUNK_SIZE')"
     exit 1
 fi
 
 mktemp_file() {
     local tmp
-    if tmp="$(mktemp -t fast-test.XXXXXX 2>/dev/null)"; then
+    if tmp="$(mktemp -t "${SCRIPT_STEM}.XXXXXX" 2>/dev/null)"; then
         printf '%s\n' "$tmp"
         return 0
     fi
-    if tmp="$(mktemp "${TMPDIR:-/tmp}/fast-test.XXXXXX" 2>/dev/null)"; then
+    if tmp="$(mktemp "${TMPDIR:-/tmp}/${SCRIPT_STEM}.XXXXXX" 2>/dev/null)"; then
         printf '%s\n' "$tmp"
         return 0
     fi
-    echo "[fast-test] mktemp failed; set TMPDIR or install a compatible mktemp" >&2
+    err "mktemp failed; set TMPDIR or install a compatible mktemp"
     return 1
 }
 
 arg_bytes() {
     local total=0
     local arg
+    local bytes
     for arg in "$@"; do
-        total=$(( total + ${#arg} + 1 ))
+        bytes="$(LC_ALL=C printf '%s' "$arg" | wc -c | tr -d '[:space:]')"
+        bytes="${bytes:-0}"
+        total=$(( total + bytes + 1 ))
     done
     printf '%s\n' "$total"
 }
@@ -127,7 +142,7 @@ while (( idx < ${#PASSTHROUGH[@]} )); do
         -n|--numprocesses|--dist)
             next="${PASSTHROUGH[$((idx + 1))]:-}"
             if [[ -z "$next" || "$next" == -* ]]; then
-                echo "[fast-test] $arg requires a value, but xdist flags are managed by this script" >&2
+                err "$arg requires a value, but xdist flags are managed by this script"
                 exit 1
             fi
             XDIST_IGNORED=1
@@ -143,12 +158,12 @@ while (( idx < ${#PASSTHROUGH[@]} )); do
 done
 
 if (( COLLECT_ONLY_REQUESTED )); then
-    echo "[fast-test] --collect-only is not supported; run pytest --collect-only directly" >&2
+    err "--collect-only is not supported; run pytest --collect-only directly"
     exit 1
 fi
 
 if (( XDIST_IGNORED )); then
-    log "[fast-test] ignoring xdist flags (-n/--numprocesses/--dist); this script manages them"
+    log "ignoring xdist flags (-n/--numprocesses/--dist); this script manages them"
 fi
 
 cleanup() {
@@ -198,32 +213,35 @@ cd "$REPO_ROOT"
 mkdir -p "$(dirname "$CURSOR_FILE")"
 
 if command -v flock >/dev/null 2>&1; then
-    exec 9>"$LOCK_FILE" || { echo "[fast-test] unable to open lock file: $LOCK_FILE" >&2; exit 1; }
+    exec 9>"$LOCK_FILE" || { err "unable to open lock file: $LOCK_FILE"; exit 1; }
     if ! flock -n 9; then
-        echo "[fast-test] another run is active (lock: $LOCK_FILE)" >&2
+        err "another run is active (lock: $LOCK_FILE)"
         exit 1
     fi
     LOCK_MODE="flock"
     LOCK_HELD=1
 else
     if [[ -L "$LOCK_DIR" ]]; then
-        echo "[fast-test] lock path is a symlink; refusing to use $LOCK_DIR" >&2
+        err "lock path is a symlink; refusing to use $LOCK_DIR"
         exit 1
     fi
     if [[ -d "$LOCK_DIR" ]]; then
         if [[ -f "$LOCK_DIR/pid" ]]; then
             PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
             if [[ "$PID_CONTENTS" =~ ^[0-9]+$ ]] && kill -0 "$PID_CONTENTS" 2>/dev/null; then
-                echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
+                err "another run is active (lock: $LOCK_DIR)"
                 exit 1
             fi
-            echo "[fast-test] removing stale lock (pid: ${PID_CONTENTS:-unknown})" >&2
+            log "removing stale lock (pid: ${PID_CONTENTS:-unknown})"
         fi
         rm -f "$LOCK_DIR/pid"
-        rmdir "$LOCK_DIR" 2>/dev/null || rm -rf "$LOCK_DIR"
+        if ! rmdir "$LOCK_DIR" 2>/dev/null; then
+            err "lock dir is not empty; refusing to remove $LOCK_DIR"
+            exit 1
+        fi
     fi
     if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-        echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
+        err "another run is active (lock: $LOCK_DIR)"
         exit 1
     fi
     LOCK_MODE="dir"
@@ -233,7 +251,7 @@ fi
 
 if (( RESET )); then
     rm -f "$CURSOR_FILE" "$CURSOR_TMP"
-    log "[fast-test] cursor cleared"
+    log "cursor cleared"
     exit 0
 fi
 
@@ -245,21 +263,21 @@ elif command -v python3 >/dev/null 2>&1; then
 elif command -v python >/dev/null 2>&1; then
     PYTEST_CMD=(python -m pytest)
 else
-    echo "[fast-test] pytest runner not found (install uv or ensure python is on PATH)" >&2
+    err "pytest runner not found (install uv or ensure python is on PATH)"
     exit 1
 fi
 
 if ! "${PYTEST_CMD[@]}" --help 2>/dev/null | grep -Eq '(-n[[:space:]]|--numprocesses)'; then
-    echo "[fast-test] pytest-xdist is required for this wrapper (missing -n/--numprocesses)." >&2
-    echo "[fast-test] install test extras, e.g. 'uv pip install -e .[test]'" >&2
+    err "pytest-xdist is required for this wrapper (missing -n/--numprocesses)."
+    err "install test extras, e.g. 'uv pip install -e .[test]'"
     exit 1
 fi
 
-log "[fast-test] collecting tests ..."
+log "collecting tests ..."
 COLLECT_ERR="$(mktemp_file)"
 COLLECT_OUT="$(mktemp_file)"
 if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
-    echo "[fast-test] test collection failed" >&2
+    err "test collection failed"
     [[ -s "$COLLECT_ERR" ]] && { echo "--- collection stderr ---"; cat "$COLLECT_ERR"; } >&2
     rm -f "$COLLECT_ERR" "$COLLECT_OUT"
     exit 1
@@ -270,7 +288,7 @@ awk 'NF' "$COLLECT_OUT" > "$COLLECT_FILTERED"
 mv "$COLLECT_FILTERED" "$COLLECT_OUT"
 TOTAL="$(wc -l < "$COLLECT_OUT" | tr -d '[:space:]')"
 if (( TOTAL == 0 )); then
-    echo "[fast-test] no tests collected" >&2
+    err "no tests collected"
     exit 1
 fi
 
@@ -279,7 +297,7 @@ if command -v getconf >/dev/null 2>&1; then
     ARG_MAX="$(getconf ARG_MAX 2>/dev/null || true)"
 fi
 if [[ "$ARG_MAX" =~ ^[0-9]+$ ]]; then
-    MAX_NODE_LEN="$(awk 'length > max { max = length } END { print max + 0 }' "$COLLECT_OUT")"
+    MAX_NODE_LEN="$(LC_ALL=C awk 'length > max { max = length } END { print max + 0 }' "$COLLECT_OUT")"
     BASE_PYTEST_ARGS=(-n auto --dist=load --no-header)
     if (( BENCH )); then
         BASE_PYTEST_ARGS+=(-q)
@@ -292,17 +310,17 @@ if [[ "$ARG_MAX" =~ ^[0-9]+$ ]]; then
     if (( PER_NODE > 0 )); then
         MAX_SAFE=$(( AVAILABLE / PER_NODE ))
         if (( MAX_SAFE <= 0 )); then
-            echo "[fast-test] chunk size too large for ARG_MAX; reduce --chunk-size" >&2
+            err "chunk size too large for ARG_MAX; reduce --chunk-size"
             exit 1
         fi
         if (( CHUNK_SIZE > MAX_SAFE )); then
-            log "[fast-test] reducing --chunk-size from $CHUNK_SIZE to $MAX_SAFE to avoid ARG_MAX"
+            log "reducing --chunk-size from $CHUNK_SIZE to $MAX_SAFE to avoid ARG_MAX"
             CHUNK_SIZE="$MAX_SAFE"
         fi
     fi
 else
     if (( CHUNK_SIZE > 1000 )); then
-        log "[fast-test] warning: large --chunk-size may exceed OS argument limits"
+        log "warning: large --chunk-size may exceed OS argument limits"
     fi
 fi
 
@@ -313,21 +331,21 @@ if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
     if [[ "$RAW_START" =~ ^[0-9]+$ ]]; then
         START="$RAW_START"
         (( START > TOTAL )) && START="$TOTAL"
-        log "[fast-test] resuming from next test index: $START"
+        log "resuming from next test index: $START"
     else
-        echo "[fast-test] cursor file is invalid ('$RAW_START'); starting from 0" >&2
+        err "cursor file is invalid ('$RAW_START'); starting from 0"
         rm -f "$CURSOR_FILE"
     fi
 fi
 
 if (( START >= TOTAL )); then
-    log "[fast-test] nothing to resume (cursor at end: $START/$TOTAL)"
+    log "nothing to resume (cursor at end: $START/$TOTAL)"
     rm -f "$CURSOR_FILE"
     exit 0
 fi
 
 CHUNKS=$(( (TOTAL - START + CHUNK_SIZE - 1) / CHUNK_SIZE ))
-log "[fast-test] $TOTAL tests · chunk=$CHUNK_SIZE · $CHUNKS chunk(s) queued · workers=auto"
+log "$TOTAL tests · chunk=$CHUNK_SIZE · $CHUNKS chunk(s) queued · workers=auto"
 
 exec 3< "$COLLECT_OUT"
 FD3_OPEN=1
@@ -349,12 +367,12 @@ while (( i < TOTAL )); do
     chunk_idx=$(( chunk_idx + 1 ))
     read_chunk
     if (( ${#CHUNK_NODES[@]} == 0 )); then
-        echo "[fast-test] no tests read for chunk; stopping" >&2
+        err "no tests read for chunk; stopping"
         write_cursor "$i"
         exit 1
     fi
     end=$(( i + ${#CHUNK_NODES[@]} ))
-    log "[fast-test] chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
+    log "chunk $chunk_idx/$CHUNKS  tests $((i+1))..$end"
 
     PYTEST_FLAGS=(-n auto --dist=load)
     if (( BENCH )); then
@@ -364,7 +382,7 @@ while (( i < TOTAL )); do
     fi
 
     if ! "${PYTEST_CMD[@]}" "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${CHUNK_NODES[@]}"; then
-        echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)" >&2
+        err "chunk failed — cursor preserved at next test index $i (use --resume to retry)"
         write_cursor "$i"
         exit 1
     fi
@@ -380,4 +398,4 @@ if (( FD3_OPEN )); then
 fi
 rm -f "$COLLECT_OUT"
 rm -f "$CURSOR_FILE"
-log "[fast-test] all $TOTAL tests passed in $((T_END - T_START))s"
+log "all $TOTAL tests passed in $((T_END - T_START))s"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -18,7 +18,7 @@
 #   scripts/dev/test.sh --chunk-size 100
 #   scripts/dev/test.sh --resume                 # continue from cursor
 #   scripts/dev/test.sh --reset                  # clear cursor
-#   scripts/dev/test.sh --bench                  # time only, no -v
+#   scripts/dev/test.sh --bench                  # quieter pytest output
 #   scripts/dev/test.sh -- tests/test_merge.py   # pass-through to pytest
 
 set -euo pipefail
@@ -32,6 +32,7 @@ RESET=0
 BENCH=0
 PASSTHROUGH=()
 RUNTIME_PASSTHROUGH=()
+COLLECT_PASSTHROUGH=()
 PYTEST_CMD=()
 LOCK_DIR="$REPO_ROOT/.pytest_cache/fast-test.lock"
 LOCK_HELD=0
@@ -73,7 +74,12 @@ mktemp_file() {
         printf '%s\n' "$tmp"
         return 0
     fi
-    mktemp
+    if tmp="$(mktemp "${TMPDIR:-/tmp}/fast-test.XXXXXX" 2>/dev/null)"; then
+        printf '%s\n' "$tmp"
+        return 0
+    fi
+    echo "[fast-test] mktemp failed; set TMPDIR or install a compatible mktemp" >&2
+    return 1
 }
 
 # Collection and execution do not share every pytest flag. Keep runtime
@@ -89,7 +95,10 @@ for arg in "${PASSTHROUGH[@]}"; do
         --collect-only|--co) ;;
         -n|--numprocesses|--dist) skip_next=1 ;;
         -n*|--numprocesses=*|--dist=*) ;;
-        *) RUNTIME_PASSTHROUGH+=("$arg") ;;
+        *)
+            RUNTIME_PASSTHROUGH+=("$arg")
+            COLLECT_PASSTHROUGH+=("$arg")
+            ;;
     esac
 done
 
@@ -150,7 +159,7 @@ fi
 echo "[fast-test] collecting tests ..."
 COLLECT_ERR="$(mktemp_file)"
 COLLECT_OUT="$(mktemp_file)"
-if ! "${PYTEST_CMD[@]}" --collect-only -q "${PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
+if ! "${PYTEST_CMD[@]}" --collect-only -q "${COLLECT_PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
     echo "[fast-test] test collection failed" >&2
     [[ -s "$COLLECT_ERR" ]] && { echo "--- collection stderr ---"; cat "$COLLECT_ERR"; } >&2
     rm -f "$COLLECT_ERR" "$COLLECT_OUT"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -52,6 +52,7 @@ COLLECT_FILTERED=""
 CHUNK_NODES=()
 XDIST_IGNORED=0
 COLLECT_ONLY_REQUESTED=0
+FD3_OPEN=0
 
 log() {
     echo "$*" >&2
@@ -92,10 +93,6 @@ if ! [[ "$CHUNK_SIZE" =~ ^[1-9][0-9]*$ ]]; then
     exit 1
 fi
 
-if (( CHUNK_SIZE > 1000 )); then
-    log "[fast-test] warning: large --chunk-size may exceed OS argument limits"
-fi
-
 mktemp_file() {
     local tmp
     if tmp="$(mktemp -t fast-test.XXXXXX 2>/dev/null)"; then
@@ -108,6 +105,15 @@ mktemp_file() {
     fi
     echo "[fast-test] mktemp failed; set TMPDIR or install a compatible mktemp" >&2
     return 1
+}
+
+arg_bytes() {
+    local total=0
+    local arg
+    for arg in "$@"; do
+        total=$(( total + ${#arg} + 1 ))
+    done
+    printf '%s\n' "$total"
 }
 
 # Collection and execution do not share every pytest flag. Keep runtime
@@ -146,7 +152,10 @@ if (( XDIST_IGNORED )); then
 fi
 
 cleanup() {
-    { exec 3<&-; } 2>/dev/null || true
+    if (( FD3_OPEN )); then
+        { exec 3<&-; } 2>/dev/null || true
+        FD3_OPEN=0
+    fi
     [[ -n "$COLLECT_ERR" && -f "$COLLECT_ERR" ]] && rm -f "$COLLECT_ERR"
     [[ -n "$COLLECT_OUT" && -f "$COLLECT_OUT" ]] && rm -f "$COLLECT_OUT"
     [[ -n "$COLLECT_FILTERED" && -f "$COLLECT_FILTERED" ]] && rm -f "$COLLECT_FILTERED"
@@ -197,6 +206,10 @@ if command -v flock >/dev/null 2>&1; then
     LOCK_MODE="flock"
     LOCK_HELD=1
 else
+    if [[ -L "$LOCK_DIR" ]]; then
+        echo "[fast-test] lock path is a symlink; refusing to use $LOCK_DIR" >&2
+        exit 1
+    fi
     if [[ -d "$LOCK_DIR" ]]; then
         if [[ -f "$LOCK_DIR/pid" ]]; then
             PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
@@ -261,6 +274,38 @@ if (( TOTAL == 0 )); then
     exit 1
 fi
 
+ARG_MAX=""
+if command -v getconf >/dev/null 2>&1; then
+    ARG_MAX="$(getconf ARG_MAX 2>/dev/null || true)"
+fi
+if [[ "$ARG_MAX" =~ ^[0-9]+$ ]]; then
+    MAX_NODE_LEN="$(awk 'length > max { max = length } END { print max + 0 }' "$COLLECT_OUT")"
+    BASE_PYTEST_ARGS=(-n auto --dist=load --no-header)
+    if (( BENCH )); then
+        BASE_PYTEST_ARGS+=(-q)
+    fi
+    BASE_ARGS_SIZE="$(arg_bytes "${PYTEST_CMD[@]}" "${BASE_PYTEST_ARGS[@]}" "${RUNTIME_PASSTHROUGH[@]}")"
+    SAFETY_MARGIN=2048
+    AVAILABLE=$(( ARG_MAX - BASE_ARGS_SIZE - SAFETY_MARGIN ))
+    (( AVAILABLE < 0 )) && AVAILABLE=0
+    PER_NODE=$(( MAX_NODE_LEN + 1 ))
+    if (( PER_NODE > 0 )); then
+        MAX_SAFE=$(( AVAILABLE / PER_NODE ))
+        if (( MAX_SAFE <= 0 )); then
+            echo "[fast-test] chunk size too large for ARG_MAX; reduce --chunk-size" >&2
+            exit 1
+        fi
+        if (( CHUNK_SIZE > MAX_SAFE )); then
+            log "[fast-test] reducing --chunk-size from $CHUNK_SIZE to $MAX_SAFE to avoid ARG_MAX"
+            CHUNK_SIZE="$MAX_SAFE"
+        fi
+    fi
+else
+    if (( CHUNK_SIZE > 1000 )); then
+        log "[fast-test] warning: large --chunk-size may exceed OS argument limits"
+    fi
+fi
+
 # 2. Determine starting cursor.
 START=0
 if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
@@ -285,6 +330,7 @@ CHUNKS=$(( (TOTAL - START + CHUNK_SIZE - 1) / CHUNK_SIZE ))
 log "[fast-test] $TOTAL tests · chunk=$CHUNK_SIZE · $CHUNKS chunk(s) queued · workers=auto"
 
 exec 3< "$COLLECT_OUT"
+FD3_OPEN=1
 skip_count=0
 while (( skip_count < START )); do
     if ! IFS= read -r _ <&3; then
@@ -328,7 +374,10 @@ while (( i < TOTAL )); do
 done
 
 T_END=$(date +%s)
-{ exec 3<&-; } 2>/dev/null || true
+if (( FD3_OPEN )); then
+    { exec 3<&-; } 2>/dev/null || true
+    FD3_OPEN=0
+fi
 rm -f "$COLLECT_OUT"
 rm -f "$CURSOR_FILE"
 log "[fast-test] all $TOTAL tests passed in $((T_END - T_START))s"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -304,7 +304,6 @@ else
     ensure_dir_safe "$LOCK_DIR" "lock dir"
     if [[ -d "$LOCK_DIR" ]]; then
         if [[ -f "$LOCK_DIR/pid" ]]; then
-            local PID_CONTENTS
             ensure_regular_file_or_missing "$LOCK_DIR/pid" "lock pid file"
             ensure_single_link "$LOCK_DIR/pid" "lock pid file"
             PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -71,6 +71,32 @@ err() {
     echo "$LOG_PREFIX ERROR: $*" >&2
 }
 
+ensure_dir_safe() {
+    local path="$1"
+    local label="$2"
+    if [[ -L "$path" ]]; then
+        err "$label is a symlink; refusing to use $path"
+        exit 1
+    fi
+    if [[ -e "$path" && ! -d "$path" ]]; then
+        err "$label is not a directory; refusing to use $path"
+        exit 1
+    fi
+}
+
+ensure_regular_file_or_missing() {
+    local path="$1"
+    local label="$2"
+    if [[ -L "$path" ]]; then
+        err "$label is a symlink; refusing to use $path"
+        exit 1
+    fi
+    if [[ -e "$path" && ! -f "$path" ]]; then
+        err "$label is not a regular file; refusing to use $path"
+        exit 1
+    fi
+}
+
 print_help() {
     awk '
         /^# Usage:/ {printing=1}
@@ -193,22 +219,8 @@ cleanup() {
 trap cleanup EXIT
 
 write_cursor() {
-    if [[ -L "$PYTEST_CACHE_DIR" ]]; then
-        err "pytest cache dir is a symlink; refusing to write $CURSOR_FILE"
-        exit 1
-    fi
-    if [[ -e "$PYTEST_CACHE_DIR" && ! -d "$PYTEST_CACHE_DIR" ]]; then
-        err "pytest cache path is not a directory; refusing to write $CURSOR_FILE"
-        exit 1
-    fi
-    if [[ -L "$(dirname "$CURSOR_FILE")" ]]; then
-        err "cursor directory is a symlink; refusing to write $CURSOR_FILE"
-        exit 1
-    fi
-    if [[ -e "$CURSOR_FILE" && -L "$CURSOR_FILE" ]]; then
-        err "cursor path is a symlink; refusing to write $CURSOR_FILE"
-        exit 1
-    fi
+    ensure_dir_safe "$PYTEST_CACHE_DIR" "pytest cache dir"
+    ensure_regular_file_or_missing "$CURSOR_FILE" "cursor path"
     printf '%s\n' "$1" > "$CURSOR_TMP"
     mv "$CURSOR_TMP" "$CURSOR_FILE"
 }
@@ -227,21 +239,11 @@ read_chunk() {
 }
 
 cd "$REPO_ROOT"
-if [[ -L "$PYTEST_CACHE_DIR" ]]; then
-    err "pytest cache dir is a symlink; refusing to use $PYTEST_CACHE_DIR"
-    exit 1
-fi
-if [[ -e "$PYTEST_CACHE_DIR" && ! -d "$PYTEST_CACHE_DIR" ]]; then
-    err "pytest cache path is not a directory; refusing to use $PYTEST_CACHE_DIR"
-    exit 1
-fi
+ensure_dir_safe "$PYTEST_CACHE_DIR" "pytest cache dir"
 mkdir -p "$PYTEST_CACHE_DIR"
 
 if command -v flock >/dev/null 2>&1; then
-    if [[ -L "$LOCK_FILE" ]]; then
-        err "lock path is a symlink; refusing to use $LOCK_FILE"
-        exit 1
-    fi
+    ensure_regular_file_or_missing "$LOCK_FILE" "lock file"
     exec 9>"$LOCK_FILE" || { err "unable to open lock file: $LOCK_FILE"; exit 1; }
     if ! flock -n 9; then
         err "another run is active (lock: $LOCK_FILE)"
@@ -250,10 +252,7 @@ if command -v flock >/dev/null 2>&1; then
     LOCK_MODE="flock"
     LOCK_HELD=1
 else
-    if [[ -L "$LOCK_DIR" ]]; then
-        err "lock path is a symlink; refusing to use $LOCK_DIR"
-        exit 1
-    fi
+    ensure_dir_safe "$LOCK_DIR" "lock dir"
     if [[ -d "$LOCK_DIR" ]]; then
         if [[ -f "$LOCK_DIR/pid" ]]; then
             PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
@@ -296,8 +295,8 @@ else
     exit 1
 fi
 
-if ! "${PYTEST_CMD[@]}" --help 2>/dev/null | grep -Eq '(-n[[:space:]]|--numprocesses)'; then
-    err "pytest-xdist is required for this wrapper (missing -n/--numprocesses)."
+if ! "${PYTEST_CMD[@]}" -p xdist --version >/dev/null 2>&1; then
+    err "pytest-xdist is required for this wrapper (missing xdist plugin)."
     err "install test extras, e.g. 'uv pip install -e .[test]'"
     exit 1
 fi

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -67,7 +67,7 @@ log() {
 }
 
 err() {
-    echo "$LOG_PREFIX $*" >&2
+    echo "$LOG_PREFIX ERROR: $*" >&2
 }
 
 print_help() {
@@ -192,6 +192,14 @@ cleanup() {
 trap cleanup EXIT
 
 write_cursor() {
+    if [[ -L "$(dirname "$CURSOR_FILE")" ]]; then
+        err "cursor directory is a symlink; refusing to write $CURSOR_FILE"
+        exit 1
+    fi
+    if [[ -e "$CURSOR_FILE" && -L "$CURSOR_FILE" ]]; then
+        err "cursor path is a symlink; refusing to write $CURSOR_FILE"
+        exit 1
+    fi
     printf '%s\n' "$1" > "$CURSOR_TMP"
     mv "$CURSOR_TMP" "$CURSOR_FILE"
 }

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -31,6 +31,7 @@ RESUME=0
 RESET=0
 BENCH=0
 PASSTHROUGH=()
+RUNTIME_PASSTHROUGH=()
 
 while (( $# )); do
     case "$1" in
@@ -41,6 +42,15 @@ while (( $# )); do
         --)           shift; PASSTHROUGH+=("$@"); break ;;
         -h|--help)    sed -n '2,22p' "$0"; exit 0 ;;
         *)            PASSTHROUGH+=("$1"); shift ;;
+    esac
+done
+
+# Collection and execution do not share every pytest flag. Keep runtime
+# passthrough aligned with user intent while stripping collect-only toggles.
+for arg in "${PASSTHROUGH[@]}"; do
+    case "$arg" in
+        --collect-only|--co) ;;
+        *) RUNTIME_PASSTHROUGH+=("$arg") ;;
     esac
 done
 
@@ -74,8 +84,14 @@ fi
 # 2. Determine starting cursor.
 START=0
 if (( RESUME )) && [[ -f "$CURSOR_FILE" ]]; then
-    START="$(cat "$CURSOR_FILE")"
-    echo "[fast-test] resuming from next test index: $START"
+    RAW_START="$(tr -d '[:space:]' < "$CURSOR_FILE")"
+    if [[ "$RAW_START" =~ ^[0-9]+$ ]]; then
+        START="$RAW_START"
+        (( START > TOTAL )) && START="$TOTAL"
+        echo "[fast-test] resuming from next test index: $START"
+    else
+        echo "[fast-test] cursor file is invalid ('$RAW_START'); starting from 0" >&2
+    fi
 fi
 
 CHUNKS=$(( (TOTAL - START + CHUNK_SIZE - 1) / CHUNK_SIZE ))
@@ -94,7 +110,7 @@ while (( i < TOTAL )); do
     PYTEST_FLAGS=(-n auto --dist=load)
     (( BENCH )) && PYTEST_FLAGS+=(-q) || PYTEST_FLAGS+=(--no-header -q)
 
-    if ! uv run pytest "${PYTEST_FLAGS[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
+    if ! uv run pytest "${PYTEST_FLAGS[@]}" "${RUNTIME_PASSTHROUGH[@]}" "${NODES[@]:i:CHUNK_SIZE}"; then
         echo "[fast-test] chunk failed — cursor preserved at next test index $i (use --resume to retry)"
         echo "$i" > "$CURSOR_FILE"
         exit 1

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -46,6 +46,17 @@ COLLECT_FILTERED=""
 CHUNK_NODES=()
 XDIST_IGNORED=0
 
+print_help() {
+    awk '
+        /^# Usage:/ {printing=1}
+        printing {
+            if ($0 !~ /^#/) {exit}
+            sub(/^# ?/, "", $0)
+            print
+        }
+    ' "$0"
+}
+
 while (( $# )); do
     case "$1" in
         --chunk-size)
@@ -82,17 +93,6 @@ mktemp_file() {
     fi
     echo "[fast-test] mktemp failed; set TMPDIR or install a compatible mktemp" >&2
     return 1
-}
-
-print_help() {
-    awk '
-        /^# Usage:/ {printing=1}
-        printing {
-            if ($0 !~ /^#/) {exit}
-            sub(/^# ?/, "", $0)
-            print
-        }
-    ' "$0"
 }
 
 # Collection and execution do not share every pytest flag. Keep runtime
@@ -176,16 +176,8 @@ else
         if [[ -f "$LOCK_DIR/pid" ]]; then
             PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
             if [[ "$PID_CONTENTS" =~ ^[0-9]+$ ]] && kill -0 "$PID_CONTENTS" 2>/dev/null; then
-                if command -v ps >/dev/null 2>&1; then
-                    CMDLINE="$(ps -p "$PID_CONTENTS" -o args= 2>/dev/null || true)"
-                    if [[ -z "$CMDLINE" || "$CMDLINE" == *"$LOCK_NAME"* ]]; then
-                        echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
-                        exit 1
-                    fi
-                else
-                    echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
-                    exit 1
-                fi
+                echo "[fast-test] another run is active (lock: $LOCK_DIR)" >&2
+                exit 1
             fi
             echo "[fast-test] removing stale lock (pid: ${PID_CONTENTS:-unknown})" >&2
         fi

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -167,15 +167,13 @@ while (( idx < ${#PASSTHROUGH[@]} )); do
     case "$arg" in
         --collect-only|--co) COLLECT_ONLY_REQUESTED=1 ;;
         -n|--numprocesses|--dist)
-            next="${PASSTHROUGH[$((idx + 1))]:-}"
-            if [[ -z "$next" || "$next" == -* ]]; then
-                err "$arg requires a value, but xdist flags are managed by this script"
-                exit 1
-            fi
-            XDIST_IGNORED=1
-            idx=$((idx + 1))
+            err "$arg is managed by this script; remove xdist flags from arguments"
+            exit 1
             ;;
-        -n*|--numprocesses=*|--dist=*) XDIST_IGNORED=1 ;;
+        -n*|--numprocesses=*|--dist=*)
+            err "$arg is managed by this script; remove xdist flags from arguments"
+            exit 1
+            ;;
         *)
             RUNTIME_PASSTHROUGH+=("$arg")
             COLLECT_PASSTHROUGH+=("$arg")
@@ -206,6 +204,7 @@ cleanup() {
         flock -u 9 2>/dev/null || true
         exec 9>&- || true
     elif [[ "$LOCK_MODE" == "dir" ]] && (( LOCK_HELD )); then
+        local PID_CONTENTS
         if [[ -f "$LOCK_DIR/pid" ]]; then
             PID_CONTENTS="$(tr -d '[:space:]' < "$LOCK_DIR/pid" 2>/dev/null || true)"
             if [[ "$PID_CONTENTS" == "$$" ]]; then
@@ -244,7 +243,7 @@ mkdir -p "$PYTEST_CACHE_DIR"
 
 if command -v flock >/dev/null 2>&1; then
     ensure_regular_file_or_missing "$LOCK_FILE" "lock file"
-    exec 9>"$LOCK_FILE" || { err "unable to open lock file: $LOCK_FILE"; exit 1; }
+    exec 9>>"$LOCK_FILE" || { err "unable to open lock file: $LOCK_FILE"; exit 1; }
     if ! flock -n 9; then
         err "another run is active (lock: $LOCK_FILE)"
         exit 1

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -79,7 +79,7 @@ mkdir -p "$(dirname "$CURSOR_FILE")"
 echo "[fast-test] collecting tests ..."
 COLLECT_ERR="$(mktemp)"
 COLLECT_OUT="$(mktemp)"
-if ! uv run pytest --collect-only -qq "${PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
+if ! uv run pytest --collect-only -q "${PASSTHROUGH[@]}" >"$COLLECT_OUT" 2>"$COLLECT_ERR"; then
     echo "[fast-test] test collection failed" >&2
     [[ -s "$COLLECT_ERR" ]] && { echo "--- collection stderr ---"; cat "$COLLECT_ERR"; } >&2
     rm -f "$COLLECT_ERR" "$COLLECT_OUT"


### PR DESCRIPTION
## Description

Adds a single-file local DX wrapper, `scripts/dev/test.sh`, that runs the existing pytest suite faster on developer machines without touching production code or CI.

**What it does**

- Collects node ids once via `pytest --collect-only -q`, then dispatches them in fixed-size chunks (default 200) through `pytest-xdist` with `-n auto --dist=load`.
- Persists a cursor at `.pytest_cache/fast-test-cursor` after every successful chunk, so a crash or `Ctrl-C` can be resumed exactly where it left off with `--resume`.
- Supports `--chunk-size N`, `--reset`, `--bench`, and `--` pass-through to pytest.

**Why this shape**

- Bounded in-flight memory (one chunk's worth of tests held by xdist workers at a time).
- Natural FIFO progression inside each chunk via `--dist=load`.
- Crash recovery without any new Python module — pure bash around the existing `uv run pytest` entrypoint.

**Measured impact (local, Windows + Git Bash, 16-core)**

| Run | Wallclock |
|---|---|
| Baseline `uv run pytest` (serial) | ~2m 37s |
| `bash scripts/dev/test.sh --bench` | **1m 29.85s** |

~1.75x speedup end-to-end with no production source changes.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Additional validation:

- Full suite executed via the new wrapper end-to-end: `bash scripts/dev/test.sh --bench` → 1m 29.85s wallclock.
- Crash recovery verified by injecting a synthetic failing test, observing the cursor pinned at the failing chunk boundary, fixing the test, and confirming `--resume` continued from exactly that point with only the remaining tests executed.
- `--reset` clears the cursor file; `--chunk-size` and `--` pass-through both exercised.
- 7 pre-existing Windows-only failures (MSYS path format + MAX_PATH) are unchanged by this PR — they reproduce identically with and without the wrapper.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot (Claude) assisted with drafting `scripts/dev/test.sh`, iterating on the chunked-FIFO dispatch design, and producing the benchmark comparison. All design decisions, validation runs, and the final wrapper shape were reviewed and accepted by the author.
