### PR TITLE
docs: add hands-off orchestration example

### DIFF
--- a/docs/community/hands-off-orchestration.md
+++ b/docs/community/hands-off-orchestration.md
@@ -8,6 +8,8 @@ Use this pattern when you want a repeatable planning pass that produces reviewed
 /speckit.specify -> /speckit.clarify -> /speckit.checklist -> /speckit.plan -> /speckit.tasks -> /speckit.analyze
 ```
 
+This ordering matches the [Quick Start Guide](../quickstart.md) workflow, where `/speckit.checklist` is a requirements-quality gate before `/speckit.plan`.
+
 The key rule is that the agent stops after analysis unless the user explicitly asks it to continue.
 
 > [!NOTE]

--- a/docs/community/hands-off-orchestration.md
+++ b/docs/community/hands-off-orchestration.md
@@ -14,7 +14,7 @@ The key rule is that the agent stops after analysis unless the user explicitly a
 
 - Generate and review artifacts before creating issues or writing code.
 - Ask the user when a product decision is required.
-- Loop back to the earlier stage when a later stage finds stale, incomplete, or inconsistent artifacts.
+- Loop back to an earlier stage when a later stage finds stale, incomplete, or inconsistent artifacts.
 - Do not run `/speckit.taskstoissues` unless the user explicitly requests issue creation.
 - Do not run `/speckit.implement` unless the user explicitly requests implementation.
 
@@ -46,11 +46,11 @@ Do not implement tasks unless I explicitly ask for implementation.
 After reviewing the generated artifacts, continue with one of these explicit prompts:
 
 ```text
-Create GitHub issues from the generated tasks, but do not implement them.
+Run /speckit.taskstoissues to create GitHub issues from the generated tasks, but do not implement them.
 ```
 
 ```text
-Implement the generated tasks now.
+Run /speckit.implement to implement the generated tasks now.
 ```
 
 Keeping issue creation and implementation as separate follow-up prompts makes the default flow safe for planning, design review, and handoff scenarios.

--- a/docs/community/hands-off-orchestration.md
+++ b/docs/community/hands-off-orchestration.md
@@ -5,16 +5,20 @@ This example shows how to ask an AI coding agent to run a hands-off, artifact-fi
 Use this pattern when you want a repeatable planning pass that produces reviewed artifacts first:
 
 ```text
-/speckit.specify -> /speckit.clarify -> /speckit.plan -> /speckit.checklist -> /speckit.tasks -> /speckit.analyze
+/speckit.specify -> /speckit.clarify -> /speckit.checklist -> /speckit.plan -> /speckit.tasks -> /speckit.analyze
 ```
 
 The key rule is that the agent stops after analysis unless the user explicitly asks it to continue.
+
+> [!NOTE]
+> This conservative example uses only `README.md` and `DESIGN.md` as in-repo guidance sources unless the user explicitly provides more context.
 
 ## Guardrails
 
 - Generate and review artifacts before creating issues or writing code.
 - Ask the user when a product decision is required.
 - Loop back to an earlier stage when a later stage finds stale, incomplete, or inconsistent artifacts.
+- Use only `README.md` and `DESIGN.md` as in-repo guidance sources unless the user explicitly provides more context.
 - Do not run `/speckit.taskstoissues` unless the user explicitly requests issue creation.
 - Do not run `/speckit.implement` unless the user explicitly requests implementation.
 
@@ -31,12 +35,13 @@ Follow this sequence:
 
 1. Run /speckit.specify for the requested feature.
 2. Run /speckit.clarify to identify ambiguity. If a real product decision is required, stop and ask me before continuing.
-3. Run /speckit.plan after the specification is clear enough to plan.
-4. Run /speckit.checklist and fix requirement-quality gaps by looping back to /speckit.clarify or /speckit.specify as needed.
+3. Run /speckit.checklist and fix requirement-quality gaps by looping back to /speckit.clarify or /speckit.specify as needed.
+4. Run /speckit.plan after the specification passes the requirements checklist.
 5. Run /speckit.tasks after the plan and checklist are consistent.
 6. Run /speckit.analyze to check cross-artifact consistency.
 7. Stop after analysis and report the generated artifacts, open questions, and recommended next step.
 
+Use only README.md and DESIGN.md as in-repo guidance sources unless I explicitly provide more context.
 Do not create GitHub issues unless I explicitly ask for issue creation.
 Do not implement tasks unless I explicitly ask for implementation.
 ```

