### PR TITLE
Update Linear Integration extension to v0.5.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1465,8 +1465,8 @@
       "id": "linear",
       "description": "Mirror spec-kit feature directories into Linear (filesystem → Linear, reconcile-based, unidirectional).",
       "author": "Ash Brener",
-      "version": "0.4.0",
-      "download_url": "https://github.com/ashbrener/spec-kit-linear-sync/archive/refs/tags/v0.4.0.zip",
+      "version": "0.5.0",
+      "download_url": "https://github.com/ashbrener/spec-kit-linear-sync/archive/refs/tags/v0.5.0.zip",
       "repository": "https://github.com/ashbrener/spec-kit-linear-sync",
       "homepage": "https://github.com/ashbrener/spec-kit-linear-sync",
       "documentation": "https://github.com/ashbrener/spec-kit-linear-sync/blob/main/README.md",
@@ -1493,7 +1493,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-06-01T00:00:00Z",
-      "updated_at": "2026-06-11T00:00:00Z"
+      "updated_at": "2026-06-16T00:00:00Z"
     },
     "m365": {
       "name": "Microsoft 365 Integration",


### PR DESCRIPTION
Updates the community-catalog `linear` entry from **0.4.0 → 0.5.0** per #2953 (follows the merged v0.4.0 bump #2931). Only `version`, `download_url`, and `updated_at` change; `id` stays `linear`.

## Changes
- `extensions/catalog.community.json`: bumped `version` to `0.5.0`, `download_url` to the v0.5.0 release archive, and refreshed `updated_at`. Preserved `created_at`, `downloads`, and `stars`.
- No `docs/community/extensions.md` change — description, category, and effect are unchanged.

## Validation
- ✅ JSON validates (`json.load`)
- ✅ Download URL returns 200: `https://github.com/ashbrener/spec-kit-linear-sync/archive/refs/tags/v0.5.0.zip`
- ✅ Extension ID `linear` unchanged; semver `0.5.0`

## What's new in 0.5.0
- Author-based attribution (opt-in, default OFF)
- ADR / decision-record mirroring as Linear Issue comments
- Consumer identity-leak hardening (install-time guard)

All additive and opt-in; command surface unchanged.

Closes #2953

cc @ashbrener