### PR TITLE
fix: register preset-provided namespaced commands

### DIFF
--- a/presets/ARCHITECTURE.md
+++ b/presets/ARCHITECTURE.md
@@ -67,11 +67,11 @@ When a preset is installed with `type: "command"` entries, the `PresetManager` r
 flowchart TD
     A["specify preset add my-preset"] --> B{Preset has type: command?}
     B -- No --> Z["done (templates only)"]
-    B -- Yes --> C{Extension command?}
-    C -- "speckit.myext.cmd\n(3+ dot segments)" --> D{Extension installed?}
+    B -- Yes --> C{Targets extension override?}
+    C -- "replaces speckit.myext.cmd\nor composition strategy" --> D{Extension installed?}
     D -- No --> E["skip (extension not active)"]
     D -- Yes --> F["register command"]
-    C -- "speckit.specify\n(core command)" --> F
+    C -- "preset-provided command\nor core command" --> F
     F --> G["detect agent directories"]
     G --> H[".claude/commands/"]
     G --> I[".gemini/commands/"]
@@ -89,7 +89,7 @@ flowchart TD
 
 ### Extension safety check
 
-Command names follow the pattern `speckit.<ext-id>.<cmd-name>`. When a command has 3+ dot segments, the system extracts the extension ID and checks if `.specify/extensions/<ext-id>/` exists. If the extension isn't installed, the command is skipped — preventing orphan files referencing non-existent extensions.
+Preset-provided commands can use namespaced command IDs such as `speckit.extendedflow.reviewer`, so dot-count alone does not make a command an extension override. The missing-extension guard applies when a command explicitly declares `replaces: speckit.<ext-id>.<cmd-name>` or when it uses a composition strategy (`prepend`, `append`, or `wrap`) that needs a lower-priority base command. In those cases, the system extracts the extension ID and checks if `.specify/extensions/<ext-id>/` exists. If the extension isn't installed, the command is skipped — preventing orphan files referencing non-existent extensions.
 
 Core commands (e.g. `speckit.specify`, with only 2 segments) are always registered.
 

--- a/src/specify_cli/presets.py
+++ b/src/specify_cli/presets.py
@@ -587,6 +587,40 @@ class PresetManager:
 
         return True
 
+    def _should_skip_missing_extension_command(
+        self,
+        command_template: Dict[str, Any],
+    ) -> bool:
+        """Return True when a preset command targets an absent extension.
+
+        Three-part command names are not enough to identify extension
+        overrides because presets can define their own namespaced commands,
+        such as ``speckit.extendedflow.reviewer``. Only commands that
+        explicitly replace an extension command, or composition strategies
+        that need a lower-priority base command, are gated on extension
+        installation.
+        """
+        command_name = command_template["name"]
+        strategy = command_template.get("strategy", "replace")
+        replaces = command_template.get("replaces")
+
+        target_name = None
+        if isinstance(replaces, str) and replaces:
+            target_name = replaces
+        elif strategy != "replace":
+            target_name = command_name
+
+        if target_name is None:
+            return False
+
+        parts = target_name.split(".")
+        if len(parts) < 3 or parts[0] != "speckit":
+            return False
+
+        ext_id = parts[1]
+        extensions_dir = self.project_root / ".specify" / "extensions"
+        return not (extensions_dir / ext_id).is_dir()
+
     def _register_commands(
         self,
         manifest: PresetManifest,
@@ -615,18 +649,10 @@ class PresetManager:
         if not command_templates:
             return {}
 
-        # Filter out extension command overrides if the extension isn't installed.
-        # Command names follow the pattern: speckit.<ext-id>.<cmd-name>
-        # Core commands (e.g. speckit.specify) have only one dot — always register.
-        extensions_dir = self.project_root / ".specify" / "extensions"
-        filtered = []
-        for cmd in command_templates:
-            parts = cmd["name"].split(".")
-            if len(parts) >= 3 and parts[0] == "speckit":
-                ext_id = parts[1]
-                if not (extensions_dir / ext_id).is_dir():
-                    continue
-            filtered.append(cmd)
+        filtered = [
+            cmd for cmd in command_templates
+            if not self._should_skip_missing_extension_command(cmd)
+        ]
 
         if not filtered:
             return {}
@@ -1234,17 +1260,10 @@ class PresetManager:
         if not command_templates:
             return []
 
-        # Filter out extension command overrides if the extension isn't installed,
-        # matching the same logic used by _register_commands().
-        extensions_dir = self.project_root / ".specify" / "extensions"
-        filtered = []
-        for cmd in command_templates:
-            parts = cmd["name"].split(".")
-            if len(parts) >= 3 and parts[0] == "speckit":
-                ext_id = parts[1]
-                if not (extensions_dir / ext_id).is_dir():
-                    continue
-            filtered.append(cmd)
+        filtered = [
+            cmd for cmd in command_templates
+            if not self._should_skip_missing_extension_command(cmd)
+        ]
 
         if not filtered:
             return []
@@ -1585,21 +1604,15 @@ class PresetManager:
             raise
 
         # Reconcile all affected commands from the full priority stack so that
-        # install order doesn't determine the winning command file.
-        # Apply the same extension-installed filter as _register_commands to
-        # avoid reconciling extension commands when the extension isn't installed.
-        extensions_dir = self.project_root / ".specify" / "extensions"
+        # install order doesn't determine the winning command file. Apply the
+        # same missing-extension override filter as _register_commands.
         cmd_names = []
         for t in manifest.templates:
             if t.get("type") != "command":
                 continue
-            name = t["name"]
-            parts = name.split(".")
-            if len(parts) >= 3 and parts[0] == "speckit":
-                ext_id = parts[1]
-                if not (extensions_dir / ext_id).is_dir():
-                    continue
-            cmd_names.append(name)
+            if self._should_skip_missing_extension_command(t):
+                continue
+            cmd_names.append(t["name"])
         if cmd_names:
             try:
                 self._reconcile_composed_commands(cmd_names)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -2181,6 +2181,7 @@ class TestSelfTestPreset:
                         "name": "speckit.fakeext.cmd",
                         "file": "commands/speckit.fakeext.cmd.md",
                         "description": "Override fakeext cmd",
+                        "replaces": "speckit.fakeext.cmd",
                     }
                 ]
             },
