### PR TITLE
feat(catalog): add linear extension to community catalog

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1246,6 +1246,39 @@
       "created_at": "2026-03-17T00:00:00Z",
       "updated_at": "2026-03-17T00:00:00Z"
     },
+    "linear": {
+      "name": "spec-kit-linear",
+      "id": "linear",
+      "description": "Mirror spec-kit feature directories into Linear (filesystem → Linear, reconcile-based, unidirectional).",
+      "author": "Ash Brener",
+      "version": "0.2.0",
+      "download_url": "https://github.com/ashbrener/spec-kit-linear/archive/refs/tags/v0.2.0.zip",
+      "repository": "https://github.com/ashbrener/spec-kit-linear",
+      "homepage": "https://github.com/ashbrener/spec-kit-linear",
+      "documentation": "https://github.com/ashbrener/spec-kit-linear/blob/main/README.md",
+      "changelog": "https://github.com/ashbrener/spec-kit-linear/releases",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.1.0"
+      },
+      "provides": {
+        "commands": 5,
+        "hooks": 6
+      },
+      "tags": [
+        "issue-tracking",
+        "linear",
+        "tasks-sync",
+        "lifecycle-mirror",
+        "memory",
+        "cross-repo"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-05-28T15:42:14Z",
+      "updated_at": "2026-05-31T05:45:58Z"
+    },
     "m365": {
       "name": "Microsoft 365 Integration",
       "id": "m365",


### PR DESCRIPTION
## Summary

Adds the **`linear`** community extension (**spec-kit-linear**) to `extensions/catalog.community.json` for discovery.

**Extension repo:** https://github.com/ashbrener/spec-kit-linear · **Release:** [v0.2.0](https://github.com/ashbrener/spec-kit-linear/releases/tag/v0.2.0)

## What it does

Mirrors spec-kit feature directories into [Linear](https://linear.app): one Linear **Issue per spec**, **sub-issues per task phase** (checklists + inter-phase blocking relations), auto-synced via six `after_*` lifecycle hooks. Direction is **filesystem → Linear, reconcile-based, unidirectional** — never mutates the local filesystem.

| | |
|---|---|
| **Category** | `integration` |
| **Effect** | Read+Write (creates per-repo config under `.specify/extensions/linear/`) |
| **Commands** | 5 — `speckit.linear.push` / `.pull` / `.status` / `.seed` / `.install` |
| **Hooks** | 6 — `after_specify/clarify/plan/tasks/implement/analyze` |
| **License** | MIT · **Requires** spec-kit ≥ 0.1.0 |
| **Tags** | issue-tracking, linear, tasks-sync, lifecycle-mirror, memory, cross-repo |

Entry fields copied verbatim from the extension's `extension.yml` manifest. `download_url` pins to the **immutable `v0.2.0` release tag**.

## Install model

`catalog.community.json` is discovery-only (`install_allowed: false` in the default stack). Install:

```bash
specify extension add linear --from https://github.com/ashbrener/spec-kit-linear/archive/refs/tags/v0.2.0.zip
```

## Test plan

- [x] Catalog JSON parses; `linear` inserted between `learn` and `m365`
- [x] `download_url` resolves (HTTP 200 — `/archive/refs/tags/v0.2.0.zip`)
- [x] `version` (0.2.0) matches `extension.yml` at the `v0.2.0` tag
- [x] `tags` use `issue-tracking` (matching `jira` / `azure-devops`)
- [ ] Entry surfaced by `specify extension search linear` once live

Companion docs-table PR: #2750. Submission issue: #2778.