### PR TITLE
fix(scripts): drop HAS_GIT from PowerShell git-extension output (parity with bash)

### DIFF
--- a/extensions/git/scripts/powershell/create-new-feature-branch.ps1
+++ b/extensions/git/scripts/powershell/create-new-feature-branch.ps1
@@ -400,8 +400,9 @@ if ($Json) {
     $obj = [PSCustomObject]@{
         BRANCH_NAME = $branchName
         FEATURE_NUM = $featureNum
-        HAS_GIT = $hasGit
     }
+    # $hasGit is computed for branch-creation logic only; it is intentionally not
+    # emitted so this output contract matches the bash twin ({BRANCH_NAME, FEATURE_NUM}).
     if ($DryRun) {
         $obj | Add-Member -NotePropertyName 'DRY_RUN' -NotePropertyValue $true
     }
@@ -409,7 +410,6 @@ if ($Json) {
 } else {
     Write-Output "BRANCH_NAME: $branchName"
     Write-Output "FEATURE_NUM: $featureNum"
-    Write-Output "HAS_GIT: $hasGit"
     if (-not $DryRun) {
         Write-Output "SPECIFY_FEATURE environment variable set to: $branchName"
     }

--- a/extensions/git/scripts/powershell/create-new-feature-branch.ps1
+++ b/extensions/git/scripts/powershell/create-new-feature-branch.ps1
@@ -402,7 +402,8 @@ if ($Json) {
         FEATURE_NUM = $featureNum
     }
     # $hasGit is computed for branch-creation logic only; it is intentionally not
-    # emitted so this output contract matches the bash twin ({BRANCH_NAME, FEATURE_NUM}).
+    # emitted so this output contract matches the bash twin: BRANCH_NAME and
+    # FEATURE_NUM, plus DRY_RUN (added just below) on dry runs.
     if ($DryRun) {
         $obj | Add-Member -NotePropertyName 'DRY_RUN' -NotePropertyValue $true
     }

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -298,6 +298,24 @@ class TestCreateFeatureBash:
         assert data["BRANCH_NAME"] == "001-user-auth"
         assert data["FEATURE_NUM"] == "001"
 
+    def test_output_omits_has_git_for_parity(self, tmp_path: Path):
+        """The bash output contract is {BRANCH_NAME, FEATURE_NUM} (+ DRY_RUN) in JSON
+        and a BRANCH_NAME:/FEATURE_NUM: text block -- no HAS_GIT key/line. This pins
+        the canonical contract the PowerShell twin must mirror."""
+        project = _setup_project(tmp_path)
+        rj = _run_bash(
+            "create-new-feature-branch.sh", project,
+            "--json", "--dry-run", "--short-name", "parity", "Parity feature",
+        )
+        assert rj.returncode == 0, rj.stderr
+        assert "HAS_GIT" not in json.loads(rj.stdout)
+        rt = _run_bash(
+            "create-new-feature-branch.sh", project,
+            "--dry-run", "--short-name", "parity", "Parity feature",
+        )
+        assert rt.returncode == 0, rt.stderr
+        assert "HAS_GIT" not in rt.stdout
+
     def test_branch_name_short_word_case_sensitivity(self, tmp_path: Path):
         """A short word is dropped from the derived branch name unless it appears
         as an acronym in UPPERCASE in the description (case-sensitive, must match the
@@ -443,6 +461,24 @@ class TestCreateFeaturePowerShell:
         assert result.returncode == 0, result.stderr
         data = json.loads(result.stdout)
         assert data["BRANCH_NAME"] == "001-user-auth"
+
+    def test_output_omits_has_git_to_match_bash(self, tmp_path: Path):
+        """PowerShell must mirror the bash twin's output contract: neither JSON nor
+        text output may include HAS_GIT (it is computed internally for branch-creation
+        logic only). Fails before the fix (PS emitted HAS_GIT), passes after."""
+        project = _setup_project(tmp_path)
+        rj = _run_pwsh(
+            "create-new-feature-branch.ps1", project,
+            "-Json", "-DryRun", "-ShortName", "parity", "Parity feature",
+        )
+        assert rj.returncode == 0, rj.stderr
+        assert "HAS_GIT" not in json.loads(rj.stdout)
+        rt = _run_pwsh(
+            "create-new-feature-branch.ps1", project,
+            "-DryRun", "-ShortName", "parity", "Parity feature",
+        )
+        assert rt.returncode == 0, rt.stderr
+        assert "HAS_GIT" not in rt.stdout
 
     def test_branch_name_short_word_case_sensitivity(self, tmp_path: Path):
         """PowerShell must match the bash twin: a short word is dropped unless it


### PR DESCRIPTION
## Description

The git extension's `create-new-feature-branch.ps1` emits a `HAS_GIT` field in its JSON output and a `HAS_GIT:` line in its text output that the **bash twin never emits**.

The bash twin's output contract is:
- JSON: `{BRANCH_NAME, FEATURE_NUM}` (+ `DRY_RUN` on dry runs)
- text: `BRANCH_NAME:` / `FEATURE_NUM:` lines

So any tool consuming the machine-readable output gets a **different shape on Windows/PowerShell than on macOS/Linux** — a cross-platform output-contract divergence. (I flagged this as a follow-up in #3129.)

### Fix

Remove the two `HAS_GIT` output emissions from the PowerShell script (JSON object + text line). `$hasGit` is still computed and used internally for branch-creation logic — only its leakage into the output contract is removed, restoring parity with bash. One-file change.

## Testing

- `uvx ruff check` clean; `tests/test_ps1_encoding.py` green (the edited `.ps1` stays ASCII / PowerShell 5.1-safe).
- New regression tests in `tests/extensions/git/test_git_extension.py`:
  - `TestCreateFeatureBash::test_output_omits_has_git_for_parity` — pins the canonical bash contract (JSON + text omit HAS_GIT).
  - `TestCreateFeaturePowerShell::test_output_omits_has_git_to_match_bash` — **fails before this change** (PS emitted HAS_GIT), passes after.
- Verified end-to-end with Windows PowerShell 5.1 and bash: both now emit identical JSON `{"BRANCH_NAME":"001-parity","FEATURE_NUM":"001","DRY_RUN":true}`, and PS text mode no longer prints a `HAS_GIT:` line.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI located the output-contract divergence across the bash/PowerShell twins and drafted the one-line removal plus regression tests; I reproduced the differing JSON shapes under Windows PowerShell 5.1 and bash, confirmed `$hasGit`'s internal use is unaffected, and reviewed the diff before submitting.