### PR TITLE
feat: surface gate detail in the workflow run/resume --json payload

### DIFF
--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2145,15 +2145,30 @@ def _gate_outcome(state: Any) -> dict[str, Any] | None:
     output = step.get("output") or {}
     # `message` and `options` may be non-string YAML literals in an unvalidated
     # workflow (GateStep coerces neither for the payload), so normalise both
-    # here for a stable JSON schema: message → str, options → list[str].
+    # here for a stable JSON schema: message → str, options → list[str] | None.
     message = output.get("message")
-    options = output.get("options")
     return {
         "step_id": state.current_step_id,
         "message": None if message is None else str(message),
-        "options": [str(o) for o in options] if isinstance(options, list) else options,
+        "options": _normalize_gate_options(output.get("options")),
         "choice": output.get("choice"),
     }
+
+
+def _normalize_gate_options(options: Any) -> list[str] | None:
+    """Normalise a gate's ``options`` to a stable ``list[str]`` (or ``None``).
+
+    A valid gate stores a list, but an unvalidated workflow could leave a
+    scalar or tuple. ``None`` stays ``None`` (no options); a list/tuple maps
+    each element through ``str``; any other scalar becomes a single-element
+    list — so the emitted JSON schema is always ``list[str] | None``. A bare
+    string is treated as one option, never iterated character-by-character.
+    """
+    if options is None:
+        return None
+    if isinstance(options, (list, tuple)):
+        return [str(o) for o in options]
+    return [str(options)]
 
 
 def _run_outcome_exit_code(status_value: str) -> int:

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2143,15 +2143,17 @@ def _gate_outcome(state: Any) -> dict[str, Any] | None:
     if not isinstance(step, dict) or not _is_gate_step(step):
         return None
     output = step.get("output") or {}
-    # `message` and `options` may be non-string YAML literals in an unvalidated
-    # workflow (GateStep coerces neither for the payload), so normalise both
-    # here for a stable JSON schema: message → str, options → list[str] | None.
+    # `message`, `options`, and `choice` may be non-string YAML literals in an
+    # unvalidated workflow (GateStep coerces none of them for the payload), so
+    # normalise all three for a stable JSON schema: message → str, options →
+    # list[str] | None, choice → str | None (None means no decision yet).
     message = output.get("message")
+    choice = output.get("choice")
     return {
         "step_id": state.current_step_id,
         "message": None if message is None else str(message),
         "options": _normalize_gate_options(output.get("options")),
-        "choice": output.get("choice"),
+        "choice": None if choice is None else str(choice),
     }
 
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2105,6 +2105,24 @@ def _workflow_run_payload(state: Any) -> dict[str, Any]:
     return payload
 
 
+def _is_gate_step(step: dict[str, Any]) -> bool:
+    """Whether a recorded step result is a gate.
+
+    Prefers the persisted ``type`` field, but when it is absent — a run paused
+    by an older version, whose step record predates ``type`` being stored —
+    falls back to the gate's unique output signature: only ``GateStep`` writes
+    an ``on_reject`` key. A record carrying a *different* known ``type`` is not
+    a gate, so the fallback applies only when ``type`` is missing entirely.
+    """
+    step_type = step.get("type")
+    if step_type == "gate":
+        return True
+    if step_type:
+        return False
+    output = step.get("output")
+    return isinstance(output, dict) and "on_reject" in output
+
+
 def _gate_outcome(state: Any) -> dict[str, Any] | None:
     """Gate detail for the structured outcome, when the run rests at a gate.
 
@@ -2122,16 +2140,18 @@ def _gate_outcome(state: Any) -> dict[str, Any] | None:
     if getattr(state.status, "value", state.status) not in ("paused", "aborted"):
         return None
     step = (getattr(state, "step_results", None) or {}).get(state.current_step_id)
-    if not isinstance(step, dict) or step.get("type") != "gate":
+    if not isinstance(step, dict) or not _is_gate_step(step):
         return None
     output = step.get("output") or {}
-    # `message` may be a non-string YAML literal (GateStep coerces it only for
-    # expression interpolation), so normalise it here for a stable JSON schema.
+    # `message` and `options` may be non-string YAML literals in an unvalidated
+    # workflow (GateStep coerces neither for the payload), so normalise both
+    # here for a stable JSON schema: message → str, options → list[str].
     message = output.get("message")
+    options = output.get("options")
     return {
         "step_id": state.current_step_id,
         "message": None if message is None else str(message),
-        "options": output.get("options"),
+        "options": [str(o) for o in options] if isinstance(options, list) else options,
         "choice": output.get("choice"),
     }
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2113,6 +2113,12 @@ def _gate_outcome(state: Any) -> dict[str, Any] | None:
     and (after an interactive choice) the decision lets orchestrators
     drive review gates without parsing the human-facing stream.
     """
