### PR TITLE
Update multi-model-review extension to v0.1.1

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-06-08T00:00:00Z",
+  "updated_at": "2026-06-09T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -1712,8 +1712,8 @@
       "id": "multi-model-review",
       "description": "Cross-model Spec Kit handoffs for spec authoring, implementation routing, and review.",
       "author": "formin",
-      "version": "0.1.0",
-      "download_url": "https://github.com/formin/multi-model-review/archive/refs/tags/v0.1.0.zip",
+      "version": "0.1.1",
+      "download_url": "https://github.com/formin/multi-model-review/archive/refs/tags/v0.1.1.zip",
       "repository": "https://github.com/formin/multi-model-review",
       "homepage": "https://github.com/formin/multi-model-review",
       "documentation": "https://github.com/formin/multi-model-review/blob/main/README.md",
@@ -1755,7 +1755,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-04T02:51:52Z",
-      "updated_at": "2026-05-04T02:51:52Z"
+      "updated_at": "2026-06-09T00:00:00Z"
     },
     "multi-sites": {
       "name": "Multi-Sites Spec Kit",


### PR DESCRIPTION
## Summary

- Update the `multi-model-review` community catalog entry from `0.1.0` to `0.1.1`.
- Point `download_url` at the published `v0.1.1` archive.
- Refresh the catalog `updated_at` timestamps for this release.

## Release

- Release: https://github.com/formin/multi-model-review/releases/tag/v0.1.1
- Archive: https://github.com/formin/multi-model-review/archive/refs/tags/v0.1.1.zip

## Validation

- `node -e` JSON parse and entry assertion for `extensions/catalog.community.json`
- `git diff --check`
- `PYTHONPATH=src .venv/Scripts/python.exe -m pytest tests/test_extensions.py -q` -> 244 passed, 1 skipped
- `specify extension add --dev <repo>` smoke test against `formin/multi-model-review` v0.1.1 -> installed 4 commands