### PR TITLE
fix: resolve GitHub release asset API URL for private repo extension downloads

### DIFF
--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1728,13 +1728,51 @@ class ExtensionCatalog(CatalogStackBase):
         from specify_cli.authentication.http import build_request
         return build_request(url)
 
-    def _open_url(self, url: str, timeout: int = 10):
+    def _open_url(
+        self,
+        url: str,
+        timeout: int = 10,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ):
         """Open a URL with provider-based auth, trying each configured provider.
 
         Delegates to :func:`specify_cli.authentication.http.open_url`.
         """
         from specify_cli.authentication.http import open_url
-        return open_url(url, timeout)
+        return open_url(url, timeout, extra_headers=extra_headers)
+
+    def _resolve_github_release_asset_api_url(
+        self,
+        download_url: str,
+        timeout: int = 60,
+    ) -> Optional[str]:
+        """Resolve a GitHub browser release asset URL to its API asset URL."""
+        import urllib.error
+        from urllib.parse import unquote, urlparse
+
+        parsed = urlparse(download_url)
+        if parsed.hostname != "github.com":
+            return None
+
+        parts = [unquote(part) for part in parsed.path.strip("/").split("/")]
+        if len(parts) < 6 or parts[2:4] != ["releases", "download"]:
+            return None
+
+        owner, repo, tag = parts[0], parts[1], parts[4]
+        asset_name = "/".join(parts[5:])
+        release_url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}"
+
+        try:
+            with self._open_url(release_url, timeout=timeout) as response:
+                release_data = json.loads(response.read())
+        except (urllib.error.URLError, json.JSONDecodeError):
+            return None
+
+        for asset in release_data.get("assets", []):
+            if asset.get("name") == asset_name and asset.get("url"):
+                return str(asset["url"])
+
+        return None
 
     def get_active_catalogs(self) -> List[CatalogEntry]:
         """Get the ordered list of active catalogs.
@@ -2134,9 +2172,15 @@ class ExtensionCatalog(CatalogStackBase):
         zip_filename = f"{extension_id}-{version}.zip"
         zip_path = target_dir / zip_filename
 
+        extra_headers = None
+        resolved_download_url = self._resolve_github_release_asset_api_url(download_url)
+        if resolved_download_url:
+            download_url = resolved_download_url
+            extra_headers = {"Accept": "application/octet-stream"}
+
         # Download the ZIP file
         try:
-            with self._open_url(download_url, timeout=60) as response:
+            with self._open_url(download_url, timeout=60, extra_headers=extra_headers) as response:
                 zip_data = response.read()
 
             zip_path.write_bytes(zip_data)

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1746,15 +1746,23 @@ class ExtensionCatalog(CatalogStackBase):
         download_url: str,
         timeout: int = 60,
     ) -> Optional[str]:
-        """Resolve a GitHub browser release asset URL to its API asset URL."""
+        """Resolve a GitHub release asset URL to its API asset URL."""
         import urllib.error
         from urllib.parse import unquote, urlparse
 
         parsed = urlparse(download_url)
+        parts = [unquote(part) for part in parsed.path.strip("/").split("/")]
+        if (
+            parsed.hostname == "api.github.com"
+            and len(parts) >= 6
+            and parts[:1] == ["repos"]
+            and parts[3:5] == ["releases", "assets"]
+        ):
+            return download_url
+
         if parsed.hostname != "github.com":
             return None
 
-        parts = [unquote(part) for part in parsed.path.strip("/").split("/")]
         if len(parts) < 6 or parts[2:4] != ["releases", "download"]:
             return None
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2815,6 +2815,51 @@ class TestExtensionCatalog:
         assert captured[1].get_header("Authorization") == "Bearer ghp_testtoken"
         assert captured[1].get_header("Accept") == "application/octet-stream"
 
+    def test_download_extension_accepts_direct_github_rest_asset_url(self, temp_dir, monkeypatch):
+        """download_extension can use a GitHub REST release asset URL directly."""
+        from unittest.mock import patch, MagicMock
+        import zipfile
+        import io
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_testtoken")
+        self._inject_github_config(monkeypatch, token_env="GITHUB_TOKEN")
+        catalog = self._make_catalog(temp_dir)
+
+        zip_buf = io.BytesIO()
+        with zipfile.ZipFile(zip_buf, "w") as zf:
+            zf.writestr("extension.yml", "id: test-ext\nname: Test\nversion: 1.0.0\n")
+        zip_bytes = zip_buf.getvalue()
+
+        asset_response = MagicMock()
+        asset_response.read.return_value = zip_bytes
+        asset_response.__enter__ = lambda s: s
+        asset_response.__exit__ = MagicMock(return_value=False)
+
+        captured = []
+        mock_opener = MagicMock()
+
+        def fake_open(req, timeout=None):
+            captured.append(req)
+            return asset_response
+
+        mock_opener.open.side_effect = fake_open
+
+        ext_info = {
+            "id": "test-ext",
+            "name": "Test Extension",
+            "version": "1.0.0",
+            "download_url": "https://api.github.com/repos/org/repo/releases/assets/1",
+        }
+
+        with patch.object(catalog, "get_extension_info", return_value=ext_info), \
+             patch("specify_cli.authentication.http.urllib.request.build_opener", return_value=mock_opener):
+            catalog.download_extension("test-ext", target_dir=temp_dir)
+
+        assert len(captured) == 1
+        assert captured[0].full_url == "https://api.github.com/repos/org/repo/releases/assets/1"
+        assert captured[0].get_header("Authorization") == "Bearer ghp_testtoken"
+        assert captured[0].get_header("Accept") == "application/octet-stream"
+
 
 
 # ===== CatalogEntry Tests =====

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2768,17 +2768,33 @@ class TestExtensionCatalog:
             zf.writestr("extension.yml", "id: test-ext\nname: Test\nversion: 1.0.0\n")
         zip_bytes = zip_buf.getvalue()
 
-        mock_response = MagicMock()
-        mock_response.read.return_value = zip_bytes
-        mock_response.__enter__ = lambda s: s
-        mock_response.__exit__ = MagicMock(return_value=False)
+        release_response = MagicMock()
+        release_response.read.return_value = json.dumps(
+            {
+                "assets": [
+                    {
+                        "name": "test-ext.zip",
+                        "url": "https://api.github.com/repos/org/repo/releases/assets/1",
+                    }
+                ]
+            }
+        ).encode()
+        release_response.__enter__ = lambda s: s
+        release_response.__exit__ = MagicMock(return_value=False)
 
-        captured = {}
+        asset_response = MagicMock()
+        asset_response.read.return_value = zip_bytes
+        asset_response.__enter__ = lambda s: s
+        asset_response.__exit__ = MagicMock(return_value=False)
+
+        captured = []
         mock_opener = MagicMock()
 
         def fake_open(req, timeout=None):
-            captured["req"] = req
-            return mock_response
+            captured.append(req)
+            if req.full_url.endswith("/releases/tags/v1"):
+                return release_response
+            return asset_response
 
         mock_opener.open.side_effect = fake_open
 
@@ -2793,7 +2809,11 @@ class TestExtensionCatalog:
              patch("specify_cli.authentication.http.urllib.request.build_opener", return_value=mock_opener):
             catalog.download_extension("test-ext", target_dir=temp_dir)
 
-        assert captured["req"].get_header("Authorization") == "Bearer ghp_testtoken"
+        assert captured[0].full_url == "https://api.github.com/repos/org/repo/releases/tags/v1"
+        assert captured[0].get_header("Authorization") == "Bearer ghp_testtoken"
+        assert captured[1].full_url == "https://api.github.com/repos/org/repo/releases/assets/1"
+        assert captured[1].get_header("Authorization") == "Bearer ghp_testtoken"
+        assert captured[1].get_header("Accept") == "application/octet-stream"
 
 
 


### PR DESCRIPTION
## Summary

- Fixes `specify extension add` when the catalog `download_url` points at a GitHub release URL for a private or SSO-protected repository
- For private/SSO repos, browser release URLs (`https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>.zip`) redirect to an HTML/SSO page instead of the ZIP asset, causing installation to fail with `BadZipFile: File is not a zip file`

## Fix — two download URL shapes are now handled

**Browser release URL** (commit 1):
- Detects GitHub browser release asset URLs during download
- Resolves the matching asset via the GitHub REST API: `GET /repos/<owner>/<repo>/releases/tags/<tag>`
- Downloads the matched asset URL with `Accept: application/octet-stream`
- Falls back to the original download URL if the API call fails

**Direct REST asset URL** (commit 2):
- When `download_url` is already a GitHub REST release asset URL (`https://api.github.com/repos/<owner>/<repo>/releases/assets/<id>`), skips the metadata lookup and downloads directly with `Accept: application/octet-stream`
- That header is required because GitHub returns release asset metadata JSON by default; `Accept: application/octet-stream` returns the ZIP payload

**Other URLs**: existing downloader behavior is unchanged.

Auth is preserved end-to-end through the existing `specify_cli.authentication.http.open_url` infrastructure.

## Test plan

- [ ] Run focused test suite to confirm new and existing behavior:
  ```bash
  UV_NATIVE_TLS=true SSL_CERT_FILE=/opt/homebrew/etc/openssl@3/cert.pem UV_DEFAULT_INDEX=https://pypi.org/simple PYTHONPATH=src uv run --extra test pytest tests/test_extensions.py -k 'make_request or fetch_single_catalog_sends_auth_header or download_extension_sends_auth_header or download_extension_accepts_direct_github_rest_asset_url'
  ```
  Expected: 13 passed, 190 deselected
- [ ] Verify `specify extension add` against an extension hosted on a private GitHub repo using a browser release URL — asset should be resolved via the API and downloaded correctly
- [ ] Verify `specify extension add` against a catalog using a direct REST asset URL (`api.github.com/repos/.../releases/assets/<id>`) — should download directly with auth and `Accept: application/octet-stream`
- [ ] Verify `specify extension add` still works for public GitHub release URLs and non-GitHub URLs (fallback paths not triggered)

> **AI disclosure**: This PR was developed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)