### PR TITLE
fix(build): include specify_cli.bundler.lib in built distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/


### PR DESCRIPTION
## Summary

Installing from source (e.g. `uv tool install specify-cli --from git+https://github.com/github/spec-kit.git`) currently produces a **completely broken CLI** — every command crashes on startup:

```
ModuleNotFoundError: No module named 'specify_cli.bundler.lib'
  File ".../specify_cli/__init__.py", line 615, in <module>
    from .commands.bundle import register as _register_bundle_cmds
  File ".../specify_cli/commands/bundle/__init__.py", line 18, in <module>
    from ...bundler.lib.project import (...)
```

This affects `init`, `check`, everything — because `commands/bundle/__init__.py` is imported at top level in `specify_cli/__init__.py`, and it imports `specify_cli.bundler.lib.project`. Introduced together with the `specify bundle` command (#3070), which added the `src/specify_cli/bundler/lib/` package.

## Root cause

The package `src/specify_cli/bundler/lib/` is tracked in git, but it is **missing from the built wheel**. The cause is the root `.gitignore`:

```gitignore
lib/
lib64/
```

These come from the standard GitHub Python template and are meant to ignore a top-level build/virtualenv `lib` directory. Because the patterns are **unanchored**, they also match the source package `src/specify_cli/bundler/lib/`. Hatchling applies `.gitignore` patterns as build-exclusion rules, so it silently drops `bundler/lib` from the wheel even though the files are tracked.

Sibling packages (`bundler/models/`, `bundler/services/`, …) are unaffected because only the directory literally named `lib` matches the pattern.

## Reproduction (current `main`)

```console
$ uv build --wheel
$ unzip -l dist/specify_cli-*.whl | grep -c 'bundler/lib/'
0          # bundler/lib is absent
$ unzip -l dist/specify_cli-*.whl | grep -c 'bundler/services/'
10         # siblings are present
```

## Fix

Anchor the patterns to the repository root so they only match the intended top-level build artifacts:

```diff
-lib/
-lib64/
+/lib/
+/lib64/
```

This preserves the original intent (ignore a root-level `lib`/`lib64` build/venv dir) while no longer excluding the source package.

## Verification (with this change)

```console
$ uv build --wheel
$ unzip -l dist/specify_cli-*.whl | grep 'bundler/lib/'
  specify_cli/bundler/lib/__init__.py
  specify_cli/bundler/lib/project.py
  specify_cli/bundler/lib/versioning.py
  specify_cli/bundler/lib/yamlio.py

# install the built wheel into a fresh venv:
$ specify --version
specify 0.11.4.dev0
$ specify bundle --help
 Usage: specify bundle [OPTIONS] COMMAND [ARGS]...
 Discover, install, and author Spec Kit bundles
```

The CLI now loads, and `specify bundle` works.

> Alternative considered: a Hatchling `force-include`/`artifacts` entry for `bundler/lib`. Anchoring the `.gitignore` patterns was chosen because it fixes the actual root cause (an over-broad ignore pattern), covers both the sdist and wheel targets, and protects any future source directory that happens to be named `lib`.