### PR TITLE
fix: update CodeBuddy install docs URL

### DIFF
--- a/src/specify_cli/integrations/codebuddy/__init__.py
+++ b/src/specify_cli/integrations/codebuddy/__init__.py
@@ -9,7 +9,7 @@ class CodebuddyIntegration(MarkdownIntegration):
         "name": "CodeBuddy",
         "folder": ".codebuddy/",
         "commands_subdir": "commands",
-        "install_url": "https://www.codebuddy.ai/cli",
+        "install_url": "https://www.codebuddy.cn/docs/cli/installation",
         "requires_cli": True,
     }
     registrar_config = {

--- a/tests/integrations/test_integration_codebuddy.py
+++ b/tests/integrations/test_integration_codebuddy.py
@@ -1,5 +1,7 @@
 """Tests for CodebuddyIntegration."""
 
+from specify_cli.integrations import get_integration
+
 from .test_integration_base_markdown import MarkdownIntegrationTests
 
 
@@ -9,3 +11,11 @@ class TestCodebuddyIntegration(MarkdownIntegrationTests):
     COMMANDS_SUBDIR = "commands"
     REGISTRAR_DIR = ".codebuddy/commands"
     CONTEXT_FILE = "CODEBUDDY.md"
+
+    def test_install_url_points_to_official_cli_install_docs(self):
+        integration = get_integration(self.KEY)
+
+        assert (
+            integration.config["install_url"]
+            == "https://www.codebuddy.cn/docs/cli/installation"
+        )

--- a/tests/integrations/test_integration_codebuddy.py
+++ b/tests/integrations/test_integration_codebuddy.py
@@ -14,6 +14,7 @@ class TestCodebuddyIntegration(MarkdownIntegrationTests):
 
     def test_install_url_points_to_official_cli_install_docs(self):
         integration = get_integration(self.KEY)
+        assert integration is not None
 
         assert (
             integration.config["install_url"]


### PR DESCRIPTION
## Summary
- update the CodeBuddy integration install URL to the current official CLI installation page
- add a focused regression test for the CodeBuddy install URL

## Testing
- `pytest tests/integrations/test_integration_codebuddy.py -v`
- `pytest tests/test_agent_config_consistency.py -v`
- smoke-tested `specify init --here --integration codebuddy --script sh` and confirmed the missing-CLI error panel shows the new URL