### PR TITLE
Point sicario-core docs to preset README

### DIFF
--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -573,7 +573,7 @@
       "repository": "https://github.com/dfirs1car1o/sicario-spec",
       "download_url": "https://github.com/dfirs1car1o/sicario-spec/releases/download/v0.4.0/sicario-core-0.4.0.zip",
       "homepage": "https://github.com/dfirs1car1o/sicario-spec",
-      "documentation": "https://github.com/dfirs1car1o/sicario-spec/blob/main/README.md",
+      "documentation": "https://github.com/dfirs1car1o/sicario-spec/blob/main/presets/sicario-core/README.md",
       "license": "MIT",
       "requires": {
         "speckit_version": ">=0.9.0"

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-06-22T00:00:00Z",
+  "updated_at": "2026-06-25T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/presets/catalog.community.json",
   "presets": {
     "a11y-governance": {
@@ -590,7 +590,7 @@
         "evidence"
       ],
       "created_at": "2026-06-22T00:00:00Z",
-      "updated_at": "2026-06-22T00:00:00Z"
+      "updated_at": "2026-06-25T00:00:00Z"
     },
     "spec2cloud": {
       "name": "Spec2Cloud",


### PR DESCRIPTION
## Summary

- Updates the `sicario-core` community catalog entry to point at the preset-scoped README instead of the repository root README.
- Aligns the catalog link with the follow-up concern in #3103: users should land on preset usage documentation, not the broader SicarioSpec product README.
- The target README is now a concise badge-backed preset landing page, with deeper workflow and adoption details moved to `USAGE.md` in dfirs1car1o/sicario-spec#25.

## Validation

- `python3 -m json.tool presets/catalog.community.json`
- Confirmed the linked README exists and includes `specify preset add --from`, `specify preset add --dev`, badges, template summary, and verification guidance.
- Verified the released preset still installs with `specify preset add --from https://github.com/dfirs1car1o/sicario-spec/releases/download/v0.4.0/sicario-core-0.4.0.zip` in a fresh Spec Kit project.

Related: #3103
