### PR TITLE
ci: pin actions to commit SHAs and add shellcheck

### DIFF
--- a/.github/workflows/catalog-assign.yml
+++ b/.github/workflows/catalog-assign.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,5 +52,5 @@ jobs:
       # shellcheck is preinstalled on ubuntu-latest runners.
       # Start at --severity=error to block real bugs without flagging style
       # (notably SC2155). Tighten in a follow-up after cleanup.
-      - name: Run shellcheck on scripts/bash
-        run: shellcheck --severity=error scripts/bash/*.sh
+      - name: Run shellcheck on shell scripts
+        run: git ls-files -z -- '*.sh' | xargs -0 shellcheck --severity=error

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # shellcheck is preinstalled on ubuntu-latest runners.
       # Start at --severity=error to block real bugs without flagging style

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,3 +42,15 @@ jobs:
           globs: |
             '**/*.md'
             !extensions/**/*.md
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # shellcheck is preinstalled on ubuntu-latest runners.
+      # Start at --severity=error to block real bugs without flagging style
+      # (notably SC2155). Tighten in a follow-up after cleanup.
+      - name: Run shellcheck on scripts/bash
+        run: shellcheck --severity=error scripts/bash/*.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ uv pip install -e ".[test]"
 #### Shell scripts
 
 ```bash
-shellcheck --severity=error scripts/bash/*.sh
+git ls-files -z -- '*.sh' | xargs -0 shellcheck --severity=error
 ```
 
 The CI `lint.yml` `shellcheck` job blocks at `--severity=error` to catch real bugs while leaving stylistic warnings (SC2155 etc.) advisory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,14 @@ uv pip install -e ".[test]"
 > `specify_cli` to this checkout's `src/`. This matches the gotcha documented in
 > `AGENTS.md` (Common Pitfalls).
 
+#### Shell scripts
+
+```bash
+shellcheck --severity=error scripts/bash/*.sh
+```
+
+The CI `lint.yml` `shellcheck` job blocks at `--severity=error` to catch real bugs while leaving stylistic warnings (SC2155 etc.) advisory.
+
 ### Manual testing
 
 #### Testing setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,9 @@ uv pip install -e ".[test]"
 git ls-files -z -- '*.sh' | xargs -0 shellcheck --severity=error
 ```
 
-The CI `lint.yml` `shellcheck` job blocks at `--severity=error` to catch real bugs while leaving stylistic warnings (SC2155 etc.) advisory.
+The CI `lint.yml` `shellcheck` job currently reports and blocks only
+error-severity findings. Warnings such as SC2155 are intentionally outside this
+job until a follow-up cleanup tightens the threshold.
 
 ### Manual testing
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,0 +1,34 @@
+"""Static checks for repository GitHub Actions workflows."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+# Match both the dedicated-step form (`        uses: x@sha`) and the
+# inline shorthand (`      - uses: x@sha`) used in catalog-assign.yml.
+USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)", re.MULTILINE)
+
+
+def test_github_actions_are_pinned_to_full_commit_shas():
+    unpinned_refs = []
+
+    workflows = sorted(
+        list(WORKFLOWS_DIR.glob("*.yml")) + list(WORKFLOWS_DIR.glob("*.yaml"))
+    )
+    assert workflows
+
+    for workflow in workflows:
+        workflow_text = workflow.read_text(encoding="utf-8")
+        for match in USES_RE.finditer(workflow_text):
+            uses_ref = match.group("ref")
+            if uses_ref.startswith(("./", "../")):
+                continue
+            if re.search(r"@[0-9a-f]{40}$", uses_ref):
+                continue
+            unpinned_refs.append(f"{workflow.relative_to(REPO_ROOT)}: {uses_ref}")
+
+    assert unpinned_refs == []

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -11,6 +11,7 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 # Match both the dedicated-step form (`        uses: x@sha`) and the
 # inline shorthand (`      - uses: x@sha`) used in catalog-assign.yml.
 USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)", re.MULTILINE)
+PINNED_SHA_RE = re.compile(r"@[0-9a-f]{40}$", re.IGNORECASE)
 
 
 def test_github_actions_are_pinned_to_full_commit_shas():
@@ -27,8 +28,14 @@ def test_github_actions_are_pinned_to_full_commit_shas():
             uses_ref = match.group("ref")
             if uses_ref.startswith(("./", "../")):
                 continue
-            if re.search(r"@[0-9a-f]{40}$", uses_ref):
+            if PINNED_SHA_RE.search(uses_ref):
                 continue
             unpinned_refs.append(f"{workflow.relative_to(REPO_ROOT)}: {uses_ref}")
 
     assert unpinned_refs == []
+
+
+def test_pinned_action_ref_accepts_uppercase_hex_sha():
+    assert PINNED_SHA_RE.search(
+        "actions/example@0123456789ABCDEF0123456789ABCDEF01234567"
+    )


### PR DESCRIPTION
Part of splitting #2442 into smaller, dedicated PRs (per maintainer request). This is the first, dependency-free slice: workflow hygiene only, no runtime code changes.

## What
- Pin `actions/github-script` in `catalog-assign.yml` to a full commit SHA (`3a2844b…` # v9). All other workflows were already pinned.
- Add `tests/test_github_workflows.py`: a repo-wide regression test asserting every non-local `uses:` ref is pinned to a 40-char commit SHA, accepting uppercase or lowercase hex.
- Add a `shellcheck` job to `lint.yml` (`git ls-files -z -- '*.sh' | xargs -0 shellcheck --severity=error`) over tracked shell scripts.
- Document the local shellcheck command in `CONTRIBUTING.md` with wording that matches what `--severity=error` actually reports.

## Why
Unpinned actions are a supply-chain risk: a moved tag can change the executed code. The shellcheck job catches error-severity bugs in committed bash scripts without expanding this PR into a broader warning cleanup.

## Validation
- `uv sync --extra test`
- `.venv/bin/python -m pytest tests/test_github_workflows.py -q`
- `uvx ruff check tests/test_github_workflows.py`
- `git diff --check`
- `git ls-files -z -- '*.sh' | xargs -0 shellcheck --severity=error`

Split from #2442. No dependency on the other split PRs.

## Disclosure
Prepared by Codex (model: GPT-5) on behalf of @PascalThuet.
