### PR TITLE
Update workflow-preset community catalog to v1.3.2

### DIFF
--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-05-31T00:00:00Z",
+  "updated_at": "2026-06-03T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/presets/catalog.community.json",
   "presets": {
     "a11y-governance": {
@@ -542,7 +542,7 @@
       ],
       "created_at": "2026-04-30T00:00:00Z",
       "updated_at": "2026-04-30T00:00:00Z"
-    }, 
+    },
     "toc-navigation": {
       "name": "Table of Contents Navigation",
       "id": "toc-navigation",
@@ -595,11 +595,11 @@
     "workflow-preset": {
       "name": "Workflow Preset",
       "id": "workflow-preset",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "description": "Behavior-first specification, design artifacts, and agent-native handoff orchestration.",
       "author": "bigsmartben",
       "repository": "https://github.com/bigsmartben/spec-kit-workflow-preset",
-      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/releases/download/v1.3.1/spec-kit-workflow-preset-v1.3.1.zip",
+      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/releases/download/v1.3.2/spec-kit-workflow-preset-v1.3.2.zip",
       "homepage": "https://github.com/bigsmartben/spec-kit-workflow-preset",
       "documentation": "https://github.com/bigsmartben/spec-kit-workflow-preset/blob/main/README.md",
       "license": "MIT",
@@ -618,7 +618,7 @@
         "handoff"
       ],
       "created_at": "2026-05-27T00:00:00Z",
-      "updated_at": "2026-05-28T00:00:00Z"
+      "updated_at": "2026-06-03T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update the workflow-preset community catalog entry from v1.3.1 to v1.3.2.
- Point the download URL at the v1.3.2 release asset.
- Refresh the catalog updated_at timestamp.

## Test Plan
- [x] `git diff --check upstream/main...origin/community/2618-update-workflow-preset`
- [x] `git show origin/community/2618-update-workflow-preset:presets/catalog.community.json | python3 -m json.tool >/tmp/workflow-preset-catalog-check.json`
- [x] `gh release view v1.3.2 --repo bigsmartben/spec-kit-workflow-preset --json assets --jq '.assets[].name'` confirmed `spec-kit-workflow-preset-v1.3.2.zip`

## AI Assistance
- This PR was prepared with Codex assistance; I reviewed the scoped catalog diff and verification output.