### PR TITLE
fix(workflows): validate requires keys and reject phantom permissions gate

### DIFF
--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -270,7 +270,7 @@ specify workflow run speckit -i spec="Build a kanban board with drag-and-drop ta
 | `fan-out`    | Dispatch a step for each item in a list          |
 | `fan-in`     | Aggregate results from a fan-out step            |
 
-> **Security note:** a `shell` step runs a local command with **your** privileges. There is no capability sandbox — `requires` (e.g. `requires.permissions`) is an advisory pre-condition block, not a runtime gate, so it does **not** restrict what a step can do. Review any catalog or downloaded workflow before running it, and use a `gate` step to require explicit approval before sensitive or destructive shell commands.
+> **Security note:** a `shell` step runs a local command with **your** privileges. There is no capability sandbox — `requires` is an advisory pre-condition block (spec-kit version, integrations), not a runtime gate, so it does **not** restrict what a step can do. In particular there is no `requires.permissions` capability gate: it is rejected by validation precisely because it would imply a sandbox that does not exist. Review any catalog or downloaded workflow before running it, and use a `gate` step to require explicit approval before sensitive or destructive shell commands.
 
 ## Expressions
 

--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -270,6 +270,8 @@ specify workflow run speckit -i spec="Build a kanban board with drag-and-drop ta
 | `fan-out`    | Dispatch a step for each item in a list          |
 | `fan-in`     | Aggregate results from a fan-out step            |
 
+> **Security note:** a `shell` step runs a local command with **your** privileges. There is no capability sandbox — `requires` (e.g. `requires.permissions`) is an advisory pre-condition block, not a runtime gate, so it does **not** restrict what a step can do. Review any catalog or downloaded workflow before running it, and use a `gate` step to require explicit approval before sensitive or destructive shell commands.
+
 ## Expressions
 
 Steps can reference inputs and previous step outputs using `{{ expression }}` syntax:

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -58,7 +58,12 @@ class WorkflowDefinition:
         # are not a security boundary. In particular there is no
         # ``requires.permissions`` capability gate: shell steps always run with
         # the user's privileges.
-        self.requires: dict[str, Any] = data.get("requires", {})
+        #
+        # Holds the raw parsed value, so before ``validate_workflow`` runs it may
+        # be a non-mapping (``None`` for a bare ``requires:``, a list for
+        # ``requires: []``, etc.); typed ``Any`` rather than ``dict[str, Any]``
+        # to avoid implying it is always a mapping at this point.
+        self.requires: Any = data.get("requires", {})
 
         # Inputs
         self.inputs: dict[str, Any] = data.get("inputs", {})

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -91,14 +91,14 @@ class WorkflowDefinition:
 # ID format: lowercase alphanumeric with hyphens
 _ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$")
 
-# Keys accepted under a workflow's ``requires`` block. These mirror the
-# pre-conditions documented in workflows/PUBLISHING.md and resolved by the
-# bundler (``speckit_version``, ``integrations``, ``tools``, ``mcp``). Any other
-# key — notably ``permissions`` — is rejected by ``validate_workflow`` so it is
-# never mistaken for an enforced runtime control.
-_RECOGNIZED_REQUIRES_KEYS = frozenset(
-    {"speckit_version", "integrations", "tools", "mcp"}
-)
+# Keys accepted under a workflow's ``requires`` block: the advisory
+# pre-conditions documented for workflows (``speckit_version`` and
+# ``integrations``). This is the *workflow* schema only — the bundle manifest's
+# ``requires`` (see ``bundler/models/manifest.py``) is a separate schema that
+# also carries ``tools``/``mcp``; those are not workflow ``requires`` keys.
+# Any other key — notably ``permissions`` — is rejected by ``validate_workflow``
+# so it is never mistaken for an enforced runtime control.
+_RECOGNIZED_REQUIRES_KEYS = frozenset({"speckit_version", "integrations"})
 
 # Valid step types (matching STEP_REGISTRY keys)
 def _get_valid_step_types() -> set[str]:

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -204,29 +204,26 @@ def validate_workflow(definition: WorkflowDefinition) -> list[str]:
     # gate exists — a ``shell`` step always runs with the user's privileges, so
     # declaring it would give a false sense of sandboxing.
     #