+    # Only a run that is actually *paused* sits at a gate awaiting a
+    # decision. RunState.current_step_id is not cleared on completion, so
+    # without this guard a completed/failed run whose last executed step was
+    # a gate would surface stale gate details (in run/resume/status --json).
+    if getattr(state.status, "value", state.status) != "paused":
+        return None
     step = (getattr(state, "step_results", None) or {}).get(state.current_step_id)
     if not isinstance(step, dict) or step.get("type") != "gate":
         return None

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2092,12 +2092,36 @@ def _parse_input_values(input_values: list[str] | None) -> dict[str, Any]:
 
 def _workflow_run_payload(state: Any) -> dict[str, Any]:
     """Machine-readable summary of a run/resume outcome."""
-    return {
+    payload = {
         "run_id": state.run_id,
         "workflow_id": state.workflow_id,
         "status": state.status.value,
         "current_step_id": state.current_step_id,
         "current_step_index": state.current_step_index,
+    }
+    gate = _gate_outcome(state)
+    if gate is not None:
+        payload["gate"] = gate
+    return payload
+
+
+def _gate_outcome(state: Any) -> dict[str, Any] | None:
+    """Gate detail for the structured outcome, if the run sits at a gate.
+
+    A paused run is otherwise indistinguishable from any other pause in
+    the machine-readable payload; surfacing the gate's prompt, options,
+    and (after an interactive choice) the decision lets orchestrators
+    drive review gates without parsing the human-facing stream.
+    """
+    step = (getattr(state, "step_results", None) or {}).get(state.current_step_id)
+    if not isinstance(step, dict) or step.get("type") != "gate":
+        return None
+    output = step.get("output") or {}
+    return {
+        "step_id": state.current_step_id,
+        "message": output.get("message"),
+        "options": output.get("options"),
+        "choice": output.get("choice"),
     }
 
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -2106,26 +2106,31 @@ def _workflow_run_payload(state: Any) -> dict[str, Any]:
 
 
 def _gate_outcome(state: Any) -> dict[str, Any] | None:
-    """Gate detail for the structured outcome, if the run sits at a gate.
+    """Gate detail for the structured outcome, when the run rests at a gate.
 
-    A paused run is otherwise indistinguishable from any other pause in
-    the machine-readable payload; surfacing the gate's prompt, options,
-    and (after an interactive choice) the decision lets orchestrators
-    drive review gates without parsing the human-facing stream.
+    A paused or gate-aborted run is otherwise indistinguishable from any
+    other pause/abort in the machine-readable payload; surfacing the gate's
+    prompt, options, and (after an interactive choice) the decision lets
+    orchestrators drive review gates without parsing the human-facing stream.
     """
-    # Only a run that is actually *paused* sits at a gate awaiting a
-    # decision. RunState.current_step_id is not cleared on completion, so
-    # without this guard a completed/failed run whose last executed step was
-    # a gate would surface stale gate details (in run/resume/status --json).
-    if getattr(state.status, "value", state.status) != "paused":
+    # Two run states rest *on* a gate: `paused` (awaiting a decision) and
+    # `aborted` (a gate rejected with `on_reject: abort` — the only path that
+    # sets ABORTED, leaving current_step_id on that gate). Any other status —
+    # notably `completed`/`failed` — must be suppressed: current_step_id is
+    # not cleared when a run whose last executed step was a gate moves on, so
+    # without this guard it would surface stale detail (run/resume/status).
+    if getattr(state.status, "value", state.status) not in ("paused", "aborted"):
         return None
     step = (getattr(state, "step_results", None) or {}).get(state.current_step_id)
     if not isinstance(step, dict) or step.get("type") != "gate":
         return None
     output = step.get("output") or {}
+    # `message` may be a non-string YAML literal (GateStep coerces it only for
+    # expression interpolation), so normalise it here for a stable JSON schema.
+    message = output.get("message")
     return {
         "step_id": state.current_step_id,
-        "message": output.get("message"),
+        "message": None if message is None else str(message),
         "options": output.get("options"),
         "choice": output.get("choice"),
     }

--- a/src/specify_cli/workflows/base.py
+++ b/src/specify_cli/workflows/base.py
@@ -47,9 +47,10 @@ class StepContext:
     #: Resolved workflow inputs (from user prompts / defaults).
     inputs: dict[str, Any] = field(default_factory=dict)
 
-    #: Accumulated step results keyed by step ID.
-    #: Each entry is ``{"integration": ..., "model": ..., "options": ...,
-    #:   "input": ..., "output": ...}``.
+    #: Accumulated step results keyed by step ID. Each entry is the dict the
+    #: engine persists per step:
+    #: ``{"type": ..., "integration": ..., "model": ..., "options": ...,
+    #:   "input": ..., "output": ..., "status": ...}``.
     steps: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     #: Current fan-out item (set only inside fan-out iterations).

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -676,6 +676,7 @@ class WorkflowEngine:
 
             # Record step results — prefer resolved values from step output
             step_data = {
+                "type": step_type,
                 "integration": result.output.get("integration")
                 or step_config.get("integration")
                 or context.default_integration,

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5381,8 +5381,10 @@ steps:
         monkeypatch.chdir(tmp_path)
         result = CliRunner().invoke(app, ["workflow", "run", str(path), "--json"])
         # Assert the CLI succeeded before parsing so a real failure surfaces
-        # the actual output instead of an opaque JSON decode error.
-        assert result.exit_code == 0, result.stdout
+        # the actual output instead of an opaque JSON decode error. Use
+        # ``result.output`` for the message: under ``--json`` step output is
+        # redirected off stdout, so the useful diagnostics live there.
+        assert result.exit_code == 0, result.output
         return _json.loads(result.stdout)
 
     def test_gate_pause_carries_gate_block(self, tmp_path, monkeypatch):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5368,7 +5368,7 @@ workflow:
 steps:
   - id: fine
     type: shell
-    run: "true"
+    run: "exit 0"
 """
 
     def _run_json(self, tmp_path, monkeypatch, content, *, expected_exit=0):
@@ -5506,6 +5506,30 @@ steps:
         assert _options_payload("approve") == ["approve"]  # bare scalar, not iterated
         assert _options_payload(7) == ["7"]  # numeric scalar
         assert _options_payload(None) is None  # absent stays absent
+
+    def test_gate_block_choice_coerced_to_string(self):
+        # An unvalidated gate can record a non-string choice; the JSON
+        # surface normalises it to str (and keeps None = no decision yet),
+        # consistent with the message/options normalization.
+        from types import SimpleNamespace
+        from specify_cli import _gate_outcome
+
+        def _choice_payload(choice):
+            state = SimpleNamespace(
+                status=SimpleNamespace(value="paused"),
+                current_step_id="review",
+                step_results={
+                    "review": {
+                        "type": "gate",
+                        "output": {"message": "m", "options": ["ok"], "choice": choice},
+                    }
+                },
+            )
+            return _gate_outcome(state)["choice"]
+
+        assert _choice_payload(None) is None  # no decision yet
+        assert _choice_payload("reject") == "reject"  # normal string passes through
+        assert _choice_payload(2) == "2"  # non-string coerced
 
     def test_gate_block_detected_without_type_field(self):
         # A run paused by an older version has no persisted step `type`. The

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5371,16 +5371,19 @@ steps:
     run: "true"
 """
 
-    def _run_json(self, tmp_path, monkeypatch, content):
-        import json as _json
+    def _invoke_json(self, tmp_path, monkeypatch, content):
         from typer.testing import CliRunner
         from specify_cli import app
 
         path = tmp_path / "wf.yml"
         path.write_text(content, encoding="utf-8")
         monkeypatch.chdir(tmp_path)
-        runner = CliRunner()
-        result = runner.invoke(app, ["workflow", "run", str(path), "--json"])
+        return CliRunner().invoke(app, ["workflow", "run", str(path), "--json"])
+
+    def _run_json(self, tmp_path, monkeypatch, content):
+        import json as _json
+
+        result = self._invoke_json(tmp_path, monkeypatch, content)
         # Assert the CLI succeeded before parsing so a real failure surfaces
         # the actual output instead of an opaque JSON decode error.
         assert result.exit_code == 0, result.stdout
@@ -5402,17 +5405,43 @@ steps:
         assert payload["status"] == "completed"
         assert "gate" not in payload
 
-    def test_gate_block_suppressed_when_run_not_paused(self):
-        # RunState.current_step_id is not cleared on completion, so a
-        # completed/failed run whose last executed step was a gate still
-        # points current_step_id at that gate. The gate block must only be
-        # emitted while the run is actually paused at it.
+    def test_gate_abort_carries_gate_block(self, tmp_path, monkeypatch):
+        # An interactive gate the operator rejects ends the run as `aborted`
+        # (on_reject defaults to abort), not `paused`. The JSON surface must
+        # still carry the gate block with the recorded choice so an
+        # orchestrator can see *why* the run stopped.
+        import json as _json
+        from specify_cli.workflows.steps.gate import GateStep
+
+        _force_gate_stdin(monkeypatch, tty=True)
+        monkeypatch.setattr(
+            GateStep, "_prompt", staticmethod(lambda _msg, _opts: "reject")
+        )
+        result = self._invoke_json(tmp_path, monkeypatch, self._WF_GATE)
+        payload = _json.loads(result.stdout)
+        assert payload["status"] == "aborted"
+        assert payload["gate"] == {
+            "step_id": "review",
+            "message": "Approve the thing?",
+            "options": ["approve", "reject"],
+            "choice": "reject",
+        }
+
+    def test_gate_block_emitted_only_when_run_rests_at_gate(self):
+        # A run rests *on* a gate only while `paused` (awaiting a decision) or
+        # `aborted` (gate rejected with on_reject: abort). current_step_id is
+        # not cleared afterwards, so a `completed`/`failed` run whose last
+        # executed step was a gate must NOT surface a stale gate block.
         from types import SimpleNamespace
         from specify_cli import _gate_outcome
 
         gate_step = {
             "type": "gate",
-            "output": {"message": "m", "options": ["approve"], "choice": "approve"},
+            "output": {
+                "message": "m",
+                "options": ["approve", "reject"],
+                "choice": "reject",
+            },
         }
 
         def _state(status):
@@ -5425,3 +5454,22 @@ steps:
         assert _gate_outcome(_state("completed")) is None
         assert _gate_outcome(_state("failed")) is None
         assert _gate_outcome(_state("paused")) is not None
+        assert _gate_outcome(_state("aborted")) is not None
+
+    def test_gate_block_message_coerced_to_string(self):
+        # message may be a non-string YAML literal (e.g. a number); the JSON
+        # surface normalises it so the emitted schema stays stable.
+        from types import SimpleNamespace
+        from specify_cli import _gate_outcome
+
+        state = SimpleNamespace(
+            status=SimpleNamespace(value="paused"),
+            current_step_id="review",
+            step_results={
+                "review": {
+                    "type": "gate",
+                    "output": {"message": 12.5, "options": ["ok"], "choice": None},
+                }
+            },
+        )
+        assert _gate_outcome(state)["message"] == "12.5"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5371,19 +5371,15 @@ steps:
     run: "true"
 """
 
-    def _invoke_json(self, tmp_path, monkeypatch, content):
+    def _run_json(self, tmp_path, monkeypatch, content):
+        import json as _json
         from typer.testing import CliRunner
         from specify_cli import app
 
         path = tmp_path / "wf.yml"
         path.write_text(content, encoding="utf-8")
         monkeypatch.chdir(tmp_path)
-        return CliRunner().invoke(app, ["workflow", "run", str(path), "--json"])
-
-    def _run_json(self, tmp_path, monkeypatch, content):
-        import json as _json
-
-        result = self._invoke_json(tmp_path, monkeypatch, content)
+        result = CliRunner().invoke(app, ["workflow", "run", str(path), "--json"])
         # Assert the CLI succeeded before parsing so a real failure surfaces
         # the actual output instead of an opaque JSON decode error.
         assert result.exit_code == 0, result.stdout
@@ -5409,16 +5405,16 @@ steps:
         # An interactive gate the operator rejects ends the run as `aborted`
         # (on_reject defaults to abort), not `paused`. The JSON surface must
         # still carry the gate block with the recorded choice so an
-        # orchestrator can see *why* the run stopped.
-        import json as _json
+        # orchestrator can see *why* the run stopped. The run helper asserts
+        # the CLI exited cleanly before parsing (a gate abort emits the
+        # payload and returns; it does not crash the command).
         from specify_cli.workflows.steps.gate import GateStep
 
         _force_gate_stdin(monkeypatch, tty=True)
         monkeypatch.setattr(
             GateStep, "_prompt", staticmethod(lambda _msg, _opts: "reject")
         )
-        result = self._invoke_json(tmp_path, monkeypatch, self._WF_GATE)
-        payload = _json.loads(result.stdout)
+        payload = self._run_json(tmp_path, monkeypatch, self._WF_GATE)
         assert payload["status"] == "aborted"
         assert payload["gate"] == {
             "step_id": "review",

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5381,6 +5381,9 @@ steps:
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
         result = runner.invoke(app, ["workflow", "run", str(path), "--json"])
+        # Assert the CLI succeeded before parsing so a real failure surfaces
+        # the actual output instead of an opaque JSON decode error.
+        assert result.exit_code == 0, result.stdout
         return _json.loads(result.stdout)
 
     def test_gate_pause_carries_gate_block(self, tmp_path, monkeypatch):
@@ -5398,3 +5401,27 @@ steps:
         payload = self._run_json(tmp_path, monkeypatch, self._WF_PLAIN)
         assert payload["status"] == "completed"
         assert "gate" not in payload
+
+    def test_gate_block_suppressed_when_run_not_paused(self):
+        # RunState.current_step_id is not cleared on completion, so a
+        # completed/failed run whose last executed step was a gate still
+        # points current_step_id at that gate. The gate block must only be
+        # emitted while the run is actually paused at it.
+        from types import SimpleNamespace
+        from specify_cli import _gate_outcome
+
+        gate_step = {
+            "type": "gate",
+            "output": {"message": "m", "options": ["approve"], "choice": "approve"},
+        }
+
+        def _state(status):
+            return SimpleNamespace(
+                status=SimpleNamespace(value=status),
+                current_step_id="review",
+                step_results={"review": gate_step},
+            )
+
+        assert _gate_outcome(_state("completed")) is None
+        assert _gate_outcome(_state("failed")) is None
+        assert _gate_outcome(_state("paused")) is not None

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5478,22 +5478,34 @@ steps:
         assert _gate_outcome(state)["message"] == "12.5"
 
     def test_gate_block_options_coerced_to_strings(self):
-        # options may be non-string YAML literals in an unvalidated workflow;
-        # the JSON surface normalises them to a list of strings.
+        # options may be non-string / non-list literals in an unvalidated
+        # workflow; the JSON surface always normalises them to list[str] | None
+        # so the emitted schema is stable regardless of the input shape.
         from types import SimpleNamespace
         from specify_cli import _gate_outcome
 
-        state = SimpleNamespace(
-            status=SimpleNamespace(value="paused"),
-            current_step_id="review",
-            step_results={
-                "review": {
-                    "type": "gate",
-                    "output": {"message": "m", "options": [1, 2.5], "choice": None},
-                }
-            },
-        )
-        assert _gate_outcome(state)["options"] == ["1", "2.5"]
+        def _options_payload(options):
+            state = SimpleNamespace(
+                status=SimpleNamespace(value="paused"),
+                current_step_id="review",
+                step_results={
+                    "review": {
+                        "type": "gate",
+                        "output": {
+                            "message": "m",
+                            "options": options,
+                            "choice": None,
+                        },
+                    }
+                },
+            )
+            return _gate_outcome(state)["options"]
+
+        assert _options_payload([1, 2.5]) == ["1", "2.5"]  # list
+        assert _options_payload(("approve", "reject")) == ["approve", "reject"]  # tuple
+        assert _options_payload("approve") == ["approve"]  # bare scalar, not iterated
+        assert _options_payload(7) == ["7"]  # numeric scalar
+        assert _options_payload(None) is None  # absent stays absent
 
     def test_gate_block_detected_without_type_field(self):
         # A run paused by an older version has no persisted step `type`. The

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5371,7 +5371,7 @@ steps:
     run: "true"
 """
 
-    def _run_json(self, tmp_path, monkeypatch, content):
+    def _run_json(self, tmp_path, monkeypatch, content, *, expected_exit=0):
         import json as _json
         from typer.testing import CliRunner
         from specify_cli import app
@@ -5380,11 +5380,14 @@ steps:
         path.write_text(content, encoding="utf-8")
         monkeypatch.chdir(tmp_path)
         result = CliRunner().invoke(app, ["workflow", "run", str(path), "--json"])
-        # Assert the CLI succeeded before parsing so a real failure surfaces
-        # the actual output instead of an opaque JSON decode error. Use
-        # ``result.output`` for the message: under ``--json`` step output is
-        # redirected off stdout, so the useful diagnostics live there.
-        assert result.exit_code == 0, result.output
+        # Assert the expected exit code before parsing so a real failure
+        # surfaces the actual output instead of an opaque JSON decode error.
+        # A terminal run still emits its JSON payload, then exits non-zero on
+        # ``failed``/``aborted`` (see ``_run_outcome_exit_code``), so callers
+        # pass the expected code. Use ``result.output`` for the message:
+        # under ``--json`` step output is redirected off stdout, so the useful
+        # diagnostics live there.
+        assert result.exit_code == expected_exit, result.output
         return _json.loads(result.stdout)
 
     def test_gate_pause_carries_gate_block(self, tmp_path, monkeypatch):
@@ -5407,16 +5410,18 @@ steps:
         # An interactive gate the operator rejects ends the run as `aborted`
         # (on_reject defaults to abort), not `paused`. The JSON surface must
         # still carry the gate block with the recorded choice so an
-        # orchestrator can see *why* the run stopped. The run helper asserts
-        # the CLI exited cleanly before parsing (a gate abort emits the
-        # payload and returns; it does not crash the command).
+        # orchestrator can see *why* the run stopped. A gate abort emits the
+        # payload and then exits non-zero (aborted → exit 1), so the helper
+        # is told to expect exit code 1.
         from specify_cli.workflows.steps.gate import GateStep
 
         _force_gate_stdin(monkeypatch, tty=True)
         monkeypatch.setattr(
             GateStep, "_prompt", staticmethod(lambda _msg, _opts: "reject")
         )
-        payload = self._run_json(tmp_path, monkeypatch, self._WF_GATE)
+        payload = self._run_json(
+            tmp_path, monkeypatch, self._WF_GATE, expected_exit=1
+        )
         assert payload["status"] == "aborted"
         assert payload["gate"] == {
             "step_id": "review",

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5476,3 +5476,63 @@ steps:
             },
         )
         assert _gate_outcome(state)["message"] == "12.5"
+
+    def test_gate_block_options_coerced_to_strings(self):
+        # options may be non-string YAML literals in an unvalidated workflow;
+        # the JSON surface normalises them to a list of strings.
+        from types import SimpleNamespace
+        from specify_cli import _gate_outcome
+
+        state = SimpleNamespace(
+            status=SimpleNamespace(value="paused"),
+            current_step_id="review",
+            step_results={
+                "review": {
+                    "type": "gate",
+                    "output": {"message": "m", "options": [1, 2.5], "choice": None},
+                }
+            },
+        )
+        assert _gate_outcome(state)["options"] == ["1", "2.5"]
+
+    def test_gate_block_detected_without_type_field(self):
+        # A run paused by an older version has no persisted step `type`. The
+        # gate is still detected by its unique output signature (`on_reject`),
+        # so resume surfaces the gate block instead of silently dropping it.
+        from types import SimpleNamespace
+        from specify_cli import _gate_outcome
+
+        state = SimpleNamespace(
+            status=SimpleNamespace(value="paused"),
+            current_step_id="review",
+            step_results={
+                "review": {
+                    # no "type" key — pre-dates the field being persisted
+                    "output": {
+                        "message": "Approve?",
+                        "options": ["approve", "reject"],
+                        "on_reject": "abort",
+                        "choice": None,
+                    },
+                }
+            },
+        )
+        gate = _gate_outcome(state)
+        assert gate is not None
+        assert gate["step_id"] == "review"
+        assert gate["options"] == ["approve", "reject"]
+
+    def test_non_gate_step_without_type_is_not_a_gate(self):
+        # A typeless record lacking the gate signature must NOT be mistaken for
+        # a gate (the fallback keys off `on_reject`, which only GateStep writes).
+        from types import SimpleNamespace
+        from specify_cli import _gate_outcome
+
+        state = SimpleNamespace(
+            status=SimpleNamespace(value="paused"),
+            current_step_id="run-tests",
+            step_results={
+                "run-tests": {"output": {"exit_code": 0, "stdout": "ok"}},
+            },
+        )
+        assert _gate_outcome(state) is None

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5341,3 +5341,60 @@ steps:
         assert resumed.exit_code == 1, resumed.stdout
         payload = _json.loads(resumed.stdout)
         assert payload["status"] == "failed"
+
+
+class TestWorkflowRunGateOutcomeJson:
+    """CLI-level tests: the --json payload surfaces gate pauses."""
+
+    _WF_GATE = """
+schema_version: "1.0"
+workflow:
+  id: "gate-json"
+  name: "Gate JSON"
+  version: "1.0.0"
+steps:
+  - id: review
+    type: gate
+    message: "Approve the thing?"
+    options: ["approve", "reject"]
+"""
+
+    _WF_PLAIN = """
+schema_version: "1.0"
+workflow:
+  id: "plain-json"
+  name: "Plain JSON"
+  version: "1.0.0"
+steps:
+  - id: fine
+    type: shell
+    run: "true"
+"""
+
+    def _run_json(self, tmp_path, monkeypatch, content):
+        import json as _json
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        path = tmp_path / "wf.yml"
+        path.write_text(content, encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(app, ["workflow", "run", str(path), "--json"])
+        return _json.loads(result.stdout)
+
+    def test_gate_pause_carries_gate_block(self, tmp_path, monkeypatch):
+        # CliRunner stdin is not a TTY, so the gate pauses for resume.
+        payload = self._run_json(tmp_path, monkeypatch, self._WF_GATE)
+        assert payload["status"] == "paused"
+        assert payload["gate"] == {
+            "step_id": "review",
+            "message": "Approve the thing?",
+            "options": ["approve", "reject"],
+            "choice": None,
+        }
+
+    def test_completed_run_has_no_gate_block(self, tmp_path, monkeypatch):
+        payload = self._run_json(tmp_path, monkeypatch, self._WF_PLAIN)
+        assert payload["status"] == "completed"
+        assert "gate" not in payload


### PR DESCRIPTION
## Description

**Reference implementation for #2964 — for discussion, direction welcome.**

When a run pauses at a gate, the `--json` outcome now carries a `gate` block (`step_id` / `message` / `options` / `choice`) so orchestrators can detect "human review needed" and present the options without parsing the human-facing stream. Two small pieces:

1. The engine records each step's `type` in the run state's step results (one added line in `step_data` — previously the type was not recoverable from state).
2. `_workflow_run_payload` adds the `gate` block via a `_gate_outcome` helper when the run's current step is a gate. `choice` populates when the outcome ends at the gate with a decision recorded (e.g. an interactive rejection with `on_reject: abort` → a `failed` payload carrying `"choice": "reject"`; an `on_reject: retry` pause likewise). A mid-flow approval proceeds past the gate, so the block clears — by design. Non-gate runs and runs that end elsewhere are unchanged — no `gate` key, payload byte-identical to today.

The issue lists alternatives (a generic `paused_step` block; a dedicated status value) — happy to rework toward either.

## Testing

- [x] Ran existing tests with `uv sync && uv run pytest` — full suite 3727 passed
- [x] Two new CLI-level tests (`TestWorkflowRunGateOutcomeJson`): a gate pause carries the exact block (CliRunner stdin is non-TTY, so the gate pauses); a completed run has no `gate` key — the gate-pause test is red against current `main`, green with the change (verified both directions)
- [x] `uvx ruff check src/` — clean
- [x] Tested locally with `uv run specify --help`
- [ ] Tested with a sample project (covered by the CLI-level tests, which drive a real gate workflow through `workflow run --json`)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Code, tests, and this description were authored with AI assistance (Claude); verified by running the repo's test suite and ruff locally in both red and green directions.

