### PR TITLE
Docs: Document /speckit.converge command

### DIFF
--- a/docs/guides/evolving-specs.md
+++ b/docs/guides/evolving-specs.md
@@ -26,7 +26,7 @@ through the standard flow:
 2. Run `/speckit.plan` to define the implementation approach.
 3. Run `/speckit.tasks` to derive the work breakdown.
 4. Run `/speckit.implement` and review the resulting code and artifact diffs.
-5. Run `/speckit.converge` to verify completeness and generate tasks for remaining gaps.
+5. Run `/speckit.converge` to verify completeness and generate tasks for remaining gaps. If tasks are appended, repeat `/speckit.implement` and `/speckit.converge` until the feature is fully complete.
 
 The previous feature directory remains intact for audit, comparison, or
 explaining how the project reached its current state. Use clear feature names or
@@ -51,7 +51,7 @@ spec:
 5. Run `/speckit.analyze` before implementation resumes to catch gaps between
    the spec, plan, and tasks.
 6. Run `/speckit.implement`, then review the code and artifact diffs together.
-7. Run `/speckit.converge` to assess completion and append any remaining work to `tasks.md`.
+7. Run `/speckit.converge` to assess completion and append any remaining work to `tasks.md`. If tasks are appended, repeat `/speckit.implement` and `/speckit.converge` until the feature is fully complete.
 
 Preserve important implementation rationale before replacing derived artifacts.
 If a plan or task list contains decisions that still matter, carry them forward

--- a/docs/guides/evolving-specs.md
+++ b/docs/guides/evolving-specs.md
@@ -26,6 +26,7 @@ through the standard flow:
 2. Run `/speckit.plan` to define the implementation approach.
 3. Run `/speckit.tasks` to derive the work breakdown.
 4. Run `/speckit.implement` and review the resulting code and artifact diffs.
+5. Run `/speckit.converge` to verify completeness and generate tasks for remaining gaps.
 
 The previous feature directory remains intact for audit, comparison, or
 explaining how the project reached its current state. Use clear feature names or
@@ -50,6 +51,7 @@ spec:
 5. Run `/speckit.analyze` before implementation resumes to catch gaps between
    the spec, plan, and tasks.
 6. Run `/speckit.implement`, then review the code and artifact diffs together.
+7. Run `/speckit.converge` to assess completion and append any remaining work to `tasks.md`.
 
 Preserve important implementation rationale before replacing derived artifacts.
 If a plan or task list contains decisions that still matter, carry them forward

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -94,8 +94,15 @@ This helps verify you are running the official Spec Kit build from GitHub, not a
 After initialization, you should see the following commands available in your coding agent:
 
 - `/speckit.specify` - Create specifications
-- `/speckit.plan` - Generate implementation plans  
+- `/speckit.plan` - Generate implementation plans
 - `/speckit.tasks` - Break down into actionable tasks
+- `/speckit.implement` - Execute implementation tasks
+- `/speckit.analyze` - Validate cross-artifact consistency
+- `/speckit.clarify` - Identify and resolve ambiguities
+- `/speckit.checklist` - Generate quality checklists
+- `/speckit.constitution` - Create or update project principles
+- `/speckit.converge` - Assess codebase against artifacts and append remaining tasks
+- `/speckit.taskstoissues` - Convert tasks to issues
 
 Scripts are installed into a variant subdirectory matching the chosen script type:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,10 +13,10 @@ This guide will help you get started with Spec-Driven Development using Spec Kit
 After installing Spec Kit and defining your project constitution, quick experiments can use the lean feature path: `/speckit.specify` -> `/speckit.plan` -> `/speckit.tasks` -> `/speckit.implement`. For production features or any work with meaningful ambiguity, treat `/speckit.clarify`, `/speckit.checklist`, and `/speckit.analyze` as regular quality gates:
 
 ```text
-/speckit.constitution -> /speckit.specify -> /speckit.clarify -> /speckit.plan -> /speckit.checklist -> /speckit.tasks -> /speckit.analyze -> /speckit.implement
+/speckit.constitution -> /speckit.specify -> /speckit.clarify -> /speckit.plan -> /speckit.checklist -> /speckit.tasks -> /speckit.analyze -> /speckit.implement -> /speckit.converge
 ```
 