-    # Guard on ``is not None`` rather than truthiness: a falsy but non-mapping
-    # value (e.g. ``requires: []`` or ``requires: ''``) is still an authoring
-    # error and must surface, whereas ``requires:`` (YAML null) is treated as
-    # an omitted block.
-    if definition.requires is not None:
-        if not isinstance(definition.requires, dict):
-            errors.append(
-                "'requires' must be a mapping (or omitted)."
-            )
-        else:
-            for key in definition.requires:
-                if key == "permissions":
-                    errors.append(
-                        "'requires.permissions' is not a recognized or "
-                        "enforced capability gate — shell steps always run "
-                        "with the user's privileges. Remove it and gate "
-                        "sensitive steps with a 'gate' step instead."
-                    )
-                elif key not in _RECOGNIZED_REQUIRES_KEYS:
-                    errors.append(
-                        f"Unknown 'requires' key {key!r}. Recognized keys: "
-                        f"{', '.join(sorted(_RECOGNIZED_REQUIRES_KEYS))}."
-                    )
+    # Mirror ``inputs`` validation: an omitted block defaults to ``{}`` and is
+    # valid, but any present-but-non-mapping value — ``requires:`` (YAML null),
+    # ``requires: []`` or ``requires: ''`` — is an authoring error and must
+    # surface here rather than be silently ignored at runtime.
+    if not isinstance(definition.requires, dict):
+        errors.append("'requires' must be a mapping (or omitted).")
+    else:
+        for key in definition.requires:
+            if key == "permissions":
+                errors.append(
+                    "'requires.permissions' is not a recognized or "
+                    "enforced capability gate — shell steps always run "
+                    "with the user's privileges. Remove it and gate "
+                    "sensitive steps with a 'gate' step instead."
+                )
+            elif key not in _RECOGNIZED_REQUIRES_KEYS:
+                errors.append(
+                    f"Unknown 'requires' key {key!r}. Recognized keys: "
+                    f"{', '.join(sorted(_RECOGNIZED_REQUIRES_KEYS))}."
+                )
 
     # -- Steps ------------------------------------------------------------
     if not isinstance(definition.steps, list):

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -52,8 +52,12 @@ class WorkflowDefinition:
         if not isinstance(self.default_options, dict):
             self.default_options = {}
 
-        # Requirements (declared but not yet enforced at runtime;
-        # enforcement is a planned enhancement)
+        # Advisory pre-conditions (spec-kit version / integrations a workflow
+        # expects). Validated by ``validate_workflow`` (recognised keys only;
+        # see ``_RECOGNISED_REQUIRES_KEYS``) but NOT enforced at run time — they
+        # are not a security boundary. In particular there is no
+        # ``requires.permissions`` capability gate: shell steps always run with
+        # the user's privileges.
         self.requires: dict[str, Any] = data.get("requires", {})
 
         # Inputs
@@ -86,6 +90,15 @@ class WorkflowDefinition:
 
 # ID format: lowercase alphanumeric with hyphens
 _ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$")
+
+# Keys accepted under a workflow's ``requires`` block. These mirror the
+# pre-conditions documented in workflows/PUBLISHING.md and resolved by the
+# bundler (``speckit_version``, ``integrations``, ``tools``, ``mcp``). Any other
+# key — notably ``permissions`` — is rejected by ``validate_workflow`` so it is
+# never mistaken for an enforced runtime control.
+_RECOGNISED_REQUIRES_KEYS = frozenset(
+    {"speckit_version", "integrations", "tools", "mcp"}
+)
 
 # Valid step types (matching STEP_REGISTRY keys)
 def _get_valid_step_types() -> set[str]:
