### PR TITLE
docs: clarify Taskify specify command

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -127,7 +127,7 @@ Initialize the project's constitution to set ground rules:
 ### Step 2: Define Requirements with `/speckit.specify`
 
 ```text
-Develop Taskify, a team productivity platform. It should allow users to create projects, add team members,
+/speckit.specify Develop Taskify, a team productivity platform. It should allow users to create projects, add team members,
 assign tasks, comment and move tasks between boards in Kanban style. In this initial phase for this feature,
 let's call it "Create Taskify," let's have multiple users but the users will be declared ahead of time, predefined.
 I want five users in two different categories, one product manager and four engineers. Let's create three


### PR DESCRIPTION
## Summary

- Clarify the Taskify quickstart example by including the `/speckit.specify` command directly in the requirements prompt.
- Keeps the detailed example consistent with the rest of the quickstart, where each chat action shows the full slash command users should enter.

Fixes #472.

## Test plan

- `npx --yes markdownlint-cli2 docs/quickstart.md`
- `git diff --check`

## AI disclosure

This PR was prepared with assistance from Codex on behalf of @Jiandong7. The change was verified locally with the checks above.
