### PR TITLE
fix(copilot): resolve active spec template

### DIFF
--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -91,7 +91,8 @@ Given that feature description, do this:
 
    **Create the directory and spec file**:
    - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
-   - Copy `templates/spec-template.md` to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
+   - Resolve the active `spec-template` through the Spec Kit preset/template resolution stack (equivalent to `specify preset resolve spec-template`)
+   - Copy the resolved `spec-template` file to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
    - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
    - Persist the resolved path to `.specify/feature.json`:
      ```json
@@ -107,7 +108,7 @@ Given that feature description, do this:
    - The spec directory name and the git branch name are independent — they may be the same but that is the user's choice
    - The spec directory and file are always created by this command, never by the hook
 
-4. Load `templates/spec-template.md` to understand required sections.
+4. Load the resolved active `spec-template` file to understand required sections.
 
 5. Follow this execution flow:
     1. Parse user description from arguments

--- a/tests/integrations/test_integration_copilot.py
+++ b/tests/integrations/test_integration_copilot.py
@@ -147,6 +147,21 @@ class TestCopilotIntegration:
             assert "__SPECKIT_COMMAND_" not in content, f"{agent_file.name} has unprocessed __SPECKIT_COMMAND_*__"
             assert "\nscripts:\n" not in content
 
+    def test_specify_agent_resolves_active_spec_template(self, tmp_path):
+        """Generated specify agent must not hardcode the core spec template."""
+        from specify_cli.integrations.copilot import CopilotIntegration
+        copilot = CopilotIntegration()
+        m = IntegrationManifest("copilot", tmp_path)
+        copilot.setup(tmp_path, m)
+
+        specify_file = tmp_path / ".github" / "agents" / "speckit.specify.agent.md"
+        content = specify_file.read_text(encoding="utf-8")
+
+        assert "specify preset resolve spec-template" in content
+        assert "resolved active `spec-template`" in content
+        assert "Copy `.specify/templates/spec-template.md`" not in content
+        assert "Load `.specify/templates/spec-template.md`" not in content
+
     def test_plan_references_correct_context_file(self, tmp_path):
         """The generated plan command must reference copilot's context file."""
         from specify_cli.integrations.copilot import CopilotIntegration


### PR DESCRIPTION
## Description

Fixes #2761.

This updates the Copilot `speckit.specify` command instructions so generated agents resolve the active `spec-template` through the Spec Kit preset/template resolution stack instead of hardcoding the core template path. This lets project overrides, presets, and extensions supply the effective spec template for new specs.

## Testing

- [x] Tested locally with `uv run --no-sync specify --help`
- [x] Ran existing tests with `uv run --no-sync pytest -q` (`3104 passed, 40 skipped`)
- [x] Ran focused Copilot integration tests with `uv run --no-sync pytest tests/integrations/test_integration_copilot.py -q` (`47 passed`)
- [x] Ran `uvx ruff check src/`
- [x] Ran `python -m compileall -q src tests/integrations/test_integration_copilot.py`
- [x] Ran `git diff --check -- templates/commands/specify.md tests/integrations/test_integration_copilot.py`
- [ ] Tested with a sample project (not applicable; covered by Copilot integration generation test)