### PR TITLE
fix: fail loudly when a fan-out 'items' expression does not resolve to a list

### DIFF
--- a/src/specify_cli/workflows/steps/fan_out/__init__.py
+++ b/src/specify_cli/workflows/steps/fan_out/__init__.py
@@ -22,11 +22,27 @@ class FanOutStep(StepBase):
     def execute(self, config: dict[str, Any], context: StepContext) -> StepResult:
         items_expr = config.get("items", "[]")
         items = evaluate_expression(items_expr, context)
-        if not isinstance(items, list):
-            items = []
-
         max_concurrency = config.get("max_concurrency", 1)
         step_template = config.get("step", {})
+
+        if not isinstance(items, list):
+            # A non-list here is a wiring error (the expression did not
+            # resolve to a collection); silently fanning out over zero
+            # items hides it. An explicit empty list remains valid input.
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"Fan-out step {config.get('id', '?')!r}: 'items' must "
+                    f"resolve to a list, got {type(items).__name__} from "
+                    f"{items_expr!r}."
+                ),
+                output={
+                    "items": [],
+                    "max_concurrency": max_concurrency,
+                    "step_template": step_template,
+                    "item_count": 0,
+                },
+            )
 
         return StepResult(
             status=StepStatus.COMPLETED,

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1475,9 +1475,9 @@ class TestFanOutStep:
         assert result.output["item_count"] == 2
         assert result.output["max_concurrency"] == 3
 
-    def test_execute_non_list_items_resolves_empty(self):
+    def test_execute_non_list_items_fails_loudly(self):
         from specify_cli.workflows.steps.fan_out import FanOutStep
-        from specify_cli.workflows.base import StepContext
+        from specify_cli.workflows.base import StepContext, StepStatus
 
         step = FanOutStep()
         ctx = StepContext()
@@ -1487,8 +1487,24 @@ class TestFanOutStep:
             "step": {"id": "impl", "command": "speckit.implement"},
         }
         result = step.execute(config, ctx)
+        assert result.status == StepStatus.FAILED
+        assert "'items' must resolve to a list" in (result.error or "")
         assert result.output["item_count"] == 0
-        assert result.output["items"] == []
+
+    def test_execute_empty_list_items_is_valid(self):
+        from specify_cli.workflows.steps.fan_out import FanOutStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = FanOutStep()
+        ctx = StepContext(steps={"tasks": {"output": {"task_list": []}}})
+        config = {
+            "id": "parallel",
+            "items": "{{ steps.tasks.output.task_list }}",
+            "step": {"id": "impl", "command": "speckit.implement"},
+        }
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["item_count"] == 0
 
     def test_validate_missing_fields(self):
         from specify_cli.workflows.steps.fan_out import FanOutStep


### PR DESCRIPTION
## Description

Fixes #2956.

`FanOutStep.execute` silently coerced any non-list `items` result to `[]`, so a mis-wired or unresolvable `items:` expression produced a vacuous zero-instance run with no error anywhere near the cause. This PR makes the step fail loudly instead, with an error naming the expression and the resolved type. An explicit empty **list** remains valid input (legitimately-empty data still completes with `item_count: 0`).

The previous behavior was pinned by `test_execute_non_list_items_resolves_empty`; that test is updated to the fail-loud contract, and a new `test_execute_empty_list_items_is_valid` locks the empty-list-stays-valid distinction. If silent-empty was intentional for some use case, happy to rework this as an opt-in knob (`allow_empty:`/`strict:`) with fail-loud as default — see the issue for that alternative.

The failure output keeps the step's four output keys (`items`/`max_concurrency`/`step_template`/`item_count`) so downstream readers of a failed run's state don't hit missing keys.

## Testing

- [x] Ran existing tests with `uv sync && uv run pytest` — 208 passed (the new non-list test fails red against current `main`, passes with the fix; verified both directions)
- [x] `uvx ruff check src/` — clean
- [x] Tested locally with `uv run specify --help`
- [ ] Tested with a sample project (covered by the unit tests above; the repro workflow from #2956 now fails at the fan-out step with the new error)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Code, tests, and this description were authored with AI assistance (Claude), driven by a real-pipeline failure investigation; everything was verified by running the repo's test suite and ruff locally in both red (unfixed) and green (fixed) directions.
