### PR TITLE
fix: derive plan path from feature.json in update-agent-context

### DIFF
--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -208,7 +208,8 @@ if [[ -z "$PLAN_PATH" ]]; then
     _feature_dir="$("$_python" - "$_feature_json" <<'PY'
 import sys, json
 try:
-    d = json.load(open(sys.argv[1], encoding="utf-8"))
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        d = json.load(fh)
     print(d.get("feature_directory", ""))
 except Exception:
     print("")

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -239,7 +239,9 @@ cand = Path(sys.argv[2]).resolve()
 try:
     print(str(PurePosixPath(cand.relative_to(root))))
 except ValueError:
-    print(str(PurePosixPath(cand)))
+    # Outside project root: use the bash-side path (already forward-slash
+    # normalised via tr), not cand which may be a WindowsPath with backslashes.
+    print(sys.argv[2])
 PY
 )"
       fi

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -233,7 +233,7 @@ PY
         # (macOS) are treated as equivalent. Mirrors the mtime-fallback approach.
         PLAN_PATH="$("$_python" - "$PROJECT_ROOT" "$_candidate" <<'PY'
 import sys
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 root = Path(sys.argv[1]).resolve()
 cand = Path(sys.argv[2]).resolve()
 try:
@@ -254,7 +254,7 @@ PY
   if [[ -z "$PLAN_PATH" ]]; then
     _plan_rel="$("$_python" - "$PROJECT_ROOT" <<'PY'
 import sys
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 root = Path(sys.argv[1]).resolve()
 specs = root / "specs"
 plans = sorted(

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -216,6 +216,8 @@ except Exception:
     print("")
 PY
 )"
+    # Normalize backslashes (written by PS on Windows) to forward slashes before path ops.
+    _feature_dir="$(printf '%s' "$_feature_dir" | tr '\\' '/')"
     _feature_dir="${_feature_dir%/}"
     if [[ -n "$_feature_dir" ]]; then
       # feature_directory may be relative or absolute (absolute paths outside PROJECT_ROOT

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -215,6 +215,7 @@ except Exception:
 PY
 )"
     if [[ -n "$_feature_dir" ]]; then
+      _feature_dir="${_feature_dir%/}"
       # feature_directory may be relative or absolute (absolute paths outside PROJECT_ROOT
       # are preserved as-is by _persist_feature_json in common.sh).
       if [[ "$_feature_dir" == /* ]]; then

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -222,7 +222,8 @@ PY
     if [[ -n "$_feature_dir" ]]; then
       # feature_directory may be relative or absolute (absolute paths outside PROJECT_ROOT
       # are preserved as-is by _persist_feature_json in common.sh).
-      if [[ "$_feature_dir" == /* ]]; then
+      # Also match drive-qualified paths (C:/...) written by PowerShell on Windows.
+      if [[ "$_feature_dir" == /* ]] || [[ "$_feature_dir" =~ ^[A-Za-z]:/ ]]; then
         _candidate="$_feature_dir/plan.md"
       else
         _candidate="$PROJECT_ROOT/$_feature_dir/plan.md"

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -237,7 +237,7 @@ from pathlib import Path, PurePosixPath
 root = Path(sys.argv[1]).resolve()
 cand = Path(sys.argv[2]).resolve()
 try:
-    print(str(PurePosixPath(cand.relative_to(root))))
+    print(cand.relative_to(root).as_posix())
 except ValueError:
     # Outside project root: use the bash-side path (already forward-slash
     # normalised via tr), not cand which may be a WindowsPath with backslashes.
@@ -264,7 +264,7 @@ plans = sorted(
 )
 if plans:
     try:
-        print(str(PurePosixPath(plans[0].relative_to(root))))
+        print(plans[0].relative_to(root).as_posix())
     except ValueError:
         print("")
 else:

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -210,13 +210,14 @@ import sys, json
 try:
     with open(sys.argv[1], encoding="utf-8") as fh:
         d = json.load(fh)
-    print(d.get("feature_directory", ""))
+    val = d.get("feature_directory", "")
+    print(val if isinstance(val, str) else "")
 except Exception:
     print("")
 PY
 )"
+    _feature_dir="${_feature_dir%/}"
     if [[ -n "$_feature_dir" ]]; then
-      _feature_dir="${_feature_dir%/}"
       # feature_directory may be relative or absolute (absolute paths outside PROJECT_ROOT
       # are preserved as-is by _persist_feature_json in common.sh).
       if [[ "$_feature_dir" == /* ]]; then

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -239,9 +239,9 @@ cand = Path(sys.argv[2]).resolve()
 try:
     print(cand.relative_to(root).as_posix())
 except ValueError:
-    # Outside project root: use the bash-side path (already forward-slash
-    # normalised via tr), not cand which may be a WindowsPath with backslashes.
-    print(sys.argv[2])
+    # Outside project root: emit the resolved path in POSIX form.
+    # as_posix() converts backslashes correctly on native Windows Python.
+    print(cand.as_posix())
 PY
 )"
       fi

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -208,7 +208,7 @@ if [[ -z "$PLAN_PATH" ]]; then
     _feature_dir="$("$_python" - "$_feature_json" <<'PY'
 import sys, json
 try:
-    d = json.load(open(sys.argv[1]))
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
     print(d.get("feature_directory", ""))
 except Exception:
     print("")

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -10,9 +10,9 @@
 #
 # Usage: update-agent-context.sh [plan_path]
 #
-# When `plan_path` is omitted, the script picks the most recently modified
-# `specs/*/plan.md` if any exist, otherwise emits the section without a
-# concrete plan path.
+# When `plan_path` is omitted, the script derives it from `.specify/feature.json`
+# (written by /speckit-specify). Falls back to the most recently modified
+# `specs/*/plan.md` only when feature.json is absent or its plan does not exist yet.
 
 set -euo pipefail
 
@@ -202,11 +202,41 @@ unset _cf_parts _seg
 
 PLAN_PATH="${1:-}"
 if [[ -z "$PLAN_PATH" ]]; then
-  # Pick the most recently modified plan.md one level deep (specs/<feature>/plan.md).
-  # Use find + sort by modification time to avoid ls/head fragility with
-  # spaces in paths or SIGPIPE from pipefail.
-  _plan_abs="$("$_python" - "$PROJECT_ROOT" <<'PY'
-import sys, os
+  # Prefer .specify/feature.json (written by /speckit-specify) over mtime heuristic.
+  _feature_json="$PROJECT_ROOT/.specify/feature.json"
+  if [[ -f "$_feature_json" ]]; then
+    _feature_dir="$("$_python" - "$_feature_json" <<'PY'
+import sys, json
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get("feature_directory", ""))
+except Exception:
+    print("")
+PY
+)"
+    if [[ -n "$_feature_dir" ]]; then
+      # feature_directory may be relative or absolute (absolute paths outside PROJECT_ROOT
+      # are preserved as-is by _persist_feature_json in common.sh).
+      if [[ "$_feature_dir" == /* ]]; then
+        _candidate="$_feature_dir/plan.md"
+      else
+        _candidate="$PROJECT_ROOT/$_feature_dir/plan.md"
+      fi
+      if [[ -f "$_candidate" ]]; then
+        # Emit a PROJECT_ROOT-relative path when possible, otherwise use the absolute path.
+        if [[ "$_candidate" == "$PROJECT_ROOT/"* ]]; then
+          PLAN_PATH="${_candidate#"$PROJECT_ROOT/"}"
+        else
+          PLAN_PATH="$_candidate"
+        fi
+      fi
+    fi
+  fi
+
+  # Fall back to mtime only when feature.json is absent or its plan does not exist yet.
+  if [[ -z "$PLAN_PATH" ]]; then
+    _plan_abs="$("$_python" - "$PROJECT_ROOT" <<'PY'
+import sys
 from pathlib import Path
 specs = Path(sys.argv[1]) / "specs"
 plans = sorted(
@@ -217,8 +247,9 @@ plans = sorted(
 print(plans[0] if plans else "")
 PY
 )"
-  if [[ -n "$_plan_abs" ]]; then
-    PLAN_PATH="${_plan_abs#"$PROJECT_ROOT/"}"
+    if [[ -n "$_plan_abs" ]]; then
+      PLAN_PATH="${_plan_abs#"$PROJECT_ROOT/"}"
+    fi
   fi
 fi
 

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -237,21 +237,30 @@ PY
   fi
 
   # Fall back to mtime only when feature.json is absent or its plan does not exist yet.
+  # Python emits a project-relative POSIX path directly to avoid bash prefix-strip
+  # issues with backslash paths on Windows (Git bash / MSYS2).
   if [[ -z "$PLAN_PATH" ]]; then
-    _plan_abs="$("$_python" - "$PROJECT_ROOT" <<'PY'
+    _plan_rel="$("$_python" - "$PROJECT_ROOT" <<'PY'
 import sys
-from pathlib import Path
-specs = Path(sys.argv[1]) / "specs"
+from pathlib import Path, PurePosixPath
+root = Path(sys.argv[1]).resolve()
+specs = root / "specs"
 plans = sorted(
     specs.glob("*/plan.md"),
     key=lambda p: p.stat().st_mtime,
     reverse=True,
 )
-print(plans[0] if plans else "")
+if plans:
+    try:
+        print(str(PurePosixPath(plans[0].relative_to(root))))
+    except ValueError:
+        print("")
+else:
+    print("")
 PY
 )"
