### PR TITLE
feat(workflows): opt-in output_format: json exposes parsed shell stdout as output.data

### DIFF
--- a/src/specify_cli/workflows/steps/shell/__init__.py
+++ b/src/specify_cli/workflows/steps/shell/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from typing import Any
 
@@ -49,6 +50,23 @@ class ShellStep(StepBase):
                     error=f"Shell command exited with code {proc.returncode}.",
                     output=output,
                 )
+            if config.get("output_format") == "json":
+                # Opt-in structured output: expose the parsed stdout under
+                # ``output.data`` so later steps can consume typed values
+                # (e.g. a fan-out's ``items:``). A parse failure fails the
+                # step — declaring ``output_format: json`` is a contract.
+                try:
+                    output["data"] = json.loads(proc.stdout)
+                except json.JSONDecodeError as exc:
+                    return StepResult(
+                        status=StepStatus.FAILED,
+                        error=(
+                            f"Shell step {config.get('id', '?')!r} declared "
+                            f"output_format: json but stdout is not valid "
+                            f"JSON: {exc}"
+                        ),
+                        output=output,
+                    )
             return StepResult(
                 status=StepStatus.COMPLETED,
                 output=output,
@@ -71,5 +89,11 @@ class ShellStep(StepBase):
         if "run" not in config:
             errors.append(
                 f"Shell step {config.get('id', '?')!r} is missing 'run' field."
+            )
+        output_format = config.get("output_format")
+        if output_format is not None and output_format != "json":
+            errors.append(
+                f"Shell step {config.get('id', '?')!r}: 'output_format' must "
+                f"be 'json' when present, got {output_format!r}."
             )
         return errors

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -909,6 +909,17 @@ class TestPromptStep:
 class TestShellStep:
     """Test the shell step type."""
 
+    @staticmethod
+    def _python_run(tmp_path, body):
+        """A portable shell ``run`` that executes ``body`` with the current
+        interpreter, avoiding non-portable shell quoting (e.g. Windows
+        ``cmd.exe`` keeping single quotes) in the output_format tests."""
+        import sys
+
+        script = tmp_path / "emit.py"
+        script.write_text(body, encoding="utf-8")
+        return f'"{sys.executable}" "{script}"'
+
     def test_execute_echo(self):
         from specify_cli.workflows.steps.shell import ShellStep
         from specify_cli.workflows.base import StepContext, StepStatus
@@ -949,7 +960,9 @@ class TestShellStep:
         ctx = StepContext(project_root=str(tmp_path))
         config = {
             "id": "emit",
-            "run": "echo '{\"items\": [1, 2]}'",
+            "run": self._python_run(
+                tmp_path, 'import json; print(json.dumps({"items": [1, 2]}))\n'
+            ),
             "output_format": "json",
         }
         result = step.execute(config, ctx)
@@ -965,7 +978,7 @@ class TestShellStep:
         ctx = StepContext(project_root=str(tmp_path))
         config = {
             "id": "emit",
-            "run": "echo not-json",
+            "run": self._python_run(tmp_path, "print('not-json')\n"),
             "output_format": "json",
         }
         result = step.execute(config, ctx)
@@ -978,7 +991,12 @@ class TestShellStep:
 
         step = ShellStep()
         ctx = StepContext(project_root=str(tmp_path))
-        config = {"id": "emit", "run": "echo '{\"items\": []}'"}
+        config = {
+            "id": "emit",
+            "run": self._python_run(
+                tmp_path, 'import json; print(json.dumps({"items": []}))\n'
+            ),
+        }
         result = step.execute(config, ctx)
         assert result.status == StepStatus.COMPLETED
         assert "data" not in result.output
@@ -987,7 +1005,7 @@ class TestShellStep:
         from specify_cli.workflows.steps.shell import ShellStep
 
         step = ShellStep()
-        errors = step.validate({"id": "emit", "run": "true", "output_format": "yaml"})
+        errors = step.validate({"id": "emit", "run": "exit 0", "output_format": "yaml"})
         assert any("'output_format' must be 'json'" in e for e in errors)
 
 class _StubStdin:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -941,6 +941,55 @@ class TestShellStep:
         assert any("missing 'run'" in e for e in errors)
 
 
+    def test_output_format_json_exposes_data(self, tmp_path):
+        from specify_cli.workflows.steps.shell import ShellStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = ShellStep()
+        ctx = StepContext(project_root=str(tmp_path))
+        config = {
+            "id": "emit",
+            "run": "echo '{\"items\": [1, 2]}'",
+            "output_format": "json",
+        }
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["data"] == {"items": [1, 2]}
+        assert result.output["exit_code"] == 0  # raw keys still present
+
+    def test_output_format_json_invalid_stdout_fails(self, tmp_path):
+        from specify_cli.workflows.steps.shell import ShellStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = ShellStep()
+        ctx = StepContext(project_root=str(tmp_path))
+        config = {
+            "id": "emit",
+            "run": "echo not-json",
+            "output_format": "json",
+        }
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.FAILED
+        assert "output_format: json" in (result.error or "")
+
+    def test_no_output_format_keeps_raw_output_only(self, tmp_path):
+        from specify_cli.workflows.steps.shell import ShellStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = ShellStep()
+        ctx = StepContext(project_root=str(tmp_path))
+        config = {"id": "emit", "run": "echo '{\"items\": []}'"}
+        result = step.execute(config, ctx)
+        assert result.status == StepStatus.COMPLETED
+        assert "data" not in result.output
+
+    def test_validate_rejects_unknown_output_format(self):
+        from specify_cli.workflows.steps.shell import ShellStep
+
+        step = ShellStep()
+        errors = step.validate({"id": "emit", "run": "true", "output_format": "yaml"})
+        assert any("'output_format' must be 'json'" in e for e in errors)
+
 class _StubStdin:
     """Stdin stub exposing only a fixed ``isatty`` result.
 


### PR DESCRIPTION
## Description

**Reference implementation for #2962 — for discussion, direction welcome.**

Adds an opt-in `output_format: json` to shell steps: when declared, stdout is parsed and exposed under `output.data` (the raw `stdout`/`stderr`/`exit_code` keys are unchanged, so there is no merge/clobber ambiguity), letting later steps consume typed values — e.g. a fan-out's `items: "{{ steps.emit.output.data.items }}"`. A parse failure fails the step with a clear error (declaring the format is a contract; silence would hide wiring bugs). Without the key, behavior is byte-identical — fully backward-compatible. `validate()` rejects unknown formats.

The issue lists `output_file:` and a declared named-`outputs:` schema as alternatives — happy to rework toward either if you prefer that direction.

**Coordination:** aware of #2443 touching the same file; this diff is isolated to the structured-output addition and I'm happy to rebase in whichever order suits.

## Testing

- [x] Ran existing tests with `uv sync && uv run pytest` — full suite 3729 passed
- [x] Four new tests in `TestShellStep`: data exposed on valid JSON; invalid stdout fails the step; no-flag backcompat (no `data` key); validate rejects unknown formats — the three behavior tests are red against current `main`, green with the change (verified both directions)
- [x] `uvx ruff check src/` — clean
- [x] Tested locally with `uv run specify --help`
- [ ] Tested with a sample project (covered by the step-level tests)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Code, tests, and this description were authored with AI assistance (Claude); verified by running the repo's test suite and ruff locally in both red and green directions.
