### PR TITLE
Add confirmation prompt for URL-based extension installs

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -3003,9 +3003,23 @@ def extension_add(
                     console.print("HTTP is only allowed for localhost URLs.")
                     raise typer.Exit(1)
 
-                # Warn about untrusted sources
-                console.print("[yellow]Warning:[/yellow] Installing from external URL.")
-                console.print("Only install extensions from sources you trust.\n")
+                # Warn about untrusted sources — default-deny confirmation
+                console.print()
+                console.print(Panel(
+                    f"[bold]You are installing an extension from an external URL that is not\n"
+                    f"listed in any of your configured extension catalogs.[/bold]\n\n"
+                    f"URL: {from_url}\n\n"
+                    f"Only install extensions from sources you trust.",
+                    title="[bold yellow]⚠ Untrusted Source[/bold yellow]",
+                    border_style="yellow",
+                    padding=(1, 2),
+                ))
+                console.print()
+                confirm = typer.confirm("Continue with installation?", default=False)
+                if not confirm:
+                    console.print("Cancelled")
+                    raise typer.Exit(0)
+
                 console.print(f"Downloading from {from_url}...")
 
                 # Download ZIP to temp location


### PR DESCRIPTION
Closes #2744

## Summary

`specify extension add <name> --from <url>` bypasses the catalog trust boundary. The user's configured extension catalogs are the primary mechanism for establishing trust in extension sources — installing from an arbitrary URL sidesteps that entirely.

Previously the CLI printed a yellow warning and proceeded silently. This PR adds a default-deny confirmation prompt so the user must consciously acknowledge they are leaving the trusted catalog path.

## Changes

**`src/specify_cli/__init__.py`** — Replace the silent warning with:
- A yellow-bordered Rich panel titled "⚠ Untrusted Source"
- The URL being installed from
- A reminder to only install from trusted sources
- A `typer.confirm()` prompt defaulting to No (`[y/N]`)

## Context

| Remote install path | Protection |
|---|---|
| `--from <url>` | HTTPS enforced + yellow panel + default-deny prompt **(new)** |
| Catalog download | User explicitly configured catalogs; `install_allowed` policy enforced |
| ZIP extraction (both paths) | Zip Slip protection — all member paths validated before extraction |

The catalog path doesn't need a prompt because the user already established trust by adding that catalog to their config.