### PR TITLE
Harden command registration path handling

### DIFF
--- a/src/specify_cli/_utils.py
+++ b/src/specify_cli/_utils.py
@@ -9,12 +9,50 @@ import stat
 import subprocess
 import tempfile
 import yaml
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 from ._console import console
 
 CLAUDE_LOCAL_PATH = Path.home() / ".claude" / "local" / "claude"
 CLAUDE_NPM_LOCAL_PATH = Path.home() / ".claude" / "local" / "node_modules" / ".bin" / "claude"
+
+
+def relative_extension_path_violation(value: Any) -> str | None:
+    """Return why ``value`` is unsafe as an extension-relative ``file`` path.
+
+    Single source of truth for the path-safety policy shared by
+    ``ExtensionManifest._validate()`` (manifest-load validation) and
+    ``CommandRegistrar.register_commands()`` (runtime guard), so the two cannot
+    drift. Returns a human-readable reason string when ``value`` is unsafe, or
+    ``None`` when it is an acceptable relative path within the extension
+    directory.
+
+    Policy: the value must be a non-empty string with no leading/trailing
+    whitespace, no absolute/anchored form, and no ``..`` traversal. The value is
+    evaluated under both POSIX and Windows path semantics because a native
+    ``Path`` is OS-dependent (a ``PurePosixPath`` on POSIX does not interpret
+    Windows drive/UNC forms, and ``C:foo`` is anchored but not ``is_absolute()``
+    yet resolves against the CWD on its drive). Rejecting any non-empty anchor
+    covers POSIX-absolute (``/abs``), Windows drive-relative (``C:foo``), Windows
+    absolute (``C:\\foo``), and UNC/rooted forms.
+    """
+    if not isinstance(value, str) or not value:
+        return "must be a non-empty string"
+    if value.strip() != value:
+        return "must not have leading or trailing whitespace"
+    posix_path = PurePosixPath(value)
+    win_path = PureWindowsPath(value)
+    if (
+        posix_path.anchor
+        or win_path.anchor
+        or ".." in posix_path.parts
+        or ".." in win_path.parts
+    ):
+        return (
+            "must be a relative path within the extension directory "
+            "(no absolute paths, drive letters, or '..' segments)"
+        )
+    return None
 
 
 def dump_frontmatter(data: dict[str, Any]) -> str:

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -562,10 +562,13 @@ class CommandRegistrar:
             except (OSError, ValueError):
                 continue
 
-            if not source_file.exists():
+            if not source_file.is_file():
                 continue
 
-            content = source_file.read_text(encoding="utf-8")
+            try:
+                content = source_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
             frontmatter, body = self.parse_frontmatter(content)
 
             if frontmatter.get("strategy") == "wrap":

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -546,7 +546,22 @@ class CommandRegistrar:
             aliases = cmd_info.get("aliases", [])
             cmd_file = cmd_info["file"]
 
-            source_file = source_dir / cmd_file
+            # Guard against path traversal: reject absolute paths and ensure
+            # the resolved file stays within the source directory. Mirrors the
+            # containment checks already applied on the skill, preset, and
+            # restore paths (see extensions.py and presets/__init__.py) so a
+            # malicious manifest ``file`` field (e.g. ``../../../etc/passwd``)
+            # cannot read arbitrary host files into a generated command.
+            cmd_path = Path(cmd_file)
+            if cmd_path.is_absolute():
+                continue
+            try:
+                source_root = source_dir.resolve()
+                source_file = (source_root / cmd_path).resolve()
+                source_file.relative_to(source_root)  # raises ValueError if outside
+            except (OSError, ValueError):
+                continue
+
             if not source_file.exists():
                 continue
 

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -540,11 +540,17 @@ class CommandRegistrar:
 
         registered = []
         is_cline_ext = agent_name == "cline" and source_id != "core"
+        source_root = source_dir.resolve()
 
         for cmd_info in commands:
             cmd_name = cmd_info["name"]
             aliases = cmd_info.get("aliases", [])
             cmd_file = cmd_info["file"]
+
+            # Skip malformed entries: a non-string/empty ``file`` cannot be a
+            # valid command body and would otherwise raise when used as a path.
+            if not isinstance(cmd_file, str) or not cmd_file:
+                continue
 
             # Guard against path traversal: reject any anchored value under
             # either POSIX or Windows semantics — POSIX-absolute (``/abs``),
@@ -559,7 +565,6 @@ class CommandRegistrar:
             if PurePosixPath(cmd_file).anchor or PureWindowsPath(cmd_file).anchor:
                 continue
             try:
-                source_root = source_dir.resolve()
                 source_file = (source_root / cmd_file).resolve()
                 source_file.relative_to(source_root)  # raises ValueError if outside
             except (OSError, ValueError):

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -10,12 +10,13 @@ import os
 import platform
 import re
 from copy import deepcopy
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
 
 from ._init_options import is_ai_skills_enabled, load_init_options
+from ._utils import relative_extension_path_violation
 
 
 def _build_agent_configs() -> dict[str, Any]:
@@ -547,32 +548,14 @@ class CommandRegistrar:
             aliases = cmd_info.get("aliases", [])
             cmd_file = cmd_info["file"]
 