@@ -175,6 +188,34 @@ def validate_workflow(definition: WorkflowDefinition) -> list[str]:
                 except ValueError as exc:
                     errors.append(
                         f"Input {input_name!r} has invalid default: {exc}"
+                    )
+
+    # -- Requires ---------------------------------------------------------
+    # ``requires`` declares advisory pre-conditions (the spec-kit version and
+    # integrations a workflow expects). Only a fixed set of keys is recognised;
+    # reject anything else so authoring typos surface here instead of being
+    # silently ignored at runtime. In particular ``requires.permissions`` is
+    # rejected explicitly: it reads like a runtime capability gate, but no such
+    # gate exists — a ``shell`` step always runs with the user's privileges, so
+    # declaring it would give a false sense of sandboxing.
+    if definition.requires:
+        if not isinstance(definition.requires, dict):
+            errors.append(
+                "'requires' must be a mapping (or omitted)."
+            )
+        else:
+            for key in definition.requires:
+                if key == "permissions":
+                    errors.append(
+                        "'requires.permissions' is not a recognised or "
+                        "enforced capability gate — shell steps always run "
+                        "with the user's privileges. Remove it and gate "
+                        "sensitive steps with a 'gate' step instead."
+                    )
+                elif key not in _RECOGNISED_REQUIRES_KEYS:
+                    errors.append(
+                        f"Unknown 'requires' key {key!r}. Recognised keys: "
+                        f"{', '.join(sorted(_RECOGNISED_REQUIRES_KEYS))}."
                     )
 
     # -- Steps ------------------------------------------------------------

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -53,8 +53,8 @@ class WorkflowDefinition:
             self.default_options = {}
 
         # Advisory pre-conditions (spec-kit version / integrations a workflow
-        # expects). Validated by ``validate_workflow`` (recognised keys only;
-        # see ``_RECOGNISED_REQUIRES_KEYS``) but NOT enforced at run time — they
+        # expects). Validated by ``validate_workflow`` (recognized keys only;
+        # see ``_RECOGNIZED_REQUIRES_KEYS``) but NOT enforced at run time — they
         # are not a security boundary. In particular there is no
         # ``requires.permissions`` capability gate: shell steps always run with
         # the user's privileges.
@@ -96,7 +96,7 @@ _ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$")
 # bundler (``speckit_version``, ``integrations``, ``tools``, ``mcp``). Any other
 # key — notably ``permissions`` — is rejected by ``validate_workflow`` so it is
 # never mistaken for an enforced runtime control.
