### PR TITLE
fix: skip recovered files during refresh_managed overwrite check

### DIFF
--- a/src/specify_cli/shared_infra.py
+++ b/src/specify_cli/shared_infra.py
@@ -313,6 +313,8 @@ def install_shared_infra(
         expected = prior_hashes.get(rel)
         if not expected or not dst.is_file() or dst.is_symlink():
             return False
+        if manifest.is_recovered(rel):
+            return False
         try:
             return _sha256(dst) == expected
         except OSError:

--- a/tests/integrations/test_integration_subcommand.py
+++ b/tests/integrations/test_integration_subcommand.py
@@ -1918,6 +1918,45 @@ class TestIntegrationSwitch:
         assert "/speckit.plan" in updated
         assert "/speckit-plan" not in updated
 
+    def test_switch_preserves_recovered_files(self, tmp_path):
+        """Regression for #2918: files marked recovered in the manifest are not overwritten.
+
+        When a file already exists on disk before init and is recorded with
+        ``recovered=True``, ``integration use``/``switch`` must not treat it as
+        managed even when the on-disk hash matches the manifest hash.
+        """
+        import hashlib
+
+        project = _init_project(tmp_path, "claude")
+        shared_script = project / ".specify" / "scripts" / "bash" / "setup-tasks.sh"
+        assert shared_script.is_file()
+
+        # Simulate a team-customized file that was recorded as recovered:
+        # write custom content, then update the manifest to record its hash
+        # with the recovered flag set.
+        custom_bytes = b"#!/usr/bin/env bash\n# team custom workflow\nexit 0\n"
+        shared_script.write_bytes(custom_bytes)
+
+        manifest_path = project / ".specify" / "integrations" / "speckit.manifest.json"
+        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        rel = ".specify/scripts/bash/setup-tasks.sh"
+        manifest_data["files"][rel] = hashlib.sha256(custom_bytes).hexdigest()
+        manifest_data.setdefault("recovered_files", []).append(rel)
+        manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(project)
+            result = runner.invoke(app, [
+                "integration", "switch", "copilot",
+                "--script", "sh",
+            ], catch_exceptions=False)
+        finally:
+            os.chdir(old_cwd)
+        assert result.exit_code == 0
+        # Recovered file must NOT be overwritten — team content preserved.
+        assert shared_script.read_bytes() == custom_bytes
+
     def test_switch_skips_symlinked_parent_directory(self, tmp_path):
         """Regression: if .specify/scripts/bash is a symlink, switch must not write through it.
 


### PR DESCRIPTION
Closes #2918

## Problem

`specify integration use`/`switch` can overwrite team-customized files under `.specify/scripts/` and `.specify/templates/` when those files are recorded with `recovered=True` in the manifest.

The `_is_managed()` function only checked hash equality to decide if a file is "managed" (safe to overwrite). It did not consult `manifest.is_recovered()`, violating the manifest API's own documented requirement:

> callers that would overwrite based on hash equality (e.g. `refresh_managed`) **MUST** check `is_recovered` first.

## Fix

Added a 2-line guard in `_is_managed()` that returns `False` for recovered files — they are never treated as managed, regardless of hash match.

## Test

Added `test_switch_preserves_recovered_files` regression test confirming that a team-customized file recorded with `recovered=True` survives `integration switch` without `--force`.