-            # Skip malformed entries: a non-string/empty ``file`` cannot be a
-            # valid command body and would otherwise raise when used as a path.
-            if not isinstance(cmd_file, str) or not cmd_file:
-                continue
-
-            # Guard against path traversal, keeping runtime policy aligned with
-            # ExtensionManifest._validate() and the skill/preset/restore readers.
-            # Evaluate the value under both POSIX and Windows path flavors
-            # because a native ``Path`` is OS-dependent (a ``PurePosixPath`` on
-            # POSIX does not interpret Windows drive/UNC forms). Reject any
-            # non-empty anchor — which covers POSIX-absolute (``/abs``), Windows
-            # drive-relative (``C:foo``, anchored but not ``is_absolute()`` yet
-            # resolved against the CWD on its drive), Windows absolute
-            # (``C:\foo``), and UNC roots — and any ``..`` segment in either
-            # separator style, so a malicious manifest ``file`` field
-            # (e.g. ``../../../outside.txt``) cannot read arbitrary host files
-            # into a generated command. The resolve()/relative_to() check below
-            # is the final containment backstop.
-            posix_path = PurePosixPath(cmd_file)
-            win_path = PureWindowsPath(cmd_file)
-            if (
-                posix_path.anchor
-                or win_path.anchor
-                or ".." in posix_path.parts
-                or ".." in win_path.parts
-            ):
+            # Guard against path traversal using the single shared policy in
+            # relative_extension_path_violation(), so the runtime guard stays
+            # aligned with ExtensionManifest._validate() and the skill/preset
+            # readers. Skip a malformed/unsafe ``file`` (non-string, empty,
+            # whitespace, absolute/anchored, or ``..`` traversal); the
+            # resolve()/relative_to() check below is the final containment
+            # backstop.
+            if relative_extension_path_violation(cmd_file):
                 continue
             try:
                 source_file = (source_root / cmd_file).resolve()
@@ -585,7 +568,14 @@ class CommandRegistrar:
 
             try:
                 content = source_file.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
+            except (OSError, UnicodeDecodeError) as exc:
+                import warnings
+
+                warnings.warn(
+                    f"Skipping command '{cmd_name}': could not read source file "
+                    f"'{cmd_file}' ({exc.__class__.__name__}: {exc}).",
+                    stacklevel=2,
+                )
                 continue
             frontmatter, body = self.parse_frontmatter(content)
 

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -552,17 +552,27 @@ class CommandRegistrar:
             if not isinstance(cmd_file, str) or not cmd_file:
                 continue
 
-            # Guard against path traversal: reject any anchored value under
-            # either POSIX or Windows semantics — POSIX-absolute (``/abs``),
-            # Windows drive-relative (``C:foo``, not ``is_absolute()`` but
+            # Guard against path traversal, keeping runtime policy aligned with
+            # ExtensionManifest._validate() and the skill/preset/restore readers.
+            # Evaluate the value under both POSIX and Windows path flavors
+            # because a native ``Path`` is OS-dependent (a ``PurePosixPath`` on
+            # POSIX does not interpret Windows drive/UNC forms). Reject any
+            # non-empty anchor — which covers POSIX-absolute (``/abs``), Windows
+            # drive-relative (``C:foo``, anchored but not ``is_absolute()`` yet
             # resolved against the CWD on its drive), Windows absolute
-            # (``C:\foo``), and rooted-without-drive (``\foo``) — then ensure
-            # the resolved file stays within the source directory. Mirrors the
-            # containment checks already applied on the skill, preset, and
-            # restore paths (see extensions.py and presets/__init__.py) so a
-            # malicious manifest ``file`` field (e.g. ``../../../outside.txt``)
-            # cannot read arbitrary host files into a generated command.
-            if PurePosixPath(cmd_file).anchor or PureWindowsPath(cmd_file).anchor:
+            # (``C:\foo``), and UNC roots — and any ``..`` segment in either
+            # separator style, so a malicious manifest ``file`` field
+            # (e.g. ``../../../outside.txt``) cannot read arbitrary host files
+            # into a generated command. The resolve()/relative_to() check below
+            # is the final containment backstop.
+            posix_path = PurePosixPath(cmd_file)
+            win_path = PureWindowsPath(cmd_file)
+            if (
+                posix_path.anchor
+                or win_path.anchor
+                or ".." in posix_path.parts
+                or ".." in win_path.parts
+            ):
                 continue
             try:
                 source_file = (source_root / cmd_file).resolve()

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -10,7 +10,7 @@ import os
 import platform
 import re
 from copy import deepcopy
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 import yaml
@@ -546,22 +546,21 @@ class CommandRegistrar:
             aliases = cmd_info.get("aliases", [])
             cmd_file = cmd_info["file"]
 
-            # Guard against path traversal: reject absolute paths (including
-            # Windows drive-relative paths like ``C:foo``, which are not
-            # ``is_absolute()`` but resolve against the CWD on their drive) and
-            # ensure the resolved file stays within the source directory.
-            # Mirrors the containment checks already applied on the skill,
-            # preset, and restore paths (see extensions.py and
-            # presets/__init__.py) so a malicious manifest ``file`` field
-            # (e.g. ``../../../outside.txt``) cannot read arbitrary host files
-            # into a generated command.
-            cmd_path = Path(cmd_file)
-            win_path = PureWindowsPath(cmd_file)
-            if cmd_path.is_absolute() or win_path.is_absolute() or win_path.drive:
+            # Guard against path traversal: reject any anchored value under
+            # either POSIX or Windows semantics — POSIX-absolute (``/abs``),
+            # Windows drive-relative (``C:foo``, not ``is_absolute()`` but
+            # resolved against the CWD on its drive), Windows absolute
+            # (``C:\foo``), and rooted-without-drive (``\foo``) — then ensure
+            # the resolved file stays within the source directory. Mirrors the
+            # containment checks already applied on the skill, preset, and
+            # restore paths (see extensions.py and presets/__init__.py) so a
+            # malicious manifest ``file`` field (e.g. ``../../../outside.txt``)
+            # cannot read arbitrary host files into a generated command.
+            if PurePosixPath(cmd_file).anchor or PureWindowsPath(cmd_file).anchor:
                 continue
             try:
                 source_root = source_dir.resolve()
