### PR TITLE
chore: update CITATION.cff to v0.10.2 (2026-06-11)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,8 +20,8 @@ authors:
 repository-code: "https://github.com/github/spec-kit"
 url: "https://github.github.io/spec-kit/"
 license: MIT
-version: "0.7.3"
-date-released: "2026-04-17"
+version: "0.10.2"
+date-released: "2026-06-11"
 keywords:
   - spec-driven development
   - ai coding agents


### PR DESCRIPTION
## Summary
`CITATION.cff` has carried `version: 0.7.3` / `date-released: 2026-04-17` since it was added, despite 10 subsequent releases. This syncs it to the latest stable release.

## Changes
- `version: 0.7.3 → 0.10.2`, `date-released: 2026-04-17 → 2026-06-11` — matching the latest release tag (verified against `gh release list`, `CHANGELOG.md`, and `pyproject.toml` `0.10.3.dev0`).

Single file, 2 lines, no behavior change. (Returning contributor — 2 prior merged PRs.)

*AI-assisted contribution.*
