### PR TITLE
fix: anchor lib/ and lib64/ patterns to repo root in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/


### PR DESCRIPTION
## Summary

`specify bundle` commands fail with a `ModuleNotFoundError` when the package is installed directly from git (e.g. `uvx --from git+https://github.com/github/spec-kit.git`):

```
ModuleNotFoundError: No module named 'specify_cli.bundler.lib'
```

## Root cause

`.gitignore` contains an unanchored `lib/` pattern (line 13) inherited from the GitHub Python gitignore template added in the initial commit. Hatchling uses `.gitignore` as its file-exclusion filter when building wheels. The unanchored pattern matches **any** `lib/` directory at any depth, including `src/specify_cli/bundler/lib/` which was introduced in #3070. As a result the entire subpackage is silently dropped from the built wheel.

## Fix

Prefix both `lib/` and `lib64/` with `/` to anchor them to the repository root:

```diff
-lib/
-lib64/
+/lib/
+/lib64/
```

A leading `/` in `.gitignore` anchors the pattern to the root of the repository, which is the intended scope — excluding top-level `lib/` artefacts produced by old-style setuptools installs — without affecting any nested source package named `lib/`.

## Verification

```bash
python -m hatchling build --target wheel
python -c "
import zipfile
whl = zipfile.ZipFile('dist/specify_cli-*.whl')
hits = [n for n in whl.namelist() if 'bundler/lib' in n]
print(hits)
"
# ['specify_cli/bundler/lib/__init__.py',
#  'specify_cli/bundler/lib/project.py',
#  'specify_cli/bundler/lib/versioning.py',
#  'specify_cli/bundler/lib/yamlio.py']
```

`bundler/lib` is now present in the wheel. Before this fix it was absent.