-                source_file = (source_root / cmd_path).resolve()
+                source_file = (source_root / cmd_file).resolve()
                 source_file.relative_to(source_root)  # raises ValueError if outside
             except (OSError, ValueError):
                 continue

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -550,7 +550,7 @@ class CommandRegistrar:
             # the resolved file stays within the source directory. Mirrors the
             # containment checks already applied on the skill, preset, and
             # restore paths (see extensions.py and presets/__init__.py) so a
-            # malicious manifest ``file`` field (e.g. ``../../../etc/passwd``)
+            # malicious manifest ``file`` field (e.g. ``../../../outside.txt``)
             # cannot read arbitrary host files into a generated command.
             cmd_path = Path(cmd_file)
             if cmd_path.is_absolute():

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -10,7 +10,7 @@ import os
 import platform
 import re
 from copy import deepcopy
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List, Optional
 
 import yaml
@@ -546,14 +546,18 @@ class CommandRegistrar:
             aliases = cmd_info.get("aliases", [])
             cmd_file = cmd_info["file"]
 
-            # Guard against path traversal: reject absolute paths and ensure
-            # the resolved file stays within the source directory. Mirrors the
-            # containment checks already applied on the skill, preset, and
-            # restore paths (see extensions.py and presets/__init__.py) so a
-            # malicious manifest ``file`` field (e.g. ``../../../outside.txt``)
-            # cannot read arbitrary host files into a generated command.
+            # Guard against path traversal: reject absolute paths (including
+            # Windows drive-relative paths like ``C:foo``, which are not
+            # ``is_absolute()`` but resolve against the CWD on their drive) and
+            # ensure the resolved file stays within the source directory.
+            # Mirrors the containment checks already applied on the skill,
+            # preset, and restore paths (see extensions.py and
+            # presets/__init__.py) so a malicious manifest ``file`` field
+            # (e.g. ``../../../outside.txt``) cannot read arbitrary host files
+            # into a generated command.
             cmd_path = Path(cmd_file)
-            if cmd_path.is_absolute():
+            win_path = PureWindowsPath(cmd_file)
+            if cmd_path.is_absolute() or win_path.is_absolute() or win_path.drive:
                 continue
             try:
                 source_root = source_dir.resolve()

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -290,6 +290,22 @@ class ExtensionManifest:
             if "name" not in cmd or "file" not in cmd:
                 raise ValidationError("Command missing 'name' or 'file'")
 
+            # Validate the 'file' field for path traversal at manifest-load
+            # time. This is defense-in-depth: the command/skill/preset readers
+            # also contain the resolved path, but rejecting a traversal here
+            # surfaces a clear error instead of silently skipping the command.
+            cmd_file = cmd["file"]
+            if not isinstance(cmd_file, str) or not cmd_file:
+                raise ValidationError(
+                    f"Command 'file' for '{cmd.get('name')}' must be a non-empty string"
+                )
+            cmd_file_path = Path(cmd_file)
+            if cmd_file_path.is_absolute() or ".." in cmd_file_path.parts:
+                raise ValidationError(
+                    f"Invalid command 'file' '{cmd_file}': must be a relative path "
+                    "within the extension directory (no absolute paths or '..' segments)"
+                )
+
             # Validate command name format
             if not EXTENSION_COMMAND_NAME_PATTERN.match(cmd["name"]):
                 corrected = self._try_correct_command_name(cmd["name"], ext["id"])

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -299,6 +299,11 @@ class ExtensionManifest:
                 raise ValidationError(
                     f"Command 'file' for '{cmd.get('name')}' must be a non-empty string"
                 )
+            if cmd_file.strip() != cmd_file:
+                raise ValidationError(
+                    f"Invalid command 'file' '{cmd_file}': must not have leading or "
+                    "trailing whitespace"
+                )
             # Evaluate the value under both POSIX and Windows path semantics so
             # the check is platform-independent. Reject any non-empty anchor —
             # which covers POSIX-absolute (``/abs``), Windows drive-relative

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -18,7 +18,7 @@ import tempfile
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Callable, Dict, List, Optional, Set
 
 import pathspec
@@ -299,11 +299,24 @@ class ExtensionManifest:
                 raise ValidationError(
                     f"Command 'file' for '{cmd.get('name')}' must be a non-empty string"
                 )
-            cmd_file_path = Path(cmd_file)
-            if cmd_file_path.is_absolute() or ".." in cmd_file_path.parts:
+            # Evaluate the value under both POSIX and Windows path semantics so
+            # the check is platform-independent: reject absolute paths, Windows
+            # drive-relative paths (e.g. ``C:foo``, which are not is_absolute()
+            # but resolve against the CWD on their drive), and ``..`` segments
+            # written with either separator.
+            posix_path = Path(cmd_file)
+            win_path = PureWindowsPath(cmd_file)
+            if (
+                posix_path.is_absolute()
+                or win_path.is_absolute()
+                or win_path.drive
+                or ".." in posix_path.parts
+                or ".." in win_path.parts
+            ):
                 raise ValidationError(
                     f"Invalid command 'file' '{cmd_file}': must be a relative path "
-                    "within the extension directory (no absolute paths or '..' segments)"
+                    "within the extension directory (no absolute paths, drive "
+                    "letters, or '..' segments)"
                 )
 
             # Validate command name format

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -305,12 +305,13 @@ class ExtensionManifest:
                     "trailing whitespace"
                 )
             # Evaluate the value under both POSIX and Windows path semantics so