-Use `/speckit.clarify` to reduce requirement ambiguity before planning, `/speckit.checklist` (after `/speckit.plan`) to generate quality checklists that validate requirements completeness, clarity, and consistency, and `/speckit.analyze` to check spec/plan/task consistency before implementation starts. You can repeat `/speckit.analyze` after implementation as an extra review, but keep the first analysis before `/speckit.implement` so gaps are caught while the plan and tasks can still be adjusted.
+Use `/speckit.clarify` to reduce requirement ambiguity before planning, `/speckit.checklist` (after `/speckit.plan`) to generate quality checklists that validate requirements completeness, clarity, and consistency, and `/speckit.analyze` to check spec/plan/task consistency before implementation starts. You can repeat `/speckit.analyze` after implementation as an extra review, but keep the first analysis before `/speckit.implement` so gaps are caught while the plan and tasks can still be adjusted. Finally, run `/speckit.converge` after implementation to verify all planned work is complete and generate tasks for any remaining gaps.
 
 ### Step 1: Install Specify
 
@@ -186,6 +186,14 @@ Finally, implement the solution:
 
 ```bash
 /speckit.implement
+```
+
+### Step 8: Converge
+
+Run the `/speckit.converge` command after implementation to assess the current codebase against the feature's artifacts and append any remaining unbuilt work as new tasks to `tasks.md`.
+
+```bash
+/speckit.converge
 ```
 
 > [!TIP]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ After installing Spec Kit and defining your project constitution, quick experime
 /speckit.constitution -> /speckit.specify -> /speckit.clarify -> /speckit.plan -> /speckit.checklist -> /speckit.tasks -> /speckit.analyze -> /speckit.implement -> /speckit.converge
 ```
 
-Use `/speckit.clarify` to reduce requirement ambiguity before planning, `/speckit.checklist` (after `/speckit.plan`) to generate quality checklists that validate requirements completeness, clarity, and consistency, and `/speckit.analyze` to check spec/plan/task consistency before implementation starts. You can repeat `/speckit.analyze` after implementation as an extra review, but keep the first analysis before `/speckit.implement` so gaps are caught while the plan and tasks can still be adjusted. Finally, run `/speckit.converge` after implementation to verify all planned work is complete and generate tasks for any remaining gaps.
+Use `/speckit.clarify` to reduce requirement ambiguity before planning, `/speckit.checklist` (after `/speckit.plan`) to generate quality checklists that validate requirements completeness, clarity, and consistency, and `/speckit.analyze` to check spec/plan/task consistency before implementation starts. You can repeat `/speckit.analyze` after implementation as an extra review, but keep the first analysis before `/speckit.implement` so gaps are caught while the plan and tasks can still be adjusted. Finally, run `/speckit.converge` after implementation to verify all planned work is complete and generate tasks for any remaining gaps. If `/speckit.converge` appends new tasks, run `/speckit.implement` again (and converge again) until it reports that the feature has converged.
 
 ### Step 1: Install Specify
 
@@ -190,7 +190,7 @@ Finally, implement the solution:
 
 ### Step 8: Converge
 
-Run the `/speckit.converge` command after implementation to assess the current codebase against the feature's artifacts and append any remaining unbuilt work as new tasks to `tasks.md`.
+Run the `/speckit.converge` command after implementation to assess the current codebase against the feature's artifacts and append any remaining unbuilt work as new tasks to `tasks.md`. If the command appends new tasks, run `/speckit.implement` again to complete them, and repeat the converge step until the feature is fully complete.
 
 ```bash
 /speckit.converge


### PR DESCRIPTION
Fixes #3176

This PR documents the `/speckit.converge` command across the documentation.
Changes made:
- Added `converge` to the recommended workflow sequence in `docs/quickstart.md`
- Added an explicit `Step 8: Converge` section in `docs/quickstart.md`
- Added `/speckit.converge` (along with missing commands) to the initialized commands list in `docs/installation.md`
- Updated the flow-forward and living spec workflows in `docs/guides/evolving-specs.md` to include a final convergence step.