### PR TITLE
fix(extensions,presets,workflows): resolve private GHES release assets via /api/v3

### DIFF
--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -69,6 +69,33 @@ Either `token` or `token_env` must be set for `bearer` and `basic-pat` schemes.
 }
 ```
 
+### GitHub Enterprise Server (GHES)
+
+To use a private catalog or extension hosted on a GitHub Enterprise Server
+instance, add a `github` entry listing your GHES host(s). The same entry
+authenticates both catalog JSON fetches **and** private release-asset
+downloads — Specify recognizes the listed hosts as GitHub Enterprise and
+resolves release downloads through the GHES REST API (`/api/v3`).
+
+```json
+{
+  "providers": [
+    {
+      "hosts": ["ghes.example.com", "raw.ghes.example.com", "codeload.ghes.example.com"],
+      "provider": "github",
+      "auth": "bearer",
+      "token_env": "GH_ENTERPRISE_TOKEN"
+    }
+  ]
+}
+```
+
+List the **bare** web host (e.g. `ghes.example.com`) — release-download URLs
+live there. If your instance uses subdomain isolation, also list the `raw.`
+and `codeload.` subdomains your catalog/extension URLs use. A
+`*.ghes.example.com` wildcard matches subdomains but **not** the bare host,
+so always include the bare host explicitly.
+
 ### Azure DevOps (`azure-devops`)
 
 | Scheme | Header | Use for |

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -1128,9 +1128,10 @@ def workflow_add(
             raise typer.Exit(1)
 
         from specify_cli._github_http import resolve_github_release_asset_api_url as _resolve_gh_asset
+        from specify_cli.authentication.http import github_provider_hosts
 
         _wf_url_extra_headers = None
-        _resolved_wf_url = _resolve_gh_asset(source, _open_url, timeout=30)
+        _resolved_wf_url = _resolve_gh_asset(source, _open_url, timeout=30, github_hosts=github_provider_hosts())
         if _resolved_wf_url:
             source = _resolved_wf_url
             _wf_url_extra_headers = {"Accept": "application/octet-stream"}
@@ -1234,10 +1235,11 @@ def workflow_add(
 
     try:
         from specify_cli.authentication.http import open_url as _open_url
+        from specify_cli.authentication.http import github_provider_hosts
         from specify_cli._github_http import resolve_github_release_asset_api_url as _resolve_gh_asset
 
         _wf_cat_extra_headers = None
-        _resolved_workflow_url = _resolve_gh_asset(workflow_url, _open_url, timeout=30)
+        _resolved_workflow_url = _resolve_gh_asset(workflow_url, _open_url, timeout=30, github_hosts=github_provider_hosts())
         if _resolved_workflow_url:
             workflow_url = _resolved_workflow_url
             _wf_cat_extra_headers = {"Accept": "application/octet-stream"}

--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -112,10 +112,15 @@ def resolve_github_release_asset_api_url(
             and segments[3:5] == ["releases", "assets"]
         )
 
-    # Already a REST API asset URL — use it directly.
+    # Already a REST API asset URL — use it directly. Pure passthrough induces
+    # no new request: the caller fetches this same URL regardless, so it is
+    # gated on path shape alone rather than the GHES allowlist. The token stays
+    # independently gated by auth.json in the download helper, and only the
+    # resolving path below (which issues a tag-lookup request) needs the
+    # allowlist as its anti-SSRF gate.
     if hostname == "api.github.com" and _is_asset_path(parts):
         return download_url
-    if is_ghes and parts[:2] == ["api", "v3"] and _is_asset_path(parts[2:]):
+    if hostname and parts[:2] == ["api", "v3"] and _is_asset_path(parts[2:]):
         return download_url
 
     # Determine the REST API base for browser release-download URLs.

--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -10,6 +10,7 @@ through the config-driven helpers in :mod:`specify_cli.authentication.http`.
 
 import os
 import urllib.request
+from fnmatch import fnmatch
 from typing import Callable, Dict, Optional
 from urllib.parse import quote, unquote, urlparse
 
@@ -56,55 +57,74 @@ def build_github_request(url: str) -> urllib.request.Request:
     return urllib.request.Request(url, headers=headers)
 
 
+def _host_matches(hostname: str, patterns: tuple[str, ...]) -> bool:
+    """Return True when *hostname* matches a pattern (exact or ``*.suffix``)."""
+    hostname = hostname.lower()
+    return any(p == hostname or fnmatch(hostname, p) for p in patterns)
+
+
 def resolve_github_release_asset_api_url(
     download_url: str,
     open_url_fn: Callable,
     timeout: int = 60,
+    github_hosts: tuple[str, ...] = (),
 ) -> Optional[str]:
-    """Resolve a GitHub browser release URL to its REST API asset URL.
+    """Resolve a GitHub release browser-download URL to its REST API asset URL.
 
-    For private or SSO-protected repositories, browser release download
-    URLs (``https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>``)
-    redirect to an HTML/SSO page instead of delivering the file.  This
-    helper resolves such a URL to the matching GitHub REST API asset URL
-    (``https://api.github.com/repos/…/releases/assets/<id>``), which can
-    then be downloaded with ``Accept: application/octet-stream`` and an
-    auth token to retrieve the actual file payload.
+    Works for public ``github.com`` and for GitHub Enterprise Server (GHES)
+    hosts. A host is treated as GHES when it matches one of *github_hosts*
+    (exact hostname or ``*.suffix``) — supply the hosts the user has trusted
+    under a ``github`` provider in ``auth.json``. This allowlist is the
+    security gate: unlisted hosts never receive GHES API treatment, so a
+    malicious catalog cannot induce an API request to an arbitrary host.
 
-    If *download_url* is already a REST API asset URL, it is returned
-    as-is.  Non-GitHub URLs and GitHub URLs that are not release-download
-    URLs return ``None``.  If the API lookup fails (e.g. network error or
-    asset not found), ``None`` is returned so callers can fall back to the
-    original URL.
+    For a public URL the API base is ``https://api.github.com``; for a GHES
+    host it is ``{scheme}://{host[:port]}/api/v3``. Returns the API asset URL
+    (downloadable with ``Accept: application/octet-stream`` + a token), the
+    input unchanged if it is already an API asset URL, or ``None`` when the
+    URL is not a resolvable GitHub release download or the lookup fails.
 
     Args:
         download_url: The URL to resolve.
         open_url_fn: A callable compatible with
-            ``specify_cli.authentication.http.open_url`` used to make the
-            authenticated API request.
+            ``specify_cli.authentication.http.open_url`` used for the
+            authenticated release-metadata lookup.
         timeout: Per-request timeout in seconds.
-
-    Returns:
-        The resolved REST API asset URL, or ``None`` if resolution is not
-        applicable or fails.
+        github_hosts: Host patterns to treat as GitHub Enterprise Server.
     """
     import json
     import urllib.error
 
     parsed = urlparse(download_url)
+    hostname = (parsed.hostname or "").lower()
     parts = [unquote(part) for part in parsed.path.strip("/").split("/")]
 
-    # Already a REST API asset URL — use it directly
-    if (
-        parsed.hostname == "api.github.com"
-        and len(parts) >= 6
-        and parts[:1] == ["repos"]
-        and parts[3:5] == ["releases", "assets"]
-    ):
+    is_ghes = (
+        bool(hostname)
+        and hostname not in GITHUB_HOSTS
+        and _host_matches(hostname, github_hosts)
+    )
+
+    def _is_asset_path(segments: list[str]) -> bool:
+        return (
+            len(segments) >= 6
+            and segments[:1] == ["repos"]
+            and segments[3:5] == ["releases", "assets"]
+        )
+
+    # Already a REST API asset URL — use it directly.
+    if hostname == "api.github.com" and _is_asset_path(parts):
+        return download_url
+    if is_ghes and parts[:2] == ["api", "v3"] and _is_asset_path(parts[2:]):
         return download_url
 
-    # Only handle github.com browser release download URLs
-    if parsed.hostname != "github.com":
+    # Determine the REST API base for browser release-download URLs.
+    if hostname == "github.com":
+        api_base = "https://api.github.com"
+    elif is_ghes:
+        authority = hostname if parsed.port is None else f"{hostname}:{parsed.port}"
+        api_base = f"{parsed.scheme}://{authority}/api/v3"
+    else:
         return None
 
     # Expecting /<owner>/<repo>/releases/download/<tag>/<asset>
@@ -114,7 +134,7 @@ def resolve_github_release_asset_api_url(
     owner, repo, tag = parts[0], parts[1], parts[4]
     asset_name = "/".join(parts[5:])
     encoded_tag = quote(tag, safe="")
-    release_url = f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{encoded_tag}"
+    release_url = f"{api_base}/repos/{owner}/{repo}/releases/tags/{encoded_tag}"
 
     try:
         with open_url_fn(release_url, timeout=timeout) as response:

--- a/src/specify_cli/authentication/http.py
+++ b/src/specify_cli/authentication/http.py
@@ -118,6 +118,20 @@ def build_request(url: str, extra_headers: dict[str, str] | None = None) -> urll
     return urllib.request.Request(url, headers=headers)
 
 
+def github_provider_hosts() -> tuple[str, ...]:
+    """Return host patterns from every ``github`` provider entry in ``auth.json``.
+
+    Used to classify which hosts are GitHub Enterprise Server instances when
+    resolving release-asset download URLs. Returns an empty tuple when no
+    ``auth.json`` exists or it contains no ``github`` entries.
+    """
+    hosts: list[str] = []
+    for entry in _load_config():
+        if entry.provider == "github":
+            hosts.extend(entry.hosts)
+    return tuple(hosts)
+
+
 def open_url(
     url: str,
     timeout: int = 10,

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -2057,12 +2057,18 @@ class ExtensionCatalog(CatalogStackBase):
     ) -> Optional[str]:
         """Resolve a GitHub release asset URL to its API asset URL.
 
-        Delegates to the shared helper in :mod:`specify_cli._github_http`.
+        Delegates to the shared helper in :mod:`specify_cli._github_http`,
+        passing the ``github`` provider hosts from ``auth.json`` so GitHub
+        Enterprise Server release assets resolve via ``/api/v3``.
         """
         from specify_cli._github_http import resolve_github_release_asset_api_url
+        from specify_cli.authentication.http import github_provider_hosts
 
         return resolve_github_release_asset_api_url(
-            download_url, self._open_url, timeout=timeout
+            download_url,
+            self._open_url,
+            timeout=timeout,
+            github_hosts=github_provider_hosts(),
         )
 
     def _validate_catalog_payload(self, catalog_data: Any, url: str) -> None:

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -1892,10 +1892,19 @@ class PresetCatalog:
         download_url: str,
         timeout: int = 60,
     ) -> Optional[str]:
-        """Resolve a GitHub release asset URL to its REST API asset URL."""
+        """Resolve a GitHub release asset URL to its REST API asset URL.
+
+        Passes the ``github`` provider hosts from ``auth.json`` so GitHub
+        Enterprise Server release assets resolve via ``/api/v3``.
+        """
         from specify_cli._github_http import resolve_github_release_asset_api_url
+        from specify_cli.authentication.http import github_provider_hosts
+
         return resolve_github_release_asset_api_url(
-            download_url, self._open_url, timeout=timeout
+            download_url,
+            self._open_url,
+            timeout=timeout,
+            github_hosts=github_provider_hosts(),
         )
 
     def _validate_catalog_payload(self, catalog_data: Any, url: str) -> None:

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -144,10 +144,13 @@ def preset_add(
                 zip_path = Path(tmpdir) / "preset.zip"
                 try:
                     from specify_cli.authentication.http import open_url as _open_url
+                    from specify_cli.authentication.http import github_provider_hosts
                     from specify_cli._github_http import resolve_github_release_asset_api_url
 
                     _preset_extra_headers = None
-                    _resolved_from_url = resolve_github_release_asset_api_url(from_url, _open_url)
+                    _resolved_from_url = resolve_github_release_asset_api_url(
+                        from_url, _open_url, github_hosts=github_provider_hosts()
+                    )
                     if _resolved_from_url:
                         from_url = _resolved_from_url
                         _preset_extra_headers = {"Accept": "application/octet-stream"}

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -900,3 +900,45 @@ class TestFetchLatestReleaseTagDelegation:
         with patch("specify_cli.authentication.http.urllib.request.urlopen", side_effect=side_effect):
             _fetch_latest_release_tag()
         assert captured["request"].get_header("Accept") == "application/vnd.github+json"
+
+
+# ---------------------------------------------------------------------------
+# github_provider_hosts
+# ---------------------------------------------------------------------------
+
+
+class TestGithubProviderHosts:
+    """Tests for github_provider_hosts() — the GHES host allowlist source."""
+
+    def _set_config(self, monkeypatch, entries):
+        from specify_cli.authentication import http as _auth_http
+        monkeypatch.setattr(_auth_http, "_config_override", entries)
+
+    def test_returns_hosts_from_github_entries(self, monkeypatch):
+        from specify_cli.authentication.http import github_provider_hosts
+        self._set_config(monkeypatch, [
+            AuthConfigEntry(hosts=("ghes.example", "raw.ghes.example"),
+                            provider="github", auth="bearer", token="t"),
+        ])
+        assert github_provider_hosts() == ("ghes.example", "raw.ghes.example")
+
+    def test_empty_when_no_config(self, monkeypatch):
+        from specify_cli.authentication.http import github_provider_hosts
+        self._set_config(monkeypatch, [])
+        assert github_provider_hosts() == ()
+
+    def test_ignores_non_github_providers(self, monkeypatch):
+        from specify_cli.authentication.http import github_provider_hosts
+        self._set_config(monkeypatch, [
+            AuthConfigEntry(hosts=("dev.azure.com",), provider="azure-devops",
+                            auth="basic-pat", token="t"),
+        ])
+        assert github_provider_hosts() == ()
+
+    def test_unions_multiple_github_entries(self, monkeypatch):
+        from specify_cli.authentication.http import github_provider_hosts
+        self._set_config(monkeypatch, [
+            AuthConfigEntry(hosts=("ghes.example",), provider="github", auth="bearer", token="t"),
+            AuthConfigEntry(hosts=("github.com",), provider="github", auth="bearer", token="t"),
+        ])
+        assert github_provider_hosts() == ("ghes.example", "github.com")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -16,8 +16,10 @@ import platform
 import tempfile
 import shutil
 import tomllib
+from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 from tests.conftest import strip_ansi
 from specify_cli.extensions import (
@@ -7280,3 +7282,36 @@ class TestExtensionForceCLI:
             )
             assert result2.exit_code == 0, strip_ansi(result2.output)
             assert "installed" in strip_ansi(result2.output)
+
+
+def test_extension_wrapper_resolves_ghes_asset_when_host_configured(tmp_path, monkeypatch):
+    """End-to-end wiring: auth.json github host → GHES asset resolution."""
+    from specify_cli.authentication import http as _auth_http
+    from specify_cli.authentication.config import AuthConfigEntry
+    from specify_cli.extensions import ExtensionCatalog
+
+    monkeypatch.setattr(_auth_http, "_config_override", [
+        AuthConfigEntry(hosts=("ghes.example",), provider="github",
+                        auth="bearer", token="t"),
+    ])
+    catalog = ExtensionCatalog(tmp_path)
+
+    captured = []
+
+    @contextmanager
+    def fake_open(url, timeout=None, extra_headers=None):
+        captured.append(url)
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({
+            "assets": [{"name": "ext.zip",
+                        "url": "https://ghes.example/api/v3/repos/o/r/releases/assets/7"}]
+        }).encode()
+        yield resp
+
+    monkeypatch.setattr(catalog, "_open_url", fake_open)
+
+    resolved = catalog._resolve_github_release_asset_api_url(
+        "https://ghes.example/o/r/releases/download/v1/ext.zip"
+    )
+    assert resolved == "https://ghes.example/api/v3/repos/o/r/releases/assets/7"
+    assert captured == ["https://ghes.example/api/v3/repos/o/r/releases/tags/v1"]

--- a/tests/test_github_http.py
+++ b/tests/test_github_http.py
@@ -233,6 +233,27 @@ class TestResolveGitHubReleaseAssetApiUrl:
         assert result is None
         assert called == []
 
+    def test_passthrough_for_unlisted_ghes_api_asset_url(self):
+        """A direct GHES /api/v3 asset URL passes through even when the host is
+        not allowlisted: passthrough issues no API request, and the download
+        helper gates the token independently, so octet-stream resolution must
+        not be withheld."""
+        called = []
+
+        @contextmanager
+        def recording_open(url, timeout=None, extra_headers=None):
+            called.append(url)
+            resp = MagicMock()
+            resp.read.return_value = b"{}"
+            yield resp
+
+        url = "https://ghes.example/api/v3/repos/o/r/releases/assets/7"
+        result = resolve_github_release_asset_api_url(
+            url, recording_open, github_hosts=("other.example",)
+        )
+        assert result == url
+        assert called == []
+
     def test_ghes_api_base_preserves_scheme_and_port(self):
         """The GHES API base mirrors the URL scheme and keeps a non-standard port."""
         captured = []

--- a/tests/test_github_http.py
+++ b/tests/test_github_http.py
@@ -188,3 +188,96 @@ class TestResolveGitHubReleaseAssetApiUrl:
         )
         assert len(captured_urls) == 1
         assert "releases/tags/v1%23beta" in captured_urls[0]
+
+    # --- GHES (GitHub Enterprise Server) ---
+
+    def test_resolves_ghes_browser_url_to_api_url(self):
+        """A GHES browser release URL resolves to the /api/v3 asset URL."""
+        release_json = {
+            "assets": [
+                {"name": "ext.zip",
+                 "url": "https://ghes.example/api/v3/repos/o/r/releases/assets/7"}
+            ]
+        }
+        result = resolve_github_release_asset_api_url(
+            "https://ghes.example/o/r/releases/download/v1/ext.zip",
+            self._make_open_url_fn(release_json),
+            github_hosts=("ghes.example",),
+        )
+        assert result == "https://ghes.example/api/v3/repos/o/r/releases/assets/7"
+
+    def test_passthrough_for_existing_ghes_api_asset_url(self):
+        """An already-resolved GHES /api/v3 asset URL is returned as-is."""
+        url = "https://ghes.example/api/v3/repos/o/r/releases/assets/7"
+        result = resolve_github_release_asset_api_url(
+            url, lambda *a, **kw: None, github_hosts=("ghes.example",)
+        )
+        assert result == url
+
+    def test_returns_none_for_ghes_host_not_in_allowlist(self):
+        """Unlisted hosts get no GHES treatment and trigger no API call (anti-SSRF)."""
+        called = []
+
+        @contextmanager
+        def recording_open(url, timeout=None, extra_headers=None):
+            called.append(url)
+            resp = MagicMock()
+            resp.read.return_value = b"{}"
+            yield resp
+
+        result = resolve_github_release_asset_api_url(
+            "https://ghes.example/o/r/releases/download/v1/ext.zip",
+            recording_open,
+            github_hosts=("other.example",),
+        )
+        assert result is None
+        assert called == []
+
+    def test_ghes_api_base_preserves_scheme_and_port(self):
+        """The GHES API base mirrors the URL scheme and keeps a non-standard port."""
+        captured = []
+
+        @contextmanager
+        def capturing_open(url, timeout=None, extra_headers=None):
+            captured.append(url)
+            resp = MagicMock()
+            resp.read.return_value = json.dumps({"assets": []}).encode()
+            yield resp
+
+        resolve_github_release_asset_api_url(
+            "http://localhost:8000/o/r/releases/download/v1/ext.zip",
+            capturing_open,
+            github_hosts=("localhost",),
+        )
+        assert captured == ["http://localhost:8000/api/v3/repos/o/r/releases/tags/v1"]
+
+    def test_ghes_wildcard_does_not_match_bare_host(self):
+        """A '*.suffix' pattern does not match the bare host (must list it explicitly)."""
+        result = resolve_github_release_asset_api_url(
+            "https://ghes.example/o/r/releases/download/v1/ext.zip",
+            lambda *a, **kw: None,
+            github_hosts=("*.ghes.example",),
+        )
+        assert result is None
+
+    def test_public_github_url_unaffected_by_github_hosts(self):
+        """Public github.com still resolves via api.github.com even with github_hosts set."""
+        captured = []
+
+        @contextmanager
+        def capturing_open(url, timeout=None, extra_headers=None):
+            captured.append(url)
+            resp = MagicMock()
+            resp.read.return_value = json.dumps({
+                "assets": [{"name": "pack.zip",
+                            "url": "https://api.github.com/repos/org/repo/releases/assets/99"}]
+            }).encode()
+            yield resp
+
+        result = resolve_github_release_asset_api_url(
+            "https://github.com/org/repo/releases/download/v1.0/pack.zip",
+            capturing_open,
+            github_hosts=("ghes.example",),
+        )
+        assert result == "https://api.github.com/repos/org/repo/releases/assets/99"
+        assert captured == ["https://api.github.com/repos/org/repo/releases/tags/v1.0"]

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -4754,6 +4754,69 @@ class TestPresetAddFromUrlResolution:
         assert captured_urls[0][0] == "https://api.github.com/repos/org/repo/releases/assets/42"
         assert captured_urls[0][1] == {"Accept": "application/octet-stream"}
 
+    def test_preset_add_from_ghes_release_url_resolves_via_api_v3(self, project_dir, monkeypatch):
+        """'preset add --from <ghes-release-url>' resolves via GHES /api/v3 endpoint."""
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+        from specify_cli.authentication import http as _auth_http
+        from specify_cli.authentication.config import AuthConfigEntry
+
+        monkeypatch.setattr(_auth_http, "_config_override", [
+            AuthConfigEntry(hosts=("ghes.example",), provider="github", auth="bearer", token="t"),
+        ])
+
+        manifest_content = yaml.dump({
+            "schema_version": "1.0",
+            "preset": {"id": "my-preset", "name": "My Preset", "version": "1.0.0", "description": "Test preset", "author": "Test", "license": "MIT"},
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {"templates": [{"type": "template", "name": "t", "file": "templates/t.md", "description": "t"}]},
+        })
+        zip_buf = __import__("io").BytesIO()
+        with zipfile.ZipFile(zip_buf, "w") as zf:
+            zf.writestr("preset.yml", manifest_content)
+        zip_bytes = zip_buf.getvalue()
+
+        captured_urls = []
+
+        class FakeResponse:
+            def __init__(self, data):
+                self._data = data
+
+            def read(self):
+                return self._data
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_open_url(url, timeout=None, extra_headers=None, redirect_validator=None):
+            captured_urls.append((url, extra_headers))
+            if "releases/tags/" in url:
+                return FakeResponse(json.dumps({
+                    "assets": [{"name": "preset.zip", "url": "https://ghes.example/api/v3/repos/org/repo/releases/assets/42"}]
+                }).encode())
+            return FakeResponse(zip_bytes)
+
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir), \
+             patch("specify_cli.get_speckit_version", return_value="1.0.0"), \
+             patch("specify_cli.authentication.http.open_url", side_effect=fake_open_url):
+            result = runner.invoke(app, [
+                "preset", "add",
+                "--from", "https://ghes.example/org/repo/releases/download/v1.0/preset.zip",
+            ])
+
+        assert result.exit_code == 0, result.output
+        # The tag-lookup call must use the GHES /api/v3 endpoint
+        assert any("ghes.example/api/v3/repos/org/repo/releases/tags/v1.0" in url for url, _ in captured_urls)
+        # The asset download call must carry Accept: application/octet-stream
+        asset_calls = [(url, h) for url, h in captured_urls if "releases/assets/" in url]
+        assert len(asset_calls) >= 1
+        assert asset_calls[0][1] == {"Accept": "application/octet-stream"}
+
 
 class TestWrapStrategy:
     """Tests for strategy: wrap preset command substitution."""

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -17,9 +17,11 @@ import tempfile
 import shutil
 import warnings
 import zipfile
+from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import yaml
 
@@ -6021,3 +6023,36 @@ def _create_pack(temp_dir, valid_pack_data, pack_id, content,
         (subdir / f"{template_name}.md").write_text(content)
 
     return pack_dir
+
+
+def test_preset_wrapper_resolves_ghes_asset_when_host_configured(tmp_path, monkeypatch):
+    """End-to-end wiring for presets: auth.json github host → GHES asset resolution."""
+    from specify_cli.authentication import http as _auth_http
+    from specify_cli.authentication.config import AuthConfigEntry
+    from specify_cli.presets import PresetCatalog
+
+    monkeypatch.setattr(_auth_http, "_config_override", [
+        AuthConfigEntry(hosts=("ghes.example",), provider="github",
+                        auth="bearer", token="t"),
+    ])
+    catalog = PresetCatalog(tmp_path)
+
+    captured = []
+
+    @contextmanager
+    def fake_open(url, timeout=None, extra_headers=None):
+        captured.append(url)
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({
+            "assets": [{"name": "pack.zip",
+                        "url": "https://ghes.example/api/v3/repos/o/r/releases/assets/9"}]
+        }).encode()
+        yield resp
+
+    monkeypatch.setattr(catalog, "_open_url", fake_open)
+
+    resolved = catalog._resolve_github_release_asset_api_url(
+        "https://ghes.example/o/r/releases/download/v2/pack.zip"
+    )
+    assert resolved == "https://ghes.example/api/v3/repos/o/r/releases/assets/9"
+    assert captured == ["https://ghes.example/api/v3/repos/o/r/releases/tags/v2"]

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -4772,7 +4772,7 @@ class TestPresetAddFromUrlResolution:
             "requires": {"speckit_version": ">=0.1.0"},
             "provides": {"templates": [{"type": "template", "name": "t", "file": "templates/t.md", "description": "t"}]},
         })
-        zip_buf = __import__("io").BytesIO()
+        zip_buf = io.BytesIO()
         with zipfile.ZipFile(zip_buf, "w") as zf:
             zf.writestr("preset.yml", manifest_content)
         zip_bytes = zip_buf.getvalue()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -5477,6 +5477,137 @@ steps:
         assert len(asset_calls) >= 1
         assert asset_calls[0][1] == {"Accept": "application/octet-stream"}
 
+    def test_workflow_add_from_ghes_release_url_resolves_via_api_v3(self, project_dir, monkeypatch):
+        """'workflow add <ghes-release-url>' resolves via GHES /api/v3 endpoint."""
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+        from specify_cli.authentication import http as _auth_http
+        from specify_cli.authentication.config import AuthConfigEntry
+
+        monkeypatch.setattr(_auth_http, "_config_override", [
+            AuthConfigEntry(hosts=("ghes.example",), provider="github", auth="bearer", token="t"),
+        ])
+
+        captured_urls = []
+
+        class FakeResponse:
+            def __init__(self, data, url=None):
+                self._data = data
+                self._url = url or "https://ghes.example/api/v3/repos/org/repo/releases/assets/42"
+
+            def read(self):
+                return self._data
+
+            def geturl(self):
+                return self._url
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def fake_open_url(url, timeout=None, extra_headers=None):
+            captured_urls.append((url, extra_headers))
+            if "releases/tags/" in url:
+                return FakeResponse(json.dumps({
+                    "assets": [{"name": "workflow.yml", "url": "https://ghes.example/api/v3/repos/org/repo/releases/assets/42"}]
+                }).encode())
+            return FakeResponse(self.VALID_WORKFLOW_YAML.encode())
+
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir), \
+             patch("specify_cli.authentication.http.open_url", side_effect=fake_open_url):
+            result = runner.invoke(app, [
+                "workflow", "add",
+                "https://ghes.example/org/repo/releases/download/v1.0/workflow.yml",
+            ])
+
+        assert result.exit_code == 0, result.output
+        # Tag lookup must use the GHES /api/v3 endpoint
+        assert any("ghes.example/api/v3/repos/org/repo/releases/tags/v1.0" in url for url, _ in captured_urls)
+        # Asset download must carry Accept: application/octet-stream
+        asset_calls = [(url, h) for url, h in captured_urls if "releases/assets/" in url]
+        assert len(asset_calls) >= 1
+        assert asset_calls[0][1] == {"Accept": "application/octet-stream"}
+
+    def test_workflow_add_catalog_based_ghes_release_url_resolves_via_api_v3(self, project_dir, monkeypatch):
+        """'workflow add <id>' with a GHES catalog URL resolves via /api/v3."""
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+        from specify_cli.authentication import http as _auth_http
+        from specify_cli.authentication.config import AuthConfigEntry
+
+        monkeypatch.setattr(_auth_http, "_config_override", [
+            AuthConfigEntry(hosts=("ghes.example",), provider="github", auth="bearer", token="t"),
+        ])
+
+        captured_urls = []
+
+        class FakeResponse:
+            def __init__(self, data, url=None):
+                self._data = data
+                self._url = url or "https://ghes.example/api/v3/repos/org/repo/releases/assets/55"
+
+            def read(self):
+                return self._data
+
+            def geturl(self):
+                return self._url
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        ghes_wf_yaml = """
+schema_version: "1.0"
+workflow:
+  id: "my-wf"
+  name: "My GHES Workflow"
+  version: "1.0.0"
+  description: "A GHES catalog workflow"
+steps:
+  - id: step-one
+    type: shell
+    run: "echo hello"
+"""
+
+        def fake_open_url(url, timeout=None, extra_headers=None):
+            captured_urls.append((url, extra_headers))
+            if "releases/tags/" in url:
+                return FakeResponse(json.dumps({
+                    "assets": [{"name": "workflow.yml", "url": "https://ghes.example/api/v3/repos/org/repo/releases/assets/55"}]
+                }).encode())
+            return FakeResponse(ghes_wf_yaml.encode())
+
+        fake_catalog_info = {
+            "id": "my-wf",
+            "name": "My GHES Workflow",
+            "version": "1.0.0",
+            "url": "https://ghes.example/org/repo/releases/download/v2.0/workflow.yml",
+            "_install_allowed": True,
+        }
+
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir), \
+             patch("specify_cli.authentication.http.open_url", side_effect=fake_open_url), \
+             patch("specify_cli.workflows.catalog.WorkflowCatalog.get_workflow_info", return_value=fake_catalog_info):
+            result = runner.invoke(app, ["workflow", "add", "my-wf"])
+
+        assert result.exit_code == 0, result.output
+        # Tag lookup must use GHES /api/v3
+        tag_calls = [url for url, _ in captured_urls if "releases/tags/" in url]
+        assert len(tag_calls) == 1
+        assert "ghes.example/api/v3/repos/org/repo/releases/tags/v2.0" in tag_calls[0]
+        # Asset download must carry Accept: application/octet-stream
+        asset_calls = [(url, h) for url, h in captured_urls if "releases/assets/" in url]
+        assert len(asset_calls) >= 1
+        assert asset_calls[0][1] == {"Accept": "application/octet-stream"}
+
 
 class TestWorkflowRunExitCodes:
     """CLI-level tests for the run/resume process exit codes."""


### PR DESCRIPTION
## Description

Fixes private **GitHub Enterprise Server (GHES)** release-asset downloads for `specify extension add`, `specify preset add`, and `specify workflow add`. Closes #3147 (approach proposed and discussed in https://github.com/github/spec-kit/issues/3147#issuecomment-4791762894).

**Background.** Catalog *fetch* from a private GHES host already works today via the opt-in `~/.specify/auth.json` mechanism (#2393) — that was simply undocumented, so the issue assumed catalogs had to be public. The real gap is the release-asset *download*.

**Root cause.** Release-asset downloads first translate a browser release URL (`https://<host>/<owner>/<repo>/releases/download/<tag>/<asset>`) into the REST API asset URL and add `Accept: application/octet-stream`; otherwise a private repo's browser URL redirects to an SSO/HTML page instead of the binary. That translation lives in one shared helper, `_github_http.resolve_github_release_asset_api_url`, which hardcoded `github.com`/`api.github.com` and returned `None` for any GHES host — so for GHES the URL was never translated and the header never set, and the download was corrupt even with a valid token.