-            # the check is platform-independent. Reject any non-empty anchor —
-            # which covers POSIX-absolute (``/abs``), Windows drive-relative
-            # (``C:foo``), Windows absolute (``C:\foo``), and rooted-without-
-            # drive (``\foo``) — plus ``..`` segments written with either
-            # separator. Native ``Path`` alone is insufficient: on Windows
-            # ``WindowsPath('/abs').is_absolute()`` is False (no drive).
+            # the check is platform-independent. A native ``Path`` is OS-
+            # dependent — a ``PurePosixPath`` on POSIX won't interpret Windows
+            # drive/UNC forms, and ``C:foo`` is anchored but not
+            # ``is_absolute()``. Reject any non-empty anchor — which covers
+            # POSIX-absolute (``/abs``), Windows drive-relative (``C:foo``),
+            # Windows absolute (``C:\foo``), and UNC/rooted forms — plus ``..``
+            # segments written with either separator.
             posix_path = PurePosixPath(cmd_file)
             win_path = PureWindowsPath(cmd_file)
             if (

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -18,7 +18,7 @@ import tempfile
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set
 
 import pathspec
@@ -28,7 +28,7 @@ from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
 from ._init_options import is_ai_skills_enabled
 from ._invocation_style import is_slash_skills_agent
-from ._utils import dump_frontmatter
+from ._utils import dump_frontmatter, relative_extension_path_violation
 from .catalogs import CatalogEntry as BaseCatalogEntry
 from .catalogs import CatalogStackBase
 
@@ -290,41 +290,17 @@ class ExtensionManifest:
             if "name" not in cmd or "file" not in cmd:
                 raise ValidationError("Command missing 'name' or 'file'")
 
-            # Validate the 'file' field for path traversal at manifest-load
-            # time. This is defense-in-depth: the command/skill/preset readers
-            # also contain the resolved path, but rejecting a traversal here
-            # surfaces a clear error instead of silently skipping the command.
+            # Validate the 'file' field at manifest-load time using the single
+            # shared policy in relative_extension_path_violation(), so manifest
+            # validation cannot drift from the runtime registrar guard. This is
+            # defense-in-depth: the command/skill/preset readers also contain
+            # the resolved path, but rejecting an unsafe value here surfaces a
+            # clear error instead of silently skipping the command.
             cmd_file = cmd["file"]
-            if not isinstance(cmd_file, str) or not cmd_file:
-                raise ValidationError(
-                    f"Command 'file' for '{cmd.get('name')}' must be a non-empty string"
-                )
-            if cmd_file.strip() != cmd_file:
-                raise ValidationError(
-                    f"Invalid command 'file' '{cmd_file}': must not have leading or "
-                    "trailing whitespace"
-                )
-            # Evaluate the value under both POSIX and Windows path semantics so
-            # the check is platform-independent. A native ``Path`` is OS-
-            # dependent — a ``PurePosixPath`` on POSIX won't interpret Windows
-            # drive/UNC forms, and ``C:foo`` is anchored but not
-            # ``is_absolute()``. Reject any non-empty anchor — which covers
-            # POSIX-absolute (``/abs``), Windows drive-relative (``C:foo``),
-            # Windows absolute (``C:\foo``), and UNC/rooted forms — plus ``..``
-            # segments written with either separator.
-            posix_path = PurePosixPath(cmd_file)
-            win_path = PureWindowsPath(cmd_file)
-            if (
-                posix_path.anchor
-                or win_path.anchor
-                or ".." in posix_path.parts
-                or ".." in win_path.parts
-            ):
-                raise ValidationError(
-                    f"Invalid command 'file' '{cmd_file}': must be a relative path "
-                    "within the extension directory (no absolute paths, drive "
-                    "letters, or '..' segments)"
-                )
+            reason = relative_extension_path_violation(cmd_file)
+            if reason:
+                label = repr(cmd_file) if isinstance(cmd_file, str) else f"for command '{cmd.get('name')}'"
+                raise ValidationError(f"Invalid command 'file' {label}: {reason}")
 
             # Validate command name format
             if not EXTENSION_COMMAND_NAME_PATTERN.match(cmd["name"]):

--- a/src/specify_cli/extensions.py
+++ b/src/specify_cli/extensions.py
@@ -18,7 +18,7 @@ import tempfile
 import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Callable, Dict, List, Optional, Set
 
 import pathspec
@@ -300,16 +300,17 @@ class ExtensionManifest:
                     f"Command 'file' for '{cmd.get('name')}' must be a non-empty string"
                 )
             # Evaluate the value under both POSIX and Windows path semantics so
