### PR TITLE
fix(workflows): preserve commas inside quoted list-literal elements

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -146,6 +146,40 @@ def _build_namespace(context: Any) -> dict[str, Any]:
     return ns
 
 
+def _split_top_level_commas(text: str) -> list[str]:
+    """Split *text* on commas that are not inside quotes or nested brackets.
+
+    Used for list-literal elements so a quoted element containing a comma
+    (e.g. ``["a, b", "c"]``) is not split mid-string, and nested lists/calls
+    (e.g. ``[[1, 2], 3]``) are kept intact.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    depth = 0
+    for ch in text:
+        if quote is not None:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+            buf.append(ch)
+        elif ch in "([{":
+            depth += 1
+            buf.append(ch)
+        elif ch in ")]}":
+            depth = max(0, depth - 1)
+            buf.append(ch)
+        elif ch == "," and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(ch)
+    parts.append("".join(buf))
+    return parts
+
+
 def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
     """Evaluate a simple expression against the namespace.
 
@@ -291,7 +325,10 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         inner = expr[1:-1].strip()
         if not inner:
             return []
-        items = [_evaluate_simple_expression(i.strip(), namespace) for i in inner.split(",")]
+        items = [
+            _evaluate_simple_expression(i.strip(), namespace)
+            for i in _split_top_level_commas(inner)
+        ]
         return items
 
     # Variable reference (dot-path)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -273,14 +273,18 @@ class TestExpressions:
         from specify_cli.workflows.base import StepContext
 
         ctx = StepContext()
-        # commas inside a quoted element must not split it
+        # commas inside a double-quoted element must not split it
         assert evaluate_expression('{{ ["a, b", "c"] }}', ctx) == ["a, b", "c"]
         assert evaluate_expression('{{ ["x, y, z"] }}', ctx) == ["x, y, z"]
+        # single-quoted elements are handled the same way
+        assert evaluate_expression("{{ ['a, b', 'c'] }}", ctx) == ["a, b", "c"]
+        assert evaluate_expression("{{ ['p, q, r'] }}", ctx) == ["p, q, r"]
         # plain and empty lists still parse correctly
         assert evaluate_expression("{{ [1, 2, 3] }}", ctx) == [1, 2, 3]
         assert evaluate_expression("{{ [] }}", ctx) == []
-        # nested list elements stay intact
+        # nested lists (commas inside the inner brackets) stay intact
         assert evaluate_expression('{{ [["a", "b"], "c"] }}', ctx) == [["a", "b"], "c"]
+        assert evaluate_expression("{{ [[1, 2], [3, 4]] }}", ctx) == [[1, 2], [3, 4]]
 
     def test_filter_default(self):
         from specify_cli.workflows.expressions import evaluate_expression

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -268,6 +268,20 @@ class TestExpressions:
         ctx = StepContext(inputs={"a": False, "b": True})
         assert evaluate_expression("{{ inputs.a or inputs.b }}", ctx) is True
 
+    def test_list_literal_preserves_quoted_commas(self):
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext()
+        # commas inside a quoted element must not split it
+        assert evaluate_expression('{{ ["a, b", "c"] }}', ctx) == ["a, b", "c"]
+        assert evaluate_expression('{{ ["x, y, z"] }}', ctx) == ["x, y, z"]
+        # plain and empty lists still parse correctly
+        assert evaluate_expression("{{ [1, 2, 3] }}", ctx) == [1, 2, 3]
+        assert evaluate_expression("{{ [] }}", ctx) == []
+        # nested list elements stay intact
+        assert evaluate_expression('{{ [["a", "b"], "c"] }}', ctx) == [["a", "b"], "c"]
+
     def test_filter_default(self):
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext


### PR DESCRIPTION
## Description

The workflow simple-expression evaluator parsed list literals with a naive `inner.split(",")`:

```python
# src/specify_cli/workflows/expressions.py
items = [_evaluate_simple_expression(i.strip(), namespace) for i in inner.split(",")]
```

That splits on commas **inside quoted strings** (and nested brackets), so a list element containing a comma is silently broken into multiple elements:

- `{{ ["a, b", "c"] }}` → `["a", "b", "c"]` (3 items) instead of `["a, b", "c"]` (2 items)
- `{{ ["x, y, z"] }}` → `["x", "y", "z"]` instead of `["x, y, z"]`

This silently corrupts any list expression with a comma inside a quoted element — most importantly a `fan-out` step's `items:`, where it changes the number of iterations and the data passed to each one, with no error raised.

### Fix

Split list-literal elements on **top-level commas only**, ignoring commas inside quotes or nested brackets, via a small `_split_top_level_commas` helper. Per-element evaluation is unchanged (elements can still be variables, nested lists, etc.), and plain/empty lists behave exactly as before.

## Testing

- [x] Tested locally with `uv run specify --help` (exit 0)
- [x] Ran existing tests with `uv sync && uv run pytest`

- `uvx ruff check src/` — All checks passed
- `uv run pytest tests/test_workflows.py` — **295 passed, 1 skipped**; the only failures on my Windows host are the pre-existing `os.symlink` `WinError 1314` privilege tests (unrelated to this change).
- New test `tests/test_workflows.py::TestExpressions::test_list_literal_preserves_quoted_commas` covers quoted commas, nested lists, and the existing plain/empty cases. It **fails on `main`** (`["a", "b", "c"]`) and **passes** with this fix.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI located the naive split, implemented the quote/bracket-aware helper, and wrote the tests; I confirmed the corruption reproduces on `main` and that the fix resolves it (and is a no-op for plain lists) before submitting. I'll disclose if any review responses are AI-assisted as well.