@@ -2196,6 +2197,50 @@ class TestSelfTestPreset:
         assert not cmd_file.exists(), "Command registered for missing extension"
         metadata = manager.registry.get("ext-override")
         assert metadata["registered_commands"] == {}
+
+    def test_three_part_preset_command_registered_without_extension(self, project_dir, temp_dir):
+        """Three-part preset-provided commands must not require extension directories."""
+        claude_dir = project_dir / ".claude" / "skills"
+        claude_dir.mkdir(parents=True)
+
+        preset_dir = temp_dir / "extendedflow-preset"
+        preset_dir.mkdir()
+        (preset_dir / "commands").mkdir()
+        (preset_dir / "commands" / "speckit.extendedflow.reviewer.md").write_text(
+            "---\ndescription: Extended flow reviewer\n---\nReview the current flow."
+        )
+        manifest_data = {
+            "schema_version": "1.0",
+            "preset": {
+                "id": "extendedflow",
+                "name": "Extended Flow",
+                "version": "1.0.0",
+                "description": "Test",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "templates": [
+                    {
+                        "type": "command",
+                        "name": "speckit.extendedflow.reviewer",
+                        "file": "commands/speckit.extendedflow.reviewer.md",
+                        "description": "Extended flow reviewer",
+                    }
+                ]
+            },
+        }
+        with open(preset_dir / "preset.yml", "w") as f:
+            yaml.dump(manifest_data, f)
+
+        manager = PresetManager(project_dir)
+        manager.install_from_directory(preset_dir, "0.1.5")
+
+        skill_file = claude_dir / "speckit-extendedflow-reviewer" / "SKILL.md"
+        assert skill_file.exists(), "Preset-provided three-part command was not registered"
+        metadata = manager.registry.get("extendedflow")
+        assert metadata["registered_commands"] == {
+            "claude": ["speckit.extendedflow.reviewer"]
+        }
 
     def test_extension_command_registered_when_extension_present(self, project_dir, temp_dir):
         """Test that extension command overrides ARE registered when the extension is installed."""
@@ -2225,6 +2270,7 @@ class TestSelfTestPreset:
                         "name": "speckit.fakeext.cmd",
                         "file": "commands/speckit.fakeext.cmd.md",
                         "description": "Override fakeext cmd",
+                        "replaces": "speckit.fakeext.cmd",
                     }
                 ]
             },


### PR DESCRIPTION
## Summary

Fixes #2862.

Preset command registration was treating every `speckit.<domain>.<command>` name as an extension command override. That made valid preset-provided commands, such as `speckit.extendedflow.reviewer`, disappear whenever `.specify/extensions/<domain>/` did not exist.

This changes the missing-extension guard so it applies only when the preset is actually targeting an extension command:

- the template explicitly declares `replaces: speckit.<ext-id>.<command>`; or
- the template uses a composition strategy (`prepend`, `append`, or `wrap`) that needs a lower-priority base command.

A default `replace` command with a three-part name and no `replaces` entry is now treated as preset-provided and is registered normally. The existing extension-override behavior is preserved by making the override tests explicit through `replaces`.

## Validation

- `uv sync --extra test`
- `uv run python -m pytest tests/test_presets.py -k "extension_command or three_part_preset_command" -q` — 6 passed
- `uv run python -m pytest tests/test_presets.py -q` — 273 passed
- `uv run specify --help`
- `git diff --check`
- `uv run python -m pytest -q` — 3576 passed, 45 skipped

## AI assistance disclosure

This PR was developed with AI assistance from Codex/ChatGPT for codebase inspection, implementation, and validation. I reviewed the resulting diff and test output before submitting.