--- a/docs/community/hands-off-orchestration.md
+++ b/docs/community/hands-off-orchestration.md
@@ -1,0 +1,67 @@
+# Hands-Off Orchestration Example
+
+This example shows how to ask an AI coding agent to run a hands-off, artifact-first Spec Kit flow without moving into issue creation or implementation by default.
+
+Use this pattern when you want a repeatable planning pass that produces reviewed artifacts first:
+
+```text
+/speckit.specify -> /speckit.clarify -> /speckit.plan -> /speckit.checklist -> /speckit.tasks -> /speckit.analyze
+```
+
+The key rule is that the agent stops after analysis unless the user explicitly asks it to continue.
+
+## Guardrails
+
+- Generate and review artifacts before creating issues or writing code.
+- Ask the user when a product decision is required.
+- Loop back to the earlier stage when a later stage finds stale, incomplete, or inconsistent artifacts.
+- Do not run `/speckit.taskstoissues` unless the user explicitly requests issue creation.
+- Do not run `/speckit.implement` unless the user explicitly requests implementation.
+
+## Example Agent Prompt
+
+Copy this prompt into your agent after initializing a Spec Kit project:
+
+```text
+Run an artifact-first Spec Kit orchestration flow for the following feature:
+
+<describe the feature here>
+
+Follow this sequence:
+
+1. Run /speckit.specify for the requested feature.
+2. Run /speckit.clarify to identify ambiguity. If a real product decision is required, stop and ask me before continuing.
+3. Run /speckit.plan after the specification is clear enough to plan.
+4. Run /speckit.checklist and fix requirement-quality gaps by looping back to /speckit.clarify or /speckit.specify as needed.
+5. Run /speckit.tasks after the plan and checklist are consistent.
+6. Run /speckit.analyze to check cross-artifact consistency.
+7. Stop after analysis and report the generated artifacts, open questions, and recommended next step.
+
+Do not create GitHub issues unless I explicitly ask for issue creation.
+Do not implement tasks unless I explicitly ask for implementation.
+```
+
+## Optional Follow-Up Prompts
+
+After reviewing the generated artifacts, continue with one of these explicit prompts:
+
+```text
+Create GitHub issues from the generated tasks, but do not implement them.
+```
+
+```text
+Implement the generated tasks now.
+```
+
+Keeping issue creation and implementation as separate follow-up prompts makes the default flow safe for planning, design review, and handoff scenarios.
+
+## When To Use This Pattern
+
+Use this pattern when:
+
+- A team lead wants implementation-ready artifacts before assigning work.
+- A project wants consistent specs, plans, and tasks for every feature request.
+- The feature has enough ambiguity that clarification and checklist passes are useful.
+- You want automation to prepare work, but not silently create issues or write code.
+
+For smaller experiments, the shorter workflow in the [Quick Start Guide](../quickstart.md) may be enough.

--- a/docs/community/hands-off-orchestration.md
+++ b/docs/community/hands-off-orchestration.md
@@ -8,7 +8,7 @@ Use this pattern when you want a repeatable planning pass that produces reviewed
 /speckit.specify -> /speckit.clarify -> /speckit.checklist -> /speckit.plan -> /speckit.tasks -> /speckit.analyze
 ```
 
-This ordering matches the [Quick Start Guide](../quickstart.md) workflow, where `/speckit.checklist` is a requirements-quality gate before `/speckit.plan` (if you are following a workflow that runs `/speckit.plan` before `/speckit.checklist`, swap those two steps).
+This ordering matches the [Quick Start Guide](../quickstart.md) recommended workflow, where `/speckit.checklist` is a requirements-quality gate before `/speckit.plan`.
 
 The key rule is that the agent stops after analysis unless the user explicitly asks it to continue.
 

--- a/docs/community/hands-off-orchestration.md
+++ b/docs/community/hands-off-orchestration.md
@@ -8,7 +8,7 @@ Use this pattern when you want a repeatable planning pass that produces reviewed
 /speckit.specify -> /speckit.clarify -> /speckit.checklist -> /speckit.plan -> /speckit.tasks -> /speckit.analyze
 ```
 
