### PR TITLE
fix: disable no-op issue reporting for catalog submission workflows

### DIFF
--- a/.github/workflows/add-community-extension.md
+++ b/.github/workflows/add-community-extension.md
@@ -22,6 +22,8 @@ checkout:
   fetch-depth: 0
 
 safe-outputs:
+  noop:
+    report-as-issue: false
   create-pull-request:
     title-prefix: "[extension] "
     labels: [extension-submission, automated]

--- a/.github/workflows/add-community-preset.md
+++ b/.github/workflows/add-community-preset.md
@@ -22,6 +22,8 @@ checkout:
   fetch-depth: 0
 
 safe-outputs:
+  noop:
+    report-as-issue: false
   create-pull-request:
     title-prefix: "[preset] "
     labels: [preset-submission, automated]


### PR DESCRIPTION
## Summary

Add `noop: report-as-issue: false` to the `safe-outputs` frontmatter in both catalog submission workflows to prevent them from posting noise comments to the [aw] No-Op Runs tracking issue (#2746).

## Changes

- `.github/workflows/add-community-extension.md` — added `noop: report-as-issue: false`
- `.github/workflows/add-community-preset.md` — added `noop: report-as-issue: false`

## Context

Both workflows trigger on `issues: [labeled]` and correctly exit as no-ops when the issue isn't a submission for them. However, they were reporting those no-ops to the tracking issue, creating noise like:

> No action needed: Issue #2744 is not an extension submission…

The tracking issue itself documents the fix: set `report-as-issue: false` in the noop safe-output.

Closes #2747