### PR TITLE
Update workflow preset catalog entry

### DIFF
--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-06-16T00:00:00Z",
+  "updated_at": "2026-06-17T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/presets/catalog.community.json",
   "presets": {
     "a11y-governance": {
@@ -651,11 +651,11 @@
     "workflow-preset": {
       "name": "Workflow Preset",
       "id": "workflow-preset",
-      "version": "1.3.2",
+      "version": "1.3.6",
       "description": "Behavior-first specification, design artifacts, and agent-native handoff orchestration.",
       "author": "bigsmartben",
       "repository": "https://github.com/bigsmartben/spec-kit-workflow-preset",
-      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/releases/download/v1.3.2/spec-kit-workflow-preset-v1.3.2.zip",
+      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/releases/download/v1.3.6/spec-kit-workflow-preset-v1.3.6.zip",
       "homepage": "https://github.com/bigsmartben/spec-kit-workflow-preset",
       "documentation": "https://github.com/bigsmartben/spec-kit-workflow-preset/blob/main/README.md",
       "license": "MIT",
@@ -674,7 +674,7 @@
         "handoff"
       ],
       "created_at": "2026-05-27T00:00:00Z",
-      "updated_at": "2026-06-03T00:00:00Z"
+      "updated_at": "2026-06-17T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
﻿## Summary
- Update the community catalog entry for `workflow-preset` from v1.3.2 to v1.3.6.
- Point the download URL at the published v1.3.6 release asset.
- Refresh catalog timestamps for the entry and catalog file.

## Validation
- `python -m json.tool presets/catalog.community.json > $null`
- `PYTHONUTF8=1 uv run --extra test pytest tests/test_presets.py` (311 passed)
