### PR TITLE
fix: derive paths-only branch from feature directory

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -151,6 +151,10 @@ get_feature_paths() {
 
     # Use printf '%q' to safely quote values, preventing shell injection
     # via crafted branch names or paths containing special characters
+    if [[ -z "$current_branch" ]]; then
+        current_branch="${feature_dir%"${feature_dir##*[!\\/]}"}"
+        current_branch="${current_branch##*[\\/]}"
+    fi
     printf 'REPO_ROOT=%q\n' "$repo_root"
     printf 'CURRENT_BRANCH=%q\n' "$current_branch"
     printf 'FEATURE_DIR=%q\n' "$feature_dir"

--- a/scripts/powershell/check-prerequisites.ps1
+++ b/scripts/powershell/check-prerequisites.ps1
@@ -59,6 +59,17 @@ EXAMPLES:
 # Get feature paths
 $paths = Get-FeaturePathsEnv
 
+# In paths-only mode, feature.json may contain a path written on another OS.
+# Derive the fallback branch from either slash style rather than relying on
+# platform-specific Path/Split-Path separator semantics.
+if ($PathsOnly -and -not $env:SPECIFY_FEATURE) {
+    $portableFeatureDir = ([string]$paths.FEATURE_DIR).TrimEnd('/', '\')
+    $portableLeaf = ($portableFeatureDir -split '[\\/]+')[-1]
+    if ($portableLeaf) {
+        $paths.CURRENT_BRANCH = $portableLeaf
+    }
+}
+
 # If paths-only mode, output paths and exit (no validation)
 if ($PathsOnly) {
     if ($Json) {

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -139,6 +139,14 @@ function Get-FeaturePathsEnv {
         [Console]::Error.WriteLine("ERROR: Feature directory not found. Set SPECIFY_FEATURE_DIRECTORY or run the specify command to create .specify/feature.json.")
         exit 1
     }
+
+    if (-not $currentBranch) {
+        $normalizedFeatureDir = $featureDir.TrimEnd(
+            [System.IO.Path]::DirectorySeparatorChar,
+            [System.IO.Path]::AltDirectorySeparatorChar
+        )
+        $currentBranch = Split-Path -Path $normalizedFeatureDir -Leaf
+    }
     
     [PSCustomObject]@{
         REPO_ROOT     = $repoRoot

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -17,7 +17,11 @@ COMMON_PS = PROJECT_ROOT / "scripts" / "powershell" / "common.ps1"
 CHECK_PREREQS_PS = PROJECT_ROOT / "scripts" / "powershell" / "check-prerequisites.ps1"
 
 HAS_PWSH = shutil.which("pwsh") is not None
-_WINDOWS_POWERSHELL = (shutil.which("powershell.exe") or shutil.which("powershell")) if os.name == "nt" else None
+_WINDOWS_POWERSHELL = (
+    (shutil.which("powershell.exe") or shutil.which("powershell"))
+    if os.name == "nt"
+    else None
+)
 
 
 def _install_bash_scripts(repo: Path) -> None:
@@ -142,6 +146,46 @@ def test_paths_only_text_mode_on_non_spec_branch(prereq_repo: Path) -> None:
 
 
 @requires_bash
+def test_paths_only_falls_back_to_feature_dir_basename(prereq_repo: Path) -> None:
+    """--paths-only should emit a non-empty branch name from feature.json."""
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True, exist_ok=True)
+    _write_feature_json(prereq_repo)
+    script = prereq_repo / ".specify" / "scripts" / "bash" / "check-prerequisites.sh"
+    result = subprocess.run(
+        ["bash", str(script), "--json", "--paths-only"],
+        cwd=prereq_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["BRANCH"] == "001-my-feature"
+
+
+@requires_bash
+def test_paths_only_fallback_handles_windows_style_feature_dir(
+    prereq_repo: Path,
+) -> None:
+    """--paths-only should derive BRANCH from backslash-separated feature dirs."""
+    _write_feature_json(prereq_repo, "specs\\001-my-feature")
+    script = prereq_repo / ".specify" / "scripts" / "bash" / "check-prerequisites.sh"
+    result = subprocess.run(
+        ["bash", str(script), "--json", "--paths-only"],
+        cwd=prereq_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["BRANCH"] == "001-my-feature"
+
+
+@requires_bash
 def test_normal_mode_still_validates_branch(prereq_repo: Path) -> None:
     """Without --paths-only, feature directory validation must still fail on main."""
     script = prereq_repo / ".specify" / "scripts" / "bash" / "check-prerequisites.sh"
@@ -160,13 +204,17 @@ def test_normal_mode_still_validates_branch(prereq_repo: Path) -> None:
 # ── PowerShell tests ──────────────────────────────────────────────────────
 
 
-@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+@pytest.mark.skipif(
+    not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available"
+)
 def test_ps_paths_only_succeeds_on_non_spec_branch(prereq_repo: Path) -> None:
     """-PathsOnly must return paths when feature.json pins the feature dir."""
     feat = prereq_repo / "specs" / "001-my-feature"
     feat.mkdir(parents=True, exist_ok=True)
     _write_feature_json(prereq_repo)
-    script = prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
+    script = (
+        prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
+    )
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
     result = subprocess.run(
         [exe, "-NoProfile", "-File", str(script), "-Json", "-PathsOnly"],
@@ -183,7 +231,9 @@ def test_ps_paths_only_succeeds_on_non_spec_branch(prereq_repo: Path) -> None:
     assert "FEATURE_DIR" in data
 
 
-@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+@pytest.mark.skipif(
+    not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available"
+)
 def test_ps_paths_only_succeeds_on_spec_branch(prereq_repo: Path) -> None:
     """-PathsOnly must also work when feature.json and SPECIFY_FEATURE agree."""
     subprocess.run(
@@ -194,7 +244,9 @@ def test_ps_paths_only_succeeds_on_spec_branch(prereq_repo: Path) -> None:
     feat = prereq_repo / "specs" / "001-my-feature"
     feat.mkdir(parents=True, exist_ok=True)
     _write_feature_json(prereq_repo)
-    script = prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
+    script = (
+        prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
+    )
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
     env = _clean_env()
     env["SPECIFY_FEATURE"] = "001-my-feature"
@@ -211,10 +263,39 @@ def test_ps_paths_only_succeeds_on_spec_branch(prereq_repo: Path) -> None:
     assert "FEATURE_DIR" in data
 
 
-@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+@pytest.mark.skipif(
+    not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available"
+)
+def test_ps_paths_only_falls_back_to_feature_dir_basename(prereq_repo: Path) -> None:
+    """-PathsOnly should emit a non-empty branch name from feature.json."""
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True, exist_ok=True)
+    _write_feature_json(prereq_repo)
+    script = (
+        prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
+    )
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(script), "-Json", "-PathsOnly"],
+        cwd=prereq_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["BRANCH"] == "001-my-feature"
+
+
+@pytest.mark.skipif(
+    not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available"
+)
 def test_ps_normal_mode_still_validates_branch(prereq_repo: Path) -> None:
     """Without -PathsOnly, feature directory validation must still fail on main."""
-    script = prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
+    script = (
+        prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
+    )
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
     result = subprocess.run(
         [exe, "-NoProfile", "-File", str(script), "-Json"],

--- a/tests/test_check_prerequisites_paths_only_cross_platform.py
+++ b/tests/test_check_prerequisites_paths_only_cross_platform.py
@@ -1,0 +1,66 @@
+"""Cross-platform regression tests for paths-only feature-directory parsing."""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+COMMON_PS = PROJECT_ROOT / "scripts" / "powershell" / "common.ps1"
+CHECK_PREREQS_PS = PROJECT_ROOT / "scripts" / "powershell" / "check-prerequisites.ps1"
+
+HAS_PWSH = shutil.which("pwsh") is not None
+_WINDOWS_POWERSHELL = (
+    (shutil.which("powershell.exe") or shutil.which("powershell"))
+    if os.name == "nt"
+    else None
+)
+
+
+@pytest.mark.skipif(
+    not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available"
+)
+def test_ps_paths_only_handles_windows_style_feature_dir_on_any_host(
+    tmp_path: Path,
+) -> None:
+    """A persisted backslash path must produce the same BRANCH on every host OS."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init", "-q"], cwd=repo, check=True
+    )
+
+    scripts = repo / ".specify" / "scripts" / "powershell"
+    scripts.mkdir(parents=True)
+    shutil.copy(COMMON_PS, scripts / "common.ps1")
+    shutil.copy(CHECK_PREREQS_PS, scripts / "check-prerequisites.ps1")
+    (repo / ".specify" / "feature.json").write_text(
+        json.dumps({"feature_directory": "specs\\001-my-feature"}),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    for key in list(env):
+        if key.startswith("SPECIFY_"):
+            env.pop(key)
+
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(scripts / "check-prerequisites.ps1"), "-Json", "-PathsOnly"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["BRANCH"] == "001-my-feature"


### PR DESCRIPTION
## Description

Closes #3026 by deriving the paths-only `BRANCH` value from the resolved feature directory leaf when no explicit `SPECIFY_FEATURE` is available.

This keeps `check-prerequisites --paths-only` / `-PathsOnly` useful for feature-context invocations that rely on `.specify/feature.json` instead of an active feature branch environment variable. The Bash fallback treats both `/` and `\` as feature-directory separators so persisted Windows-style paths still produce the correct leaf name.

Split out from #3053 after maintainer feedback to keep each bug fix in its own PR.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

Additional validation after addressing review feedback:

- `uv run --extra test python -m pytest tests/test_check_prerequisites_paths_only.py -q` - 4 passed, 6 skipped
- `uvx ruff check tests/test_check_prerequisites_paths_only.py` - passed
- `uvx ruff format --check tests/test_check_prerequisites_paths_only.py` - passed
- `git diff --check` - passed

## Manual test results

**Agent**: Codex (GPT-5) | **OS/Shell**: Windows 11 / PowerShell 7.5.4

| Command tested | Notes |
|----------------|-------|
| `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` | Covered by regression tests for `/` and `\` feature directory separators. |
| `.specify/scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly` | Covered by regression test for non-empty `BRANCH` fallback from feature directory basename. |

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

This PR was implemented by Codex (GPT-5) acting as an AI coding agent on behalf of @luohui1. The agent read the repository contribution/security/code-of-conduct docs and issue templates, inspected the relevant code paths, implemented the changes, ran the validation listed above, and prepared this PR description.