### PR TITLE
Cover init command hint display

### DIFF
--- a/tests/test_init_command_invocations.py
+++ b/tests/test_init_command_invocations.py
@@ -1,0 +1,88 @@
+"""Regression tests for integration-aware init command hints."""
+
+from typer.testing import CliRunner
+
+from tests.conftest import strip_ansi
+
+
+def _clean_output(output: str) -> str:
+    return strip_ansi(output)
+
+
+def test_init_codex_next_steps_use_dollar_skills(tmp_path):
+    from specify_cli import app
+
+    project = tmp_path / "codex-init"
+    result = CliRunner().invoke(
+        app,
+        [
+            "init",
+            str(project),
+            "--integration",
+            "codex",
+            "--script",
+            "sh",
+            "--ignore-agent-tools",
+        ],
+        catch_exceptions=False,
+    )
+
+    output = _clean_output(result.output)
+    assert result.exit_code == 0, result.output
+    assert "$speckit-plan" in output
+    assert "$speckit-analyze" in output
+    assert "/speckit-plan" not in output
+    assert "/speckit.plan" not in output
+
+
+def test_init_copilot_next_steps_keep_slash_dot(tmp_path):
+    from specify_cli import app
+
+    project = tmp_path / "copilot-init"
+    result = CliRunner().invoke(
+        app,
+        [
+            "init",
+            str(project),
+            "--integration",
+            "copilot",
+            "--script",
+            "sh",
+            "--ignore-agent-tools",
+        ],
+        catch_exceptions=False,
+    )
+
+    output = _clean_output(result.output)
+    assert result.exit_code == 0, result.output
+    assert "/speckit.plan" in output
+    assert "/speckit.tasks" in output
+    assert "$speckit-plan" not in output
+
+
+def test_init_copilot_skills_next_steps_keep_slash_hyphen(tmp_path):
+    from specify_cli import app
+
+    project = tmp_path / "copilot-skills-init"
+    result = CliRunner().invoke(
+        app,
+        [
+            "init",
+            str(project),
+            "--integration",
+            "copilot",
+            "--integration-options",
+            "--skills",
+            "--script",
+            "sh",
+            "--ignore-agent-tools",
+        ],
+        catch_exceptions=False,
+    )
+
+    output = _clean_output(result.output)
+    assert result.exit_code == 0, result.output
+    assert "/speckit-plan" in output
+    assert "/speckit-tasks" in output
+    assert "/speckit.plan" not in output
+    assert "$speckit-plan" not in output


### PR DESCRIPTION
## Description

Adds regression coverage for the user-facing command hints printed by `specify init`.

This is intentionally display-only: it verifies Codex shows `$speckit-...` in the init next-steps output, Copilot default mode keeps `/speckit.<name>`, and Copilot skills mode keeps `/speckit-<name>`. The broader template/script/hook/preset plumbing from the earlier version of this PR has been removed.

## Testing

```bash
uv run pytest tests/test_init_command_invocations.py -q
uv run pytest tests/integrations tests/test_extensions.py tests/test_workflows.py tests/test_setup_tasks.py tests/test_init_command_invocations.py -q
uv run --with ruff ruff check src/specify_cli tests
git diff --cached --check
```

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented with Codex assistance in this repository workspace.
