### PR TITLE
chore: ignore Copilot dogfooding scaffolding in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,14 @@ docs/dev
 .specify/extensions/.cache/
 .specify/extensions/.backup/
 .specify/extensions/*/local-config.yml
+
+# 
+# The following directories/file are intentionally ignored so that they are not accidentally 
+# committed to the repository. They contain the scaffolding `specify init --integration copilot`
+# does and they are meant for dogfooding Spec Kit during its own feature development.
+#
+.github/agents/
+.github/prompts/
+.github/copilot-instructions.md
+.specify/
+specs/

--- a/.gitignore
+++ b/.gitignore
@@ -51,11 +51,9 @@ docs/dev
 .specify/extensions/.backup/
 .specify/extensions/*/local-config.yml
 
-# 
-# The following directories/file are intentionally ignored so that they are not accidentally 
+# The following directories/file are intentionally ignored so that they are not accidentally
 # committed to the repository. They contain the scaffolding `specify init --integration copilot`
 # does and they are meant for dogfooding Spec Kit during its own feature development.
-#
 .github/agents/
 .github/prompts/
 .github/copilot-instructions.md


### PR DESCRIPTION
## Summary

Adds `.gitignore` entries for the scaffolding generated by `specify init --integration copilot`, so the dogfooding artifacts used during Spec Kit feature development aren't accidentally committed.

Ignored paths:
- `.github/agents/`
- `.github/prompts/`
- `.github/copilot-instructions.md`
- `.specify/`
- `specs/`

## Notes

Posted on behalf of @mnriem by GitHub Copilot.