### PR TITLE
feat(workflows): add from_json expression filter

### DIFF
--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -280,7 +280,7 @@ Steps can reference inputs and previous step outputs using `{{ expression }}` sy
 | `steps.specify.output.file`    | Output from a previous step          |
 | `item`                         | Current item in a fan-out iteration  |
 
-Available filters: `default`, `join`, `contains`, `map`.
+Available filters: `default`, `join`, `contains`, `map`, `from_json`.
 
 Example:
 

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -158,6 +158,18 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         value = _evaluate_simple_expression(parts[0].strip(), namespace)
         filter_expr = parts[1].strip()
 
+        # `from_json` is strict and takes no arguments. Match the filter name
+        # tolerant of whitespace and reject any parenthesized form
+        # (`from_json()`, `from_json('x')`, `from_json ()`) so a mis-wired
+        # template fails loudly instead of silently returning the unparsed
+        # value.
+        if filter_expr.split("(", 1)[0].strip() == "from_json":
+            if "(" in filter_expr:
+                raise ValueError(
+                    "from_json: filter takes no arguments (use '| from_json')"
+                )
+            return _filter_from_json(value)
+
         # Parse filter name and argument
         filter_match = re.match(r"(\w+)\((.+)\)", filter_expr)
         if filter_match:
@@ -175,8 +187,6 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         filter_name = filter_expr.strip()
         if filter_name == "default":
             return _filter_default(value)
-        if filter_name == "from_json":
-            return _filter_from_json(value)
         return value
 
     # Boolean operators — parse 'or' first (lower precedence) so that

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -1,7 +1,8 @@
 """Sandboxed expression evaluator for workflow templates.
 
 Provides a safe Jinja2 subset for evaluating expressions in workflow YAML.
-No file I/O, no imports, no arbitrary code execution.
+Templates cannot perform file I/O, import modules, or run arbitrary code —
+the evaluator only walks the namespace and applies a fixed set of filters.
 """
 
 from __future__ import annotations
@@ -158,15 +159,19 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         value = _evaluate_simple_expression(parts[0].strip(), namespace)
         filter_expr = parts[1].strip()
 
-        # `from_json` is strict and takes no arguments. Match the filter name
-        # tolerant of whitespace and reject any parenthesized form
-        # (`from_json()`, `from_json('x')`, `from_json ()`) so a mis-wired
-        # template fails loudly instead of silently returning the unparsed
-        # value.
-        if filter_expr.split("(", 1)[0].strip() == "from_json":
-            if "(" in filter_expr:
+        # `from_json` is strict: it takes no arguments and tolerates no
+        # trailing tokens. Match on the leading filter name and require the
+        # whole filter to be exactly `from_json`, so every mis-wired form
+        # (`from_json()`, `from_json('x')`, `from_json)`, `from_json extra`)
+        # fails loudly instead of silently falling through to the
+        # unknown-filter path and returning the unparsed value. (filter_expr
+        # is already stripped above.)
+        leading = re.match(r"\w+", filter_expr)
+        if leading and leading.group(0) == "from_json":
+            if filter_expr != "from_json":
                 raise ValueError(
-                    "from_json: filter takes no arguments (use '| from_json')"
+                    "from_json: expected '| from_json' with no arguments or "
+                    f"trailing tokens, got '| {filter_expr}'"
                 )
             return _filter_from_json(value)
 

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -6,6 +6,7 @@ No file I/O, no imports, no arbitrary code execution.
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
@@ -55,6 +56,23 @@ def _filter_contains(value: Any, substring: str) -> bool:
     if isinstance(value, list):
         return substring in value
     return False
