### PR TITLE
docs: clarify project-defined constitution articles

### DIFF
--- a/spec-driven.md
+++ b/spec-driven.md
@@ -318,6 +318,12 @@ No implementation code shall be written before:
 
 This completely inverts traditional AI code generation. Instead of generating code and hoping it works, the LLM must first generate comprehensive tests that define behavior, get them approved, and only then generate implementation.
 
+#### Articles IV, V & VI: Project-Defined Governance
+
+Articles IV, V, and VI are intentionally defined by each project's constitution rather than prescribed by Spec Kit. The constitution template provides placeholder slots and example concerns such as integration testing, observability, versioning, and breaking changes, but teams replace those placeholders with the principles that match their system and organization.
+
+This keeps the nine-article structure stable while allowing each project to encode its own non-negotiable standards. For one project, Article IV might govern security and access boundaries; for another, it might define integration test requirements. The `/speckit.analyze` command evaluates the concrete constitution in the project, so these project-defined articles participate in compliance checks just like the built-in examples.
+
 #### Articles VII & VIII: Simplicity and Anti-Abstraction
 
 These paired articles combat over-engineering:


### PR DESCRIPTION
﻿## Summary

Clarifies that Articles IV, V, and VI in the SDD constitution are project-defined governance slots rather than fixed Spec Kit rules.

## Why

Issue #2466 notes that `spec-driven.md` describes Articles I, II, III, VII, VIII, and IX, but does not explain how Articles IV, V, and VI should be understood. The added section documents that these articles are intentionally customized by each project's constitution while preserving the nine-article structure.

## Validation

- Ran `git diff --check`
- Confirmed `/speckit.analyze` is an existing command in the repository docs/templates

## AI assistance disclosure

This PR was prepared with assistance from OpenAI Codex. The change was reviewed locally and kept to a focused documentation update.