**What this does.**
- Adds `github_provider_hosts()` — enumerates the hosts a user has listed under a `github` provider in `auth.json`.
- Generalizes the resolver to build GHES REST API URLs (`{scheme}://{host[:port]}/api/v3/...`) for those hosts. Public `github.com` handling is unchanged (`github_hosts=()` reproduces prior behavior byte-for-byte).
- Threads the host allowlist into **all five** call sites of the shared resolver (the extension/preset catalog wrappers, `preset add --from`, and both `workflow add` paths).
- Documents the GHES `auth.json` recipe in `docs/reference/authentication.md`.

**Design notes.**
- **No new config surface** — no env vars, no catalog-schema fields, no CLI flags. The same `auth.json` entry supplies the token *and* classifies the host as GitHub Enterprise.
- **Security:** the `auth.json` allowlist is the anti-SSRF gate — only hosts the user explicitly trusts locally get `/api/v3` treatment, so a remote catalog can never induce an API request to an arbitrary host. The host-classification list is injected into `_github_http` (which imports nothing from the auth layer), keeping that module's dependency boundary intact.

**Scope:** the issue's `GH_HOST` / `GH_ENTERPRISE_TOKEN` "zero-config" idea was intentionally **not** implemented — `auth.json` already carries the token and preserves the file-based opt-in model; reusing env vars would auto-send credentials based on environment alone. Easy to add later if there's demand.

