### PR TITLE
fix(presets): use _repo_root() for bundled-core source-checkout fallback (#3086)

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -2703,7 +2703,7 @@ class PresetResolver:
         # (source-checkout / editable install).  This is the canonical home for
         # speckit's built-in command/template files and must always be checked
         # so that strategy:wrap presets can locate {CORE_TEMPLATE}.
-        from specify_cli import _locate_core_pack  # local import to avoid cycles
+        from specify_cli import _locate_core_pack, _repo_root  # local import to avoid cycles
         _core_pack = _locate_core_pack()
         if _core_pack is not None:
             # Wheel install path
@@ -2723,7 +2723,7 @@ class PresetResolver:
                 return candidate
         else:
             # Source-checkout / editable install: templates live at repo root
-            repo_root = Path(__file__).parent.parent.parent
+            repo_root = _repo_root()
             if template_type == "template":
                 candidate = repo_root / "templates" / f"{template_name}.md"
             elif template_type == "command":
@@ -3075,7 +3075,7 @@ class PresetResolver:
         ``.specify/templates/`` doesn't contain the core file.
         """
         try:
-            from specify_cli import _locate_core_pack
+            from specify_cli import _locate_core_pack, _repo_root
         except ImportError:
             return None
 
@@ -3098,7 +3098,7 @@ class PresetResolver:
                 if c.exists():
                     return c
         else:
-            repo_root = Path(__file__).parent.parent.parent
+            repo_root = _repo_root()
             for name in names:
                 if template_type == "template":
                     c = repo_root / "templates" / f"{name}.md"

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1094,7 +1094,33 @@ class TestResolveCore:
         result = resolver.resolve_core("nonexistent", "command")
         assert result is None
 
-    def test_resolve_extension_command_via_manifest_skips_oserror_manifests(self, project_dir):
+    def test_collect_all_layers_finds_bundled_core_without_specify_commands(
+        self, project_dir
+    ):
+        """Tier-5 fallback locates the bundled core command when
+        .specify/templates/commands/ has no matching file.
+
+        Regression test for #3086: a stale ``.parent`` chain made the
+        source-checkout fallback resolve to ``src/templates/...`` (which does
+        not exist), so ``wrap`` presets found no base layer. The fallback must
+        resolve against the real repo-root ``templates/commands`` tree.
+        """
+        # project_dir's commands dir is empty, so tier-4 cannot satisfy this.
+        resolver = PresetResolver(project_dir)
+        layers = resolver.collect_all_layers("speckit.implement", "command")
+        assert layers, "expected a bundled core base layer to be found"
+        assert layers[-1]["source"] == "core (bundled)"
+        assert layers[-1]["path"].parts[-2:] == ("commands", "implement.md")
+
+    def test_resolve_command_falls_back_to_bundled_core(self, project_dir):
+        """resolve() tier-5 returns the bundled core command when
+        .specify/templates/commands/ lacks it (regression for #3086)."""
+        resolver = PresetResolver(project_dir)
+        result = resolver.resolve("speckit.implement", "command")
+        assert result is not None
+        assert result.parts[-2:] == ("commands", "implement.md")
+
+
         """resolve_extension_command_via_manifest skips extensions whose manifest raises OSError."""
         import unittest.mock as mock
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1033,6 +1033,32 @@ class TestPresetResolver:
         result = resolver.resolve("hidden-template")
         assert result is None
 
+    def test_collect_all_layers_finds_bundled_core_without_specify_commands(
+        self, project_dir
+    ):
+        """Tier-5 fallback locates the bundled core command when
+        .specify/templates/commands/ has no matching file.
+
+        Regression test for #3086: a stale ``.parent`` chain made the
+        source-checkout fallback resolve to ``src/templates/...`` (which does
+        not exist), so ``wrap`` presets found no base layer. The fallback must
+        resolve against the real repo-root ``templates/commands`` tree.
+        """
+        # project_dir's commands dir is empty, so tier-4 cannot satisfy this.
+        resolver = PresetResolver(project_dir)
+        layers = resolver.collect_all_layers("speckit.implement", "command")
+        assert layers, "expected a bundled core base layer to be found"
+        assert layers[-1]["source"] == "core (bundled)"
+        assert layers[-1]["path"].parts[-2:] == ("commands", "implement.md")
+
+    def test_resolve_command_falls_back_to_bundled_core(self, project_dir):
+        """resolve() tier-5 returns the bundled core command when
+        .specify/templates/commands/ lacks it (regression for #3086)."""
+        resolver = PresetResolver(project_dir)
+        result = resolver.resolve("speckit.implement", "command")
+        assert result is not None
+        assert result.parts[-2:] == ("commands", "implement.md")
+
 
 class TestResolveCore:
     """Test PresetResolver.resolve_core() skips the installed-presets tier."""
@@ -1093,32 +1119,6 @@ class TestResolveCore:
         resolver = PresetResolver(project_dir)
         result = resolver.resolve_core("nonexistent", "command")
         assert result is None
-
-    def test_collect_all_layers_finds_bundled_core_without_specify_commands(
-        self, project_dir
-    ):
-        """Tier-5 fallback locates the bundled core command when
-        .specify/templates/commands/ has no matching file.
-
-        Regression test for #3086: a stale ``.parent`` chain made the
-        source-checkout fallback resolve to ``src/templates/...`` (which does
-        not exist), so ``wrap`` presets found no base layer. The fallback must
-        resolve against the real repo-root ``templates/commands`` tree.
-        """
-        # project_dir's commands dir is empty, so tier-4 cannot satisfy this.
-        resolver = PresetResolver(project_dir)
-        layers = resolver.collect_all_layers("speckit.implement", "command")
-        assert layers, "expected a bundled core base layer to be found"
-        assert layers[-1]["source"] == "core (bundled)"
-        assert layers[-1]["path"].parts[-2:] == ("commands", "implement.md")
-
-    def test_resolve_command_falls_back_to_bundled_core(self, project_dir):
-        """resolve() tier-5 returns the bundled core command when
-        .specify/templates/commands/ lacks it (regression for #3086)."""
-        resolver = PresetResolver(project_dir)
-        result = resolver.resolve("speckit.implement", "command")
-        assert result is not None
-        assert result.parts[-2:] == ("commands", "implement.md")
 
     def test_resolve_extension_command_via_manifest_skips_oserror_manifests(self, project_dir):
         """resolve_extension_command_via_manifest skips extensions whose manifest raises OSError."""

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1120,7 +1120,7 @@ class TestResolveCore:
         assert result is not None
         assert result.parts[-2:] == ("commands", "implement.md")
 
-
+    def test_resolve_extension_command_via_manifest_skips_oserror_manifests(self, project_dir):
         """resolve_extension_command_via_manifest skips extensions whose manifest raises OSError."""
         import unittest.mock as mock
 


### PR DESCRIPTION
## Summary

Assessment and fix for #3086.

The issue claims `specify init` not copying `templates/commands/` into `.specify/templates/commands/` causes `wrap`-strategy presets to fail. That root cause is **incorrect**: `PresetResolver` has an explicit Priority‑5 fallback (`_find_bundled_core`, plus the matching tier‑5 branch in `resolve()`) specifically designed to locate the core base layer when `.specify/templates/commands/` is absent. The missing copy is a layout/cosmetic gap, not a functional one.

However, while verifying, I found a **real** bug that *does* break `wrap` presets — but only in **source/editable installs**, and for a different reason:

Both fallbacks computed the repo root as `Path(__file__).parent.parent.parent`. After `presets.py` was moved to `presets/__init__.py` (#2826), that chain is one level short — it resolves to `src/` and looks for `src/templates/commands/<cmd>.md`, which never exists. So the base layer was never found.

Wheel installs were unaffected because they take the `core_pack` branch.

## Fix

Use the shared `_repo_root()` helper (from `_assets.py`) in both `resolve()` and `_find_bundled_core()` instead of a hand-rolled `.parent` chain, so the path stays correct regardless of module nesting.

## Tests

- Added two regression tests asserting the bundled-core fallback resolves `speckit.implement` via both `collect_all_layers()` and `resolve()` when `.specify/templates/commands/` has no matching file.
- Full preset suite (312 tests) passes.

## Why not the issue's suggested fix

Copying `templates/commands/` into `.specify/templates/commands/` during `specify init` touches the core SDD install/manifest/upgrade flow to solve a non-problem (the fallback already covers wheel installs). This PR keeps the change isolated to the preset resolver and does not alter the SDD process.

Refs #3086
