### PR TITLE
fix: fail loudly on an unknown workflow expression filter

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -192,7 +192,18 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         filter_name = filter_expr.strip()
         if filter_name == "default":
             return _filter_default(value)
-        return value
+        # No recognized filter matched — an unknown filter name, or a known
+        # filter used in an unsupported form. Fail loudly rather than silently
+        # returning the unfiltered value: a passthrough turns a mis-typed or
+        # unsupported filter into a wrong result with no signal. Mirrors the
+        # strict `from_json` handling above.
+        leading_name = re.match(r"\w+", filter_expr)
+        name = leading_name.group(0) if leading_name else filter_expr
+        raise ValueError(
+            f"unknown filter '{name}': expected one of default('x'), "
+            "join('sep'), map('attr'), contains('s'), or from_json "
+            f"(got '| {filter_expr}')"
+        )
 
     # Boolean operators — parse 'or' first (lower precedence) so that
     # 'a or b and c' is evaluated as 'a or (b and c)'.

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -215,8 +215,8 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         leading_name = re.match(r"\w+", filter_expr)
         name = leading_name.group(0) if leading_name else filter_expr
         expected = (
-            "expected one of default('x'), join('sep'), map('attr'), "
-            "contains('s'), or from_json"
+            "expected one of default or default('x'), join('sep'), "
+            "map('attr'), contains('s'), or from_json"
         )
         if name in _REGISTERED_FILTERS:
             raise ValueError(

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -12,6 +12,19 @@ import re
 from typing import Any
 
 
+# The filters the expression evaluator recognizes. Used to tell a
+# *registered* filter used in an unsupported form (e.g. `| join` with no
+# argument) apart from a genuinely unknown filter name, so each raises an
+# error that names the real problem.
+_REGISTERED_FILTERS: tuple[str, ...] = (
+    "default",
+    "join",
+    "map",
+    "contains",
+    "from_json",
+)
+
+
 # -- Custom filters -------------------------------------------------------
 
 def _filter_default(value: Any, default_value: Any = "") -> Any:
@@ -192,17 +205,26 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         filter_name = filter_expr.strip()
         if filter_name == "default":
             return _filter_default(value)
-        # No recognized filter matched — an unknown filter name, or a known
-        # filter used in an unsupported form. Fail loudly rather than silently
+        # No recognized filter matched. Fail loudly rather than silently
         # returning the unfiltered value: a passthrough turns a mis-typed or
         # unsupported filter into a wrong result with no signal. Mirrors the
-        # strict `from_json` handling above.
+        # strict `from_json` handling above. Distinguish a *registered* filter
+        # used in an unsupported form (e.g. `| join` or `| map` with no
+        # argument) from a genuinely unknown filter name, so the message names
+        # the real problem instead of calling a known filter "unknown".
         leading_name = re.match(r"\w+", filter_expr)
         name = leading_name.group(0) if leading_name else filter_expr
+        expected = (
+            "expected one of default('x'), join('sep'), map('attr'), "
+            "contains('s'), or from_json"
+        )
+        if name in _REGISTERED_FILTERS:
+            raise ValueError(
+                f"filter '{name}' used in an unsupported form (got "
+                f"'| {filter_expr}'): {expected}"
+            )
         raise ValueError(
-            f"unknown filter '{name}': expected one of default('x'), "
-            "join('sep'), map('attr'), contains('s'), or from_json "
-            f"(got '| {filter_expr}')"
+            f"unknown filter '{name}': {expected} (got '| {filter_expr}')"
         )
 
     # Boolean operators — parse 'or' first (lower precedence) so that

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -342,6 +342,49 @@ class TestExpressions:
                     "{{ steps.emit.output.stdout | " + bad + " }}", ctx
                 )
 
+    def test_filter_unknown_name_raises(self):
+        # An unregistered filter name must fail loudly rather than silently
+        # returning the unfiltered value (which hides a typo / unsupported
+        # filter as a wrong result).
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(inputs={"items": [1, 2, 3]})
+        with pytest.raises(ValueError, match="unknown filter 'length'"):
+            evaluate_expression("{{ inputs.items | length }}", ctx)
+
+    def test_filter_unknown_name_with_args_raises(self):
+        # The unknown-filter path must also catch the `name(arg)` form, which
+        # otherwise falls through the recognized-args branch silently.
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(inputs={"text": "hello"})
+        with pytest.raises(ValueError, match="unknown filter 'upper'"):
+            evaluate_expression("{{ inputs.text | upper('x') }}", ctx)
+
+    def test_registered_filters_unaffected(self):
+        # Regression: the five registered filters keep working unchanged.
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(
+            inputs={"tags": ["a", "b", "c"], "text": "hello world", "missing": ""},
+            steps={"emit": {"output": {"stdout": '{"n": 1}'}}},
+        )
+        assert (
+            evaluate_expression("{{ inputs.missing | default('fb') }}", ctx) == "fb"
+        )
+        assert evaluate_expression("{{ inputs.tags | join(', ') }}", ctx) == "a, b, c"
+        assert (
+            evaluate_expression("{{ inputs.text | contains('world') }}", ctx) is True
+        )
+        assert evaluate_expression(
+            "{{ steps.emit.output.stdout | from_json }}", ctx
+        ) == {"n": 1}
+
     def test_condition_evaluation(self):
         from specify_cli.workflows.expressions import evaluate_condition
         from specify_cli.workflows.base import StepContext

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -366,24 +366,48 @@ class TestExpressions:
             evaluate_expression("{{ inputs.text | upper('x') }}", ctx)
 
     def test_registered_filters_unaffected(self):
