### PR TITLE
fix: move URL install confirmation prompt before spinner (#2783)

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -3082,6 +3082,38 @@ def extension_add(
     manager = ExtensionManager(project_root)
     speckit_version = get_speckit_version()
 
+    # Prompt for URL-based installs BEFORE the spinner so the user can
+    # actually see and respond to the confirmation (the Rich status
+    # spinner overwrites the typer.confirm prompt line, making it appear
+    # as though the command is hung).
+    if from_url:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(from_url)
+        is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
+
+        if parsed.scheme != "https" and not (parsed.scheme == "http" and is_localhost):
+            console.print("[red]Error:[/red] URL must use HTTPS for security.")
+            console.print("HTTP is only allowed for localhost URLs.")
+            raise typer.Exit(1)
+
+        # Warn about untrusted sources — default-deny confirmation
+        console.print()
+        console.print(Panel(
+            f"[bold]You are installing an extension from an external URL that is not\n"
+            f"listed in any of your configured extension catalogs.[/bold]\n\n"
+            f"URL: {from_url}\n\n"
+            f"Only install extensions from sources you trust.",
+            title="[bold yellow]⚠ Untrusted Source[/bold yellow]",
+            border_style="yellow",
+            padding=(1, 2),
+        ))
+        console.print()
+        confirm = typer.confirm("Continue with installation?", default=False)
+        if not confirm:
+            console.print("Cancelled")
+            raise typer.Exit(0)
+
     try:
         with console.status(f"[cyan]Installing extension: {extension}[/cyan]"):
             if dev:
@@ -3106,33 +3138,6 @@ def extension_add(
                 # Install from URL (ZIP file)
                 import urllib.request
                 import urllib.error
-                from urllib.parse import urlparse
-
-                # Validate URL
-                parsed = urlparse(from_url)
-                is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
-
-                if parsed.scheme != "https" and not (parsed.scheme == "http" and is_localhost):
-                    console.print("[red]Error:[/red] URL must use HTTPS for security.")
-                    console.print("HTTP is only allowed for localhost URLs.")
-                    raise typer.Exit(1)
-
-                # Warn about untrusted sources — default-deny confirmation
-                console.print()
-                console.print(Panel(
-                    f"[bold]You are installing an extension from an external URL that is not\n"
-                    f"listed in any of your configured extension catalogs.[/bold]\n\n"
-                    f"URL: {from_url}\n\n"
-                    f"Only install extensions from sources you trust.",
-                    title="[bold yellow]⚠ Untrusted Source[/bold yellow]",
-                    border_style="yellow",
-                    padding=(1, 2),
-                ))
-                console.print()
-                confirm = typer.confirm("Continue with installation?", default=False)
-                if not confirm:
-                    console.print("Cancelled")
-                    raise typer.Exit(0)
 
                 console.print(f"Downloading from {from_url}...")
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -3141,12 +3141,9 @@ def extension_add(
 
             elif from_url:
                 # Install from URL (ZIP file)
-                import urllib.request
                 import urllib.error
 
-                from rich.markup import escape as _escape_markup
-
-                console.print(f"Downloading from {_escape_markup(from_url)}...")
+                console.print(f"Downloading from {safe_url}...")
 
                 # Download ZIP to temp location
                 download_dir = project_root / ".specify" / "extensions" / ".cache" / "downloads"
@@ -3163,7 +3160,7 @@ def extension_add(
                     # Install from downloaded ZIP
                     manifest = manager.install_from_zip(zip_path, speckit_version, priority=priority)
                 except urllib.error.URLError as e:
-                    console.print(f"[red]Error:[/red] Failed to download from {from_url}: {e}")
+                    console.print(f"[red]Error:[/red] Failed to download from {safe_url}: {e}")
                     raise typer.Exit(1)
                 finally:
                     # Clean up downloaded ZIP

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -3088,6 +3088,7 @@ def extension_add(
     # as though the command is hung).
     if from_url:
         from urllib.parse import urlparse
+        from rich.markup import escape as rich_escape
 
         parsed = urlparse(from_url)
         is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
@@ -3102,7 +3103,7 @@ def extension_add(
         console.print(Panel(
             f"[bold]You are installing an extension from an external URL that is not\n"
             f"listed in any of your configured extension catalogs.[/bold]\n\n"
-            f"URL: {from_url}\n\n"
+            f"URL: {rich_escape(from_url)}\n\n"
             f"Only install extensions from sources you trust.",
             title="[bold yellow]⚠ Untrusted Source[/bold yellow]",
             border_style="yellow",

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -3086,9 +3086,11 @@ def extension_add(
     # actually see and respond to the confirmation (the Rich status
     # spinner overwrites the typer.confirm prompt line, making it appear
     # as though the command is hung).
-    if from_url:
+    # Guard with ``not dev`` so that --dev + --from does not show a
+    # confusing confirmation for a URL that will be ignored.
+    if from_url and not dev:
         from urllib.parse import urlparse
-        from rich.markup import escape as rich_escape
+        from rich.markup import escape as _escape_markup
 
         parsed = urlparse(from_url)
         is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
@@ -3098,12 +3100,14 @@ def extension_add(
             console.print("HTTP is only allowed for localhost URLs.")
             raise typer.Exit(1)
 
+        safe_url = _escape_markup(from_url)
+
         # Warn about untrusted sources — default-deny confirmation
         console.print()
         console.print(Panel(
             f"[bold]You are installing an extension from an external URL that is not\n"
             f"listed in any of your configured extension catalogs.[/bold]\n\n"
-            f"URL: {rich_escape(from_url)}\n\n"
+            f"URL: {safe_url}\n\n"
             f"Only install extensions from sources you trust.",
             title="[bold yellow]⚠ Untrusted Source[/bold yellow]",
             border_style="yellow",
@@ -3140,7 +3144,9 @@ def extension_add(
                 import urllib.request
                 import urllib.error
 
-                console.print(f"Downloading from {from_url}...")
+                from rich.markup import escape as _escape_markup
+
+                console.print(f"Downloading from {_escape_markup(from_url)}...")
 
                 # Download ZIP to temp location
                 download_dir = project_root / ".specify" / "extensions" / ".cache" / "downloads"

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -3807,6 +3807,67 @@ class TestExtensionAddCLI:
         assert "bundled with spec-kit" in result.output
         assert "reinstall" in result.output.lower()
 
+    def test_add_from_url_prompts_before_spinner(self, tmp_path):
+        """Confirm prompt for --from <url> must fire before the console.status spinner.
+
+        Regression test for #2783: typer.confirm() inside console.status()
+        was overwritten by the Rich spinner, making the command appear hung.
+        """
+        from typer.testing import CliRunner
+        from unittest.mock import patch, MagicMock
+        from specify_cli import app
+
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+        (project_dir / ".specify").mkdir()
+
+        call_order: list[str] = []
+
+        original_status = MagicMock()
+
+        def record_status(*args, **kwargs):
+            call_order.append("spinner")
+            return original_status
+
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir), \
+             patch("specify_cli.console.status", side_effect=record_status), \
+             patch("typer.confirm", side_effect=lambda *a, **kw: (call_order.append("confirm"), False)[-1]):
+            result = runner.invoke(
+                app,
+                ["extension", "add", "my-ext", "--from", "https://example.com/ext.zip"],
+                catch_exceptions=True,
+            )
+
+        assert "confirm" in call_order, "confirm prompt was never called"
+        # The confirm must fire BEFORE the spinner is entered
+        if "spinner" in call_order:
+            assert call_order.index("confirm") < call_order.index("spinner"), \
+                f"confirm must precede spinner, got: {call_order}"
+        assert result.exit_code == 0  # user declined → clean exit
+
+    def test_add_from_url_cancel_exits_cleanly(self, tmp_path):
+        """Declining the --from <url> confirmation should exit with code 0."""
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+        (project_dir / ".specify").mkdir()
+
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir), \
+             patch("typer.confirm", return_value=False):
+            result = runner.invoke(
+                app,
+                ["extension", "add", "my-ext", "--from", "https://example.com/ext.zip"],
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+
 
 class TestDownloadExtensionBundled:
     """Tests for download_extension handling of bundled extensions."""


### PR DESCRIPTION
## Summary

Fixes #2783 — `specify extension add --from <url>` appears hung on 0.8.18 because the `typer.confirm()` prompt is rendered inside the `console.status()` spinner block. Rich's spinner thread overwrites the prompt line, so the user only sees `⠦ Installing extension: ...` indefinitely.

## Changes

Move the URL validation and default-deny confirmation prompt **before** the `with console.status(...)` block so the `[y/N]` prompt is visible and the user can respond.

## Testing

- Reproduced the bug: spinner overwrites `typer.confirm()` output
- Full test suite: 3202 passed, 1 skipped (unrelated Windows PowerShell test), 0 failures