### PR TITLE
fix: count worktree branches in git extension numbering

### DIFF
--- a/extensions/git/scripts/bash/create-new-feature-branch.sh
+++ b/extensions/git/scripts/bash/create-new-feature-branch.sh
@@ -127,7 +127,7 @@ get_highest_from_specs() {
 
 # Function to get highest number from git branches
 get_highest_from_branches() {
-    git branch -a 2>/dev/null | sed 's/^[* ]*//; s|^remotes/[^/]*/||' | _extract_highest_number
+    git branch -a 2>/dev/null | sed 's/^[+* ]*//; s|^remotes/[^/]*/||' | _extract_highest_number
 }
 
 # Extract the highest sequential feature number from a list of ref names (one per line).

--- a/extensions/git/scripts/bash/create-new-feature-branch.sh
+++ b/extensions/git/scripts/bash/create-new-feature-branch.sh
@@ -127,7 +127,7 @@ get_highest_from_specs() {
 
 # Function to get highest number from git branches
 get_highest_from_branches() {
-    git branch -a 2>/dev/null | sed 's/^[+* ]*//; s|^remotes/[^/]*/||' | _extract_highest_number
+    git branch -a 2>/dev/null | sed -E 's/^[+*][[:space:]]+//; s/^[[:space:]]+//; s|^remotes/[^/]*/||' | _extract_highest_number
 }
 
 # Extract the highest sequential feature number from a list of ref names (one per line).

--- a/extensions/git/scripts/powershell/create-new-feature-branch.ps1
+++ b/extensions/git/scripts/powershell/create-new-feature-branch.ps1
@@ -88,7 +88,7 @@ function Get-HighestNumberFromBranches {
         $branches = git branch -a 2>$null
         if ($LASTEXITCODE -eq 0 -and $branches) {
             $cleanNames = $branches | ForEach-Object {
-                $_.Trim() -replace '^\*?\s+', '' -replace '^remotes/[^/]+/', ''
+                $_.Trim() -replace '^[+*]?\s+', '' -replace '^remotes/[^/]+/', ''
             }
             return Get-HighestNumberFromNames -Names $cleanNames
         }

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -338,6 +338,25 @@ class TestCreateFeatureBash:
         assert data["BRANCH_NAME"] == "008-next"
         assert data["FEATURE_NUM"] == "008"
 
+    def test_dry_run_preserves_literal_plus_branch_prefix(self, tmp_path: Path):
+        """A literal leading plus in a branch name is not a git worktree marker."""
+        project = _setup_project(tmp_path)
+        subprocess.run(
+            ["git", "branch", "+007-plus-prefix"],
+            cwd=project,
+            check=True,
+        )
+
+        result = _run_bash(
+            "create-new-feature-branch.sh", project,
+            "--json", "--dry-run", "--short-name", "next", "Next feature",
+        )
+
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["BRANCH_NAME"] == "001-next"
+        assert data["FEATURE_NUM"] == "001"
+
     def test_no_git_graceful_degradation(self, tmp_path: Path):
         """create-new-feature-branch.sh works without git (outputs branch name, skips branch creation)."""
         project = _setup_project(tmp_path, git=False)

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -89,6 +89,17 @@ def _write_config(project: Path, content: str) -> Path:
     return config_path
 
 
+def _add_sibling_worktree(project: Path, path: Path, branch: str) -> None:
+    """Add a sibling worktree so `git branch -a` marks it with `+`."""
+    subprocess.run(
+        ["git", "worktree", "add", "-q", "-b", branch, str(path), "HEAD"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 # Git identity env vars for CI runners without global git config
 _GIT_ENV = {
     "GIT_AUTHOR_NAME": "Test User",
@@ -312,6 +323,21 @@ class TestCreateFeatureBash:
         data = json.loads(result.stdout)
         assert data["FEATURE_NUM"] == "003"
 
+    def test_dry_run_counts_branches_checked_out_in_worktrees(self, tmp_path: Path):
+        """Branches checked out in sibling worktrees still reserve their prefix."""
+        project = _setup_project(tmp_path / "project")
+        _add_sibling_worktree(project, tmp_path / "sibling-worktree", "007-worktree-feature")
+
+        result = _run_bash(
+            "create-new-feature-branch.sh", project,
+            "--json", "--dry-run", "--short-name", "next", "Next feature",
+        )
+
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["BRANCH_NAME"] == "008-next"
+        assert data["FEATURE_NUM"] == "008"
+
     def test_no_git_graceful_degradation(self, tmp_path: Path):
         """create-new-feature-branch.sh works without git (outputs branch name, skips branch creation)."""
         project = _setup_project(tmp_path, git=False)
@@ -350,6 +376,21 @@ class TestCreateFeaturePowerShell:
         assert result.returncode == 0, result.stderr
         data = json.loads(result.stdout)
         assert data["BRANCH_NAME"] == "001-user-auth"
+
+    def test_dry_run_counts_branches_checked_out_in_worktrees(self, tmp_path: Path):
+        """Branches checked out in sibling worktrees still reserve their prefix."""
+        project = _setup_project(tmp_path / "project")
+        _add_sibling_worktree(project, tmp_path / "sibling-worktree", "007-worktree-feature")
+
+        result = _run_pwsh(
+            "create-new-feature-branch.ps1", project,
+            "-Json", "-DryRun", "-ShortName", "next", "Next feature",
+        )
+
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["BRANCH_NAME"] == "008-next"
+        assert data["FEATURE_NUM"] == "008"
 
     def test_creates_branch_timestamp(self, tmp_path: Path):
         """Extension create-new-feature-branch.ps1 creates timestamp branch."""


### PR DESCRIPTION
## Summary
- Strip Git's `+` worktree marker when the bundled Git extension scans `git branch -a` for sequential feature prefixes.
- Apply marker normalization in Bash and PowerShell branch-creation scripts without stripping literal leading `+` characters from valid branch names.
- Add regression coverage for sibling worktree branches and Bash literal-plus branch prefixes.

## Root Cause
`git branch -a` prefixes branches checked out in another worktree with `+`. The Git extension only removed `*` and spaces before extracting numeric prefixes, so sibling worktree branches were ignored and the next generated feature branch could reuse an existing prefix.

A review also pointed out that the initial Bash normalization stripped any leading `+`, including literal `+` characters that Git allows inside branch names. The Bash path now strips only the `git branch` marker column when it is followed by whitespace.

## Validation
- `uv run --extra test pytest tests/extensions/git/test_git_extension.py::TestCreateFeaturePowerShell::test_dry_run_counts_branches_checked_out_in_worktrees -q` (red before fix: produced `001-next`; green after fix)
- `uv run --extra test pytest tests/extensions/git/test_git_extension.py -q` (23 passed, 27 skipped on Windows)
- `uv run --extra test pytest tests/test_timestamp_branches.py -q` (18 passed, 52 skipped on Windows)
- WSL Bash smoke for `create-new-feature-branch.sh --json --dry-run` with sibling worktree `007-worktree-feature` produced `{"BRANCH_NAME":"008-next","FEATURE_NUM":"008","DRY_RUN":true}`
- Review fix: `uv run --extra test pytest tests/extensions/git/test_git_extension.py::TestCreateFeatureBash::test_dry_run_counts_branches_checked_out_in_worktrees tests/extensions/git/test_git_extension.py::TestCreateFeatureBash::test_dry_run_preserves_literal_plus_branch_prefix tests/extensions/git/test_git_extension.py::TestCreateFeaturePowerShell::test_dry_run_counts_branches_checked_out_in_worktrees -q` (1 passed, 2 skipped on Windows)
- `uvx ruff check src/ tests/extensions/git/test_git_extension.py`
- `uvx ruff check tests/extensions/git/test_git_extension.py`
- `git diff --check`

Full `uv run --extra test pytest -q` was attempted locally but timed out after 15 minutes before producing a pass/fail summary, so it is not claimed as passing here.

## AI Assistance
Prepared with AI assistance and manually reviewed before submission.

Closes #1066
