### PR TITLE
Update Reqnroll BDD extension to v1.1.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-05-28T00:00:00Z",
+  "updated_at": "2026-05-30T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -2218,8 +2218,8 @@
       "id": "reqnroll-bdd",
       "description": "Adds Reqnroll BDD planning, Gherkin generation, traceability, safe task injection, handoff, and verification to Spec Kit.",
       "author": "LoogaCY Studio",
-      "version": "1.0.0",
-      "download_url": "https://github.com/LoogacyStudio/spec-kit-reqnroll-bdd/archive/refs/tags/v1.0.0.zip",
+      "version": "1.1.0",
+      "download_url": "https://github.com/LoogacyStudio/spec-kit-reqnroll-bdd/archive/refs/tags/v1.1.0.zip",
       "repository": "https://github.com/LoogacyStudio/spec-kit-reqnroll-bdd",
       "homepage": "https://github.com/LoogacyStudio/spec-kit-reqnroll-bdd",
       "documentation": "https://github.com/LoogacyStudio/spec-kit-reqnroll-bdd#readme",
@@ -2249,7 +2249,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-13T00:00:00Z",
-      "updated_at": "2026-05-13T00:00:00Z"
+      "updated_at": "2026-05-30T00:00:00Z"
     },
     "retro": {
       "name": "Retro Extension",


### PR DESCRIPTION
Update `reqnroll-bdd` community extension from v1.0.0 to v1.1.0.

Submitted by @stenyin in #2764.

## Validation

| Check | Result |
|-------|--------|
| Repository public | ✅ |
| `extension.yml` present | ✅ |
| `README.md` present | ✅ |
| `LICENSE` present | ✅ |
| v1.1.0 release exists | ✅ |
| Download URL valid | ✅ |
| Extension ID format | ✅ `reqnroll-bdd` |
| Semver version | ✅ `1.1.0` |

## Changes

- `extensions/catalog.community.json`: updated `version` (1.0.0 → 1.1.0), `download_url` (v1.0.0 → v1.1.0), entry `updated_at`, and catalog-level `updated_at`

## What's new in v1.1.0

- `@infrastructure` tag convention for CI/CD pipeline identification
- Skeleton → implementation transition guide with Given/When/Then patterns
- Expected test state transition table
- Concrete BDD-004 implementation guidance
- Domain-neutral language (replaces Godot-specific terminology)
- Generic business domain examples (Account Balance / Deposit)

Closes #2764