### PR TITLE
Update Security Review extension to v1.5.3

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-06-04T00:00:00Z",
+  "updated_at": "2026-06-08T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -2555,8 +2555,8 @@
       "id": "security-review",
       "description": "Full-project secure-by-design security audits plus staged, branch/PR, plan, task, follow-up, and apply reviews",
       "author": "DyanGalih",
-      "version": "1.5.0",
-      "download_url": "https://github.com/DyanGalih/spec-kit-security-review/archive/refs/tags/v1.5.0.zip",
+      "version": "1.5.3",
+      "download_url": "https://github.com/DyanGalih/spec-kit-security-review/archive/refs/tags/v1.5.3.zip",
       "repository": "https://github.com/DyanGalih/spec-kit-security-review",
       "homepage": "https://github.com/DyanGalih/spec-kit-security-review",
       "documentation": "https://github.com/DyanGalih/spec-kit-security-review/blob/main/README.md",
@@ -2580,7 +2580,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-04-03T03:24:03Z",
-      "updated_at": "2026-05-11T14:58:00Z"
+      "updated_at": "2026-06-08T00:00:00Z"
     },
     "sf": {
       "name": "SFSpeckit — Salesforce Spec-Driven Development",

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -2554,7 +2554,7 @@
       "name": "Security Review",
       "id": "security-review",
       "description": "Full-project secure-by-design security audits plus staged, branch/PR, plan, task, follow-up, and apply reviews",
-      "author": "DyanGalih",
+      "author": "Spec-Kit Security Team",
       "version": "1.5.3",
       "download_url": "https://github.com/DyanGalih/spec-kit-security-review/archive/refs/tags/v1.5.3.zip",
       "repository": "https://github.com/DyanGalih/spec-kit-security-review",


### PR DESCRIPTION
## Summary

Update the Security Review community extension from v1.5.0 to v1.5.3 in the catalog.

## Validation

- ✅ Repository exists and is public
- ✅ `extension.yml` manifest present
- ✅ README.md present
- ✅ LICENSE file present
- ✅ GitHub release v1.5.3 exists
- ✅ Download URL follows correct pattern
- ✅ Extension ID is lowercase-with-hyphens
- ✅ Version follows semver

## Changes

- `extensions/catalog.community.json`: Updated `version`, `download_url`, `updated_at` for `security-review` entry; refreshed top-level `updated_at`

Closes #2869

cc @DyanGalih