### PR TITLE
fix(scripts): honor explicit -Number 0 in PowerShell create-new-feature (parity with bash)

### DIFF
--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -142,8 +142,10 @@ if ($ShortName) {
     $branchSuffix = Get-BranchName -Description $featureDesc
 }
 
-# Warn if -Number and -Timestamp are both specified
-if ($Timestamp -and $Number -ne 0) {
+# Warn if -Number and -Timestamp are both specified. Use ContainsKey (not
+# `-ne 0`) so an explicit `-Number 0` is also detected, matching the bash twin's
+# `[ -n "$BRANCH_NUMBER" ]` check.
+if ($Timestamp -and $PSBoundParameters.ContainsKey('Number')) {
     Write-Warning "[specify] Warning: -Number is ignored when -Timestamp is used"
     $Number = 0
 }
@@ -153,8 +155,10 @@ if ($Timestamp) {
     $featureNum = Get-Date -Format 'yyyyMMdd-HHmmss'
     $branchName = "$featureNum-$branchSuffix"
 } else {
-    # Determine branch number from existing feature directories
-    if ($Number -eq 0) {
+    # Determine branch number from existing feature directories. Auto-detect only
+    # when -Number was not supplied; an explicit value (including 0) is honored,
+    # matching the bash twin's `[ -z "$BRANCH_NUMBER" ]` check.
+    if (-not $PSBoundParameters.ContainsKey('Number')) {
         $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
     }
 

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -275,6 +275,19 @@ class TestSequentialBranch:
                 branch = line.split(":", 1)[1].strip()
         assert branch == "1001-next-feat", f"expected 1001-next-feat, got: {branch}"
 
+    def test_explicit_number_zero_is_honored(self, git_repo: Path):
+        """An explicit --number 0 is honored literally (FEATURE_NUM 000), not treated
+        as auto-detect, even when higher-numbered specs already exist. This pins the
+        canonical bash behavior the PowerShell twin must mirror."""
+        (git_repo / "specs" / "003-existing").mkdir(parents=True)
+        r = run_script(
+            git_repo, "--json", "--dry-run", "--number", "0", "--short-name", "zero", "Zero feature",
+        )
+        assert r.returncode == 0, r.stderr
+        data = json.loads(r.stdout)
+        assert data["FEATURE_NUM"] == "000"
+        assert data["BRANCH_NAME"] == "000-zero"
+
 
 class TestSequentialBranchPowerShell:
     def test_powershell_scanner_uses_long_tryparse_for_large_prefixes(self):
@@ -301,6 +314,23 @@ class TestSequentialBranchPowerShell:
         r2 = _run("Use GO now")
         assert r2.returncode == 0, r2.stderr
         assert json.loads(r2.stdout)["BRANCH_NAME"] == "001-use-go-now"
+
+    @pytest.mark.skipif(not _has_pwsh(), reason="pwsh not installed")
+    def test_explicit_number_zero_is_honored_matching_bash(self, ps_git_repo: Path):
+        """An explicit -Number 0 must be honored (FEATURE_NUM 000) like the bash twin,
+        even when higher-numbered specs exist. Before the fix, PowerShell could not
+        distinguish -Number 0 from the default and silently auto-detected (e.g. 004)."""
+        script = ps_git_repo / "scripts" / "powershell" / "create-new-feature.ps1"
+        (ps_git_repo / "specs" / "003-existing").mkdir(parents=True)
+        result = subprocess.run(
+            ["pwsh", "-NoProfile", "-File", str(script),
+             "-Json", "-DryRun", "-Number", "0", "-ShortName", "zero", "Zero feature"],
+            cwd=ps_git_repo, capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["FEATURE_NUM"] == "000"
+        assert data["BRANCH_NAME"] == "000-zero"
 
 
 # ── check_feature_branch Tests ───────────────────────────────────────────────


### PR DESCRIPTION
## Description

`create-new-feature.ps1` could not honor an explicit `-Number 0`. The parameter used `[long]$Number = 0` as **both** the default and the auto-detect sentinel:

```powershell
if ($Number -eq 0) { $Number = (Get-HighestNumberFromSpecs ...) + 1 }
```

So `-Number 0` was indistinguishable from *not supplied* and silently auto-incremented. The bash twin keys off whether the value is **non-empty** (`[ -z "$BRANCH_NUMBER" ]`), so `--number 0` is honored and yields `FEATURE_NUM=000`.

Result — identical input, different output across platforms:

| input | bash | PowerShell (before) |
|-------|------|---------------------|
| `--number 0` | `000-feature` | `001-feature` (auto) |

### Fix

Use `$PSBoundParameters.ContainsKey('Number')` to detect whether `-Number` was actually supplied, so an explicit value (including `0`) is honored and only a missing `-Number` auto-detects — mirroring bash's empty-check. This also aligns the `-Timestamp`+`-Number` warning, which bash emits for `--number 0 --timestamp` (non-empty check) but PowerShell previously skipped.

## Testing

- `uvx ruff check` clean; `tests/test_ps1_encoding.py` green (edited `.ps1` stays ASCII / PowerShell 5.1-safe).
- New regression tests:
  - `TestSequentialBranch::test_explicit_number_zero_is_honored` (bash) — pins the canonical `--number 0` -> `000` behavior.
  - `TestSequentialBranchPowerShell::test_explicit_number_zero_is_honored_matching_bash` — **fails before** this change (PS auto-detected), passes after.
- Verified end-to-end with Windows PowerShell 5.1: `-Number 0` -> `000-zero` (even with `specs/003-*` present), `-Number 5` -> `005-zero`, and no `-Number` still auto-detects (`004-zero` with `specs/003-*`). bash confirmed `--number 0` -> `000-zero`.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI located the default-vs-sentinel ambiguity across the bash/PowerShell twins and drafted the `ContainsKey` fix plus regression tests; I reproduced the differing `FEATURE_NUM` under Windows PowerShell 5.1 and bash, confirmed auto-detect and explicit non-zero paths are unchanged, and reviewed the diff before submitting.