### PR TITLE
docs(agents): add PR review response guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,6 +423,17 @@ When an issue exists, include its number immediately after the prefix — this i
 
 ---
 
+## Responding to PR Review Comments
+
+- If you are an agent working on behalf of a human, **disclose your identity in your PR comment** — name the agent (and model, if applicable) and the human you are acting for (e.g., "Posted on behalf of @user by GitHub Copilot (Claude Sonnet 4.5)").
+- Post **one** top-level summary comment per review round listing what changed and the commit SHA. Do not reply on every individual comment.
+- Reply inline only when context is needed (disagreement, deferral, non-obvious fix). Keep it to a sentence or two.
+- **Never click "Resolve conversation"** — that belongs to the reviewer or PR author.
+- No emoji, no celebratory framing, no checklist mirroring the reviewer's items, no restating what the reviewer wrote.
+- Re-request review once per round (when all feedback is addressed), not after every intermediate push.
+
+---
+
 ## Common Pitfalls
 
 1. **Using shorthand keys for CLI-based integrations**: For CLI-based integrations (`requires_cli: True`), the `key` must match the executable name (e.g., `"cursor-agent"` not `"cursor"`). `shutil.which(key)` is used for CLI tool checks — mismatches require special-case mappings. IDE-based integrations (`requires_cli: False`) are not subject to this constraint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,7 +425,7 @@ When an issue exists, include its number immediately after the prefix — this i
 
 ## Responding to PR Review Comments
 
-- If you are an agent working on behalf of a human, **disclose your identity in your PR comment** — name the agent (and model, if applicable) and the human you are acting for (e.g., "Posted on behalf of @user by GitHub Copilot (Claude Sonnet 4.5)").
+- If you are an agent working on behalf of a human, **disclose your identity in your PR comment** — name the agent (and model, if applicable) and the human you are acting for (e.g., "Posted on behalf of @user by GitHub Copilot (model: <name-if-known>)").
 - Post **one** top-level summary comment per review round listing what changed and the commit SHA. Do not reply on every individual comment.
 - Reply inline only when context is needed (disagreement, deferral, non-obvious fix). Keep it to a sentence or two.
 - **Never click "Resolve conversation"** — that belongs to the reviewer or PR author.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,7 +425,7 @@ When an issue exists, include its number immediately after the prefix — this i
 
 ## Responding to PR Review Comments
 
-- If you are an agent working on behalf of a human, **disclose your identity in your PR comment** — name the agent (and model, if applicable) and the human you are acting for (e.g., "Posted on behalf of @user by GitHub Copilot (model: <name-if-known>)").
+- If you are an agent working on behalf of a human, **disclose your identity in your PR comment** — name the agent (and model, if applicable) and the human you are acting for (e.g., "Posted on behalf of @user by GitHub Copilot (model: &lt;name-if-known&gt;)").
 - Post **one** top-level summary comment per review round listing what changed and the commit SHA. Do not reply on every individual comment.
 - Reply inline only when context is needed (disagreement, deferral, non-obvious fix). Keep it to a sentence or two.
 - **Never click "Resolve conversation"** — that belongs to the reviewer or PR author.


### PR DESCRIPTION
Closes #2849.

## Summary

Adds a short "Responding to PR Review Comments" section to `AGENTS.md` (between "Branch Naming Convention" and "Common Pitfalls") so agents acting on PRs in this repo stop posting one reply per review comment.

## Background

Recent PR review cycles have produced large numbers of agent-authored reply comments — one per reviewer finding, each starting with a "Fixed in `<sha>`" status header that mirrors the reviewer's items 1:1. #2704 is the visible example: the latest Copilot review there generated 9 inline comments, and the author posted 9 near-identical replies in a row. That floods the conversation, buries the diff, and is visibly not how a human maintainer would respond.

`AGENTS.md` had no guidance on this, so agents fell back to default per-comment-reply behavior.

## The new section

Six directive bullets, kept terse on purpose:

- Agent self-disclosure (name the agent, model, and the human being acted for)
- One top-level summary comment per review round
- Inline replies only when context is needed (disagreement, deferral, non-obvious fix)
- Never click "Resolve conversation" — that belongs to the reviewer or PR author
- No emoji, no celebratory framing, no checklist mirroring the reviewer's items, no restating what the reviewer wrote
- Re-request review once per round, not after every intermediate push

## Out of scope

- Doesn't change `.github/copilot-instructions.md` or any agent-specific instruction file. If maintainers want this enforced on the Copilot coding-agent path specifically, that can be a follow-up.
- Doesn't add automated enforcement (e.g., a PR check). This is documentation-only behavioral guidance.
