### PR TITLE
chore: remove unused open_github_url/_StripAuthOnRedirect from _github_http.py

### DIFF
--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -1,9 +1,11 @@
-"""Shared GitHub-authenticated HTTP helpers.
+"""Shared GitHub HTTP request helpers.
 
-Used by both ExtensionCatalog and PresetCatalog to attach
-GITHUB_TOKEN / GH_TOKEN credentials to requests targeting
-GitHub-hosted domains, while preventing token leakage to
-third-party hosts on redirects.
+Provides ``build_github_request()`` for attaching GITHUB_TOKEN / GH_TOKEN
+credentials to requests targeting GitHub-hosted domains, and
+``resolve_github_release_asset_api_url()`` — used by extensions, presets,
+and workflow URL resolution — to translate browser release-download URLs
+into GitHub REST API asset URLs. Authenticated downloads themselves go
+through the config-driven helpers in :mod:`specify_cli.authentication.http`.
 """
 
 import os
@@ -52,28 +54,6 @@ def build_github_request(url: str) -> urllib.request.Request:
     if token and hostname in GITHUB_HOSTS:
         headers["Authorization"] = f"Bearer {token}"
     return urllib.request.Request(url, headers=headers)
-
-
-class _StripAuthOnRedirect(urllib.request.HTTPRedirectHandler):
-    """Redirect handler that drops the Authorization header when leaving GitHub.
-
-    Prevents token leakage to CDNs or other third-party hosts that GitHub
-    may redirect to (e.g. S3 for release asset downloads, objects.githubusercontent.com).
-    Auth is preserved as long as the redirect target remains within GITHUB_HOSTS.
-    """
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        original_auth = req.get_header("Authorization")
-        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
-        if new_req is not None:
-            hostname = (urlparse(newurl).hostname or "").lower()
-            if hostname in GITHUB_HOSTS:
-                if original_auth:
-                    new_req.add_unredirected_header("Authorization", original_auth)
-            else:
-                new_req.headers.pop("Authorization", None)
-                new_req.unredirected_hdrs.pop("Authorization", None)
-        return new_req
 
 
 def resolve_github_release_asset_api_url(
@@ -147,20 +127,3 @@ def resolve_github_release_asset_api_url(
             return str(asset["url"])
 
     return None
-
-
-def open_github_url(url: str, timeout: int = 10):
-    """Open a URL with GitHub auth, stripping the header on cross-host redirects.
-
-    When the request carries an Authorization header, a custom redirect
-    handler drops that header if the redirect target is not a GitHub-owned
-    domain, preventing token leakage to CDNs or other third-party hosts
-    that GitHub may redirect to (e.g. S3 for release asset downloads).
-    """
-    req = build_github_request(url)
-
-    if not req.get_header("Authorization"):
-        return urllib.request.urlopen(req, timeout=timeout)
-
-    opener = urllib.request.build_opener(_StripAuthOnRedirect)
-    return opener.open(req, timeout=timeout)


### PR DESCRIPTION
Closes #2876

## Description

Removes the two helpers in `src/specify_cli/_github_http.py` that have no callers anywhere in the repo (production, tests, docs, templates, or workflows):

- `open_github_url()` — orphaned when #2393 moved download authentication to the config-driven registry in `authentication/http.py`. Its only remaining reference was its own definition.
- `_StripAuthOnRedirect` (the `_github_http` copy) — referenced only by `open_github_url()` itself, and a duplicate of the **live** redirect/strip-auth implementation in `specify_cli/authentication/http.py` (a separate class taking a `hosts` tuple, covered by `tests/test_authentication.py::TestRedirectStripping`), which is untouched.

**No runtime behavior change** — dead-code removal only. `resolve_github_release_asset_api_url()` (used by `extensions.py`, `presets.py`, and `__init__.py`) is retained with all 8 of its tests, and the module docstring is updated to describe what the module does today.

Caller-sweep evidence (string-literal, `getattr`, and `__all__` dynamic patterns also checked — zero matches):

```console
$ git grep -n "open_github_url"
src/specify_cli/_github_http.py:152:def open_github_url(...)    # definition only — no callers

$ git grep -n "_StripAuthOnRedirect"
src/specify_cli/_github_http.py:57,165                # dead copy (removed here)
src/specify_cli/authentication/http.py:59,138         # live implementation — untouched
tests/test_authentication.py:773,776,785,788,798,802  # all import the live authentication.http class
```

**Decision on `build_github_request()` / `GITHUB_HOSTS`** (acceptance criterion 3): **kept** as a tested, self-contained utility (11 passing tests in `tests/test_github_http.py`). That keeps this PR to a single source file with zero test-file changes. Happy to remove them here or in a follow-up if maintainers prefer.

Note on #2442: that open PR currently extends `open_github_url`, but #2876 was filed by #2442's own author after narrowing that work, asking for these symbols' removal — the corresponding hunks can be dropped from #2442 on its next rebase.

## Testing

- [x] Tested locally with `uv run specify --help` (exit 0)
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (N/A — the removed code has zero callers, so no command behavior changes)

Details (Windows 11, Python 3.12.12):

- `uvx ruff check src/` — All checks passed
- `uv run pytest tests/test_github_http.py tests/test_authentication.py -q` — **100 passed, 1 skipped**
- Full suite `uv run pytest` — **3474 passed, 160 skipped, 14 failed**; counts identical to clean `main` on the same host. The 14 failures are pre-existing environment-only failures (`os.symlink` → `WinError 1314`; symlink creation requires elevation/Developer Mode on Windows), unrelated to this change and not touching `_github_http.py`.
- Repo-wide grep after the change: no references to the removed symbols remain.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

This PR was developed with Claude Code (Claude Opus 4.8) under my direction — the caller-sweep analysis, the code removal, the local verification runs quoted above, and this description. I reviewed the diff and the evidence before submission. If any of my review responses are AI-assisted, I will disclose that in the thread as well.