-    if [[ -n "$_plan_abs" ]]; then
-      PLAN_PATH="${_plan_abs#"$PROJECT_ROOT/"}"
+    if [[ -n "$_plan_rel" ]]; then
+      PLAN_PATH="$_plan_rel"
     fi
   fi
 fi

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -229,12 +229,19 @@ PY
         _candidate="$PROJECT_ROOT/$_feature_dir/plan.md"
       fi
       if [[ -f "$_candidate" ]]; then
-        # Emit a PROJECT_ROOT-relative path when possible, otherwise use the absolute path.
-        if [[ "$_candidate" == "$PROJECT_ROOT/"* ]]; then
-          PLAN_PATH="${_candidate#"$PROJECT_ROOT/"}"
-        else
-          PLAN_PATH="$_candidate"
-        fi
+        # Resolve symlinks before comparing so paths like /var/… vs /private/var/…
+        # (macOS) are treated as equivalent. Mirrors the mtime-fallback approach.
+        PLAN_PATH="$("$_python" - "$PROJECT_ROOT" "$_candidate" <<'PY'
+import sys
+from pathlib import Path, PurePosixPath
+root = Path(sys.argv[1]).resolve()
+cand = Path(sys.argv[2]).resolve()
+try:
+    print(str(PurePosixPath(cand.relative_to(root))))
+except ValueError:
+    print(str(PurePosixPath(cand)))
+PY
+)"
       fi
     fi
   fi

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -9,6 +9,10 @@
 #   .specify/extensions/agent-context/agent-context-config.yml
 #
 # Usage: update-agent-context.ps1 [plan_path]