-            # the check is platform-independent: reject absolute paths, Windows
-            # drive-relative paths (e.g. ``C:foo``, which are not is_absolute()
-            # but resolve against the CWD on their drive), and ``..`` segments
-            # written with either separator.
-            posix_path = Path(cmd_file)
+            # the check is platform-independent. Reject any non-empty anchor —
+            # which covers POSIX-absolute (``/abs``), Windows drive-relative
+            # (``C:foo``), Windows absolute (``C:\foo``), and rooted-without-
+            # drive (``\foo``) — plus ``..`` segments written with either
+            # separator. Native ``Path`` alone is insufficient: on Windows
+            # ``WindowsPath('/abs').is_absolute()`` is False (no drive).
+            posix_path = PurePosixPath(cmd_file)
             win_path = PureWindowsPath(cmd_file)
             if (
-                posix_path.is_absolute()
-                or win_path.is_absolute()
-                or win_path.drive
+                posix_path.anchor
+                or win_path.anchor
                 or ".." in posix_path.parts
                 or ".." in win_path.parts
             ):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -379,7 +379,7 @@ class TestExtensionManifest:
 
     @pytest.mark.parametrize(
         "bad_file",
-        ["../../../etc/passwd", "../escape.md", "a/../../escape.md", "/etc/passwd"],
+        ["../../../outside.md", "../escape.md", "a/../../escape.md", "/abs/outside.md"],
     )
     def test_command_file_traversal_rejected(self, temp_dir, valid_manifest_data, bad_file):
         """Manifest 'file' field with traversal/absolute path raises ValidationError.

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -377,6 +377,26 @@ class TestExtensionManifest:
         with pytest.raises(ValidationError, match="Invalid command name"):
             ExtensionManifest(manifest_path)
 
+    @pytest.mark.parametrize(
+        "bad_file",
+        ["../../../etc/passwd", "../escape.md", "a/../../escape.md", "/etc/passwd"],
+    )
+    def test_command_file_traversal_rejected(self, temp_dir, valid_manifest_data, bad_file):
+        """Manifest 'file' field with traversal/absolute path raises ValidationError.
+
+        Defense-in-depth for GHSA-w5fv-7w9x-7fc5.
+        """
+        import yaml
+
+        valid_manifest_data["provides"]["commands"][0]["file"] = bad_file
+
+        manifest_path = temp_dir / "extension.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_manifest_data, f)
+
+        with pytest.raises(ValidationError, match="Invalid command 'file'"):
+            ExtensionManifest(manifest_path)
+
     def test_command_name_autocorrect_speckit_prefix(self, temp_dir, valid_manifest_data):
         """Test that 'speckit.command' is auto-corrected to 'speckit.{ext_id}.command'."""
         import yaml

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -391,10 +391,24 @@ class TestExtensionManifest:
         valid_manifest_data["provides"]["commands"][0]["file"] = bad_file
 
         manifest_path = temp_dir / "extension.yml"
-        with open(manifest_path, 'w') as f:
-            yaml.dump(valid_manifest_data, f)
+        with open(manifest_path, 'w', encoding='utf-8') as f:
+            yaml.safe_dump(valid_manifest_data, f)
 
         with pytest.raises(ValidationError, match="Invalid command 'file'"):
+            ExtensionManifest(manifest_path)
+
+    @pytest.mark.parametrize("bad_file", [" commands/hello.md", "commands/hello.md ", "\tcommands/hello.md"])
+    def test_command_file_whitespace_rejected(self, temp_dir, valid_manifest_data, bad_file):
+        """Manifest 'file' with leading/trailing whitespace raises ValidationError."""
+        import yaml
+
+        valid_manifest_data["provides"]["commands"][0]["file"] = bad_file
+
+        manifest_path = temp_dir / "extension.yml"
+        with open(manifest_path, 'w', encoding='utf-8') as f:
+            yaml.safe_dump(valid_manifest_data, f)
+
+        with pytest.raises(ValidationError, match="leading or trailing whitespace"):
             ExtensionManifest(manifest_path)
 
     def test_command_name_autocorrect_speckit_prefix(self, temp_dir, valid_manifest_data):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -379,7 +379,7 @@ class TestExtensionManifest:
 
     @pytest.mark.parametrize(
         "bad_file",
-        ["../../../outside.md", "../escape.md", "a/../../escape.md", "/abs/outside.md"],
+        ["../../../outside.md", "../escape.md", "a/../../escape.md", "/abs/outside.md", "C:escape.md", "C:\\Windows\\x.md", "..\\..\\escape.md"],
     )
     def test_command_file_traversal_rejected(self, temp_dir, valid_manifest_data, bad_file):
         """Manifest 'file' field with traversal/absolute path raises ValidationError.

--- a/tests/test_registrar_path_traversal.py
+++ b/tests/test_registrar_path_traversal.py
@@ -141,6 +141,7 @@ FILE_FIELD_PAYLOADS = [
     "../outside.txt",
     "../../outside.txt",
     "commands/../../outside.txt",
+    "C:outside.txt",
     ABS_OUTSIDE,
 ]
 

--- a/tests/test_registrar_path_traversal.py
+++ b/tests/test_registrar_path_traversal.py
@@ -214,6 +214,23 @@ class TestCommandFileTraversal:
         ]
         assert leaked == [], f"Outside file leaked into generated command: {leaked}"
 
+    @pytest.mark.parametrize("bad_value", [None, 123, "", ["x"]])
+    def test_non_string_file_is_skipped(self, tmp_path, bad_value):
+        """A non-string/empty ``file`` must be skipped, not raise TypeError."""
+        project, ext_dir = _project_and_source(tmp_path)
+        (project / ".gemini" / "commands").mkdir(parents=True)
+
+        registrar = CommandRegistrar()
+        registered = registrar.register_commands(
+            "gemini",
+            [{"name": "speckit.myext.hello", "file": bad_value, "aliases": []}],
+            "myext",
+            ext_dir,
+            project,
+        )
+
+        assert registered == []
+
 
 class TestSafeRegistration:
     """Positive regression — well-formed names continue to register."""

--- a/tests/test_registrar_path_traversal.py
+++ b/tests/test_registrar_path_traversal.py
@@ -135,34 +135,34 @@ class TestCopilotPromptTraversal:
         _assert_no_stray_files(tmp_path, Path(bad_name).name.replace("/", ""))
 
 
-ABS_SECRET = "__ABS_SECRET__"
+ABS_OUTSIDE = "__ABS_OUTSIDE__"
 
 FILE_FIELD_PAYLOADS = [
-    "../secret.txt",
-    "../../secret.txt",
-    "commands/../../secret.txt",
-    ABS_SECRET,
+    "../outside.txt",
+    "../../outside.txt",
+    "commands/../../outside.txt",
+    ABS_OUTSIDE,
 ]
 
 
