### PR TITLE
Update Agent Governance catalog entry to Repository Governance v2.0.2

### DIFF
--- a/docs/community/extensions.md
+++ b/docs/community/extensions.md
@@ -23,7 +23,6 @@ The following community-contributed extensions are available in [`catalog.commun
 | Extension | Purpose | Category | Effect | URL |
 |-----------|---------|----------|--------|-----|
 | Agent Assign | Assign specialized Claude Code agents to spec-kit tasks for targeted execution | `process` | Read+Write | [spec-kit-agent-assign](https://github.com/xymelon/spec-kit-agent-assign) |
-| Agent Governance | Generate agent-platform repository governance files from Spec Kit metadata | `process` | Read+Write | [spec-kit-agent-governance](https://github.com/bigsmartben/spec-kit-agent-governance) |
 | AI-Driven Engineering (AIDE) | A structured 7-step workflow for building new projects from scratch with AI assistants — from vision through implementation | `process` | Read+Write | [aide](https://github.com/mnriem/spec-kit-extensions/tree/main/aide) |
 | API Evolve | Managed API contract evolution — breaking-change detection, semver enforcement, deprecation orchestration, and lifecycle gates across REST, GraphQL, and gRPC | `process` | Read+Write | [spec-kit-api-evolve](https://github.com/Quratulain-bilal/spec-kit-api-evolve) |
 | Architect Impact Previewer | Predicts architectural impact, complexity, and risks of proposed changes before implementation. | `visibility` | Read-only | [spec-kit-architect-preview](https://github.com/UmmeHabiba1312/spec-kit-architect-preview) |
@@ -88,6 +87,7 @@ The following community-contributed extensions are available in [`catalog.commun
 | Ralph Loop | Autonomous implementation loop using AI agent CLI | `code` | Read+Write | [spec-kit-ralph](https://github.com/Rubiss-Projects/spec-kit-ralph) |
 | Reconcile Extension | Reconcile implementation drift by surgically updating feature artifacts. | `docs` | Read+Write | [spec-kit-reconcile](https://github.com/stn1slv/spec-kit-reconcile) |
 | Red Team | Adversarial review of specs before /speckit.plan — parallel lens agents surface risks that clarify/analyze structurally can't (prompt injection, integrity gaps, cross-spec drift, silent failures). Produces a structured findings report; no auto-edits to specs. | `docs` | Read+Write | [spec-kit-red-team](https://github.com/ashbrener/spec-kit-red-team) |
+| Repository Governance | Generate or update the active Repository Governance Framework file with vertical SSOT routing and evidence | `process` | Read+Write | [spec-kit-agent-governance](https://github.com/bigsmartben/spec-kit-agent-governance) |
 | Repository Index | Generate index for existing repo for overview, architecture and module level. | `docs` | Read-only | [spec-kit-repoindex](https://github.com/liuyiyu/spec-kit-repoindex) |
 | Reqnroll BDD | Adds Reqnroll BDD planning, Gherkin generation, traceability, safe task injection, handoff, and verification to Spec Kit | `process` | Read+Write | [spec-kit-reqnroll-bdd](https://github.com/LoogacyStudio/spec-kit-reqnroll-bdd) |
 | Retro Extension | Sprint retrospective analysis with metrics, spec accuracy assessment, and improvement suggestions | `process` | Read+Write | [spec-kit-retro](https://github.com/arunt14/spec-kit-retro) |

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-06-02T00:00:00Z",
+  "updated_at": "2026-06-03T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -67,43 +67,6 @@
       "stars": 0,
       "created_at": "2026-03-31T00:00:00Z",
       "updated_at": "2026-03-31T00:00:00Z"
-    },
-    "agent-governance": {
-      "name": "Agent Governance",
-      "id": "agent-governance",
-      "description": "Generate agent-platform repository governance files from Spec Kit metadata.",
-      "author": "bigben",
-      "version": "1.2.0",
-      "download_url": "https://github.com/bigsmartben/spec-kit-agent-governance/archive/refs/tags/v1.2.0.zip",
-      "repository": "https://github.com/bigsmartben/spec-kit-agent-governance",
-      "homepage": "https://github.com/bigsmartben/spec-kit-agent-governance",
-      "documentation": "https://github.com/bigsmartben/spec-kit-agent-governance/blob/main/README.md",
-      "changelog": "https://github.com/bigsmartben/spec-kit-agent-governance/blob/main/CHANGELOG.md",
-      "license": "MIT",
-      "requires": {
-        "speckit_version": ">=0.8.0",
-        "tools": [
-          {
-            "name": "uv",
-            "required": true
-          }
-        ]
-      },
-      "provides": {
-        "commands": 1,
-        "hooks": 3
-      },
-      "tags": [
-        "governance",
-        "agents",
-        "memory",
-        "context"
-      ],
-      "verified": false,
-      "downloads": 0,
-      "stars": 0,
-      "created_at": "2026-05-14T00:00:00Z",
-      "updated_at": "2026-05-21T00:00:00Z"
     },
     "agent-orchestrator": {
       "name": "Intelligent Agent Orchestrator",
@@ -2281,6 +2244,44 @@
       "stars": 0,
       "created_at": "2026-04-08T00:00:00Z",
       "updated_at": "2026-04-08T00:00:00Z"
+    },
+    "repository-governance": {
+      "name": "Repository Governance",
+      "id": "repository-governance",
+      "description": "Generate or update the active Repository Governance Framework file with vertical SSOT routing and evidence.",
+      "author": "bigben",
+      "version": "2.0.2",
+      "download_url": "https://github.com/bigsmartben/spec-kit-agent-governance/archive/refs/tags/v2.0.2.zip",
+      "repository": "https://github.com/bigsmartben/spec-kit-agent-governance",
+      "homepage": "https://github.com/bigsmartben/spec-kit-agent-governance",
+      "documentation": "https://github.com/bigsmartben/spec-kit-agent-governance/blob/main/README.md",
+      "changelog": "https://github.com/bigsmartben/spec-kit-agent-governance/blob/main/CHANGELOG.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.8.0",
+        "tools": [
+          {
+            "name": "uv",
+            "required": true
+          }
+        ]
+      },
+      "provides": {
+        "commands": 1,
+        "hooks": 3
+      },
+      "tags": [
+        "governance",
+        "repository",
+        "ssot",
+        "agents",
+        "context"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-05-14T00:00:00Z",
+      "updated_at": "2026-06-03T00:00:00Z"
     },
     "repoindex": {
       "name": "Repository Index",


### PR DESCRIPTION
## Summary
- Replace the existing Agent Governance community catalog entry with the current repository-governance extension metadata.
- Update the extension version to v2.0.2 and refresh the download URL and timestamps.
- Move the docs table row from Agent Governance to Repository Governance.

## Test Plan
- [x] `git diff --check upstream/main...origin/community/2624-update-repository-governance`
- [x] `git show origin/community/2624-update-repository-governance:extensions/catalog.community.json | python3 -m json.tool >/tmp/repository-governance-catalog-check.json`
- [x] `gh release view v2.0.2 --repo bigsmartben/spec-kit-agent-governance --json assets --jq '.assets[].name'` confirmed `repository-governance-v2.0.2.zip`

## AI Assistance
- This PR was prepared with Codex assistance; I reviewed the scoped catalog/docs diff and verification output.