+#
+# When `plan_path` is omitted, the script derives it from `.specify/feature.json`
+# (written by /speckit-specify). Falls back to the most recently modified
+# `specs/*/plan.md` only when feature.json is absent or its plan does not exist yet.
 
 [CmdletBinding()]
 param(
@@ -280,21 +284,52 @@ if ($cm) {
 }
 
 if (-not $PlanPath) {
-    # Discover plan.md exactly one level deep (specs/<feature>/plan.md),
-    # matching the bash glob specs/*/plan.md. Wrap in try/catch so access errors under
-    # $ErrorActionPreference = 'Stop' don't abort the script.
-    try {
-        $specsDir = Join-Path $ProjectRoot 'specs'
-        $candidate = Get-ChildItem -Path $specsDir -Directory -ErrorAction SilentlyContinue |
-            ForEach-Object { Get-Item -LiteralPath (Join-Path $_.FullName 'plan.md') -ErrorAction SilentlyContinue } |
-            Where-Object { $_ } |
-            Sort-Object LastWriteTime -Descending |
-            Select-Object -First 1
-        if ($candidate) {
-            $PlanPath = [System.IO.Path]::GetRelativePath($ProjectRoot, $candidate.FullName).Replace('\','/')
+    # Prefer .specify/feature.json (written by /speckit-specify) over mtime heuristic.
+    $FeatureJson = Join-Path $ProjectRoot '.specify/feature.json'
+    if (Test-Path -LiteralPath $FeatureJson) {
+        try {
+            $fj = Get-Content -LiteralPath $FeatureJson -Raw -Encoding UTF8 | ConvertFrom-Json
+            $featureDir = $fj.feature_directory
+            if ($featureDir) {
+                # Join-Path on Unix does not treat absolute ChildPath as "wins"; check explicitly.
+                if ([System.IO.Path]::IsPathRooted($featureDir)) {
+                    $candidatePlan = Join-Path $featureDir 'plan.md'
+                } else {
+                    $candidatePlan = Join-Path (Join-Path $ProjectRoot $featureDir) 'plan.md'
+                }
+                if (Test-Path -LiteralPath $candidatePlan) {
+                    # Normalize absolute feature paths to project-relative (mirrors bash behavior).
+                    $relDir = $featureDir
+                    if ([System.IO.Path]::IsPathRooted($featureDir)) {
+                        $normRoot = $ProjectRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+                        $normDir  = $featureDir.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+                        if ($normDir.StartsWith($normRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                            $relDir = $normDir.Substring($normRoot.Length)
+                        }
+                    }
+                    $PlanPath = $relDir.Replace('\', '/') + '/plan.md'
+                }
+            }
+        } catch {
+            # Non-fatal: fall through to mtime heuristic.
         }
-    } catch {
-        # Non-fatal: continue without a plan path.
+    }
+
+    # Fall back to mtime only when feature.json is absent or its plan does not exist yet.
+    if (-not $PlanPath) {
+        try {
+            $specsDir = Join-Path $ProjectRoot 'specs'
+            $candidate = Get-ChildItem -Path $specsDir -Directory -ErrorAction SilentlyContinue |
+                ForEach-Object { Get-Item -LiteralPath (Join-Path $_.FullName 'plan.md') -ErrorAction SilentlyContinue } |
+                Where-Object { $_ } |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+            if ($candidate) {
+                $PlanPath = [System.IO.Path]::GetRelativePath($ProjectRoot, $candidate.FullName).Replace('\','/')
+            }
+        } catch {
+            # Non-fatal: continue without a plan path.
+        }
     }
 }
 

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -132,7 +132,7 @@ if (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue) {
     try {
         $Options = Get-Content -LiteralPath $ExtConfig -Raw -Encoding UTF8 | ConvertFrom-Yaml -ErrorAction Stop
     } catch {
-        # fall through to Python fallback
+        # fall through to ConvertFrom-Json fallback
     }
 }
 

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -324,7 +324,7 @@ if (-not $PlanPath) {
                     $cmp = if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
                     if ($normDir.StartsWith($normRoot, $cmp)) {
                         $relDir = $normDir.Substring($normRoot.Length).TrimEnd('\', '/')
-                        $PlanPath = $relDir.Replace('\', '/') + '/plan.md'
+                        $PlanPath = if ($relDir) { $relDir.Replace('\', '/') + '/plan.md' } else { 'plan.md' }
                     } else {
                         $PlanPath = $resolvedPlan.Replace('\', '/')
                     }

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -321,8 +321,7 @@ if (-not $PlanPath) {
                     $resolvedDir  = [System.IO.Path]::GetDirectoryName($resolvedPlan)
                     $normRoot = $ProjectRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
                     $normDir  = $resolvedDir.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
-                    if ($null -ne $IsWindows) { $onWin = $IsWindows } else { $onWin = $true }
-                    $cmp = if ($onWin) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+                    $cmp = if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
                     if ($normDir.StartsWith($normRoot, $cmp)) {
                         $relDir = $normDir.Substring($normRoot.Length).TrimEnd('\', '/')
                         $PlanPath = $relDir.Replace('\', '/') + '/plan.md'
@@ -350,8 +349,7 @@ if (-not $PlanPath) {
                 # Use case-insensitive comparison on Windows only (matches common.ps1 pattern).
                 $fullPath = $candidate.FullName.Replace('\', '/')
                 $normRoot = $ProjectRoot.Replace('\', '/').TrimEnd('/') + '/'
-                if ($null -ne $IsWindows) { $onWin = $IsWindows } else { $onWin = $true }
-                $cmp = if ($onWin) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+                $cmp = if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
                 if ($fullPath.StartsWith($normRoot, $cmp)) {
                     $PlanPath = $fullPath.Substring($normRoot.Length)
                 } else {

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -325,7 +325,14 @@ if (-not $PlanPath) {
                 Sort-Object LastWriteTime -Descending |
                 Select-Object -First 1
             if ($candidate) {
-                $PlanPath = [System.IO.Path]::GetRelativePath($ProjectRoot, $candidate.FullName).Replace('\','/')
+                # GetRelativePath is .NET 5+ only; strip prefix manually for PS 5.1 compat.
+                $fullPath = $candidate.FullName.Replace('\', '/')
+                $normRoot = $ProjectRoot.Replace('\', '/').TrimEnd('/') + '/'
+                if ($fullPath.StartsWith($normRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $PlanPath = $fullPath.Substring($normRoot.Length)
+                } else {
+                    $PlanPath = $fullPath
+                }
             }
         } catch {
             # Non-fatal: continue without a plan path.

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -290,8 +290,8 @@ if (-not $PlanPath) {
         try {
             $fj = Get-Content -LiteralPath $FeatureJson -Raw -Encoding UTF8 | ConvertFrom-Json
             $featureDir = $fj.feature_directory
-            if ($featureDir -is [string]) { $featureDir = $featureDir.TrimEnd('\\', '/') }
-            if ($featureDir) {
+            if ($featureDir -isnot [string]) { $featureDir = $null }
+            if ($featureDir) { $featureDir = $featureDir.TrimEnd('\\', '/') }
                 # Join-Path on Unix does not treat absolute ChildPath as "wins"; check explicitly.
                 if ([System.IO.Path]::IsPathRooted($featureDir)) {
                     $candidatePlan = Join-Path $featureDir 'plan.md'

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -137,7 +137,19 @@ if (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue) {
 }
 
 if ($null -eq $Options) {
-    # ConvertFrom-Yaml unavailable or failed; fall back to Python+PyYAML.
+    # ConvertFrom-Yaml unavailable or failed; try ConvertFrom-Json (no external deps,
+    # works when the config file is valid JSON, which is a subset of YAML).
+    try {
+        $raw = Get-Content -LiteralPath $ExtConfig -Raw -Encoding UTF8
+        $Options = $raw | ConvertFrom-Json -ErrorAction Stop
+        if (-not (Test-ConfigObject -Object $Options)) { $Options = $null }
+    } catch {
+        $Options = $null
+    }
+}
+
+if ($null -eq $Options) {
+    # ConvertFrom-Yaml/Json unavailable or failed; fall back to Python+PyYAML.
     $pythonCmd = $null
     $pythonCandidates = @()
     if ($env:SPECKIT_PYTHON) {

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -290,6 +290,7 @@ if (-not $PlanPath) {
         try {
             $fj = Get-Content -LiteralPath $FeatureJson -Raw -Encoding UTF8 | ConvertFrom-Json
             $featureDir = $fj.feature_directory
+            if ($featureDir -is [string]) { $featureDir = $featureDir.TrimEnd('\\', '/') }
             if ($featureDir) {
                 # Join-Path on Unix does not treat absolute ChildPath as "wins"; check explicitly.
                 if ([System.IO.Path]::IsPathRooted($featureDir)) {

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -130,7 +130,7 @@ if (-not (Test-Path -LiteralPath $ExtConfig)) {
 $Options = $null
 if (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue) {
     try {
-        $Options = Get-Content -LiteralPath $ExtConfig -Raw | ConvertFrom-Yaml -ErrorAction Stop
+        $Options = Get-Content -LiteralPath $ExtConfig -Raw -Encoding UTF8 | ConvertFrom-Yaml -ErrorAction Stop
     } catch {
         # fall through to Python fallback
     }

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -316,11 +316,14 @@ if (-not $PlanPath) {
                 }
                 if (Test-Path -LiteralPath $candidatePlan) {
                     # Normalize absolute feature paths to project-relative (mirrors bash behavior).
+                    # Use case-insensitive comparison on Windows only (matches common.ps1 pattern).
                     $relDir = $featureDir
                     if ([System.IO.Path]::IsPathRooted($featureDir)) {
                         $normRoot = $ProjectRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
                         $normDir  = $featureDir.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
-                        if ($normDir.StartsWith($normRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        if ($null -ne $IsWindows) { $onWin = $IsWindows } else { $onWin = $true }
+                        $cmp = if ($onWin) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+                        if ($normDir.StartsWith($normRoot, $cmp)) {
                             $relDir = $normDir.Substring($normRoot.Length)
                         }
                     }
@@ -343,9 +346,12 @@ if (-not $PlanPath) {
                 Select-Object -First 1
             if ($candidate) {
                 # GetRelativePath is .NET 5+ only; strip prefix manually for PS 5.1 compat.
+                # Use case-insensitive comparison on Windows only (matches common.ps1 pattern).
                 $fullPath = $candidate.FullName.Replace('\', '/')
                 $normRoot = $ProjectRoot.Replace('\', '/').TrimEnd('/') + '/'
-                if ($fullPath.StartsWith($normRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                if ($null -ne $IsWindows) { $onWin = $IsWindows } else { $onWin = $true }
+                $cmp = if ($onWin) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+                if ($fullPath.StartsWith($normRoot, $cmp)) {
                     $PlanPath = $fullPath.Substring($normRoot.Length)
                 } else {
                     $PlanPath = $fullPath

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -290,8 +290,12 @@ if (-not $PlanPath) {
         try {
             $fj = Get-Content -LiteralPath $FeatureJson -Raw -Encoding UTF8 | ConvertFrom-Json
             $featureDir = $fj.feature_directory
-            if ($featureDir -isnot [string]) { $featureDir = $null }
-            if ($featureDir) { $featureDir = $featureDir.TrimEnd('\\', '/') }
+            if ($featureDir -isnot [string] -or -not $featureDir) {
+                $featureDir = $null
+            } else {
+                $featureDir = $featureDir.TrimEnd('\', '/')
+            }
+            if ($featureDir) {
                 # Join-Path on Unix does not treat absolute ChildPath as "wins"; check explicitly.
                 if ([System.IO.Path]::IsPathRooted($featureDir)) {
                     $candidatePlan = Join-Path $featureDir 'plan.md'

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -315,19 +315,20 @@ if (-not $PlanPath) {
                     $candidatePlan = Join-Path (Join-Path $ProjectRoot $featureDir) 'plan.md'
                 }
                 if (Test-Path -LiteralPath $candidatePlan) {
-                    # Normalize absolute feature paths to project-relative (mirrors bash behavior).
-                    # Use case-insensitive comparison on Windows only (matches common.ps1 pattern).
-                    $relDir = $featureDir
-                    if ([System.IO.Path]::IsPathRooted($featureDir)) {
-                        $normRoot = $ProjectRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
-                        $normDir  = $featureDir.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
-                        if ($null -ne $IsWindows) { $onWin = $IsWindows } else { $onWin = $true }
-                        $cmp = if ($onWin) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
-                        if ($normDir.StartsWith($normRoot, $cmp)) {
-                            $relDir = $normDir.Substring($normRoot.Length)
-                        }
+                    # Resolve ./ .. segments before relativizing (mirrors bash Path.resolve()).
+                    # GetFullPath is available in .NET Framework 4.x (PS 5.1 compatible).
+                    $resolvedPlan = [System.IO.Path]::GetFullPath($candidatePlan)
+                    $resolvedDir  = [System.IO.Path]::GetDirectoryName($resolvedPlan)
+                    $normRoot = $ProjectRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+                    $normDir  = $resolvedDir.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+                    if ($null -ne $IsWindows) { $onWin = $IsWindows } else { $onWin = $true }
+                    $cmp = if ($onWin) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+                    if ($normDir.StartsWith($normRoot, $cmp)) {
+                        $relDir = $normDir.Substring($normRoot.Length).TrimEnd('\', '/')
+                        $PlanPath = $relDir.Replace('\', '/') + '/plan.md'
+                    } else {
+                        $PlanPath = $resolvedPlan.Replace('\', '/')
                     }
-                    $PlanPath = $relDir.Replace('\', '/') + '/plan.md'
                 }
             }
         } catch {

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -185,7 +185,7 @@ def test_bash_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (project / "CLAUDE.md").read_text(encoding="utf-8")
-    assert str(external) + "/plan.md" in ctx
+    assert (external / "plan.md").resolve().as_posix() in ctx
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
@@ -208,8 +208,7 @@ def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     # Must be project-relative, not machine-specific absolute
     assert "at specs/001-active/plan.md" in ctx
-    assert str(tmp_path) not in ctx
-
+    assert tmp_path.resolve().as_posix() not in ctx
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_ps_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -> None:

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -14,7 +14,6 @@ from tests.extensions.test_extension_agent_context import (
     BASH,
     POWERSHELL,
     _bash_posix_path,
-    _install_agent_context_config,
     _run_bash_agent_context_script,
     _run_powershell_agent_context_script,
 )
@@ -25,14 +24,20 @@ def _setup_project(root: Path, context_file: str = "CLAUDE.md") -> None:
 
     JSON is valid YAML so bash+PyYAML can parse it, and PowerShell's built-in
     ConvertFrom-Json can parse it without needing powershell-yaml or Python.
+    Written directly as JSON (not via yaml.safe_dump) so the PS ConvertFrom-Json
+    fallback actually works on Windows CI.
     """
-    _install_agent_context_config(
-        root,
-        context_file=context_file,
-        context_markers={
-            "start": "<!-- SPECKIT START -->",
-            "end": "<!-- SPECKIT END -->",
-        },
+    cfg_dir = root / ".specify" / "extensions" / "agent-context"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "agent-context-config.yml").write_text(
+        json.dumps({
+            "context_file": context_file,
+            "context_markers": {
+                "start": "<!-- SPECKIT START -->",
+                "end": "<!-- SPECKIT END -->",
+            },
+        }),
+        encoding="utf-8",
     )
 
 

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -181,7 +181,7 @@ def test_bash_absolute_feature_dir_under_project_root(tmp_path: Path) -> None:
     # Must be project-relative, not machine-specific absolute
     assert "specs/001-active/plan.md" in ctx
     assert "specs/000-stale/plan.md" not in ctx
-    assert str(tmp_path) not in ctx
+    assert _to_bash_path(tmp_path) not in ctx
 
 
 @requires_bash

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -104,9 +104,11 @@ def test_bash_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path)
 def test_bash_falls_back_to_mtime_when_feature_json_absent(tmp_path: Path) -> None:
     """No feature.json → mtime fallback selects the most recently modified plan."""
     _setup_project(tmp_path)
-    _make_plan(tmp_path, "specs/000-old")
-    time.sleep(0.05)
-    _make_plan(tmp_path, "specs/001-newer")
+    old = _make_plan(tmp_path, "specs/000-old")
+    newer = _make_plan(tmp_path, "specs/001-newer")
+    now = time.time()
+    os.utime(old, (now - 10, now - 10))
+    os.utime(newer, (now, now))
 
     result = subprocess.run(
         ["bash", str(UPDATE_AGENT_CTX_SH)],
@@ -188,10 +190,11 @@ def test_bash_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
-    """PowerShell: feature.json points to the active feature; that plan is injected."""
+    """PowerShell: absolute feature_directory under project root is normalized to relative path."""
     _setup_project(tmp_path)
     _make_plan(tmp_path, "specs/001-active")
-    _write_feature_json(tmp_path, "specs/001-active")
+    # Use absolute path to exercise the normalization code path
+    _write_feature_json(tmp_path, str(tmp_path / "specs" / "001-active"))
 
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
     result = subprocess.run(
@@ -203,16 +206,20 @@ def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
-    assert "specs/001-active/plan.md" in ctx
+    # Must be project-relative, not machine-specific absolute
+    assert "at specs/001-active/plan.md" in ctx
+    assert str(tmp_path) not in ctx
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_ps_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -> None:
     """PowerShell: stale plan touched more recently must not win over feature.json."""
     _setup_project(tmp_path)
-    _make_plan(tmp_path, "specs/001-active")
-    time.sleep(0.05)
-    _make_plan(tmp_path, "specs/000-stale")
+    active = _make_plan(tmp_path, "specs/001-active")
+    stale = _make_plan(tmp_path, "specs/000-stale")
+    now = time.time()
+    os.utime(active, (now - 10, now - 10))
+    os.utime(stale, (now, now))
     _write_feature_json(tmp_path, "specs/001-active")
 
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -79,9 +79,11 @@ def test_bash_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path)
     _setup_project(tmp_path)
 
     # Create active feature plan first, then touch the stale one to make it newer.
-    _make_plan(tmp_path, "specs/001-active")
-    time.sleep(0.05)
-    _make_plan(tmp_path, "specs/000-stale")
+    active = _make_plan(tmp_path, "specs/001-active")
+    stale = _make_plan(tmp_path, "specs/000-stale")
+    now = time.time()
+    os.utime(active, (now - 10, now - 10))
+    os.utime(stale, (now, now))
 
     _write_feature_json(tmp_path, "specs/001-active")
 

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -26,14 +26,23 @@ _WINDOWS_POWERSHELL = (shutil.which("powershell.exe") or shutil.which("powershel
 
 
 def _setup_project(root: Path, context_file: str = "CLAUDE.md") -> None:
-    """Write the minimal agent-context extension config."""
+    """Write the minimal agent-context extension config as JSON.
+
+    JSON is a valid subset of YAML so bash+Python/PyYAML can still parse it,
+    but it also lets PowerShell's built-in ConvertFrom-Json parse it without
+    needing the powershell-yaml module or an external Python call.
+    """
     cfg_dir = root / ".specify" / "extensions" / "agent-context"
     cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg = {
+        "context_file": context_file,
+        "context_markers": {
+            "start": "<!-- SPECKIT START -->",
+            "end": "<!-- SPECKIT END -->",
+        },
+    }
     (cfg_dir / "agent-context-config.yml").write_text(
-        f"context_file: {context_file}\n"
-        "context_markers:\n"
-        "  start: '<!-- SPECKIT START -->'\n"
-        "  end: '<!-- SPECKIT END -->'\n",
+        json.dumps(cfg),
         encoding="utf-8",
     )
 

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -146,8 +146,12 @@ def test_bash_falls_back_to_mtime_when_plan_not_yet_created(tmp_path: Path) -> N
 def test_bash_absolute_feature_dir_under_project_root(tmp_path: Path) -> None:
     """Absolute feature_directory under PROJECT_ROOT → project-relative path in context."""
     _setup_project(tmp_path)
-    _make_plan(tmp_path, "specs/001-active")
-    # Write absolute path to feature.json
+    active = _make_plan(tmp_path, "specs/001-active")
+    stale = _make_plan(tmp_path, "specs/000-stale")
+    now = time.time()
+    os.utime(active, (now - 10, now - 10))
+    os.utime(stale, (now, now))
+    # Write absolute path to feature.json — mtime would pick 000-stale without it
     _write_feature_json(tmp_path, str(tmp_path / "specs" / "001-active"))
 
     result = subprocess.run(
@@ -161,6 +165,7 @@ def test_bash_absolute_feature_dir_under_project_root(tmp_path: Path) -> None:
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     # Must be project-relative, not machine-specific absolute
     assert "specs/001-active/plan.md" in ctx
+    assert "specs/000-stale/plan.md" not in ctx
     assert str(tmp_path) not in ctx
 
 
@@ -192,8 +197,12 @@ def test_bash_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
 def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     """PowerShell: absolute feature_directory under project root is normalized to relative path."""
     _setup_project(tmp_path)
-    _make_plan(tmp_path, "specs/001-active")
-    # Use absolute path to exercise the normalization code path
+    active = _make_plan(tmp_path, "specs/001-active")
+    stale = _make_plan(tmp_path, "specs/000-stale")
+    now = time.time()
+    os.utime(active, (now - 10, now - 10))
+    os.utime(stale, (now, now))
+    # Write absolute path to feature.json — mtime would pick 000-stale without it
     _write_feature_json(tmp_path, str(tmp_path / "specs" / "001-active"))
 
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
@@ -208,6 +217,7 @@ def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     # Must be project-relative, not machine-specific absolute
     assert "at specs/001-active/plan.md" in ctx
+    assert "specs/000-stale/plan.md" not in ctx
     assert tmp_path.resolve().as_posix() not in ctx
 
 

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -138,6 +138,52 @@ def test_bash_falls_back_to_mtime_when_plan_not_yet_created(tmp_path: Path) -> N
     assert "specs/000-old/plan.md" in ctx
 
 
+@requires_bash
+def test_bash_absolute_feature_dir_under_project_root(tmp_path: Path) -> None:
+    """Absolute feature_directory under PROJECT_ROOT → project-relative path in context."""
+    _setup_project(tmp_path)
+    _make_plan(tmp_path, "specs/001-active")
+    # Write absolute path to feature.json
+    _write_feature_json(tmp_path, str(tmp_path / "specs" / "001-active"))
+
+    result = subprocess.run(
+        ["bash", str(UPDATE_AGENT_CTX_SH)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    # Must be project-relative, not machine-specific absolute
+    assert "specs/001-active/plan.md" in ctx
+    assert str(tmp_path) not in ctx
+
+
+@requires_bash
+def test_bash_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
+    """Absolute feature_directory outside PROJECT_ROOT → absolute path preserved in context."""
+    project = tmp_path / "project"
+    external = tmp_path / "external" / "001-feature"
+    project.mkdir()
+    external.mkdir(parents=True)
+    (external / "plan.md").write_text("# plan\n", encoding="utf-8")
+
+    _setup_project(project)
+    _write_feature_json(project, str(external))
+
+    result = subprocess.run(
+        ["bash", str(UPDATE_AGENT_CTX_SH)],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (project / "CLAUDE.md").read_text(encoding="utf-8")
+    assert str(external) + "/plan.md" in ctx
+
+
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     """PowerShell: feature.json points to the active feature; that plan is injected."""

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -4,46 +4,35 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
-import subprocess
 import time
 from pathlib import Path
 
 import pytest
 
 from tests.conftest import requires_bash
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-UPDATE_AGENT_CTX_SH = (
-    PROJECT_ROOT / "extensions" / "agent-context" / "scripts" / "bash" / "update-agent-context.sh"
+from tests.extensions.test_extension_agent_context import (
+    BASH,
+    POWERSHELL,
+    _bash_posix_path,
+    _install_agent_context_config,
+    _run_bash_agent_context_script,
+    _run_powershell_agent_context_script,
 )
-UPDATE_AGENT_CTX_PS = (
-    PROJECT_ROOT / "extensions" / "agent-context" / "scripts" / "powershell" / "update-agent-context.ps1"
-)
-
-HAS_PWSH = shutil.which("pwsh") is not None
-_WINDOWS_POWERSHELL = (shutil.which("powershell.exe") or shutil.which("powershell")) if os.name == "nt" else None
 
 
 def _setup_project(root: Path, context_file: str = "CLAUDE.md") -> None:
-    """Write the minimal agent-context extension config as JSON.
+    """Write agent-context extension config as JSON.
 
-    JSON is a valid subset of YAML so bash+Python/PyYAML can still parse it,
-    but it also lets PowerShell's built-in ConvertFrom-Json parse it without
-    needing the powershell-yaml module or an external Python call.
+    JSON is valid YAML so bash+PyYAML can parse it, and PowerShell's built-in
+    ConvertFrom-Json can parse it without needing powershell-yaml or Python.
     """
-    cfg_dir = root / ".specify" / "extensions" / "agent-context"
-    cfg_dir.mkdir(parents=True, exist_ok=True)
-    cfg = {
-        "context_file": context_file,
-        "context_markers": {
+    _install_agent_context_config(
+        root,
+        context_file=context_file,
+        context_markers={
             "start": "<!-- SPECKIT START -->",
             "end": "<!-- SPECKIT END -->",
         },
-    }
-    (cfg_dir / "agent-context-config.yml").write_text(
-        json.dumps(cfg),
-        encoding="utf-8",
     )
 
 
@@ -54,21 +43,6 @@ def _write_feature_json(root: Path, feature_directory: str) -> None:
         json.dumps({"feature_directory": feature_directory}),
         encoding="utf-8",
     )
-
-
-def _to_bash_path(p: Path) -> str:
-    """Return a path string usable inside Git-for-Windows bash.
-
-    On Windows, Python paths use drive letters (C:\\...) but Git bash (MSYS2)
-    expects POSIX-style paths (/c/...). On all other platforms the path is
-    returned unchanged.
-    """
-    if os.name != "nt":
-        return str(p.resolve())
-    posix = p.resolve().as_posix()  # C:/foo/bar
-    if len(posix) >= 2 and posix[1] == ":":
-        return "/" + posix[0].lower() + posix[2:]
-    return posix
 
 
 def _make_plan(root: Path, feature_dir: str, content: str = "# plan\n") -> Path:
@@ -85,13 +59,7 @@ def test_bash_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     _make_plan(tmp_path, "specs/001-active")
     _write_feature_json(tmp_path, "specs/001-active")
 
-    result = subprocess.run(
-        ["bash", str(UPDATE_AGENT_CTX_SH)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_bash_agent_context_script(tmp_path)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     assert "specs/001-active/plan.md" in ctx
@@ -101,23 +69,14 @@ def test_bash_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
 def test_bash_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -> None:
     """An older spec's plan.md modified more recently must NOT win over feature.json."""
     _setup_project(tmp_path)
-
-    # Create active feature plan first, then touch the stale one to make it newer.
     active = _make_plan(tmp_path, "specs/001-active")
     stale = _make_plan(tmp_path, "specs/000-stale")
     now = time.time()
     os.utime(active, (now - 10, now - 10))
     os.utime(stale, (now, now))
-
     _write_feature_json(tmp_path, "specs/001-active")
 
-    result = subprocess.run(
-        ["bash", str(UPDATE_AGENT_CTX_SH)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_bash_agent_context_script(tmp_path)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     assert "specs/001-active/plan.md" in ctx
@@ -134,13 +93,7 @@ def test_bash_falls_back_to_mtime_when_feature_json_absent(tmp_path: Path) -> No
     os.utime(old, (now - 10, now - 10))
     os.utime(newer, (now, now))
 
-    result = subprocess.run(
-        ["bash", str(UPDATE_AGENT_CTX_SH)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_bash_agent_context_script(tmp_path)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     assert "specs/001-newer/plan.md" in ctx
@@ -151,16 +104,9 @@ def test_bash_falls_back_to_mtime_when_plan_not_yet_created(tmp_path: Path) -> N
     """feature.json exists but plan.md not yet written → fall back to mtime."""
     _setup_project(tmp_path)
     _make_plan(tmp_path, "specs/000-old")
-    # feature.json points to 001-new but its plan.md doesn't exist yet
     _write_feature_json(tmp_path, "specs/001-new")
 
-    result = subprocess.run(
-        ["bash", str(UPDATE_AGENT_CTX_SH)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_bash_agent_context_script(tmp_path)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     assert "specs/000-old/plan.md" in ctx
@@ -175,22 +121,15 @@ def test_bash_absolute_feature_dir_under_project_root(tmp_path: Path) -> None:
     now = time.time()
     os.utime(active, (now - 10, now - 10))
     os.utime(stale, (now, now))
-    # Write absolute path to feature.json — mtime would pick 000-stale without it
-    _write_feature_json(tmp_path, _to_bash_path(tmp_path / "specs" / "001-active"))
+    # Write POSIX absolute path — mtime would pick 000-stale without feature.json
+    _write_feature_json(tmp_path, _bash_posix_path(tmp_path / "specs" / "001-active"))
 
-    result = subprocess.run(
-        ["bash", str(UPDATE_AGENT_CTX_SH)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_bash_agent_context_script(tmp_path)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
-    # Must be project-relative, not machine-specific absolute
     assert "specs/001-active/plan.md" in ctx
     assert "specs/000-stale/plan.md" not in ctx
-    assert _to_bash_path(tmp_path) not in ctx
+    assert _bash_posix_path(tmp_path) not in ctx
 
 
 @requires_bash
@@ -203,21 +142,15 @@ def test_bash_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
     (external / "plan.md").write_text("# plan\n", encoding="utf-8")
 
     _setup_project(project)
-    _write_feature_json(project, _to_bash_path(external))
+    _write_feature_json(project, _bash_posix_path(external))
 
-    result = subprocess.run(
-        ["bash", str(UPDATE_AGENT_CTX_SH)],
-        cwd=project,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_bash_agent_context_script(project)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (project / "CLAUDE.md").read_text(encoding="utf-8")
-    assert _to_bash_path(external) + "/plan.md" in ctx
+    assert _bash_posix_path(external) + "/plan.md" in ctx
 
 
-@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+@pytest.mark.skipif(not POWERSHELL, reason="no PowerShell available")
 def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     """PowerShell: absolute feature_directory under project root is normalized to relative path."""
     _setup_project(tmp_path)
@@ -226,27 +159,18 @@ def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     now = time.time()
     os.utime(active, (now - 10, now - 10))
     os.utime(stale, (now, now))
-    # Write absolute path to feature.json — mtime would pick 000-stale without it
-    # Use native str() here: PowerShell expects Windows-native paths, not MSYS2 /c/... form
+    # Native str() — PowerShell expects Windows-native paths, not MSYS2 /c/... form
     _write_feature_json(tmp_path, str(tmp_path / "specs" / "001-active"))
 
-    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
-    result = subprocess.run(
-        [exe, "-NoProfile", "-File", str(UPDATE_AGENT_CTX_PS)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_powershell_agent_context_script(tmp_path)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
-    # Must be project-relative, not machine-specific absolute
     assert "at specs/001-active/plan.md" in ctx
     assert "specs/000-stale/plan.md" not in ctx
     assert tmp_path.resolve().as_posix() not in ctx
 
 
-@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+@pytest.mark.skipif(not POWERSHELL, reason="no PowerShell available")
 def test_ps_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -> None:
     """PowerShell: stale plan touched more recently must not win over feature.json."""
     _setup_project(tmp_path)
@@ -257,21 +181,14 @@ def test_ps_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -
     os.utime(stale, (now, now))
     _write_feature_json(tmp_path, "specs/001-active")
 
-    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
-    result = subprocess.run(
-        [exe, "-NoProfile", "-File", str(UPDATE_AGENT_CTX_PS)],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_powershell_agent_context_script(tmp_path)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     assert "specs/001-active/plan.md" in ctx
     assert "specs/000-stale/plan.md" not in ctx
 
 
-@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+@pytest.mark.skipif(not POWERSHELL, reason="no PowerShell available")
 def test_ps_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
     """PowerShell: absolute feature_directory outside project root → absolute path preserved."""
     project = tmp_path / "project"
@@ -283,14 +200,7 @@ def test_ps_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
     _setup_project(project)
     _write_feature_json(project, str(external))
 
-    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
-    result = subprocess.run(
-        [exe, "-NoProfile", "-File", str(UPDATE_AGENT_CTX_PS)],
-        cwd=project,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_powershell_agent_context_script(project)
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (project / "CLAUDE.md").read_text(encoding="utf-8")
     assert external.resolve().as_posix() + "/plan.md" in ctx

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -210,6 +210,7 @@ def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     assert "at specs/001-active/plan.md" in ctx
     assert tmp_path.resolve().as_posix() not in ctx
 
+
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_ps_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -> None:
     """PowerShell: stale plan touched more recently must not win over feature.json."""

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -1,0 +1,181 @@
+"""Tests that update-agent-context.sh/.ps1 prefer feature.json over mtime."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import requires_bash
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+UPDATE_AGENT_CTX_SH = (
+    PROJECT_ROOT / "extensions" / "agent-context" / "scripts" / "bash" / "update-agent-context.sh"
+)
+UPDATE_AGENT_CTX_PS = (
+    PROJECT_ROOT / "extensions" / "agent-context" / "scripts" / "powershell" / "update-agent-context.ps1"
+)
+
+HAS_PWSH = shutil.which("pwsh") is not None
+_WINDOWS_POWERSHELL = (shutil.which("powershell.exe") or shutil.which("powershell")) if os.name == "nt" else None
+
+
+def _setup_project(root: Path, context_file: str = "CLAUDE.md") -> None:
+    """Write the minimal agent-context extension config."""
+    cfg_dir = root / ".specify" / "extensions" / "agent-context"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "agent-context-config.yml").write_text(
+        f"context_file: {context_file}\n"
+        "context_markers:\n"
+        "  start: '<!-- SPECKIT START -->'\n"
+        "  end: '<!-- SPECKIT END -->'\n",
+        encoding="utf-8",
+    )
+
+
+def _write_feature_json(root: Path, feature_directory: str) -> None:
+    specify_dir = root / ".specify"
+    specify_dir.mkdir(parents=True, exist_ok=True)
+    (specify_dir / "feature.json").write_text(
+        json.dumps({"feature_directory": feature_directory}),
+        encoding="utf-8",
+    )
+
+
+def _make_plan(root: Path, feature_dir: str, content: str = "# plan\n") -> Path:
+    p = root / feature_dir / "plan.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+@requires_bash
+def test_bash_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
+    """feature.json points to the active feature; that plan.md is injected."""
+    _setup_project(tmp_path)
+    _make_plan(tmp_path, "specs/001-active")
+    _write_feature_json(tmp_path, "specs/001-active")
+
+    result = subprocess.run(
+        ["bash", str(UPDATE_AGENT_CTX_SH)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "specs/001-active/plan.md" in ctx
+
+
+@requires_bash
+def test_bash_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -> None:
+    """An older spec's plan.md modified more recently must NOT win over feature.json."""
+    _setup_project(tmp_path)
+
+    # Create active feature plan first, then touch the stale one to make it newer.
+    _make_plan(tmp_path, "specs/001-active")
+    time.sleep(0.05)
+    _make_plan(tmp_path, "specs/000-stale")
+
+    _write_feature_json(tmp_path, "specs/001-active")
+
+    result = subprocess.run(
+        ["bash", str(UPDATE_AGENT_CTX_SH)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "specs/001-active/plan.md" in ctx
+    assert "specs/000-stale/plan.md" not in ctx
+
+
+@requires_bash
+def test_bash_falls_back_to_mtime_when_feature_json_absent(tmp_path: Path) -> None:
+    """No feature.json → mtime fallback selects the most recently modified plan."""
+    _setup_project(tmp_path)
+    _make_plan(tmp_path, "specs/000-old")
+    time.sleep(0.05)
+    _make_plan(tmp_path, "specs/001-newer")
+
+    result = subprocess.run(
+        ["bash", str(UPDATE_AGENT_CTX_SH)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "specs/001-newer/plan.md" in ctx
+
+
+@requires_bash
+def test_bash_falls_back_to_mtime_when_plan_not_yet_created(tmp_path: Path) -> None:
+    """feature.json exists but plan.md not yet written → fall back to mtime."""
+    _setup_project(tmp_path)
+    _make_plan(tmp_path, "specs/000-old")
+    # feature.json points to 001-new but its plan.md doesn't exist yet
+    _write_feature_json(tmp_path, "specs/001-new")
+
+    result = subprocess.run(
+        ["bash", str(UPDATE_AGENT_CTX_SH)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "specs/000-old/plan.md" in ctx
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
+    """PowerShell: feature.json points to the active feature; that plan is injected."""
+    _setup_project(tmp_path)
+    _make_plan(tmp_path, "specs/001-active")
+    _write_feature_json(tmp_path, "specs/001-active")
+
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(UPDATE_AGENT_CTX_PS)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "specs/001-active/plan.md" in ctx
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_ps_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -> None:
+    """PowerShell: stale plan touched more recently must not win over feature.json."""
+    _setup_project(tmp_path)
+    _make_plan(tmp_path, "specs/001-active")
+    time.sleep(0.05)
+    _make_plan(tmp_path, "specs/000-stale")
+    _write_feature_json(tmp_path, "specs/001-active")
+
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(UPDATE_AGENT_CTX_PS)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "specs/001-active/plan.md" in ctx
+    assert "specs/000-stale/plan.md" not in ctx

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -47,6 +47,21 @@ def _write_feature_json(root: Path, feature_directory: str) -> None:
     )
 
 
+def _to_bash_path(p: Path) -> str:
+    """Return a path string usable inside Git-for-Windows bash.
+
+    On Windows, Python paths use drive letters (C:\\...) but Git bash (MSYS2)
+    expects POSIX-style paths (/c/...). On all other platforms the path is
+    returned unchanged.
+    """
+    if os.name != "nt":
+        return str(p.resolve())
+    posix = p.resolve().as_posix()  # C:/foo/bar
+    if len(posix) >= 2 and posix[1] == ":":
+        return "/" + posix[0].lower() + posix[2:]
+    return posix
+
+
 def _make_plan(root: Path, feature_dir: str, content: str = "# plan\n") -> Path:
     p = root / feature_dir / "plan.md"
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -152,7 +167,7 @@ def test_bash_absolute_feature_dir_under_project_root(tmp_path: Path) -> None:
     os.utime(active, (now - 10, now - 10))
     os.utime(stale, (now, now))
     # Write absolute path to feature.json — mtime would pick 000-stale without it
-    _write_feature_json(tmp_path, str(tmp_path / "specs" / "001-active"))
+    _write_feature_json(tmp_path, _to_bash_path(tmp_path / "specs" / "001-active"))
 
     result = subprocess.run(
         ["bash", str(UPDATE_AGENT_CTX_SH)],
@@ -179,7 +194,7 @@ def test_bash_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
     (external / "plan.md").write_text("# plan\n", encoding="utf-8")
 
     _setup_project(project)
-    _write_feature_json(project, str(external))
+    _write_feature_json(project, _to_bash_path(external))
 
     result = subprocess.run(
         ["bash", str(UPDATE_AGENT_CTX_SH)],
@@ -203,7 +218,7 @@ def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     os.utime(active, (now - 10, now - 10))
     os.utime(stale, (now, now))
     # Write absolute path to feature.json — mtime would pick 000-stale without it
-    _write_feature_json(tmp_path, str(tmp_path / "specs" / "001-active"))
+    _write_feature_json(tmp_path, _to_bash_path(tmp_path / "specs" / "001-active"))
 
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
     result = subprocess.run(

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -233,3 +233,28 @@ def test_ps_ignores_newer_stale_plan_when_feature_json_present(tmp_path: Path) -
     ctx = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
     assert "specs/001-active/plan.md" in ctx
     assert "specs/000-stale/plan.md" not in ctx
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_ps_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
+    """PowerShell: absolute feature_directory outside project root → absolute path preserved."""
+    project = tmp_path / "project"
+    external = tmp_path / "external" / "001-feature"
+    project.mkdir()
+    external.mkdir(parents=True)
+    (external / "plan.md").write_text("# plan\n", encoding="utf-8")
+
+    _setup_project(project)
+    _write_feature_json(project, str(external))
+
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(UPDATE_AGENT_CTX_PS)],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    ctx = (project / "CLAUDE.md").read_text(encoding="utf-8")
+    assert external.resolve().as_posix() + "/plan.md" in ctx

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -205,7 +205,7 @@ def test_bash_absolute_feature_dir_outside_project_root(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr + result.stdout
     ctx = (project / "CLAUDE.md").read_text(encoding="utf-8")
-    assert (external / "plan.md").resolve().as_posix() in ctx
+    assert _to_bash_path(external) + "/plan.md" in ctx
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
@@ -218,7 +218,8 @@ def test_ps_uses_feature_json_when_plan_exists(tmp_path: Path) -> None:
     os.utime(active, (now - 10, now - 10))
     os.utime(stale, (now, now))
     # Write absolute path to feature.json — mtime would pick 000-stale without it
-    _write_feature_json(tmp_path, _to_bash_path(tmp_path / "specs" / "001-active"))
+    # Use native str() here: PowerShell expects Windows-native paths, not MSYS2 /c/... form
+    _write_feature_json(tmp_path, str(tmp_path / "specs" / "001-active"))
 
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
     result = subprocess.run(


### PR DESCRIPTION
## Summary

- `update-agent-context.sh` and `update-agent-context.ps1` now prefer `.specify/feature.json` (written by `/speckit-specify`) over the mtime heuristic when no explicit `plan_path` argument is given
- Falls back to most-recently-modified `specs/*/plan.md` only when `feature.json` is absent or the derived `plan.md` does not exist yet (e.g. `/speckit-plan` hasn't run yet)
- Handles absolute `feature_directory` values in both scripts, normalizing to project-relative paths for the context file output
- PowerShell implementation is PS 5.1-compatible: nested `Join-Path`, `IsPathRooted` guard (Unix `Join-Path` does not treat absolute ChildPaths as "wins"), and manual prefix-strip instead of `GetRelativePath`

Fixes #3067

## AI disclosure

This PR was written with AI assistance (Claude Code). All changes were reviewed, tested, and understood by me before submission.

## Manual test results

**Agent**: Claude Code | **OS/Shell**: macOS/zsh

| Command tested | Notes |
|----------------|-------|
| `/speckit.specify` → `/speckit.plan` | `CLAUDE.md` references the correct active feature's `plan.md` |
| Multi-spec repo with stale plan touched after specify | `CLAUDE.md` still points to active feature, not the stale one |

## Test plan

- [x] `uv run pytest tests/extensions/test_update_agent_context_feature_json.py` — 4 new bash tests pass (2 PS skipped, no `pwsh` on CI)
- [x] `uv run pytest tests/test_agent_config_consistency.py tests/extensions/test_extension_agent_context.py` — all 62 existing tests pass