+
+
+def _filter_from_json(value: Any) -> Any:
+    """Parse a JSON string into a typed value (list/dict/scalar).
+
+    Raises ``ValueError`` on non-string input or invalid JSON — a parse
+    failure here means the pipeline wiring is wrong, and silently
+    passing the unparsed value through would hide it.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"from_json: expected a JSON string, got {type(value).__name__}"
+        )
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"from_json: invalid JSON: {exc}") from exc
 
 
 # -- Expression resolution ------------------------------------------------
@@ -122,7 +140,7 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
     - Comparisons: ``==``, ``!=``, ``>``, ``<``, ``>=``, ``<=``
     - Boolean operators: ``and``, ``or``, ``not``
     - ``in``, ``not in``
-    - Pipe filters: ``| default('...')``, ``| join(', ')``, ``| contains('...')``, ``| map('...')``
+    - Pipe filters: ``| default('...')``, ``| join(', ')``, ``| contains('...')``, ``| from_json``, ``| map('...')``
     - String and numeric literals
     """
     expr = expr.strip()
@@ -157,6 +175,8 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         filter_name = filter_expr.strip()
         if filter_name == "default":
             return _filter_default(value)
+        if filter_name == "from_json":
+            return _filter_from_json(value)
         return value
 
     # Boolean operators — parse 'or' first (lower precedence) so that

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -286,7 +286,7 @@ class TestExpressions:
         ctx = StepContext(inputs={"text": "hello world"})
         assert evaluate_expression("{{ inputs.text | contains('world') }}", ctx) is True
 
-    def test_filter_from_json_parses_list(self):
+    def test_filter_from_json_parses_object(self):
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext
 
@@ -313,6 +313,21 @@ class TestExpressions:
         ctx = StepContext(steps={"emit": {"output": {"exit_code": 0}}})
         with pytest.raises(ValueError, match="expected a JSON string"):
             evaluate_expression("{{ steps.emit.output.exit_code | from_json }}", ctx)
+
+    def test_filter_from_json_rejects_arguments(self):
+        # `from_json` is strict and takes no arguments. Both the empty-parens
+        # and accidental-arg forms must raise rather than silently return the
+        # unparsed value, so a mis-wired template is caught immediately.
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(steps={"emit": {"output": {"stdout": '{"a": 1}'}}})
+        for bad in ("from_json()", "from_json('x')", "from_json ()", "from_json ('x')"):
+            with pytest.raises(ValueError, match="from_json: filter takes no arguments"):
+                evaluate_expression(
+                    "{{ steps.emit.output.stdout | " + bad + " }}", ctx
+                )
 
     def test_condition_evaluation(self):
         from specify_cli.workflows.expressions import evaluate_condition

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -286,6 +286,34 @@ class TestExpressions:
         ctx = StepContext(inputs={"text": "hello world"})
         assert evaluate_expression("{{ inputs.text | contains('world') }}", ctx) is True
 
+    def test_filter_from_json_parses_list(self):
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(
+            steps={"emit": {"output": {"stdout": '{"items": [1, 2, 3]}'}}}
+        )
+        result = evaluate_expression("{{ steps.emit.output.stdout | from_json }}", ctx)
+        assert result == {"items": [1, 2, 3]}
+
+    def test_filter_from_json_invalid_json_raises(self):
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(steps={"emit": {"output": {"stdout": "not json"}}})
+        with pytest.raises(ValueError, match="from_json: invalid JSON"):
+            evaluate_expression("{{ steps.emit.output.stdout | from_json }}", ctx)
+
+    def test_filter_from_json_non_string_raises(self):
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(steps={"emit": {"output": {"exit_code": 0}}})
+        with pytest.raises(ValueError, match="expected a JSON string"):
+            evaluate_expression("{{ steps.emit.output.exit_code | from_json }}", ctx)
+
     def test_condition_evaluation(self):
         from specify_cli.workflows.expressions import evaluate_condition
         from specify_cli.workflows.base import StepContext

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -314,17 +314,27 @@ class TestExpressions:
         with pytest.raises(ValueError, match="expected a JSON string"):
             evaluate_expression("{{ steps.emit.output.exit_code | from_json }}", ctx)
 
