### PR TITLE
fix: bash 3.2 compatibility in create-new-feature.sh (${word^^} bad substitution on macOS)

### DIFF
--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -152,7 +152,7 @@ generate_branch_name() {
         if ! echo "$word" | grep -qiE "$stop_words"; then
             if [ ${#word} -ge 3 ]; then
                 meaningful_words+=("$word")
-            elif echo "$description" | grep -q "\b${word^^}\b"; then
+            elif echo "$description" | grep -q "\b$(echo "$word" | tr '[:lower:]' '[:upper:]')\b"; then
                 # Keep short words if they appear as uppercase in original (likely acronyms)
                 meaningful_words+=("$word")
             fi


### PR DESCRIPTION
## Problem

`scripts/bash/create-new-feature.sh` uses `${word^^}` (bash 4+ uppercase parameter expansion) on line 155. **macOS ships with bash 3.2 by default**, where this syntax fails:

```
create-new-feature.sh: line 155: \b${word^^}\b: bad substitution
```

The error is printed (4× for a multi-word description) and the `elif` branch is silently skipped, so the acronym-preservation logic stops working — short uppercase words like `API` get dropped from the generated branch name.

## Reproduction (macOS, bash 3.2)

```bash
bash scripts/bash/create-new-feature.sh --json "Integrate API for posts"
# -> create-new-feature.sh: line 155: \b${word^^}\b: bad substitution
```

## Fix

Replace `${word^^}` with `$(echo "$word" | tr '[:lower:]' '[:upper:]')` — POSIX-compatible, works on bash 3.2 **and** 4+.

After the fix, no errors are printed and the acronym is correctly preserved in the branch name (e.g. `002-integrate-api-for-posts`).

## Notes

- Single-line change, no behavior change on bash 4+.
- Verified there are no other `${var^^}` / `${var,,}` usages under `scripts/bash/`.