-        # Regression: the five registered filters keep working unchanged.
+        # Regression: all five registered filters keep working unchanged.
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext
 
         ctx = StepContext(
-            inputs={"tags": ["a", "b", "c"], "text": "hello world", "missing": ""},
+            inputs={
+                "tags": ["a", "b", "c"],
+                "text": "hello world",
+                "missing": "",
+                "rows": [{"id": "a"}, {"id": "b"}],
+            },
             steps={"emit": {"output": {"stdout": '{"n": 1}'}}},
         )
         assert (
             evaluate_expression("{{ inputs.missing | default('fb') }}", ctx) == "fb"
         )
         assert evaluate_expression("{{ inputs.tags | join(', ') }}", ctx) == "a, b, c"
+        assert evaluate_expression("{{ inputs.rows | map('id') }}", ctx) == ["a", "b"]
         assert (
             evaluate_expression("{{ inputs.text | contains('world') }}", ctx) is True
         )
         assert evaluate_expression(
             "{{ steps.emit.output.stdout | from_json }}", ctx
         ) == {"n": 1}
+
+    def test_registered_filter_unsupported_form_raises(self):
+        # A *registered* filter used in an unsupported form (e.g. `| join` with
+        # no argument) must fail loudly with a message that names it as a known
+        # filter misused, not as an "unknown filter".
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(inputs={"tags": ["a", "b", "c"]})
+        with pytest.raises(
+            ValueError, match="filter 'join' used in an unsupported form"
+        ):
+            evaluate_expression("{{ inputs.tags | join }}", ctx)
+        with pytest.raises(
+            ValueError, match="filter 'map' used in an unsupported form"
+        ):
+            evaluate_expression("{{ inputs.tags | map }}", ctx)
 
     def test_condition_evaluation(self):
         from specify_cli.workflows.expressions import evaluate_condition


### PR DESCRIPTION
## Description

Fixes #3073.

The expression evaluator's filter dispatch fell through to `return value` for any **unregistered filter**, so a typo'd or unsupported filter — e.g. `{{ items | length }}` — rendered the value **unchanged with no error**, and the run completed. A silent wrong result, with nothing pointing at the cause.

This makes the unknown-filter path **fail loudly**: an unrecognized filter raises a clear `ValueError` naming the offending filter and the valid ones, reusing the same strict-`ValueError` style already used for `from_json` (which raises on its mis-wired forms precisely to avoid "silently falling through to the unknown-filter path and returning the unparsed value"). It closes that path in general, consistent with the fail-loud direction of #2957 (`fan-out items`) and #2961 (`from_json`).

- The five registered filters (`default` / `join` / `map` / `contains` / `from_json`) are **unchanged** — no behavior change for any valid usage.
- Both forms of an unknown filter are caught: the no-arg form (`| length`) and the `name(arg)` form (`| upper('x')`), which previously also fell through silently.

**Backward-compat note (calling it out honestly):** this turns a previously **silent** author error into a **loud** one. Any workflow that today relies on an unknown filter being silently dropped would now error. That passthrough was never intentional (the `from_json` strictness comment already names it as a path to avoid), and a scan of the repo's own workflow/template YAMLs found no `{{ … | <unknown-filter> }}` usage, and the full suite stays green — but flagging it so you can weigh the direction. Happy to rework as a warning-instead-of-raise, or gate it, if you'd prefer.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` — full suite **3913 passed, 59 skipped**
- [x] Tested with a sample project (if applicable) — ran a workflow whose shell step used `{{ [1,2,3] | length }}`: pre-fix it printed `count=[1, 2, 3]` and completed; post-fix the run fails loudly with `unknown filter 'length'`.

Tests in `TestExpressions` (`tests/test_workflows.py`):
- `test_filter_unknown_name_raises` — `| length` raises `ValueError`.
- `test_filter_unknown_name_with_args_raises` — `| upper('x')` raises (the `name(arg)` form).
- `test_registered_filter_unsupported_form_raises` — a registered filter in an unsupported form (`| join`, `| map` with no arg) raises a *misused-filter* message, not "unknown filter".
- `test_registered_filters_unaffected` — regression: all five registered filters still work, now including `map('attr')`.

The two unknown-filter tests are red against `main` (DID NOT RAISE), green with the fix.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

This change was authored with Claude Code: the AI drafted the fix and the tests and ran the suite. I discovered the behavior through end-to-end workflow-expression testing, verified the root cause and the red-against-main / green-with-fix tests myself, and reviewed the diff. The fix deliberately reuses the existing `from_json` error style rather than inventing a new one.
