### PR TITLE
fix(scripts): count subdirectory-only dirs as non-empty in PowerShell (parity with bash)

### DIFF
--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -210,7 +210,7 @@ function Test-FileExists {
 function Test-DirHasFiles {
     param([string]$Path, [string]$Description)
     # A directory counts as non-empty when Get-ChildItem returns any entry
-    # (files or subdirectories) — matching the JSON contracts checks in
+    # (files or subdirectories) -- matching the JSON contracts checks in
     # check-prerequisites.ps1 / setup-tasks.ps1, and treating a directory whose
     # only contents are subdirectories (e.g. contracts/v1/openapi.yaml) as
     # non-empty like bash check_dir. Filtering out subdirectories would

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -209,10 +209,12 @@ function Test-FileExists {
 
 function Test-DirHasFiles {
     param([string]$Path, [string]$Description)
-    # A directory counts as non-empty when it contains ANY entry (files or
-    # subdirectories), matching bash check_dir (`-n $(ls -A ...)`) and the JSON
-    # contracts checks. Filtering out subdirectories would mis-report a dir whose
-    # only contents are subdirectories (e.g. contracts/v1/openapi.yaml) as empty.
+    # A directory counts as non-empty when Get-ChildItem returns any entry
+    # (files or subdirectories) — matching the JSON contracts checks in
+    # check-prerequisites.ps1 / setup-tasks.ps1, and treating a directory whose
+    # only contents are subdirectories (e.g. contracts/v1/openapi.yaml) as
+    # non-empty like bash check_dir. Filtering out subdirectories would
+    # mis-report such a directory as empty.
     if ((Test-Path -Path $Path -PathType Container) -and (Get-ChildItem -Path $Path -ErrorAction SilentlyContinue | Select-Object -First 1)) {
         Write-Output "  [OK] $Description"
         return $true

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -209,7 +209,11 @@ function Test-FileExists {
 
 function Test-DirHasFiles {
     param([string]$Path, [string]$Description)
-    if ((Test-Path -Path $Path -PathType Container) -and (Get-ChildItem -Path $Path -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer } | Select-Object -First 1)) {
+    # A directory counts as non-empty when it contains ANY entry (files or
+    # subdirectories), matching bash check_dir (`-n $(ls -A ...)`) and the JSON
+    # contracts checks. Filtering out subdirectories would mis-report a dir whose
+    # only contents are subdirectories (e.g. contracts/v1/openapi.yaml) as empty.
+    if ((Test-Path -Path $Path -PathType Container) -and (Get-ChildItem -Path $Path -ErrorAction SilentlyContinue | Select-Object -First 1)) {
         Write-Output "  [OK] $Description"
         return $true
     } else {

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -878,7 +878,7 @@ def test_check_dir_bash_counts_subdir_only_contracts(tasks_repo: Path) -> None:
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
-def test_test_dir_has_files_ps_counts_subdir_only_contracts(tasks_repo: Path) -> None:
+def test_dir_has_files_ps_counts_subdir_only_contracts(tasks_repo: Path) -> None:
     """Test-DirHasFiles must match bash: a subdir-only dir counts as non-empty."""
     contracts = tasks_repo / "contracts" / "v1"
     contracts.mkdir(parents=True)

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -840,3 +840,49 @@ def test_setup_tasks_ps_errors_without_feature_context(
     output = result.stderr + result.stdout
     assert result.returncode != 0
     assert "Feature directory not found" in output
+
+
+# ---------------------------------------------------------------------------
+# Directory non-emptiness parity: a dir whose only contents are subdirectories
+# (e.g. contracts/v1/openapi.yaml) must count as non-empty in both shells.
+# ---------------------------------------------------------------------------
+
+def _run_bash_check_dir(repo: Path, target: Path) -> subprocess.CompletedProcess:
+    script = repo / ".specify" / "scripts" / "bash" / "common.sh"
+    return subprocess.run(
+        ["bash", "-c", 'source "$1"; check_dir "$2" "contracts/"', "bash", str(script), str(target)],
+        cwd=repo, capture_output=True, text=True, check=False, env=_clean_env(),
+    )
+
+
+def _run_powershell_test_dir(repo: Path, target: Path) -> subprocess.CompletedProcess:
+    script = repo / ".specify" / "scripts" / "powershell" / "common.ps1"
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    return subprocess.run(
+        [exe, "-NoProfile", "-Command",
+         '& { param($common, $dir) . $common; Test-DirHasFiles -Path $dir -Description "contracts/" }',
+         str(script), str(target)],
+        cwd=repo, capture_output=True, text=True, check=False, env=_clean_env(),
+    )
+
+
+@requires_bash
+def test_check_dir_bash_counts_subdir_only_contracts(tasks_repo: Path) -> None:
+    """bash check_dir treats a dir containing only subdirectories as non-empty."""
+    contracts = tasks_repo / "contracts" / "v1"
+    contracts.mkdir(parents=True)
+    (contracts / "openapi.yaml").write_text("openapi: 3.0\n", encoding="utf-8")
+    result = _run_bash_check_dir(tasks_repo, tasks_repo / "contracts")
+    assert result.returncode == 0, result.stderr
+    assert "✓" in result.stdout and "✗" not in result.stdout
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_test_dir_has_files_ps_counts_subdir_only_contracts(tasks_repo: Path) -> None:
+    """Test-DirHasFiles must match bash: a subdir-only dir counts as non-empty."""
+    contracts = tasks_repo / "contracts" / "v1"
+    contracts.mkdir(parents=True)
+    (contracts / "openapi.yaml").write_text("openapi: 3.0\n", encoding="utf-8")
+    result = _run_powershell_test_dir(tasks_repo, tasks_repo / "contracts")
+    assert result.returncode == 0, result.stderr
+    assert "[OK]" in result.stdout and "[FAIL]" not in result.stdout

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -851,7 +851,9 @@ def _run_bash_check_dir(repo: Path, target: Path) -> subprocess.CompletedProcess
     script = repo / ".specify" / "scripts" / "bash" / "common.sh"
     return subprocess.run(
         ["bash", "-c", 'source "$1"; check_dir "$2" "contracts/"', "bash", str(script), str(target)],
-        cwd=repo, capture_output=True, text=True, check=False, env=_clean_env(),
+        # check_dir echoes the non-ASCII markers ✓/✗; decode UTF-8 explicitly so
+        # the result does not depend on the platform locale (e.g. cp1252 on Windows).
+        cwd=repo, capture_output=True, text=True, encoding="utf-8", check=False, env=_clean_env(),
     )
 
 
@@ -862,7 +864,7 @@ def _run_powershell_test_dir(repo: Path, target: Path) -> subprocess.CompletedPr
         [exe, "-NoProfile", "-Command",
          '& { param($common, $dir) . $common; Test-DirHasFiles -Path $dir -Description "contracts/" }',
          str(script), str(target)],
-        cwd=repo, capture_output=True, text=True, check=False, env=_clean_env(),
+        cwd=repo, capture_output=True, text=True, encoding="utf-8", check=False, env=_clean_env(),
     )
 
 

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -873,8 +873,9 @@ def test_check_dir_bash_counts_subdir_only_contracts(tasks_repo: Path) -> None:
     contracts.mkdir(parents=True)
     (contracts / "openapi.yaml").write_text("openapi: 3.0\n", encoding="utf-8")
     result = _run_bash_check_dir(tasks_repo, tasks_repo / "contracts")
-    assert result.returncode == 0, result.stderr
-    assert "✓" in result.stdout and "✗" not in result.stdout
+    # check_dir always exits 0 (it echoes ✓/✗ instead of setting an exit code),
+    # so the ✓ marker in stdout — not the return code — is what proves non-emptiness.
+    assert "✓" in result.stdout and "✗" not in result.stdout, result.stderr + result.stdout
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
@@ -884,5 +885,7 @@ def test_dir_has_files_ps_counts_subdir_only_contracts(tasks_repo: Path) -> None
     contracts.mkdir(parents=True)
     (contracts / "openapi.yaml").write_text("openapi: 3.0\n", encoding="utf-8")
     result = _run_powershell_test_dir(tasks_repo, tasks_repo / "contracts")
-    assert result.returncode == 0, result.stderr
-    assert "[OK]" in result.stdout and "[FAIL]" not in result.stdout
+    # Test-DirHasFiles returns a boolean and pwsh still exits 0 when it returns
+    # $false, so the [OK] marker in stdout — not the return code — is what proves
+    # non-emptiness.
+    assert "[OK]" in result.stdout and "[FAIL]" not in result.stdout, result.stderr + result.stdout


### PR DESCRIPTION
## Description

`Test-DirHasFiles` in `scripts/powershell/common.ps1` (the documented PowerShell twin of bash `check_dir`) tested directory non-emptiness with:

```powershell
Get-ChildItem -Path $Path | Where-Object { -not $_.PSIsContainer } | Select-Object -First 1
```

The `Where-Object { -not $_.PSIsContainer }` filter counts only top-level **files** and ignores subdirectories. But the three sibling code paths all count **any** entry:

- bash `check_dir` (common.sh): `[[ -d "$1" && -n $(ls -A "$1") ]]`
- PowerShell JSON contracts checks (`check-prerequisites.ps1`, `setup-tasks.ps1`): `Get-ChildItem ... | Select-Object -First 1` (no filter)

So a `contracts/` directory whose only contents are subdirectories (e.g. a versioned/grouped layout `contracts/v1/openapi.yaml`) was reported **present** by bash, by bash JSON, and by PowerShell JSON — but `[FAIL]`/absent by PowerShell text mode. `Test-DirHasFiles` is the lone outlier, and it's internally inconsistent with the JSON path in its own files.

### Fix

Drop the `PSIsContainer` filter so `Test-DirHasFiles` counts any entry, matching the other three paths (one-line change).

## Testing

- [x] Tested locally with `uv run specify --help` (exit 0)
- [x] Ran existing tests with `uv sync && uv run pytest`

- `uvx ruff check` clean.
- `uv run pytest tests/test_setup_tasks.py` — **10 passed, 16 skipped** (no regressions; bash + pwsh-only tests skip on my host).
- Verified directly with PowerShell: before, a subdir-only `contracts/` → `[FAIL]`; after → `[OK]`; a genuinely empty dir and a missing dir still → `[FAIL]`.
- New parity tests in `tests/test_setup_tasks.py` (bash `check_dir` + PowerShell `Test-DirHasFiles`) assert a subdir-only `contracts/` is reported non-empty in both shells. The PowerShell test **fails on `main`** (`[FAIL] contracts/`) and passes with this fix.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI located the divergence across the four code paths; I reproduced the `[FAIL]` vs present discrepancy under PowerShell, confirmed the one-line fix restores parity (and that empty/missing dirs still report `[FAIL]`), and reviewed the diff before submitting. I'll disclose if any review responses are AI-assisted as well.
