### PR TITLE
fix(presets): preserve argument-hint in preset SKILL.md generation

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -357,6 +357,33 @@ class CommandRegistrar:
         return skill_frontmatter
 
     @staticmethod
+    def apply_argument_hint(
+        source_frontmatter: dict,
+        skill_frontmatter: dict,
+        integration: object,
+    ) -> None:
+        """Carry a command's ``argument-hint`` into its generated skill frontmatter.
+
+        Copies ``argument-hint`` from the parsed source command frontmatter into
+        *skill_frontmatter* (mutated in place) before serialization, so that a
+        folded multi-line ``description`` cannot be split into invalid YAML. Only
+        integrations that support the field — those exposing
+        ``inject_argument_hint`` (currently Claude) — receive the key, leaving
+        :meth:`build_skill_frontmatter`'s shared shape unchanged for every other
+        agent. Built-in templates carry no ``argument-hint``, so this is a no-op
+        for the core path.
+        """
+        if not isinstance(source_frontmatter, dict):
+            return
+        argument_hint = source_frontmatter.get("argument-hint")
+        if (
+            argument_hint
+            and integration is not None
+            and hasattr(integration, "inject_argument_hint")
+        ):
+            skill_frontmatter["argument-hint"] = str(argument_hint)
+
+    @staticmethod
     def resolve_skill_placeholders(
         agent_name: str, frontmatter: dict, body: str, project_root: Path
     ) -> str:

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -358,9 +358,9 @@ class CommandRegistrar:
 
     @staticmethod
     def apply_argument_hint(
-        source_frontmatter: dict,
-        skill_frontmatter: dict,
-        integration: object,
+        source_frontmatter: Dict[str, Any],
+        skill_frontmatter: Dict[str, Any],
+        integration: Optional[object] = None,
     ) -> None:
         """Carry a command's ``argument-hint`` into its generated skill frontmatter.
 
@@ -373,7 +373,7 @@ class CommandRegistrar:
         agent. Built-in templates carry no ``argument-hint``, so this is a no-op
         for the core path.
         """
-        if not isinstance(source_frontmatter, dict):
+        if not isinstance(source_frontmatter, dict) or not isinstance(skill_frontmatter, dict):
             return
         argument_hint = source_frontmatter.get("argument-hint")
         if (

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -1061,20 +1061,10 @@ class ExtensionManager:
             )
             # Preserve the command's argument-hint in the generated skill,
             # mirroring the core template path (ClaudeIntegration.setup injects
-            # it for built-in commands). The value is added to the frontmatter
-            # dict before serialization — rather than via the string-based
-            # inject_argument_hint helper — so that a folded multi-line
-            # description cannot be split by the inserted line. Gated on the
-            # integration exposing inject_argument_hint so only argument-hint
-            # aware agents receive the key, leaving build_skill_frontmatter's
-            # shared shape unchanged for every other agent.
-            argument_hint = frontmatter.get("argument-hint")
-            if (
-                argument_hint
-                and integration is not None
-                and hasattr(integration, "inject_argument_hint")
-            ):
-                frontmatter_data["argument-hint"] = str(argument_hint)
+            # it for built-in commands). See CommandRegistrar.apply_argument_hint
+            # for why the value is added to the dict before serialization rather
+            # than via the string-based inject_argument_hint helper.
+            registrar.apply_argument_hint(frontmatter, frontmatter_data, integration)
             frontmatter_text = dump_frontmatter(frontmatter_data)
 
             # Derive a human-friendly title from the command name

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -1064,11 +1064,14 @@ class PresetManager:
                         body = self._resolve_skill_command_refs(
                             body, registrar, selected_ai
                         )
+                    from ..integrations import get_integration
+                    integration = get_integration(selected_ai) if isinstance(selected_ai, str) else None
                     fm_data = registrar.build_skill_frontmatter(
                         selected_ai if isinstance(selected_ai, str) else "",
                         skill_name, desc,
                         f"override:{cmd_name}",
                     )
+                    registrar.apply_argument_hint(fm, fm_data, integration)
                     fm_text = dump_frontmatter(fm_data)
                     skill_title = self._skill_title_from_command(cmd_name)
                     skill_content = (
@@ -1076,8 +1079,6 @@ class PresetManager:
                         f"# Speckit {skill_title} Skill\n\n{body}\n"
                     )
                     # Apply integration post-processing (e.g. Claude flags)
-                    from ..integrations import get_integration
-                    integration = get_integration(selected_ai) if isinstance(selected_ai, str) else None
                     if integration is not None and hasattr(integration, "post_process_skill_content"):
                         skill_content = integration.post_process_skill_content(skill_content)
                     skill_file.write_text(skill_content, encoding="utf-8")
