### PR TITLE
Update Superpowers Implementation Bridge extension to v1.0.2

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-06-02T00:00:00Z",
+  "updated_at": "2026-06-04T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -2756,8 +2756,8 @@
       "id": "speckit-superpowers-bridge",
       "description": "Thin orchestrator between Spec Kit (design) and Superpowers (implementation). Cross-agent.",
       "author": "lihan3238",
-      "version": "0.7.0",
-      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v0.7.0/speckit-superpowers-bridge-v0.7.0.zip",
+      "version": "1.0.2",
+      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/latest/download/speckit-superpowers-bridge.zip",
       "repository": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "homepage": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "documentation": "https://github.com/lihan3238/speckit-superpowers-bridge#readme",
@@ -2798,7 +2798,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-15T00:00:00Z",
-      "updated_at": "2026-05-28T00:00:00Z"
+      "updated_at": "2026-06-04T00:00:00Z"
     },
     "speckit-utils": {
       "name": "SDD Utilities",

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -2757,7 +2757,7 @@
       "description": "Thin orchestrator between Spec Kit (design) and Superpowers (implementation). Cross-agent.",
       "author": "lihan3238",
       "version": "1.0.2",
-      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/latest/download/speckit-superpowers-bridge.zip",
+      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v1.0.2/speckit-superpowers-bridge-v1.0.2.zip",
       "repository": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "homepage": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "documentation": "https://github.com/lihan3238/speckit-superpowers-bridge#readme",


### PR DESCRIPTION
Updates the `speckit-superpowers-bridge` community extension from v0.7.0 to v1.0.2 per submission #2848.

## Changes

- `extensions/catalog.community.json`
  - `version`: `0.7.0` → `1.0.2`
  - `download_url`: pinned to `https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v1.0.2/speckit-superpowers-bridge-v1.0.2.zip` (version-pinned per catalog convention; the submitter proposed the `releases/latest/download/` alias but pinning matches the rest of the catalog)
  - Entry `updated_at`: `2026-05-28` → `2026-06-04`
  - Top-level `updated_at`: `2026-06-02` → `2026-06-04`
  - Preserved `created_at`, `downloads`, `stars`

No change to `docs/community/extensions.md` — description and link are unchanged and the row carries no version.

## Validation

- [x] Release `v1.0.2` exists at https://github.com/lihan3238/speckit-superpowers-bridge/releases/tag/v1.0.2
- [x] Version-pinned download asset present in the release
- [x] Repository public; `extension.yml`, `README.md`, `LICENSE` present
- [x] Extension ID matches `^[a-z][a-z0-9-]*$`
- [x] Version is semver
- [x] Submission checklists confirmed in the issue
- [x] JSON validated

Closes #2848

cc @lihan3238