### PR TITLE
Update Superpowers Implementation Bridge extension to v1.0.3

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-06-11T00:00:00Z",
+  "updated_at": "2026-06-16T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "aide": {
@@ -3065,8 +3065,8 @@
       "id": "speckit-superpowers-bridge",
       "description": "Thin orchestrator between Spec Kit (design) and Superpowers (implementation). Cross-agent.",
       "author": "lihan3238",
-      "version": "1.0.2",
-      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v1.0.2/speckit-superpowers-bridge-v1.0.2.zip",
+      "version": "1.0.3",
+      "download_url": "https://github.com/lihan3238/speckit-superpowers-bridge/releases/download/v1.0.3/speckit-superpowers-bridge-v1.0.3.zip",
       "repository": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "homepage": "https://github.com/lihan3238/speckit-superpowers-bridge",
       "documentation": "https://github.com/lihan3238/speckit-superpowers-bridge#readme",
@@ -3109,7 +3109,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-15T00:00:00Z",
-      "updated_at": "2026-06-04T00:00:00Z"
+      "updated_at": "2026-06-16T00:00:00Z"
     },
     "speckit-utils": {
       "name": "SDD Utilities",


### PR DESCRIPTION
Updates the `speckit-superpowers-bridge` community catalog entry to v1.0.3, submitted by @lihan3238.

## Changes
- `extensions/catalog.community.json`: bumped `version` to `1.0.3`, updated `download_url` to the v1.0.3 release asset, and refreshed both the entry-level and top-level `updated_at` timestamps.
- No `docs/community/extensions.md` change needed — name, description, category, and effect are unchanged for this version bump.

## Note on `download_url`
The submitter proposed the floating `releases/latest/download/speckit-superpowers-bridge.zip` alias, but this PR intentionally pins to the immutable v1.0.3 asset (`.../releases/download/v1.0.3/speckit-superpowers-bridge-v1.0.3.zip`), consistent with the prior v1.0.2 entry and the publishing guide's version-pinned URL convention. Pinning guarantees the catalog references a fixed, reviewed artifact — a `latest` alias can change contents after review, which would undermine reproducibility and the `version`/`verified` fields.

## Validation
- Release `v1.0.3` exists on `lihan3238/speckit-superpowers-bridge` with the versioned ZIP asset (`speckit-superpowers-bridge-v1.0.3.zip`) and the stable `speckit-superpowers-bridge.zip` alias.
- `extensions/catalog.community.json` validated as valid JSON.
- `created_at`, `downloads`, and `stars` preserved from the existing entry.

Closes #2945

cc @lihan3238