### PR TITLE
fix(scripts): match bash case-sensitivity for acronym retention in PowerShell branch names

### DIFF
--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -111,8 +111,11 @@ function Get-BranchName {
         # Keep words that are length >= 3 OR appear as uppercase in original (likely acronyms)
         if ($word.Length -ge 3) {
             $meaningfulWords += $word
-        } elseif ($Description -match "\b$($word.ToUpper())\b") {
-            # Keep short words if they appear as uppercase in original (likely acronyms)
+        } elseif ($Description -cmatch "\b$($word.ToUpper())\b") {
+            # Keep short words only if they appear as uppercase in original (likely
+            # acronyms). Use -cmatch so the comparison is case-sensitive, matching the
+            # bash script's case-sensitive grep; -match would be case-insensitive and
+            # would keep every short word.
             $meaningfulWords += $word
         }
     }

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -869,6 +869,52 @@ class TestPowerShellDryRun:
         assert "DRY_RUN" not in data, f"DRY_RUN should not be in normal JSON: {data}"
 
 
+# ── Short-Word / Acronym Branch-Name Tests ──────────────────────────────────
+
+
+def _branch_from_output(stdout: str) -> str | None:
+    for line in stdout.splitlines():
+        if line.startswith("BRANCH_NAME:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+SHORT_WORD_CASES = [
+    # description, expected branch — "go" (lowercase short word) is dropped,
+    # "AI" (uppercase short word / acronym) is kept, "now" (>=3 chars) is kept.
+    ("go AI now", "001-ai-now"),
+    # A short word that is lowercase everywhere is dropped entirely.
+    ("go to the pub", "001-pub"),
+]
+
+
+@requires_bash
+class TestShortWordRetentionBash:
+    """A short word is kept only when it appears in uppercase (an acronym)."""
+
+    @pytest.mark.parametrize("description,expected", SHORT_WORD_CASES)
+    def test_short_word_retention(self, git_repo: Path, description: str, expected: str):
+        result = run_script(git_repo, "--dry-run", description)
+        assert result.returncode == 0, result.stderr
+        assert _branch_from_output(result.stdout) == expected
+
+
+@pytest.mark.skipif(not _has_pwsh(), reason="pwsh not available")
+class TestShortWordRetentionPowerShell:
+    """PowerShell must match bash: a short word is kept only when uppercase.
+
+    Regression guard for the `-match` (case-insensitive) vs `-cmatch`
+    (case-sensitive) divergence — with `-match`, every short non-stop word
+    leaked into the branch name even when it was lowercase.
+    """
+
+    @pytest.mark.parametrize("description,expected", SHORT_WORD_CASES)
+    def test_short_word_retention(self, ps_git_repo: Path, description: str, expected: str):
+        result = run_ps_script(ps_git_repo, "-DryRun", description)
+        assert result.returncode == 0, result.stderr
+        assert _branch_from_output(result.stdout) == expected
+
+
 # ── GIT_BRANCH_NAME Override Tests ──────────────────────────────────────────
 
 


### PR DESCRIPTION
closes #3131

## what

`create-new-feature` keeps a short (<3 char) word in the generated branch name only when that word appears in **uppercase** in the description — the idea is to preserve acronyms like `AI` or `ML` while dropping ordinary short words. The code comment says exactly this.

the bash script does the check with a case-sensitive `grep`:

```bash
elif echo "$description" | grep -q "${word^^}"; then
```

but the PowerShell script used `-match`, which is **case-insensitive by default**:

```powershell
} elseif ($Description -match "$($word.ToUpper())") {
```

since the word being tested is itself lowercased earlier, `-match` against its uppercased form always matches — so on PowerShell *every* short non-stop word was kept, not just acronyms.

## impact

same description, different branch name depending on the shell:

| description | bash | powershell (before) |
|---|---|---|
| `go AI now` | `001-ai-now` | `001-go-ai-now` |
| `go to the pub` | `001-pub` | `001-go-pub` |

`go` is a 2-char non-stop word that is lowercase, so it should be dropped (and is, on bash). on PowerShell it leaked into the branch name.

## fix

switch `-match` to `-cmatch` so the comparison is case-sensitive, matching the bash `grep`. one-character change plus a clarifying comment.

## tests

added parity tests (`TestShortWordRetentionBash` / `...PowerShell`) covering a dropped lowercase short word and a kept uppercase acronym. verified the PowerShell case fails on the pre-fix script (`go AI now` -> `001-go-ai-now`) and passes after.

---

note: i used an ai assistant to help investigate and prepare this change. disclosing per CONTRIBUTING.md.
