### PR TITLE
fix: keep devcontainer setup running after Kiro failure

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -21,6 +21,24 @@ run_command() {
     fi
 }
 
+# Function to run an optional command and continue on error
+run_optional_command() {
+    local command_to_run="$*"
+    local output
+    local exit_code
+
+    output=$(eval "$command_to_run" 2>&1) || exit_code=$?
+    exit_code=${exit_code:-0}
+
+    if [ $exit_code -ne 0 ]; then
+        echo -e "\033[0;33m[WARN] Optional command failed (Exit Code $exit_code): $command_to_run\033[0m" >&2
+        echo -e "\033[0;33m$output\033[0m" >&2
+        return $exit_code
+    fi
+
+    return 0
+}
+
 # Installing CLI-based AI Agents
 
 echo -e "\n🤖 Installing Copilot CLI..."
@@ -70,23 +88,39 @@ cleanup_kiro_installer() {
 }
 trap cleanup_kiro_installer EXIT
 
-run_command "curl -fsSL \"$KIRO_INSTALLER_URL\" -o \"$KIRO_INSTALLER_PATH\""
-run_command "echo \"$KIRO_INSTALLER_SHA256  $KIRO_INSTALLER_PATH\" | sha256sum -c -"
+kiro_install_ok=true
 
-run_command "bash \"$KIRO_INSTALLER_PATH\""
+run_optional_command "curl -fsSL \"$KIRO_INSTALLER_URL\" -o \"$KIRO_INSTALLER_PATH\"" || kiro_install_ok=false
 
-kiro_binary=""
-if command -v kiro-cli >/dev/null 2>&1; then
-  kiro_binary="kiro-cli"
-elif command -v kiro >/dev/null 2>&1; then
-  kiro_binary="kiro"
-else
-  echo -e "\033[0;31m[ERROR] Kiro CLI installation did not create 'kiro-cli' or 'kiro' in PATH.\033[0m" >&2
-  exit 1
+if [ "$kiro_install_ok" = true ]; then
+  run_optional_command "echo \"$KIRO_INSTALLER_SHA256  $KIRO_INSTALLER_PATH\" | sha256sum -c -" || kiro_install_ok=false
 fi
 
-run_command "$kiro_binary --help > /dev/null"
-echo "✅ Done"
+if [ "$kiro_install_ok" = true ]; then
+  run_optional_command "bash \"$KIRO_INSTALLER_PATH\"" || kiro_install_ok=false
+fi
+
+if [ "$kiro_install_ok" = true ]; then
+  kiro_binary=""
+  if command -v kiro-cli >/dev/null 2>&1; then
+    kiro_binary="kiro-cli"
+  elif command -v kiro >/dev/null 2>&1; then
+    kiro_binary="kiro"
+  else
+    echo -e "\033[0;33m[WARN] Kiro CLI installation did not create 'kiro-cli' or 'kiro' in PATH.\033[0m" >&2
+    kiro_install_ok=false
+  fi
+fi
+
+if [ "$kiro_install_ok" = true ]; then
+  run_optional_command "$kiro_binary --help > /dev/null" || kiro_install_ok=false
+fi
+
+if [ "$kiro_install_ok" = true ]; then
+  echo "✅ Done"
+else
+  echo -e "\033[0;33m[WARN] Skipping Kiro CLI installation; continuing devcontainer setup.\033[0m" >&2
+fi
 
 echo -e "\n🤖 Installing Kimi CLI..."
 # https://code.kimi.com

--- a/tests/test_agent_config_consistency.py
+++ b/tests/test_agent_config_consistency.py
@@ -59,6 +59,19 @@ class TestAgentConfigConsistency:
         assert "sha256sum -c -" in post_create_text
         assert "KIRO_SKIP_KIRO_INSTALLER_VERIFY" not in post_create_text
 
+    def test_devcontainer_kiro_install_is_non_blocking(self):
+        """Kiro install failures should not stop later devcontainer setup steps."""
+        post_create_text = (REPO_ROOT / ".devcontainer" / "post-create.sh").read_text(
+            encoding="utf-8"
+        )
+        kiro_block = post_create_text.split("Installing Kiro CLI...", 1)[1].split(
+            "Installing Kimi CLI...", 1
+        )[0]
+
+        assert "run_optional_command" in kiro_block
+        assert "exit 1" not in kiro_block
+        assert "continuing devcontainer setup" in kiro_block
+
     # --- Tabnine CLI consistency checks ---
 
     def test_runtime_config_includes_tabnine(self):


### PR DESCRIPTION
## Summary

Fixes #2605.

The devcontainer `post-create.sh` script used the fatal `run_command` wrapper for every Kiro installer step. When the upstream Kiro installer URL returns 404, that exits the whole post-create script and prevents later tools from installing, including Kimi CLI, CodeBuddy, uv, and DocFx.

This keeps the pinned Kiro installer checksum verification in place when the installer is available, but makes the Kiro block non-blocking:

- adds `run_optional_command` for installer steps that should warn and continue;
- applies it only to the Kiro install/check flow;
- preserves fatal behavior for the rest of the setup script;
- adds a regression check that the Kiro block does not contain a direct `exit 1` and advertises continued setup.

The reason for limiting the optional behavior to Kiro is that #2605 is caused by one unavailable optional upstream installer. Making every devcontainer install non-fatal would hide real setup failures for core tooling.

## Validation

- `bash -n .devcontainer/post-create.sh`
- `uv run python -m pytest tests/test_agent_config_consistency.py -q` — 30 passed
- `uv run python -m pytest tests/integrations/test_integration_kiro_cli.py tests/test_agent_config_consistency.py -q` — 55 passed
- `git diff --check`
- `uv run python -m pytest -q` — 3576 passed, 45 skipped

## AI assistance disclosure

This PR was developed with AI assistance from Codex/ChatGPT for codebase inspection, implementation, and validation. I reviewed the diff and test output before submitting.
