### PR TITLE
Update SicarioSpec Core preset to v0.5.1

### DIFF
--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -567,11 +567,11 @@
     "sicario-core": {
       "name": "SicarioSpec Core",
       "id": "sicario-core",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "description": "Evidence-first security operations governance that maps feature risk to controls, gates, evidence, owners, approval, and accepted-risk decisions.",
       "author": "SicarioSpec Contributors",
       "repository": "https://github.com/dfirs1car1o/sicario-spec",
-      "download_url": "https://github.com/dfirs1car1o/sicario-spec/releases/download/v0.4.0/sicario-core-0.4.0.zip",
+      "download_url": "https://github.com/dfirs1car1o/sicario-spec/releases/download/v0.5.1/sicario-core-0.5.1.zip",
       "homepage": "https://github.com/dfirs1car1o/sicario-spec",
       "documentation": "https://github.com/dfirs1car1o/sicario-spec/blob/main/presets/sicario-core/README.md",
       "license": "MIT",


### PR DESCRIPTION
## Summary
- updates the existing `sicario-core` community preset entry from `0.4.0` to `0.5.1`
- points the download URL at the published `sicario-core-0.5.1.zip` release asset

## Validation
- `python3 -c "import json; json.load(open('presets/catalog.community.json')); print('Valid JSON')"`
- `curl -fsSI https://github.com/dfirs1car1o/sicario-spec/releases/download/v0.5.1/sicario-core-0.5.1.zip`
- `uv sync --extra test && uv run pytest tests/contract/test_catalog_schema.py -q`