-This ordering matches the [Quick Start Guide](../quickstart.md) workflow, where `/speckit.checklist` is a requirements-quality gate before `/speckit.plan`.
+This ordering matches the [Quick Start Guide](../quickstart.md) workflow, where `/speckit.checklist` is a requirements-quality gate before `/speckit.plan` (if you are following a workflow that runs `/speckit.plan` before `/speckit.checklist`, swap those two steps).
 
 The key rule is that the agent stops after analysis unless the user explicitly asks it to continue.
 

--- a/docs/community/walkthroughs.md
+++ b/docs/community/walkthroughs.md
@@ -5,6 +5,8 @@
 
 See Spec-Driven Development in action across different scenarios with these community-contributed walkthroughs:
 
+- **[Hands-off orchestration example](hands-off-orchestration.md)** — Shows an artifact-first flow that runs specify, clarify, plan, checklist, tasks, and analyze, then stops before issue creation or implementation unless the user explicitly opts in.
+
 - **[Greenfield .NET CLI tool](https://github.com/mnriem/spec-kit-dotnet-cli-demo)** — Builds a Timezone Utility as a .NET single-binary CLI tool from a blank directory, covering the full spec-kit workflow: constitution, specify, plan, tasks, and multi-pass implement using GitHub Copilot agents.
 
 - **[Greenfield Spring Boot + React platform](https://github.com/mnriem/spec-kit-spring-react-demo)** — Builds an LLM performance analytics platform (REST API, graphs, iteration tracking) from scratch using Spring Boot, embedded React, PostgreSQL, and Docker Compose, with a clarify step and a cross-artifact consistency analysis pass included.

--- a/docs/community/walkthroughs.md
+++ b/docs/community/walkthroughs.md
@@ -1,11 +1,17 @@
 # Community Walkthroughs
 
-> [!NOTE]
-> Community walkthroughs are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review their content before following along and use at your own discretion.
+## Spec Kit Examples
 
-See Spec-Driven Development in action across different scenarios with these community-contributed walkthroughs:
+These examples are maintained in the Spec Kit documentation:
 
 - **[Hands-off orchestration example](hands-off-orchestration.md)** — Shows an artifact-first flow that runs specify, clarify, plan, checklist, tasks, and analyze, then stops before issue creation or implementation unless the user explicitly opts in.
+
+## Community Walkthroughs
+
+> [!NOTE]
+> External community walkthroughs are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review their content before following along and use at your own discretion.
+
+See Spec-Driven Development in action across different scenarios with these community-contributed walkthroughs:
 
 - **[Greenfield .NET CLI tool](https://github.com/mnriem/spec-kit-dotnet-cli-demo)** — Builds a Timezone Utility as a .NET single-binary CLI tool from a blank directory, covering the full spec-kit workflow: constitution, specify, plan, tasks, and multi-pass implement using GitHub Copilot agents.
 

--- a/docs/community/walkthroughs.md
+++ b/docs/community/walkthroughs.md
@@ -4,7 +4,7 @@
 
 These examples are maintained in the Spec Kit documentation:
 
-- **[Hands-off orchestration example](hands-off-orchestration.md)** — Shows an artifact-first flow that runs specify, clarify, plan, checklist, tasks, and analyze, then stops before issue creation or implementation unless the user explicitly opts in.
+- **[Hands-off orchestration example](hands-off-orchestration.md)** — Shows an artifact-first flow that runs specify, clarify, checklist, plan, tasks, and analyze, then stops before issue creation or implementation unless the user explicitly opts in.
 
 ## Community Walkthroughs
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -60,5 +60,7 @@
       href: community/presets.md
     - name: Walkthroughs
       href: community/walkthroughs.md
+    - name: Hands-Off Orchestration
+      href: community/hands-off-orchestration.md
     - name: Friends
       href: community/friends.md


### PR DESCRIPTION
## Description

Adds a website documentation example for an artifact-first hands-off orchestration pattern. The example follows the maintainer direction in #2789 to start with a docs example, and shows how to run specify, clarify, plan, checklist, tasks, and analyze before stopping unless the user explicitly opts into issue creation or implementation.

Fixes #2789

## Testing

- [x] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Additional validation:

- `git diff --check`
- `npx -y markdownlint-cli2 "docs/community/hands-off-orchestration.md" "docs/community/walkthroughs.md"`

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

This PR was prepared with Cursor AI assistance. I reviewed the issue discussion, scoped the change to documentation, ran local validation, and created this draft PR for maintainer feedback.

Made with [Cursor](https://cursor.com)