### PR TITLE
docs: document integration `search`/`info`/`scaffold` subcommands (#3174)

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -54,6 +54,27 @@ Shows all available integrations, which one is currently installed, and whether 
 When multiple integrations are installed, the list marks the default integration separately from the other installed integrations.
 The list also shows whether each built-in integration is declared multi-install safe.
 
+## Search Available Integrations
+
+```bash
+specify integration search [query]
+```
+
+| Option     | Description        |
+| ---------- | ------------------ |
+| `--tag`    | Filter by tag      |
+| `--author` | Filter by author   |
+
+Searches the active catalog stack for integrations matching the query. Without a query, lists all available integrations. Must be run inside a Spec Kit project.
+
+## Integration Info
+
+```bash
+specify integration info <integration_id>
+```
+
+Shows catalog details for a single integration, including its description, type (CLI-based or IDE-based), author, and tags. Must be run inside a Spec Kit project.
+
 ## Install an Integration
 
 ```bash
@@ -165,6 +186,18 @@ Example:
 ```bash
 specify integration install generic --integration-options="--commands-dir .myagent/cmds"
 ```
+
+## Scaffold a New Integration
+
+```bash
+specify integration scaffold <key>
+```
+
+Creates a minimal built-in integration package and a matching test skeleton, then prints the next steps for wiring it up. The `<key>` must be lowercase kebab-case (for example, `my-agent`).
+
+| Option   | Description                                                       |
+| -------- | ---------------------------------------------------------------- |
+| `--type` | Scaffold template to use: `markdown` (default), `skills`, `toml`, or `yaml` |
 
 ## FAQ
 

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -73,7 +73,7 @@ Searches the active catalog stack for integrations matching the query. Without a
 specify integration info <integration_id>
 ```
 
-Shows catalog details for a single integration, including its description, type (CLI-based or IDE-based), author, and tags. Must be run inside a Spec Kit project.
+Shows catalog details for a single integration, including its description, author, license, tags, source catalog, repository (when available), and whether it is currently active. Must be run inside a Spec Kit project.
 
 ## Install an Integration
 

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -193,7 +193,7 @@ specify integration install generic --integration-options="--commands-dir .myage
 specify integration scaffold <key>
 ```
 
-Creates a minimal built-in integration package and a matching test skeleton, then prints the next steps for wiring it up. The `<key>` must be lowercase kebab-case (for example, `my-agent`).
+Creates a minimal built-in integration package and a matching test skeleton in the Spec Kit repository, then prints the next steps for wiring it up. Run this command from the Spec Kit repository root. The `<key>` must be lowercase kebab-case (for example, `my-agent`).
 
 | Option   | Description                                                       |
 | -------- | ---------------------------------------------------------------- |


### PR DESCRIPTION
## What

`docs/reference/integrations.md` documented the `integration` commands but omitted three subcommands that exist in code. This broke parity with the `extension`, `preset`, `bundle`, and `workflow` references, all of which document their `search`/`info` equivalents.

Fixes #3174.

## Missing commands now documented

| Command | Code location |
| --- | --- |
| `specify integration search [query]` (`--tag`, `--author`) | `src/specify_cli/integrations/_query_commands.py` |
| `specify integration info <integration_id>` | `src/specify_cli/integrations/_query_commands.py` |
| `specify integration scaffold <key>` (`--type`) | `src/specify_cli/integrations/_scaffold_commands.py` |

## How

Added three sections matching the structure used for the analogous extension/preset/bundle references:
- **Search Available Integrations** and **Integration Info** after *List Available Integrations*.
- **Scaffold a New Integration** after *Integration-Specific Options*.

All option names, the kebab-case key requirement, and the scaffold `--type` values (`markdown` default, plus `skills`, `toml`, `yaml`) were taken directly from the command definitions and docstrings in the source, so the docs match runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)