### PR TITLE
chore: align ruff lint scope

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.14"
 
       - name: Run ruff check
-        run: uvx ruff check src/
+        run: uvx ruff check src tests
 
   pytest:
     runs-on: ${{ matrix.os }}

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -120,10 +120,10 @@ generated metadata, then add the import and `_register()` call in
 
 ## 7. Run Lint / Basic Checks
 
-CI enforces `ruff check src/` (see `.github/workflows/test.yml`), so run it locally before pushing:
+CI enforces `ruff check src tests` (see `.github/workflows/test.yml`), so run it locally before pushing:
 
 ```bash
-uvx ruff check src/
+uvx ruff check src tests
 ```
 
 You can also quickly sanity check importability:

--- a/tests/extensions/test_update_agent_context_feature_json.py
+++ b/tests/extensions/test_update_agent_context_feature_json.py
@@ -11,7 +11,6 @@ import pytest
 
 from tests.conftest import requires_bash
 from tests.extensions.test_extension_agent_context import (
-    BASH,
     POWERSHELL,
     _bash_posix_path,
     _run_bash_agent_context_script,

--- a/tests/test_github_http.py
+++ b/tests/test_github_http.py
@@ -144,7 +144,7 @@ class TestResolveGitHubReleaseAssetApiUrl:
         @contextmanager
         def failing_open(url, timeout=None, extra_headers=None):
             raise urllib.error.URLError("network error")
-            yield  # noqa: unreachable
+            yield  # pragma: no cover
 
         result = resolve_github_release_asset_api_url(
             "https://github.com/org/repo/releases/download/v1/pack.zip",


### PR DESCRIPTION
## What
- Expand the Python Ruff CI job from `src/` to `src tests`.
- Replace an invalid test-only `# noqa: unreachable` with `# pragma: no cover`.
- Remove the unused `BASH` import exposed by linting the test suite.
- Keep the local development guide aligned with the CI lint command.

## Why
PR #3132 added Ruff subprocess-security checks that were verified against tests locally, but CI only linted `src/`. This keeps CI aligned with the intended `src tests` Ruff scope and removes the pre-existing lint issues exposed by that scope.

## Validation
- `uvx ruff check src tests`
- `.venv/bin/python -m pytest tests/test_github_http.py tests/extensions/test_update_agent_context_feature_json.py tests/test_github_workflows.py -q` (36 passed, 3 skipped)
- `.venv/bin/python -m pytest -o addopts="" -q` (4431 passed, 112 skipped)
- `git diff --check`
