### PR TITLE
fix(scripts): emit 'Copied plan template' status in setup-plan.ps1 (parity with bash)

### DIFF
--- a/scripts/powershell/setup-plan.ps1
+++ b/scripts/powershell/setup-plan.ps1
@@ -40,6 +40,13 @@ if (Test-Path $paths.IMPL_PLAN -PathType Leaf) {
         $content = [System.IO.File]::ReadAllText($template)
         $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
         [System.IO.File]::WriteAllText($paths.IMPL_PLAN, $content, $utf8NoBom)
+        # Emit the copy status like the bash twin (setup-plan.sh); route to stderr
+        # in -Json mode so stdout stays pure JSON, matching the sibling messages.
+        if ($Json) {
+            [Console]::Error.WriteLine("Copied plan template to $($paths.IMPL_PLAN)")
+        } else {
+            Write-Output "Copied plan template to $($paths.IMPL_PLAN)"
+        }
     } else {
         Write-Warning "Plan template not found"
         # Create a basic plan file if template doesn't exist

--- a/tests/test_setup_plan_no_overwrite.py
+++ b/tests/test_setup_plan_no_overwrite.py
@@ -224,3 +224,25 @@ def test_ps_setup_plan_preserves_existing_plan(plan_repo: Path) -> None:
     assert "IMPL_PLAN" in data
     # The skip message should be on stderr
     assert "already exists" in result.stderr
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_ps_setup_plan_copied_message_on_stderr_in_json_mode(plan_repo: Path) -> None:
+    """First run in -Json mode must emit 'Copied plan template' on stderr (matching
+    the bash twin) while keeping stdout pure JSON. Before the fix the PowerShell
+    script emitted no copy status at all."""
+    script = plan_repo / ".specify" / "scripts" / "powershell" / "setup-plan.ps1"
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(script), "-Json"],
+        cwd=plan_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),
+    )
+    assert result.returncode == 0, result.stderr
+    # stdout stays parseable JSON; the status message goes to stderr.
+    data = json.loads(result.stdout)
+    assert "IMPL_PLAN" in data
+    assert "Copied plan template" in result.stderr


### PR DESCRIPTION
## Description

`setup-plan.sh` prints a status message after copying the plan template on a fresh run:

```bash
cp "$TEMPLATE" "$IMPL_PLAN"
if $JSON_MODE; then echo "Copied plan template to $IMPL_PLAN" >&2
else echo "Copied plan template to $IMPL_PLAN"; fi
```

The PowerShell twin `setup-plan.ps1` emitted **nothing** on the successful-copy path — only the `Plan already exists` skip message and the `Plan template not found` warning had equivalents. So on a first run the two scripts had a divergent status-output contract (the bash behavior is even covered by a test, `test_setup_plan_json_parseable_on_first_run`, which asserts `Copied plan template` on stderr).

### Fix

Emit the same message after `WriteAllText`, routed exactly like the sibling `Plan already exists` message — `[Console]::Error.WriteLine` in `-Json` mode so stdout stays pure JSON, `Write-Output` in text mode. Mirrors the bash wording and stream routing. One source file.

## Testing

- `uvx ruff check` clean; `tests/test_ps1_encoding.py` green (edited `.ps1` stays ASCII / PowerShell 5.1-safe).
- New `test_ps_setup_plan_copied_message_on_stderr_in_json_mode` mirrors the existing bash `test_setup_plan_json_parseable_on_first_run`: asserts `-Json` first-run stdout is parseable JSON **and** `Copied plan template` is on stderr.
- Verified fail-before / pass-after locally with Windows PowerShell 5.1: before, stderr is empty and the test fails; after, the message is on stderr and stdout remains pure JSON (`{...,"BRANCH":""}`). Existing setup-plan tests still pass.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI located the missing status message across the bash/PowerShell twins and drafted the fix plus a mirroring regression test; I confirmed the bash wording/stream routing, verified fail-before/pass-after under Windows PowerShell 5.1 (stdout stays pure JSON), and reviewed the diff before submitting.