-def _resolve_payload(bad_file: str, secret: Path) -> str:
-    """Map the absolute-path sentinel to the real, existing secret file.
+def _resolve_payload(bad_file: str, outside_file: Path) -> str:
+    """Map the absolute-path sentinel to the real, existing outside file.
 
-    Using the temp secret's own absolute path (instead of ``/etc/passwd``)
+    Using the temp file's own absolute path (instead of ``/etc/passwd``)
     guarantees the file exists on every platform — so the test fails if the
     absolute-path guard regresses, rather than passing because the target
     happens not to exist (e.g. on Windows runners).
     """
-    return str(secret) if bad_file == ABS_SECRET else bad_file
+    return str(outside_file) if bad_file == ABS_OUTSIDE else bad_file
 
 
 class TestCommandFileTraversal:
-    """The manifest ``file`` field must not read host files outside source_dir.
+    """The manifest ``file`` field must not read files outside source_dir.
 
     Regression for GHSA-w5fv-7w9x-7fc5: ``register_commands`` read
     ``source_dir / cmd_file`` with no containment check, so a manifest with
-    ``file: ../../../etc/passwd`` (or an absolute path) leaked arbitrary host
-    files verbatim into the generated agent command.
+    a traversal (``file: ../../../outside.txt``) or an absolute path read an
+    arbitrary host file verbatim into the generated agent command.
     """
 
     @pytest.mark.parametrize("bad_file", FILE_FIELD_PAYLOADS)
@@ -170,13 +170,13 @@ class TestCommandFileTraversal:
         project, ext_dir = _project_and_source(tmp_path)
         (project / ".claude" / "skills").mkdir(parents=True)
 