-    def test_filter_from_json_rejects_arguments(self):
-        # `from_json` is strict and takes no arguments. Both the empty-parens
-        # and accidental-arg forms must raise rather than silently return the
-        # unparsed value, so a mis-wired template is caught immediately.
+    def test_filter_from_json_rejects_malformed_forms(self):
+        # `from_json` is strict: no arguments and no trailing tokens. Every
+        # mis-wired form — parenthesized, accidental arg, or trailing
+        # garbage — must raise rather than silently fall through to the
+        # unknown-filter path and return the unparsed value.
         import pytest
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext
 
         ctx = StepContext(steps={"emit": {"output": {"stdout": '{"a": 1}'}}})
-        for bad in ("from_json()", "from_json('x')", "from_json ()", "from_json ('x')"):
-            with pytest.raises(ValueError, match="from_json: filter takes no arguments"):
+        bad_forms = (
+            "from_json()",
+            "from_json('x')",
+            "from_json ()",
+            "from_json ('x')",
+            "from_json)",
+            "from_json extra",
+            "from_json 'x'",
+        )
+        for bad in bad_forms:
+            with pytest.raises(ValueError, match="from_json: expected"):
                 evaluate_expression(
                     "{{ steps.emit.output.stdout | " + bad + " }}", ctx
                 )

--- a/workflows/ARCHITECTURE.md
+++ b/workflows/ARCHITECTURE.md
@@ -118,6 +118,7 @@ Workflow definitions use Jinja2-like `{{ expression }}` syntax for dynamic value
 | Filter: `join` | `{{ list \| join(', ') }}` | Join list elements |
 | Filter: `contains` | `{{ text \| contains('sub') }}` | Substring/membership check |
 | Filter: `map` | `{{ list \| map('attr') }}` | Extract attribute from each item |
+| Filter: `from_json` | `{{ steps.emit.output.stdout \| from_json }}` | Parse a JSON string into a typed value (raises on invalid JSON) |
 
 **Single expressions** (`{{ expr }}` only) return typed values. **Mixed templates** (`"text {{ expr }} more"`) return interpolated strings.
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -314,7 +314,7 @@ condition: "{{ steps.run-tests.output.exit_code != 0 }}"
 message: "{{ status | default('pending') }}"
 ```
 
-Supported filters: `default`, `join`, `contains`, `map`.
+Supported filters: `default`, `join`, `contains`, `map`, `from_json`.
 
 ### Runtime Context
 


### PR DESCRIPTION
## Description

Fixes #2960.

Adds one arg-less pipe filter to the sandboxed expression evaluator:

```yaml
items: "{{ steps.emit.output.stdout | from_json }}"
```

`_filter_from_json` parses a JSON string into its typed value (list/dict/scalar). Semantics are parse-or-raise: invalid JSON or non-string input raises a clear `ValueError` — never a silent passthrough, since a parse failure means the pipeline wiring is wrong and silence would hide it. The module docstring's filter list is updated; no other filter or evaluator behavior is touched.

This is the smallest unblock for feeding `fan-out` `items:` (or any condition/arg) from a step that computes a collection at runtime. It composes with — and doesn't preclude — a future declared-`outputs:` mechanism, which I'm proposing separately.

## Testing

- [x] Ran existing tests with `uv sync && uv run pytest` — `tests/test_workflows.py` 210 passed
- [x] Three new tests in `TestExpressions` (valid JSON → typed value; invalid JSON raises; non-string raises) — all three are red against current `main`, green with the filter (verified both directions)
- [x] `uvx ruff check src/` — clean
- [x] Tested locally with `uv run specify --help`
- [ ] Tested with a sample project (covered by the evaluator tests; exercised manually with the #2956 repro workflow rewired through `| from_json`)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Code, tests, and this description were authored with AI assistance (Claude); verified by running the repo's test suite and ruff locally in both red and green directions.
