### PR TITLE
Update Superpowers Implementation Bridge to v0.7.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-05-27T00:00:00Z",
+  "updated_at": "2026-05-28T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -2650,8 +2650,8 @@
       "id": "speckit-superpowers-bridge",
       "description": "Thin orchestrator between Spec Kit (design) and Superpowers (implementation). Cross-agent.",
       "author": "lihan3238",
-      "version": "0.5.0",
-      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v0.5.0/speckit-superpowers-bridge-v0.5.0.zip",
+      "version": "0.7.0",
+      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/latest/download/speckit-superpowers-bridge.zip",
       "repository": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "homepage": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "documentation": "https://github.com/lihan3238/speckit-superpowers-bridge#readme",
@@ -2692,7 +2692,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-15T00:00:00Z",
-      "updated_at": "2026-05-20T00:00:00Z"
+      "updated_at": "2026-05-28T00:00:00Z"
     },
     "speckit-utils": {
       "name": "SDD Utilities",

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -2651,7 +2651,7 @@
       "description": "Thin orchestrator between Spec Kit (design) and Superpowers (implementation). Cross-agent.",
       "author": "lihan3238",
       "version": "0.7.0",
-      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/latest/download/speckit-superpowers-bridge.zip",
+      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v0.7.0/speckit-superpowers-bridge-v0.7.0.zip",
       "repository": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "homepage": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "documentation": "https://github.com/lihan3238/speckit-superpowers-bridge#readme",


### PR DESCRIPTION
## Summary

Update `speckit-superpowers-bridge` community extension from v0.5.0 to v0.7.0.

### Changes to `extensions/catalog.community.json`

- **`version`**: `0.5.0` → `0.7.0`
- **`download_url`**: switched to stable-alias URL (`releases/latest/download/speckit-superpowers-bridge.zip`) — per v0.6.0 decoupling, no future URL edits needed on subsequent releases
- **`updated_at`** (entry + top-level catalog): → `2026-05-28T00:00:00Z`
- Preserved: `created_at`, `downloads`, `stars`, all other fields

No changes to `docs/community/extensions.md` — the table row content is identical.

### Validation

- [x] Repository exists and is public
- [x] `extension.yml` manifest present
- [x] README.md present
- [x] LICENSE file present (MIT)
- [x] GitHub release v0.7.0 exists with assets
- [x] Download URL accessible (stable-alias resolves to latest release)
- [x] Extension ID is lowercase-with-hyphens
- [x] Version follows semver
- [x] Submission checklists all checked
- [x] JSON validates after edit

Closes #2731

cc @lihan3238