### PR TITLE
Update Linear Integration extension to v0.4.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1465,12 +1465,12 @@
       "id": "linear",
       "description": "Mirror spec-kit feature directories into Linear (filesystem → Linear, reconcile-based, unidirectional).",
       "author": "Ash Brener",
-      "version": "0.3.0",
-      "download_url": "https://github.com/ashbrener/spec-kit-linear-sync/archive/refs/tags/v0.3.0.zip",
+      "version": "0.4.0",
+      "download_url": "https://github.com/ashbrener/spec-kit-linear-sync/archive/refs/tags/v0.4.0.zip",
       "repository": "https://github.com/ashbrener/spec-kit-linear-sync",
       "homepage": "https://github.com/ashbrener/spec-kit-linear-sync",
       "documentation": "https://github.com/ashbrener/spec-kit-linear-sync/blob/main/README.md",
-      "changelog": "https://github.com/ashbrener/spec-kit-linear-sync/releases",
+      "changelog": "https://github.com/ashbrener/spec-kit-linear-sync/blob/main/CHANGELOG.md",
       "license": "MIT",
       "category": "integration",
       "effect": "read-write",
@@ -1493,7 +1493,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-06-01T00:00:00Z",
-      "updated_at": "2026-06-08T00:00:00Z"
+      "updated_at": "2026-06-11T00:00:00Z"
     },
     "m365": {
       "name": "Microsoft 365 Integration",


### PR DESCRIPTION
Update `linear` extension from v0.3.0 → v0.4.0 in the community catalog.

## Validation

- ✅ Repository exists and is public
- ✅ `extension.yml` manifest present at v0.4.0 tag
- ✅ GitHub release exists for v0.4.0
- ✅ Download URL returns 302 → codeload (accessible)
- ✅ Extension ID is valid (`linear`)
- ✅ Version follows semver (`0.4.0`)

## Changes

- `extensions/catalog.community.json`: updated `version`, `download_url`, `changelog`, and `updated_at`

## What's new in 0.4.0

- Operator-configurable spec→Linear artifact mapping
- Lifecycle fix so Linear issues no longer stick at "in-progress" when a spec's branch differs from its directory name

Closes #2931
cc @ashbrener