### PR TITLE
Update Ralph community extension to v1.1.1

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -2149,10 +2149,10 @@
     "ralph": {
       "name": "Ralph Loop",
       "id": "ralph",
-      "description": "Autonomous implementation loop using AI agent CLI.",
+      "description": "Autonomous implementation loop using AI agent CLI",
       "author": "Rubiss",
-      "version": "1.0.2",
-      "download_url": "https://github.com/Rubiss-Projects/spec-kit-ralph/archive/refs/tags/v1.0.2.zip",
+      "version": "1.1.1",
+      "download_url": "https://github.com/Rubiss-Projects/spec-kit-ralph/archive/refs/tags/v1.1.1.zip",
       "repository": "https://github.com/Rubiss-Projects/spec-kit-ralph",
       "homepage": "https://github.com/Rubiss-Projects/spec-kit-ralph",
       "documentation": "https://github.com/Rubiss-Projects/spec-kit-ralph/blob/main/README.md",
@@ -2163,7 +2163,11 @@
         "tools": [
           {
             "name": "copilot",
-            "required": true
+            "required": false
+          },
+          {
+            "name": "codex",
+            "required": false
           },
           {
             "name": "git",
@@ -2179,13 +2183,14 @@
         "implementation",
         "automation",
         "loop",
-        "copilot"
+        "copilot",
+        "codex"
       ],
       "verified": false,
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-03-09T00:00:00Z",
-      "updated_at": "2026-05-04T17:02:08Z"
+      "updated_at": "2026-06-05T03:11:06Z"
     },
     "reconcile": {
       "name": "Reconcile Extension",


### PR DESCRIPTION
## Summary
- update the Ralph Loop community catalog entry to v1.1.1
- point the download URL at the v1.1.1 tag archive
- sync catalog metadata with the v1.1.1 extension manifest, including optional Codex/Copilot agent CLI support

## Validation
- `uv run python -m json.tool extensions\catalog.community.json > $null`
- `uv run python -m pytest tests\test_extensions.py::TestExtensionCatalog -q`

## AI assistance disclosure
This PR was prepared with assistance from Codex (GPT-5) on behalf of @Rubiss. The agent inspected the contributing guidelines, verified the upstream `spec-kit-ralph` v1.1.1 tag metadata, made the catalog update, and ran the validation commands above.