-        secret = tmp_path / "secret.txt"
-        secret.write_text("TOP-SECRET-CREDENTIAL", encoding="utf-8")
+        outside_file = tmp_path / "outside.txt"
+        outside_file.write_text("OUTSIDE-FILE-MARKER", encoding="utf-8")
 
         registrar = CommandRegistrar()
         registered = registrar.register_commands(
             "claude",
-            [{"name": "speckit.myext.hello", "file": _resolve_payload(bad_file, secret), "aliases": []}],
+            [{"name": "speckit.myext.hello", "file": _resolve_payload(bad_file, outside_file), "aliases": []}],
             "myext",
             ext_dir,
             project,
@@ -185,22 +185,22 @@ class TestCommandFileTraversal:
         assert registered == []
         leaked = [
             p for p in (project).rglob("*")
-            if p.is_file() and "TOP-SECRET-CREDENTIAL" in p.read_text(encoding="utf-8", errors="ignore")
+            if p.is_file() and "OUTSIDE-FILE-MARKER" in p.read_text(encoding="utf-8", errors="ignore")
         ]
-        assert leaked == [], f"Secret leaked into generated command: {leaked}"
+        assert leaked == [], f"Outside file leaked into generated command: {leaked}"
 
     @pytest.mark.parametrize("bad_file", FILE_FIELD_PAYLOADS)
     def test_gemini_skips_traversal_in_file_field(self, tmp_path, bad_file):
         project, ext_dir = _project_and_source(tmp_path)
         (project / ".gemini" / "commands").mkdir(parents=True)
 
-        secret = tmp_path / "secret.txt"
-        secret.write_text("TOP-SECRET-CREDENTIAL", encoding="utf-8")
+        outside_file = tmp_path / "outside.txt"
+        outside_file.write_text("OUTSIDE-FILE-MARKER", encoding="utf-8")
 
         registrar = CommandRegistrar()
         registered = registrar.register_commands(
             "gemini",
-            [{"name": "speckit.myext.hello", "file": _resolve_payload(bad_file, secret), "aliases": []}],
+            [{"name": "speckit.myext.hello", "file": _resolve_payload(bad_file, outside_file), "aliases": []}],
             "myext",
             ext_dir,
             project,
@@ -209,9 +209,9 @@ class TestCommandFileTraversal:
         assert registered == []
         leaked = [
             p for p in (project).rglob("*")
-            if p.is_file() and "TOP-SECRET-CREDENTIAL" in p.read_text(encoding="utf-8", errors="ignore")
+            if p.is_file() and "OUTSIDE-FILE-MARKER" in p.read_text(encoding="utf-8", errors="ignore")
         ]
-        assert leaked == [], f"Secret leaked into generated command: {leaked}"
+        assert leaked == [], f"Outside file leaked into generated command: {leaked}"
 
 
 class TestSafeRegistration:

--- a/tests/test_registrar_path_traversal.py
+++ b/tests/test_registrar_path_traversal.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from specify_cli.agents import CommandRegistrar
+from specify_cli._utils import relative_extension_path_violation
 
 
 TRAVERSAL_PAYLOADS = [
@@ -141,7 +142,6 @@ FILE_FIELD_PAYLOADS = [
     "../outside.txt",
     "../../outside.txt",
     "commands/../../outside.txt",
-    "commands/../cmd.md",  # in-bounds after resolve; only the '..' check rejects it
     "C:outside.txt",
     ABS_OUTSIDE,
 ]
@@ -233,9 +233,88 @@ class TestCommandFileTraversal:
 
         assert registered == []
 
+    def test_dotdot_rejected_even_when_target_is_in_bounds(self, tmp_path):
+        """An in-bounds ``..`` payload is rejected by the ``..`` check itself.
 
-class TestSafeRegistration:
-    """Positive regression — well-formed names continue to register."""
+        ``commands/../cmd.md`` resolves to ``ext_dir/cmd.md`` — inside
+        source_dir — so the resolve()/relative_to() containment backstop would
+        allow it. Creating that target file ensures the command is skipped
+        because of the ``..`` rejection, not merely because the file is absent.
+        """
+        project, ext_dir = _project_and_source(tmp_path)
+        (project / ".gemini" / "commands").mkdir(parents=True)
+        (ext_dir / "cmd.md").write_text(
+            "---\ndescription: test\n---\n\nbody\n", encoding="utf-8"
+        )
+
+        registrar = CommandRegistrar()
+        registered = registrar.register_commands(
+            "gemini",
+            [{"name": "speckit.myext.hello", "file": "commands/../cmd.md", "aliases": []}],
+            "myext",
+            ext_dir,
+            project,
+        )
+
+        assert registered == []
+
+
+class TestRelativeExtensionPathPolicy:
+    """Unit tests for the shared ``relative_extension_path_violation`` policy."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "commands/hello.md",
+            "hello.md",
+            "a/b/c/hello.md",
+        ],
+    )
+    def test_safe_relative_paths_have_no_violation(self, value):
+        assert relative_extension_path_violation(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            123,
+            ["x"],
+            "",
+            "   ",
+            " hello.md",
+            "hello.md ",
+            "/abs/outside.md",
+            "/etc/passwd",
+            "C:foo.md",
+            "C:\\Windows\\system32",
+            "\\\\server\\share\\x.md",
+            "../escape.md",
+            "commands/../../escape.md",
+        ],
+    )
+    def test_unsafe_values_report_violation(self, value):
+        assert relative_extension_path_violation(value) is not None
+
+
+class TestReadSkipWarning:
+    """Unregisterable but in-bounds files warn instead of failing silently."""
+
+    def test_unreadable_target_warns_and_skips(self, tmp_path):
+        project, ext_dir = _project_and_source(tmp_path)
+        (project / ".gemini" / "commands").mkdir(parents=True)
+        (ext_dir / "cmd.md").write_bytes(b"\xff\xfe\x00\x80bad")
+
+        registrar = CommandRegistrar()
+        with pytest.warns(UserWarning):
+            registered = registrar.register_commands(
+                "gemini",
+                [{"name": "speckit.myext.hello", "file": "cmd.md", "aliases": []}],
+                "myext",
+                ext_dir,
+                project,
+            )
+
+        assert registered == []
 
     def test_symlinked_subdir_under_commands_dir_is_preserved(self, tmp_path):
         """Lexical check must not block legitimately symlinked sub-directories.

--- a/tests/test_registrar_path_traversal.py
+++ b/tests/test_registrar_path_traversal.py
@@ -141,6 +141,7 @@ FILE_FIELD_PAYLOADS = [
     "../outside.txt",
     "../../outside.txt",
     "commands/../../outside.txt",
+    "commands/../cmd.md",  # in-bounds after resolve; only the '..' check rejects it
     "C:outside.txt",
     ABS_OUTSIDE,
 ]
@@ -155,6 +156,15 @@ def _resolve_payload(bad_file: str, outside_file: Path) -> str:
     happens not to exist (e.g. on Windows runners).
     """
     return str(outside_file) if bad_file == ABS_OUTSIDE else bad_file
+
+
+def _assert_no_marker_leak(project: Path, marker: str) -> None:
+    """Fail if ``marker`` content was written into any file under ``project``."""
+    leaked = [
+        p for p in project.rglob("*")
+        if p.is_file() and marker in p.read_text(encoding="utf-8", errors="ignore")
+    ]
+    assert leaked == [], f"Outside file leaked into generated command: {leaked}"
 
 
 class TestCommandFileTraversal:
@@ -184,11 +194,7 @@ class TestCommandFileTraversal:
         )
 
         assert registered == []
-        leaked = [
-            p for p in (project).rglob("*")
-            if p.is_file() and "OUTSIDE-FILE-MARKER" in p.read_text(encoding="utf-8", errors="ignore")
-        ]
-        assert leaked == [], f"Outside file leaked into generated command: {leaked}"
+        _assert_no_marker_leak(project, "OUTSIDE-FILE-MARKER")
 
     @pytest.mark.parametrize("bad_file", FILE_FIELD_PAYLOADS)
     def test_gemini_skips_traversal_in_file_field(self, tmp_path, bad_file):
@@ -208,11 +214,7 @@ class TestCommandFileTraversal:
         )
 
         assert registered == []
-        leaked = [
-            p for p in (project).rglob("*")
-            if p.is_file() and "OUTSIDE-FILE-MARKER" in p.read_text(encoding="utf-8", errors="ignore")
-        ]
-        assert leaked == [], f"Outside file leaked into generated command: {leaked}"
+        _assert_no_marker_leak(project, "OUTSIDE-FILE-MARKER")
 
     @pytest.mark.parametrize("bad_value", [None, 123, "", ["x"]])
     def test_non_string_file_is_skipped(self, tmp_path, bad_value):

--- a/tests/test_registrar_path_traversal.py
+++ b/tests/test_registrar_path_traversal.py
@@ -135,6 +135,72 @@ class TestCopilotPromptTraversal:
         _assert_no_stray_files(tmp_path, Path(bad_name).name.replace("/", ""))
 
 
+FILE_FIELD_PAYLOADS = [
+    "../secret.txt",
+    "../../secret.txt",
+    "commands/../../secret.txt",
+    "/etc/passwd",
+]
+
+
+class TestCommandFileTraversal:
+    """The manifest ``file`` field must not read host files outside source_dir.
+
+    Regression for GHSA-w5fv-7w9x-7fc5: ``register_commands`` read
+    ``source_dir / cmd_file`` with no containment check, so a manifest with
+    ``file: ../../../etc/passwd`` (or an absolute path) leaked arbitrary host
+    files verbatim into the generated agent command.
+    """
+
+    @pytest.mark.parametrize("bad_file", FILE_FIELD_PAYLOADS)
+    def test_claude_skips_traversal_in_file_field(self, tmp_path, bad_file):
+        project, ext_dir = _project_and_source(tmp_path)
+        (project / ".claude" / "skills").mkdir(parents=True)
+
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP-SECRET-CREDENTIAL", encoding="utf-8")
+
+        registrar = CommandRegistrar()
+        registered = registrar.register_commands(
+            "claude",
+            [{"name": "speckit.myext.hello", "file": bad_file, "aliases": []}],
+            "myext",
+            ext_dir,
+            project,
+        )
+
+        assert registered == []
+        leaked = [
+            p for p in (project).rglob("*")
+            if p.is_file() and "TOP-SECRET-CREDENTIAL" in p.read_text(encoding="utf-8", errors="ignore")
+        ]
+        assert leaked == [], f"Secret leaked into generated command: {leaked}"
+
+    @pytest.mark.parametrize("bad_file", FILE_FIELD_PAYLOADS)
+    def test_gemini_skips_traversal_in_file_field(self, tmp_path, bad_file):
+        project, ext_dir = _project_and_source(tmp_path)
+        (project / ".gemini" / "commands").mkdir(parents=True)
+
+        secret = tmp_path / "secret.txt"
+        secret.write_text("TOP-SECRET-CREDENTIAL", encoding="utf-8")
+
+        registrar = CommandRegistrar()
+        registered = registrar.register_commands(
+            "gemini",
+            [{"name": "speckit.myext.hello", "file": bad_file, "aliases": []}],
+            "myext",
+            ext_dir,
+            project,
+        )
+
+        assert registered == []
+        leaked = [
+            p for p in (project).rglob("*")
+            if p.is_file() and "TOP-SECRET-CREDENTIAL" in p.read_text(encoding="utf-8", errors="ignore")
+        ]
+        assert leaked == [], f"Secret leaked into generated command: {leaked}"
+
+
 class TestSafeRegistration:
     """Positive regression — well-formed names continue to register."""
 

--- a/tests/test_registrar_path_traversal.py
+++ b/tests/test_registrar_path_traversal.py
@@ -135,12 +135,25 @@ class TestCopilotPromptTraversal:
         _assert_no_stray_files(tmp_path, Path(bad_name).name.replace("/", ""))
 
 
+ABS_SECRET = "__ABS_SECRET__"
+
 FILE_FIELD_PAYLOADS = [
     "../secret.txt",
     "../../secret.txt",
     "commands/../../secret.txt",
-    "/etc/passwd",
+    ABS_SECRET,
 ]
+
+
+def _resolve_payload(bad_file: str, secret: Path) -> str:
+    """Map the absolute-path sentinel to the real, existing secret file.
+
+    Using the temp secret's own absolute path (instead of ``/etc/passwd``)
+    guarantees the file exists on every platform — so the test fails if the
+    absolute-path guard regresses, rather than passing because the target
+    happens not to exist (e.g. on Windows runners).
+    """
+    return str(secret) if bad_file == ABS_SECRET else bad_file
 
 
 class TestCommandFileTraversal:
@@ -163,7 +176,7 @@ class TestCommandFileTraversal:
         registrar = CommandRegistrar()
         registered = registrar.register_commands(
             "claude",
-            [{"name": "speckit.myext.hello", "file": bad_file, "aliases": []}],
+            [{"name": "speckit.myext.hello", "file": _resolve_payload(bad_file, secret), "aliases": []}],
             "myext",
             ext_dir,
             project,
@@ -187,7 +200,7 @@ class TestCommandFileTraversal:
         registrar = CommandRegistrar()
         registered = registrar.register_commands(
             "gemini",
-            [{"name": "speckit.myext.hello", "file": bad_file, "aliases": []}],
+            [{"name": "speckit.myext.hello", "file": _resolve_payload(bad_file, secret), "aliases": []}],
             "myext",
             ext_dir,
             project,


### PR DESCRIPTION
## What this fixes

`CommandRegistrar.register_commands()` read each command body from `source_dir / cmd_file` using the manifest's `file` field without validating it. Unlike the parallel skill and preset readers — which already reject absolute paths and `..` traversal and require the resolved path to stay within the extension directory — the shared command path applied no such check.

As a result, a manifest with `file: ../../../etc/passwd` (or a bare absolute path) could cause an arbitrary host file to be read verbatim into a generated agent command file at a predictable path under the project (e.g. `.claude/commands/...`, mirrored for each detected agent).

## Changes

- **`agents.py` — `register_commands()`**: add the same containment guard used by the skill/preset readers before reading the source file — reject absolute paths and ensure the resolved path stays within `source_dir`; skip the command otherwise.
- **`extensions.py` — `ExtensionManifest._validate()`**: reject an absolute or `..`-containing `file` value at manifest-load time with a clear `ValidationError` (defense-in-depth, surfaces a real error instead of a silent skip).
- **Tests**:
  - `test_registrar_path_traversal.py`: new `TestCommandFileTraversal` covering the `file` read path (the existing tests only covered command name/alias output traversal). Asserts traversal/absolute `file` values register nothing and never leak file contents into generated commands.
  - `test_extensions.py`: parametrized manifest-load validation test for the `file` field.

## Verification

New and targeted suites pass. Full suite: 3975 passed, with 2 pre-existing failures in `test_init_dir.py` (a `SPECIFY_INIT_DIR` core-scripts environment issue) confirmed unrelated to these changes by stashing.