### PR TITLE
fix: render valid TOML when a command body contains backslashes

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -236,9 +236,14 @@ class CommandRegistrar:
         toml_lines.append(f"# Source: {source_id}")
         toml_lines.append("")
 
-        # Keep TOML output valid even when body contains triple-quote delimiters.
-        # Prefer multiline forms, then fall back to escaped basic string.
-        if '"""' not in body:
+        # Keep TOML output valid even when body contains triple-quote delimiters
+        # or backslashes. Prefer multiline forms, then fall back to escaped basic
+        # string. A multiline *basic* string ("""...""") processes backslash escape
+        # sequences, so a body containing a backslash (e.g. a Windows path
+        # ``C:\\Users\\...`` whose ``\\U`` reads as an invalid unicode escape) would
+        # produce unparseable TOML — route those to the *literal* form ('''...'''),
+        # which does not process escapes, or to the escaped basic string.
+        if '"""' not in body and "\\" not in body:
             toml_lines.append('prompt = """')
             toml_lines.append(body)
             toml_lines.append('"""')

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1669,6 +1669,47 @@ $ARGUMENTS
 
         assert parsed["description"] == "first line\nsecond line\n"
 
+    def test_render_toml_command_preserves_backslashes_in_body(self):
+        """A backslash in the body (e.g. a Windows path) must not break TOML.
+
+        A multiline basic string ("\"\"\"") processes backslash escapes, so
+        ``C:\\Users`` (``\\U``) would render as invalid TOML; the body must
+        round-trip with backslashes intact.
+        """
+        from specify_cli.agents import CommandRegistrar as AgentCommandRegistrar
+
+        registrar = AgentCommandRegistrar()
+        output = registrar.render_toml_command(
+            {"description": "x"},
+            r"Run C:\Users\dev\tool.exe then report.",
+            "extension:test-ext",
+        )
+        parsed = tomllib.loads(output)  # must not raise
+        assert parsed["prompt"].strip() == r"Run C:\Users\dev\tool.exe then report."
+
+    def test_render_toml_command_handles_trailing_backslash(self):
+        """A body ending in a backslash must round-trip without corruption."""
+        from specify_cli.agents import CommandRegistrar as AgentCommandRegistrar
+
+        registrar = AgentCommandRegistrar()
+        output = registrar.render_toml_command(
+            {"description": "x"},
+            "path ends with sep\\",
+            "extension:test-ext",
+        )
+        parsed = tomllib.loads(output)
+        assert parsed["prompt"].strip() == "path ends with sep\\"
+
+    def test_render_toml_command_backslash_with_both_triple_quotes_escapes(self):
+        """Body with a backslash and both triple-quote styles → escaped basic string."""
+        from specify_cli.agents import CommandRegistrar as AgentCommandRegistrar
+
+        registrar = AgentCommandRegistrar()
+        body = "a \\ b\nc \"\"\" d\ne ''' f"
+        output = registrar.render_toml_command({"description": "x"}, body, "extension:test-ext")
+        parsed = tomllib.loads(output)
+        assert parsed["prompt"] == body
+
     def test_register_commands_for_claude(self, extension_dir, project_dir):
         """Test registering commands for Claude agent."""
         # Create .claude directory


### PR DESCRIPTION
## Description

`CommandRegistrar.render_toml_command()` renders a command body into a multiline **basic** TOML string (`"""..."""`). Basic strings process backslash escape sequences, but the body was emitted raw — so any backslash in the body breaks the output:

- A Windows path like `C:\Users\...` contains `\U`, which TOML reads as an 8-digit unicode escape → the agent's TOML loader fails with `Invalid hex value` and the generated **Gemini / Tabnine** command file is completely unparseable.
- A body ending in a single `\` becomes a TOML line-continuation that silently swallows the closing newline.

Reproduced with `tomllib`:

```python
render_toml_command({}, r"Run C:\Users\dev\tool.exe", "src")
# -> prompt = """ ... C:\Users\dev\tool.exe ... """
# tomllib.loads(...) -> TOMLDecodeError: Invalid hex value
```

### Fix

Route bodies containing a backslash away from the basic-string branch: prefer the multiline **literal** form (`'''...'''`), which does not process escapes, and fall back to the escaped basic string (`_render_basic_toml_string`) when both triple-quote styles are present. This mirrors the backslash escaping already done by `base.py`'s `TomlIntegration`. One-line condition change; behavior is unchanged for backslash-free bodies.

## Testing

- [x] Tested locally with `uv run specify --help` (exit 0)
- [x] Ran existing tests with `uv sync && uv run pytest`

- `uvx ruff check src/` — All checks passed
- `uv run pytest tests/test_extensions.py tests/integrations/test_integration_gemini.py tests/integrations/test_integration_tabnine.py` — **381 passed, 3 skipped** (no regressions; the existing 3 `render_toml_command` tests still pass).
- New tests in `tests/test_extensions.py`: a Windows-path body, a trailing-backslash body, and a backslash + both-triple-quote-styles fallback — each asserts `tomllib.loads()` succeeds and the body round-trips. The first two **fail on `main`** (`TOMLDecodeError` / dropped backslash) and pass with this fix.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI located the unescaped basic-string branch, confirmed the existing `TomlIntegration` escaping precedent, implemented the routing fix, and wrote the tests; I reproduced the `tomllib` parse failure on `main` and verified the fix + no regressions in the Gemini/Tabnine suites before submitting. I'll disclose if any review responses are AI-assisted as well.
