### PR TITLE
[extension] Update Linear Integration extension to v0.8.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-08-11T00:00:00Z",
+  "updated_at": "2026-08-12T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "adrkit": {
@@ -2214,8 +2214,8 @@
       "id": "linear",
       "description": "Mirror spec-kit feature directories into Linear (filesystem → Linear, reconcile-based, unidirectional).",
       "author": "Ash Brener",
-      "version": "0.7.0",
-      "download_url": "https://github.com/ashbrener/spec-kit-linear-sync/archive/refs/tags/v0.7.0.zip",
+      "version": "0.8.0",
+      "download_url": "https://github.com/ashbrener/spec-kit-linear-sync/archive/refs/tags/v0.8.0.zip",
       "repository": "https://github.com/ashbrener/spec-kit-linear-sync",
       "homepage": "https://github.com/ashbrener/spec-kit-linear-sync",
       "documentation": "https://github.com/ashbrener/spec-kit-linear-sync/blob/main/README.md",
@@ -2242,7 +2242,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-06-01T00:00:00Z",
-      "updated_at": "2026-06-22T00:00:00Z"
+      "updated_at": "2026-08-12T00:00:00Z"
     },
     "linear-weave": {
       "name": "Linear Weave",


### PR DESCRIPTION
Updates the `linear` community catalog entry from **v0.7.0 → v0.8.0**, submitted by `@ashbrener`.

## Changes

- `extensions/catalog.community.json`: updated `version`, `download_url`, `updated_at`; preserved `created_at`, `downloads`, `stars`.
- `docs/community/extensions.md`: no display-column changes (description, category, effect, and repo link are unchanged).

## What's new in v0.8.0 — hook self-healing

The community update path (`specify extension add linear --from <release-zip> --force`) silently strips the bridge's six `after_*` auto-sync hooks from `.specify/extensions.yml`, so auto-sync quietly stops and the Linear board drifts with no signal. The bridge now self-reports its own hook health:

- On every `speckit.linear.push` and `speckit.linear.status`, missing `after_*` hooks raise one named, non-blocking warning + the `/speckit.linear.install` remediation.
- `speckit.linear.status` reports hook health as a first-class line (all present / partial+names / none); exit code unchanged.
- Interactive sessions offer a single y/N consented self-heal that re-registers all missing hooks at once (preserving any `enabled: false`); non-interactive runs are warn-only and mutate nothing.

Additive; `extension.id` stays `linear`; no command/hook surface change. Release: https://github.com/ashbrener/spec-kit-linear-sync/releases/tag/v0.8.0 · download_url archive verified HTTP 200.