### PR TITLE
fix: align checklist guidance with docs

### DIFF
--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -776,7 +776,7 @@ def register(app: typer.Typer) -> None:
             "",
             f"○ [cyan]{_display_cmd('clarify')}[/] [bright_black](optional)[/bright_black] - Ask structured questions to de-risk ambiguous areas before planning (run before [cyan]{_display_cmd('plan')}[/] if used)",
             f"○ [cyan]{_display_cmd('analyze')}[/] [bright_black](optional)[/bright_black] - Cross-artifact consistency & alignment report (after [cyan]{_display_cmd('tasks')}[/], before [cyan]{_display_cmd('implement')}[/])",
-            f"○ [cyan]{_display_cmd('checklist')}[/] [bright_black](optional)[/bright_black] - Generate quality checklists to validate requirements completeness, clarity, and consistency (after [cyan]{_display_cmd('plan')}[/])"
+            f"○ [cyan]{_display_cmd('checklist')}[/] [bright_black](optional)[/bright_black] - Generate quality checklists to validate requirements completeness, clarity, and consistency (before [cyan]{_display_cmd('plan')}[/])"
         ]
         enhancements_title = "Enhancement Skills" if native_skill_mode else "Enhancement Commands"
         enhancements_panel = Panel("\n".join(enhancement_lines), title=enhancements_title, border_style="cyan", padding=(1, 2))

--- a/tests/integrations/test_integration_copilot.py
+++ b/tests/integrations/test_integration_copilot.py
@@ -792,3 +792,9 @@ class TestCopilotSkillsMode:
         assert "/speckit.plan" not in result.output, (
             f"Should not show /speckit.plan in skills mode:\n{result.output}"
         )
+        assert "before /speckit-plan" in result.output, (
+            f"Checklist guidance should align with docs and run before planning:\n{result.output}"
+        )
+        assert "after /speckit-plan" not in result.output, (
+            f"Checklist guidance should not say it runs after planning:\n{result.output}"
+        )


### PR DESCRIPTION
## Description

Aligns the `specify init` next-steps guidance with the Quick Start docs by describing `/speckit.checklist` as a requirements-quality gate to run before `/speckit.plan`, not after it.

Fixes #2606

## Testing

- [x] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

Additional validation:

- `uv run pytest tests/integrations/test_integration_copilot.py::TestCopilotSkillsMode::test_init_skills_next_steps_show_skill_syntax -q`
- `git diff --check`
- `uv run specify init <tmp>/checklist-order --integration copilot --integration-options "--skills" --no-git` and verified the output says `before /speckit-plan` and not `after /speckit-plan`

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

This PR was prepared with Cursor AI assistance. I reviewed the issue, compared the CLI guidance with the Quick Start docs, made the minimal text change, and added a focused regression assertion.

Made with [Cursor](https://cursor.com)