## Testing

- [x] Tested locally with `uv run specify --help` (and exercised the real `specify preset add --from` CLI in the manual test below)
- [x] Ran existing tests — full suite via `.venv/bin/python -m pytest tests -q` (the repo's recommended form over bare `uv run pytest`, per CONTRIBUTING/AGENTS.md). New: 6 resolver unit tests, `github_provider_hosts()` unit tests, and CLI/integration tests for every wired caller.
- [x] Tested with a sample project (manual smoke below)

### Manual test results

**Agent**: Claude Code (Opus 4.8)  |  **OS/Shell**: macOS / zsh

| Command tested | Notes |
|----------------|-------|
| `specify preset add --from <private GHES release URL>` | **PASS — verified against a real private GitHub Enterprise Server.** Browser release URL resolved to `…/api/v3/repos/…/releases/assets/<id>`, authenticated with the `auth.json` bearer token, downloaded with `Accept: application/octet-stream`, preset installed (exit 0). |
| Private GHES **extension** release asset (`ExtensionCatalog` resolver path) | **PASS (real GHES).** Resolved via `/api/v3` and authenticated-downloaded a valid extension archive (verified valid zip + contents). |
| Negative — no `auth.json` (local mock) | **PASS (gate holds).** Host not classified as GHES → no `/api/v3` attempted → request 401s → command exits non-zero. |
| `specify extension add` · `specify preset add <id>` · `specify workflow add` | Same shared resolver path; additionally covered by automated `CliRunner` integration tests (GHES resolution + `Accept: application/octet-stream`). |

**Note on the suite:** all new tests pass. Three failures present in my environment are **pre-existing and unrelated** to this branch: `test_get_pack_info` and `test_default_active_catalogs` come from a developer-global preset catalog leaking into tests that don't isolate `~/.specify` (they pass once that global registry is moved aside); `test_timestamp_branches…[go AI now]` fails on pristine `main` as well. Happy to file separate issues for the test-isolation gaps.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

This change was developed with Claude Code (Anthropic), and the loop was AI-driven, disclosed as such:

- **Design:** spec-driven, with me making the scope/approach decisions (e.g. rejecting the env-var and catalog-schema alternatives, choosing how far to wire the fix).
- **Implementation and the automated tests** were performed by AI subagents (Claude Sonnet) under my direction; an AI code-review pass (Claude Opus) then found and fixed a real gap (3 unwired call sites).
- **I personally ran the manual end-to-end validation against my own private GHES instance** — resolution plus authenticated download of real preset and extension release assets, and a full `preset add --from` install — and confirmed the results.
- I reviewed the design, the scope decisions, and the results at each step; I have not hand-edited every line.
- Every commit carries an `Assisted-by: Claude Code (model: …, autonomous)` trailer, and the issue comment proposing this approach was likewise AI-drafted and disclosed.

Happy to walk through any part in more detail.
