### PR TITLE
fix(cli): force UTF-8 stdout/stderr on Windows to prevent UnicodeEncodeError

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -4780,6 +4780,17 @@ def workflow_catalog_remove(
 
 
 def main():
+    # On Windows the default stdout/stderr code page (e.g. cp1252) cannot encode
+    # the Rich banner and box-drawing glyphs, so the CLI crashes with
+    # UnicodeEncodeError whenever output is not a UTF-8 TTY (piped, redirected to
+    # a file, or running under a legacy code page). Force UTF-8 with graceful
+    # replacement so output degrades instead of aborting. No-op on POSIX.
+    if sys.platform == "win32":
+        for _stream in (sys.stdout, sys.stderr):
+            try:
+                _stream.reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, ValueError, OSError):
+                pass
     app()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

On Windows, `specify` crashes with `UnicodeEncodeError` whenever stdout/stderr
are not a UTF-8 TTY — i.e. when output is piped, redirected to a file, or the
console uses a legacy code page (e.g. cp1252). Rich renders the ASCII-art
banner and box-drawing characters, and the default Windows text encoding can't
encode them, so even `specify --help` and `specify version` abort with a
traceback instead of printing.

Repro (Windows, default code page):

    > specify --help | more
    ... UnicodeEncodeError: 'charmap' codec can't encode characters ...

Fix: at the `main()` entry point, on `win32` only, reconfigure
`sys.stdout`/`sys.stderr` to UTF-8 with `errors="replace"` so output degrades
gracefully instead of crashing.

- No-op on POSIX.
- Guarded by `try/except (AttributeError, ValueError, OSError)` so unusual
  stream setups (already-wrapped/detached streams) can never make things worse.
- Placed at the CLI entry point, so importing `specify_cli` as a library does
  not mutate global streams.

```python
if sys.platform == "win32":
    for _stream in (sys.stdout, sys.stderr):
        try:
            _stream.reconfigure(encoding="utf-8", errors="replace")
        except (AttributeError, ValueError, OSError):
            pass
```

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (N/A — change only affects console stream encoding)

On Windows 11, cp1252 console, **without** `PYTHONUTF8`/`PYTHONIOENCODING`:
- `specify --help` piped → renders banner + option boxes, exit 0 (was: `UnicodeEncodeError`).
- `specify version > out.txt` → renders correctly, exit 0 (was: traceback).

Full suite: **3217 passed, 119 skipped**. The 11 failures are pre-existing and
unrelated to this change — `os.symlink()` calls in test *setup* raise
`OSError [WinError 1314]` because the Windows host lacks symlink-create
privilege; they pass on POSIX / elevated Windows.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Diagnosed, implemented, and verified with Claude (Claude Code); reviewed before
submission. Reflected in the commit's `Co-Authored-By` trailer.
