### PR TITLE
fix(workflows): reject infinite number-input default instead of raising OverflowError

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -1010,7 +1010,12 @@ class WorkflowEngine:
                 value = float(value)
                 if value == int(value):
                     value = int(value)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, OverflowError):
+                # OverflowError: `int(value)` raises it for an infinite float
+                # (e.g. a `default: .inf` authoring mistake), which would
+                # otherwise escape validate_workflow's `except ValueError` and
+                # break its "return errors, never raise" contract. Surface it as
+                # the same clean "expected a number" error as NaN does.
                 msg = f"Input {name!r} expected a number, got {value!r}."
                 raise ValueError(msg) from None
         elif input_type == "boolean":

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2810,6 +2810,47 @@ steps:
         errors = validate_workflow(definition)
         assert any("invalid default" in e for e in errors), errors
 
+    def test_coerce_number_input_rejects_infinity_cleanly(self):
+        """An infinite float must surface as a clean ValueError (like NaN), not
+        let ``int(inf)``'s OverflowError escape: ``int()`` of an infinity raises
+        OverflowError, which is not ValueError/TypeError.
+        """
+        from specify_cli.workflows.engine import WorkflowEngine
+
+        for value in (float("inf"), float("-inf"), "inf", "Infinity", "-inf"):
+            with pytest.raises(ValueError, match="expected a number"):
+                WorkflowEngine._coerce_input("count", value, {"type": "number"})
+        # Finite values still coerce (whole floats normalize to int).
+        assert WorkflowEngine._coerce_input("count", 5.0, {"type": "number"}) == 5
+        assert WorkflowEngine._coerce_input("count", 3.5, {"type": "number"}) == 3.5
+
+    def test_validate_workflow_rejects_infinite_default_for_number_type(self):
+        """``type: number`` with an infinite default (YAML ``.inf``) must be
+        reported as an error, not raise. ``int(inf)`` raises OverflowError during
+        coercion, which previously escaped validate_workflow's ValueError handler
+        and broke its "return a list of errors" contract.
+        """
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "inf-as-number"
+  name: "Inf As Number"
+  version: "1.0.0"
+inputs:
+  count:
+    type: number
+    default: .inf
+steps:
+  - id: noop
+    type: gate
+    message: "noop"
+    options: [approve]
+""")
+        errors = validate_workflow(definition)
+        assert any("invalid default" in e for e in errors), errors
+
     def test_validate_workflow_rejects_non_string_default_for_string_type(self):
         """``type: string`` must require an actual string — a numeric YAML
         default like ``5`` would otherwise slip through unvalidated.


### PR DESCRIPTION
## Description

`WorkflowEngine._coerce_input` normalizes a whole-valued number to `int`:

```python
value = float(value)
if value == int(value):   # int(inf) raises OverflowError
    value = int(value)
except (ValueError, TypeError):   # OverflowError is NOT caught
    ...
```

For an infinite float — e.g. a `type: number` input with YAML `default: .inf` — `int(inf)` raises **OverflowError**, which isn't in the `except` tuple. `validate_workflow` eager-coerces declared defaults and is documented to **return a list of error messages**, but it only catches `ValueError`, so the `OverflowError` **escaped and `validate_workflow` raised** instead of reporting the bad default — breaking its contract. (`NaN` already surfaced cleanly, since `int(nan)` raises `ValueError`.)

### Fix

Add `OverflowError` to the `except` tuple so an infinite default surfaces as the same clean `expected a number` `ValueError` as `NaN`, consistent with the function's existing fail-fast-on-authoring-mistakes design (the same rationale already documented for rejecting bool defaults). Finite values are unaffected.

## Testing

- `uvx ruff check` clean.
- New tests in `TestWorkflowEngine`:
  - `test_coerce_number_input_rejects_infinity_cleanly` — `float('inf')`/`'inf'`/`'Infinity'`/`'-inf'` raise a clean `ValueError`; `5.0 -> 5` and `3.5 -> 3.5` still coerce.
  - `test_validate_workflow_rejects_infinite_default_for_number_type` — a workflow with `default: .inf` returns a "invalid default" error rather than raising (mirrors the existing `...rejects_bool_default_for_number_type`).
- Verified fail-before / pass-after: without the fix both tests fail with `OverflowError: cannot convert float infinity to integer` (validate_workflow raises); with it they pass.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI traced the uncaught `OverflowError` from `int(inf)` through `validate_workflow`'s `except ValueError` and drafted the one-line fix plus regression tests; I reproduced the escape against the real engine (confirming NaN already behaves and finite values are unaffected) and reviewed the diff before submitting.