-_RECOGNISED_REQUIRES_KEYS = frozenset(
+_RECOGNIZED_REQUIRES_KEYS = frozenset(
     {"speckit_version", "integrations", "tools", "mcp"}
 )
 
@@ -192,13 +192,18 @@ def validate_workflow(definition: WorkflowDefinition) -> list[str]:
 
     # -- Requires ---------------------------------------------------------
     # ``requires`` declares advisory pre-conditions (the spec-kit version and
-    # integrations a workflow expects). Only a fixed set of keys is recognised;
+    # integrations a workflow expects). Only a fixed set of keys is recognized;
     # reject anything else so authoring typos surface here instead of being
     # silently ignored at runtime. In particular ``requires.permissions`` is
     # rejected explicitly: it reads like a runtime capability gate, but no such
     # gate exists — a ``shell`` step always runs with the user's privileges, so
     # declaring it would give a false sense of sandboxing.
-    if definition.requires:
+    #
+    # Guard on ``is not None`` rather than truthiness: a falsy but non-mapping
+    # value (e.g. ``requires: []`` or ``requires: ''``) is still an authoring
+    # error and must surface, whereas ``requires:`` (YAML null) is treated as
+    # an omitted block.
+    if definition.requires is not None:
         if not isinstance(definition.requires, dict):
             errors.append(
                 "'requires' must be a mapping (or omitted)."
@@ -207,15 +212,15 @@ def validate_workflow(definition: WorkflowDefinition) -> list[str]:
             for key in definition.requires:
                 if key == "permissions":
                     errors.append(
-                        "'requires.permissions' is not a recognised or "
+                        "'requires.permissions' is not a recognized or "
                         "enforced capability gate — shell steps always run "
                         "with the user's privileges. Remove it and gate "
                         "sensitive steps with a 'gate' step instead."
                     )
-                elif key not in _RECOGNISED_REQUIRES_KEYS:
+                elif key not in _RECOGNIZED_REQUIRES_KEYS:
                     errors.append(
-                        f"Unknown 'requires' key {key!r}. Recognised keys: "
-                        f"{', '.join(sorted(_RECOGNISED_REQUIRES_KEYS))}."
+                        f"Unknown 'requires' key {key!r}. Recognized keys: "
+                        f"{', '.join(sorted(_RECOGNIZED_REQUIRES_KEYS))}."
                     )
 
     # -- Steps ------------------------------------------------------------

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2130,9 +2130,9 @@ steps:
         assert any("requires.permissions" in e and "gate" in e for e in errors)
 
     def test_requires_empty_sequence_is_rejected_as_non_mapping(self):
-        """A falsy-but-non-mapping ``requires`` (e.g. an empty list) is still an
-        authoring error: validation must guard on ``is not None`` rather than
-        truthiness, otherwise ``requires: []`` would silently pass.
+        """A non-mapping ``requires`` (e.g. an empty list) is an authoring
+        error. Mirroring ``inputs``, validation checks ``isinstance(..., dict)``
+        so ``requires: []`` surfaces instead of silently passing.
         """
         from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
 
@@ -2148,6 +2148,47 @@ steps:
 """)
         errors = validate_workflow(definition)
         assert any("'requires' must be a mapping" in e for e in errors)
+
+    def test_requires_yaml_null_is_rejected_as_non_mapping(self):
+        """A bare ``requires:`` parses as YAML null. Like ``inputs``, a present
+        block must be a mapping, so YAML null is rejected as an authoring error
+        rather than being silently treated as an omitted block. (A truly
+        omitted ``requires`` defaults to ``{}`` and stays valid.)
+        """
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string("""
+workflow:
+  id: "test"
+  name: "Test"
+  version: "1.0.0"
+requires:
+steps:
+  - id: step-one
+    command: speckit.specify
+""")
+        errors = validate_workflow(definition)
+        assert any("'requires' must be a mapping" in e for e in errors)
+
+    def test_requires_omitted_is_valid(self):
+        """A workflow with no ``requires`` block at all defaults to ``{}`` and
+        must validate cleanly — only a present-but-non-mapping value is an
+        error (guards against over-correcting YAML-null rejection into also
+        flagging the omitted case).
+        """
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string("""
+workflow:
+  id: "test"
+  name: "Test"
+  version: "1.0.0"
+steps:
+  - id: step-one
+    command: speckit.specify
+""")
+        errors = validate_workflow(definition)
+        assert not any("requires" in e for e in errors)
 
 
 # ===== Workflow Engine Tests =====

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2048,6 +2048,83 @@ steps:
         errors = validate_workflow(definition)
         assert any("invalid type" in e.lower() for e in errors)
 
+    def test_requires_with_recognized_keys_is_valid(self):
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string("""
+workflow:
+  id: "test"
+  name: "Test"
+  version: "1.0.0"
+requires:
+  speckit_version: ">=0.7.2"
+  integrations:
+    any: ["claude", "gemini"]
+steps:
+  - id: step-one
+    command: speckit.specify
+""")
+        errors = validate_workflow(definition)
+        assert errors == []
+
+    def test_requires_must_be_mapping(self):
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string("""
+workflow:
+  id: "test"
+  name: "Test"
+  version: "1.0.0"
+requires: "claude"
+steps:
+  - id: step-one
+    command: speckit.specify
+""")
+        errors = validate_workflow(definition)
+        assert any("'requires' must be a mapping" in e for e in errors)
+
+    def test_requires_unknown_key_is_rejected(self):
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string("""
+workflow:
+  id: "test"
+  name: "Test"
+  version: "1.0.0"
+requires:
+  speckit_version: ">=0.7.2"
+  typo_key: true
+steps:
+  - id: step-one
+    command: speckit.specify
+""")
+        errors = validate_workflow(definition)
+        assert any("typo_key" in e and "requires" in e for e in errors)
+
+    def test_requires_permissions_is_rejected_as_not_enforced(self):
+        """A `requires.permissions` block looks like a runtime capability gate
+        but no such gate exists — shell steps always run with the user's
+        privileges. Reject it explicitly so authors are not misled into
+        believing the declaration sandboxes execution.
+        """
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string("""
+workflow:
+  id: "test"
+  name: "Test"
+  version: "1.0.0"
+requires:
+  permissions:
+    shell: true
+steps:
+  - id: run
+    type: shell
+    run: "echo hi"
+""")
+        errors = validate_workflow(definition)
+        assert any("permissions" in e and "not" in e.lower() for e in errors)
+
 
 # ===== Workflow Engine Tests =====
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2123,7 +2123,31 @@ steps:
     run: "echo hi"
 """)
         errors = validate_workflow(definition)
-        assert any("permissions" in e and "not" in e.lower() for e in errors)
+        # Assert on specific markers from the intended message (the offending
+        # key and the `gate` remediation) so the test fails if the validation
+        # path or wording drifts, rather than passing on any error that merely
+        # happens to contain "permissions" and "not".
+        assert any("requires.permissions" in e and "gate" in e for e in errors)
+
+    def test_requires_empty_sequence_is_rejected_as_non_mapping(self):
+        """A falsy-but-non-mapping ``requires`` (e.g. an empty list) is still an
+        authoring error: validation must guard on ``is not None`` rather than
+        truthiness, otherwise ``requires: []`` would silently pass.
+        """
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string("""
+workflow:
+  id: "test"
+  name: "Test"
+  version: "1.0.0"
+requires: []
+steps:
+  - id: step-one
+    command: speckit.specify
+""")
+        errors = validate_workflow(definition)
+        assert any("'requires' must be a mapping" in e for e in errors)
 
 
 # ===== Workflow Engine Tests =====

--- a/workflows/PUBLISHING.md
+++ b/workflows/PUBLISHING.md
@@ -268,6 +268,7 @@ When releasing a new version:
 
 ### Shell Steps
 
+- **Shell runs with the user's privileges** — a `shell` step executes a local command directly; there is no capability sandbox. `requires` is an advisory pre-condition block (recognised keys: `speckit_version`, `integrations`, `tools`, `mcp`), **not** a runtime permission gate — there is no `requires.permissions`. Gate sensitive commands explicitly with a `gate` step.
 - **Avoid destructive commands** — don't delete files or directories without explicit confirmation via a gate
 - **Quote variables** — use proper quoting in shell commands to handle spaces
 - **Check exit codes** — shell step failures stop the workflow; make sure commands are robust

--- a/workflows/PUBLISHING.md
+++ b/workflows/PUBLISHING.md
@@ -268,7 +268,7 @@ When releasing a new version:
 
 ### Shell Steps
 
-- **Shell runs with the user's privileges** — a `shell` step executes a local command directly; there is no capability sandbox. `requires` is an advisory pre-condition block (recognised keys: `speckit_version`, `integrations`, `tools`, `mcp`), **not** a runtime permission gate — there is no `requires.permissions`. Gate sensitive commands explicitly with a `gate` step.
+- **Shell runs with the user's privileges** — a `shell` step executes a local command directly; there is no capability sandbox. `requires` is an advisory pre-condition block (recognised keys: `speckit_version`, `integrations`), **not** a runtime permission gate — there is no `requires.permissions`. Gate sensitive commands explicitly with a `gate` step.
 - **Avoid destructive commands** — don't delete files or directories without explicit confirmation via a gate
 - **Quote variables** — use proper quoting in shell commands to handle spaces
 - **Check exit codes** — shell step failures stop the workflow; make sure commands are robust


### PR DESCRIPTION
## Description

A workflow's `requires:` block was parsed (`WorkflowDefinition.requires`) but its keys were never validated, so a typo or an unsupported key was silently ignored.

Most importantly, an author could write:

```yaml
requires:
  permissions:
    shell: true
```

expecting a runtime capability gate — but no such gate exists. A `shell` step always runs with the user's privileges, so this declaration gives a false sense of sandboxing. (This came up in #2440, where it was understandably assumed that such a declaration was already enforced.)

This PR makes `validate_workflow` honest about `requires`:

- Only the recognised keys are accepted: `speckit_version`, `integrations`.
- Any unknown key is rejected (a typo surfaces at validation time instead of being silently dropped) — same spirit as the recent "fail loudly on unknown" hardening.
- `requires.permissions` is rejected with an explicit message pointing authors at a `gate` step for approval, so nobody mistakes it for a security boundary.

It does **not** add any per-step permission system or runtime prompt — `requires` stays advisory. The model comment and the docs (`docs/reference/workflows.md`, `workflows/PUBLISHING.md`) are updated to say so plainly.

## Testing

- [x] Ran existing tests with `pytest` (full suite green, no regressions)
- [ ] Tested locally with `uv run specify --help`
- [x] Added tests: valid recognised keys, non-mapping `requires`, unknown key, and `requires.permissions`

Validation is reached on the user-facing paths (`workflow add` / `info` / `run`), so the new errors actually surface.

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

AI assistance (an AI coding agent) was used for the initial code review that surfaced the issue, and to help draft the implementation, tests, and documentation wording. All changes were reviewed and verified by me (red→green tests, full suite, `ruff`) before submitting.