@@ -1346,6 +1347,7 @@ class PresetManager:
                     enhanced_desc,
                     f"preset:{manifest.id}",
                 )
+                registrar.apply_argument_hint(frontmatter, frontmatter_data, integration)
                 frontmatter_text = dump_frontmatter(frontmatter_data)
                 skill_content = (
                     f"---\n"
@@ -1442,6 +1444,7 @@ class PresetManager:
                     enhanced_desc,
                     f"templates/commands/{short_name}.md",
                 )
+                registrar.apply_argument_hint(frontmatter, frontmatter_data, integration)
                 frontmatter_text = dump_frontmatter(frontmatter_data)
                 skill_title = self._skill_title_from_command(short_name)
                 skill_content = (
@@ -1479,6 +1482,7 @@ class PresetManager:
                     frontmatter.get("description", f"Extension command: {command_name}"),
                     extension_restore["source"],
                 )
+                registrar.apply_argument_hint(frontmatter, frontmatter_data, integration)
                 frontmatter_text = dump_frontmatter(frontmatter_data)
                 skill_content = (
                     f"---\n"

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -2997,6 +2997,84 @@ class TestPresetSkills:
         metadata = manager.registry.get("self-test")
         assert "speckit-specify" in metadata.get("registered_skills", [])
 
+    def _install_arg_hint_preset(self, project_dir, temp_dir, ai, skills_dir, description, arg_hint):
+        """Install a preset whose command declares argument-hint; return the SKILL.md path."""
+        self._write_init_options(project_dir, ai=ai)
+        self._create_skill(skills_dir, "speckit-hinttest-cmd")
+        (project_dir / ".specify" / "extensions" / "hinttest").mkdir(parents=True, exist_ok=True)
+
+        preset_dir = temp_dir / f"hint-preset-{ai}"
+        preset_dir.mkdir()
+        (preset_dir / "commands").mkdir()
+        (preset_dir / "commands" / "speckit.hinttest.cmd.md").write_text(
+            "---\n"
+            f'description: "{description}"\n'
+            f'argument-hint: "{arg_hint}"\n'
+            "---\n\n"
+            "Preset command body.\n",
+            encoding="utf-8",
+        )
+        manifest_data = {
+            "schema_version": "1.0",
+            "preset": {
+                "id": f"hint-preset-{ai}",
+                "name": "Hint Preset",
+                "version": "1.0.0",
+                "description": "Test",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "templates": [
+                    {
+                        "type": "command",
+                        "name": "speckit.hinttest.cmd",
+                        "file": "commands/speckit.hinttest.cmd.md",
+                    }
+                ]
+            },
+        }
+        with open(preset_dir / "preset.yml", "w") as f:
+            yaml.dump(manifest_data, f)
+
+        manager = PresetManager(project_dir)
+        manager.install_from_directory(preset_dir, "0.1.5")
+        return skills_dir / "speckit-hinttest-cmd" / "SKILL.md"
+
+    def test_argument_hint_preserved_for_preset_command(self, project_dir, temp_dir):
+        """argument-hint from a preset command must survive into the SKILL.md.
+
+        Follow-up to #2903/#2916 for the preset skill generator. The
+        description is long enough to fold across lines when serialized,
+        guarding against an in-place string injection that would split the
+        folded scalar into invalid YAML.
+        """
+        long_description = (
+            "Build and maintain a lean, static context/ knowledge folder so "
+            "coding agents load only what is relevant and save tokens"
+        )
+        arg_hint = "<init | update | list | check> [area] [slug] [-- notes]"
+        skills_dir = project_dir / ".claude" / "skills"
+
+        skill_file = self._install_arg_hint_preset(
+            project_dir, temp_dir, "claude", skills_dir, long_description, arg_hint
+        )
+        assert skill_file.exists()
+        parsed = yaml.safe_load(skill_file.read_text(encoding="utf-8").split("---", 2)[1])
+        assert parsed["argument-hint"] == arg_hint
+        assert parsed["description"] == long_description
+
+    def test_argument_hint_not_added_for_non_claude_preset_command(self, project_dir, temp_dir):
+        """Non-Claude skills agents must not receive argument-hint in preset skills."""
+        arg_hint = "<init | update | list | check> [area]"
+        skills_dir = project_dir / ".agents" / "skills"
+
+        skill_file = self._install_arg_hint_preset(
+            project_dir, temp_dir, "codex", skills_dir, "Build context", arg_hint
+        )
+        assert skill_file.exists()
+        parsed = yaml.safe_load(skill_file.read_text(encoding="utf-8").split("---", 2)[1])
+        assert "argument-hint" not in parsed
+
     def test_register_skills_resolves_command_refs(self, project_dir, temp_dir):
         """Preset skill overrides must resolve __SPECKIT_COMMAND_*__ tokens (issue #2717).
 


### PR DESCRIPTION
## Description

Follow-up to #2903 / #2916. That fix preserved `argument-hint` for **extension** commands when generating Claude `SKILL.md`; the same field is still dropped by the **preset** skill generators.

When a preset-provided command (or a preset override of an extension command) declares `argument-hint:` in its frontmatter, the generated `.claude/skills/<name>/SKILL.md` loses it, because the preset generators build the skill frontmatter via the shared `CommandRegistrar.build_skill_frontmatter()` (which only emits `name` / `description` / `compatibility` / `metadata`) and never forward `argument-hint`. It is also re-dropped on **preset removal**, when an overridden skill is restored from its source command — which silently undoes the #2916 extension fix in a real workflow (override an extension skill via a preset, then remove the preset).

### Change

Rather than copy the #2916 inline block to each site, this factors the carry-over into one helper and reuses it:

- **`agents.py`** — new `CommandRegistrar.apply_argument_hint(source_frontmatter, skill_frontmatter, integration)`. It copies `argument-hint` from the parsed source command frontmatter into the skill frontmatter **dict, before `yaml.safe_dump`** (so a folded multi-line `description` can't be split into invalid YAML — the failure mode #2916 documented), and only when the integration exposes `inject_argument_hint`.
- **`presets.py`** — applied at all four `build_skill_frontmatter` sites: `_register_skills`, the reconcile override-restore path, and the core/extension `_unregister_skills` restore paths.
- **`extensions.py`** — the #2916 inline block now calls the shared helper (no behavior change).

### Why it's safe (no behavior change for non-Claude agents or the core path)

- `inject_argument_hint` is defined **only** on `ClaudeIntegration` (not inherited), so the `hasattr` gate adds the key for Claude only — `build_skill_frontmatter`'s shared shape is byte-identical for every other agent (codex, kimi, …).
- Core command templates carry **no** `argument-hint` (0 of 9 `templates/commands/*.md`), so the core-template restore site is a deliberate no-op.
- The helper no-ops on a missing hint or a non-dict frontmatter.
- The one structural tweak — at the override-restore site, the existing `get_integration(...)` lookup is hoisted a few lines above `build_skill_frontmatter` so the hint can be applied pre-serialization — is a pure reorder: `get_integration` is a side-effect-free registry lookup, the same value still feeds `post_process_skill_content`, and there is no import cycle (it was already a method-local import).

### Scope

Kept focused per CONTRIBUTING. The init-time `agents.py::render_skill_command` generator also omits `argument-hint`, but it takes an `agent_name` (no integration object) and so needs separate plumbing — deferred to a follow-up rather than widening this PR.

### Heads-up on overlapping PRs

Open PRs **#2917** ("preserve non-ASCII characters in skill frontmatter") and **#2103** touch the same `presets.py` skill-generation lines. The concerns are orthogonal — `apply_argument_hint` mutates the frontmatter dict *before* whatever dump function runs, so it composes cleanly with #2917's `dump_frontmatter()` swap. Happy to rebase whichever lands first.

## Testing

- [x] Tested locally with `uv run specify --help` (exit 0)
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (N/A — generation-only frontmatter change; covered by the unit tests below)

Details (Windows 11, Python 3.12.12):

- `uvx ruff check src/` — All checks passed
- `uv run pytest tests/test_presets.py tests/test_extension_skills.py tests/integrations/test_integration_claude.py -q` — **397 passed, 2 skipped** (the #2916 extension tests pass unchanged, confirming the refactor is behavior-preserving)
- Full suite `uv run pytest` — **3610 passed, 148 skipped, 14 failed**; the 14 failures are pre-existing and environment-only (`os.symlink` → `WinError 1314`; creating symlinks needs elevation/Developer Mode on Windows), identical to clean `main` on this host and unrelated to this change.

New tests in `tests/test_presets.py`:

- `test_argument_hint_preserved_for_preset_command` — installs a preset command with `argument-hint` and a **long, folding** description; asserts the generated `SKILL.md` frontmatter parses and retains both `argument-hint` and the full description. (Fails on `main` with `KeyError: 'argument-hint'`.)
- `test_argument_hint_not_added_for_non_claude_preset_command` — same under a non-Claude skills agent (codex); asserts `argument-hint` is **not** present, proving the Claude-only gate.

Manual sanity: this changes only the emitted `SKILL.md` frontmatter — no slash command's behavior changes; generated files parse as valid YAML and surface the hint in Claude Code.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Developed with Claude Code (Claude Opus 4.8) under my direction — identifying the parallel preset drop sites, factoring the shared helper, writing the regression tests, and running the verification above. I personally confirmed the no-op behavior for non-Claude agents and the core path, verified the override-restore reorder is behavior-preserving, and reviewed the full diff before submitting. I'll disclose if any review responses are AI-assisted as well.
