### PR TITLE
test(workflows): cover executable override fallback preflight

### DIFF
--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -657,6 +657,47 @@ class TestCommandStep:
         # Claude is a SkillsIntegration so uses /speckit-specify
         assert "/speckit-specify login" in call_args[0][0][2]
 
+    def test_dispatch_uses_executable_override_for_fallback_preflight(self, tmp_path, monkeypatch):
+        """Command preflight falls back to build_exec_args() argv[0]."""
+        from unittest.mock import MagicMock, patch
+        from specify_cli.workflows.steps.command import CommandStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        monkeypatch.setenv("SPECKIT_INTEGRATION_CLAUDE_EXECUTABLE", "/opt/claude")
+        seen_which: list[str] = []
+
+        def fake_which(name: str) -> str | None:
+            seen_which.append(name)
+            return name if name == "/opt/claude" else None
+
+        step = CommandStep()
+        ctx = StepContext(
+            inputs={"name": "login"},
+            default_integration="claude",
+            project_root=str(tmp_path),
+        )
+        config = {
+            "id": "test",
+            "command": "speckit.specify",
+            "input": {"args": "{{ inputs.name }}"},
+        }
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = '{"result": "done"}'
+        mock_result.stderr = ""
+
+        with patch("specify_cli.workflows.steps.command.shutil.which", side_effect=fake_which), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = step.execute(config, ctx)
+
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["dispatched"] is True
+        assert seen_which[:2] == ["claude", "/opt/claude"]
+        call_args = mock_run.call_args
+        assert call_args[0][0][0] == "/opt/claude"
+        assert "/speckit-specify login" in call_args[0][0][2]
+
     def test_dispatch_failure_returns_failed_status(self, tmp_path):
         """When the CLI exits non-zero, the step should fail."""
         from unittest.mock import patch, MagicMock
@@ -808,6 +849,46 @@ class TestPromptStep:
         assert result.status == StepStatus.COMPLETED
         assert result.output["dispatched"] is True
         assert result.output["exit_code"] == 0
+
+    def test_dispatch_uses_executable_override_for_fallback_preflight(self, tmp_path, monkeypatch):
+        """Prompt preflight falls back to build_exec_args() argv[0]."""
+        from unittest.mock import MagicMock, patch
+        from specify_cli.workflows.steps.prompt import PromptStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        monkeypatch.setenv("SPECKIT_INTEGRATION_CLAUDE_EXECUTABLE", "/opt/claude")
+        seen_which: list[str] = []
+
+        def fake_which(name: str) -> str | None:
+            seen_which.append(name)
+            return name if name == "/opt/claude" else None
+
+        step = PromptStep()
+        ctx = StepContext(
+            default_integration="claude",
+            project_root=str(tmp_path),
+        )
+        config = {
+            "id": "ask",
+            "type": "prompt",
+            "prompt": "Explain this code",
+        }
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Here is the explanation"
+        mock_result.stderr = ""
+
+        with patch("specify_cli.workflows.steps.prompt.shutil.which", side_effect=fake_which), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = step.execute(config, ctx)
+
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["dispatched"] is True
+        assert seen_which[:2] == ["claude", "/opt/claude"]
+        call_args = mock_run.call_args
+        assert call_args[0][0][0] == "/opt/claude"
+        assert call_args[0][0][2] == "Explain this code"
 
     def test_validate_missing_prompt(self):
         from specify_cli.workflows.steps.prompt import PromptStep


### PR DESCRIPTION
## Description

After #2539 landed, workflow command and prompt dispatch already include the `impl.key` -> `build_exec_args()[0]` fallback path during CLI availability preflight.

This updates #2843 to focus on regression coverage for the executable override case that originally motivated the change: when `impl.key` is not available on PATH, but `SPECKIT_INTEGRATION_<KEY>_EXECUTABLE` points to an available executable, workflow preflight should allow dispatch and the spawned argv should use the resolved override.

The remaining diff adds coverage for this path in both workflow command and prompt dispatch.

## Testing

- [x] Ran `git diff --check origin/main...HEAD`
- [x] Ran `git diff --check`
- [x] Ran `.venv/bin/pytest tests/test_workflows.py::TestCommandStep::test_dispatch_uses_executable_override_for_fallback_preflight tests/test_workflows.py::TestPromptStep::test_dispatch_uses_executable_override_for_fallback_preflight -v`
- [x] Ran `.venv/bin/pytest tests/test_workflows.py::TestCommandStep tests/test_workflows.py::TestPromptStep -v`
- [x] Ran `.venv/bin/pytest tests/test_workflows.py -v`
- [x] Ran `UV_CACHE_DIR=/tmp/uv-cache-spec-kit-pr2843 uvx ruff check src/ tests/test_workflows.py`
- [ ] Tested locally with `uv run specify --help` (not applicable; no CLI help path changed)
- [ ] Tested with a sample project (covered by workflow step regression tests)
