### PR TITLE
fix: add missing agent-context extension entries to Cline `_expected_files`

### DIFF
--- a/tests/integrations/test_integration_cline.py
+++ b/tests/integrations/test_integration_cline.py
@@ -206,6 +206,16 @@ class TestClineIntegration(MarkdownIntegrationTests):
         files.append(".specify/workflows/speckit/workflow.yml")
         files.append(".specify/workflows/workflow-registry.json")
 
+        # Bundled agent-context extension
+        files.append(".specify/extensions.yml")
+        files.append(".specify/extensions/.registry")
+        files.append(".specify/extensions/agent-context/README.md")
+        files.append(".specify/extensions/agent-context/agent-context-config.yml")
+        files.append(".specify/extensions/agent-context/commands/speckit.agent-context.update.md")
+        files.append(".specify/extensions/agent-context/extension.yml")
+        files.append(".specify/extensions/agent-context/scripts/bash/update-agent-context.sh")
+        files.append(".specify/extensions/agent-context/scripts/powershell/update-agent-context.ps1")
+
         # Agent context file (if set)
         if i.context_file:
             files.append(i.context_file)


### PR DESCRIPTION
## Summary

Fixes #2796

`TestClineIntegration._expected_files()` overrides the base-class version but was never updated when the bundled `agent-context` extension files were added to `test_integration_base_markdown.py`. This caused `test_complete_file_inventory_sh` and `test_complete_file_inventory_ps` to fail with 8 "extra" files reported.

## Change

Added the 8 missing agent-context extension file entries to `TestClineIntegration._expected_files()` in `tests/integrations/test_integration_cline.py`, mirroring what the base class already lists:

- `.specify/extensions.yml`
- `.specify/extensions/.registry`
- `.specify/extensions/agent-context/README.md`
- `.specify/extensions/agent-context/agent-context-config.yml`
- `.specify/extensions/agent-context/commands/speckit.agent-context.update.md`
- `.specify/extensions/agent-context/extension.yml`
- `.specify/extensions/agent-context/scripts/bash/update-agent-context.sh`
- `.specify/extensions/agent-context/scripts/powershell/update-agent-context.ps1`

## Testing

All 3345 tests pass (1 skipped).