### PR TITLE
Feat/plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ specify init <project_name> --integration copilot --ignore-agent-tools
 If you are working across multiple projects and want to avoid duplicate skill files, you can use the global plugin mode (requires the `adg` CLI):
 
 ```bash
-specify init <project_name> --integration claude --plugin
+specify init <project_name> --plugin
 ```
 
 ### **STEP 1:** Establish project principles

--- a/README.md
+++ b/README.md
@@ -409,6 +409,12 @@ The CLI will check if you have Claude Code, Gemini CLI, Cursor CLI, Qwen CLI, op
 specify init <project_name> --integration copilot --ignore-agent-tools
 ```
 
+If you are working across multiple projects and want to avoid duplicate skill files, you can use the global plugin mode (requires the `adg` CLI):
+
+```bash
+specify init <project_name> --integration claude --plugin
+```
+
 ### **STEP 1:** Establish project principles
 
 Go to the project folder and run your coding agent. In our example, we're using `claude`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,6 +79,33 @@ If you prefer to get the templates without checking for the right tools:
 specify init <project_name> --integration claude --ignore-agent-tools
 ```
 
+### Global Plugin Mode (ADG Plugin)
+
+By default, Spec Kit copies all core skills and templates into the project's local agent folder (e.g. `.claude/skills/`). For developers working across multiple projects, this can result in duplicate files.
+
+Spec Kit supports an opt-in **Global Plugin Mode** using the external [Agent Directory Group (adg)](https://github.com/rbbtsn0w/adg) CLI to manage core skills as a single, global plugin:
+
+1. **Install the `adg` CLI** globally:
+   ```bash
+   npm install -g @rbbtsn0w/adg
+   ```
+
+2. **Initialize a project** with the `--plugin` flag:
+   ```bash
+   specify init <PROJECT_NAME> --integration claude --plugin
+   ```
+   On first use, Spec Kit will bundle and register the core skills globally under `~/.agents/plugins/` using `adg`, then configure your coding agent runtime to consume the global plugin.
+
+3. **Offline / CI Environments (Degraded Mode)**:
+   If `adg` is not installed on the system (e.g., in a CI pipeline or offline environment), you can combine the `--plugin` flag with `--plugin-out <dir>` to build the plugin source tree without linking:
+   ```bash
+   specify init <PROJECT_NAME> --integration claude --plugin --plugin-out ./my-plugin-source
+   ```
+   You can later register the plugin globally once the `adg` tool is available:
+   ```bash
+   adg plugins add ./my-plugin-source --global
+   ```
+
 ## Verification
 
 After installation, run the following command to confirm the correct version is installed:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,14 +92,16 @@ Spec Kit supports an opt-in **Global Plugin Mode** using the external [Agent Dir
 
 2. **Initialize a project** with the `--plugin` flag:
    ```bash
-   specify init <PROJECT_NAME> --integration claude --plugin
+   specify init <PROJECT_NAME> --plugin
    ```
+   *Note: Without `--integration`, plugin mode defaults to the generic `codex` integration. This sets up an agent-agnostic `AGENTS.md` context file in your project root, while the global `adg` plugin handles routing skills to your actual active agent.*
+
    On first use, Spec Kit will bundle and register the core skills globally under `~/.agents/plugins/` using `adg`, then configure your coding agent runtime to consume the global plugin.
 
 3. **Offline / CI Environments (Degraded Mode)**:
    If `adg` is not installed on the system (e.g., in a CI pipeline or offline environment), you can combine the `--plugin` flag with `--plugin-out <dir>` to build the plugin source tree without linking:
    ```bash
-   specify init <PROJECT_NAME> --integration claude --plugin --plugin-out ./my-plugin-source
+   specify init <PROJECT_NAME> --plugin --plugin-out ./my-plugin-source
    ```
    You can later register the plugin globally once the `adg` tool is available:
    ```bash

--- a/plugin/hooks/ensure-specify.sh
+++ b/plugin/hooks/ensure-specify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Spec Kit plugin lifecycle hook.
+#
+# Fires (via UserPromptExpansion, matcher "speckit") just before a `/speckit:*`
+# command expands into a prompt. When the speckit skills are installed globally
+# as a plugin, the per-project `.specify/` runtime state may be absent — this
+# hook provisions it on first use so the command's scripts and templates
+# resolve. It is idempotent, never blocks the command, and only acts when a
+# speckit command is actually being invoked.
+
+set -u
+
+INPUT="$(cat 2>/dev/null || true)"
+
+# `cwd` is provided in the hook payload; fall back to the process cwd.
+CWD=""
+if command -v jq >/dev/null 2>&1; then
+    CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)"
+fi
+[ -z "$CWD" ] && CWD="$PWD"
+
+# Idempotent: an initialized speckit project has this sentinel.
+if [ -f "$CWD/.specify/init-options.json" ]; then
+    exit 0
+fi
+
+cd "$CWD" 2>/dev/null || exit 0
+
+if command -v specify >/dev/null 2>&1; then
+    if ! specify init --here --plugin --force >&2 2>&1; then
+        echo "Spec Kit: could not provision .specify/. Run: specify init --here --plugin" >&2
+    fi
+else
+    echo "Spec Kit: '.specify/' is missing and the 'specify' CLI was not found." >&2
+    echo "Install spec-kit, then run: specify init --here --plugin" >&2
+fi
+
+# Always allow the command to proceed; the hook only prepares the environment.
+exit 0

--- a/plugin/hooks/ensure-specify.sh
+++ b/plugin/hooks/ensure-specify.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # Spec Kit plugin lifecycle hook.
 #
-# Fires (via UserPromptExpansion, matcher "speckit") just before a `/speckit:*`
-# command expands into a prompt. When the speckit skills are installed globally
-# as a plugin, the per-project `.specify/` runtime state may be absent — this
-# hook provisions it on first use so the command's scripts and templates
-# resolve. It is idempotent, never blocks the command, and only acts when a
-# speckit command is actually being invoked.
+# Fires (via the Claude hooks.json UserPromptExpansion matcher "speckit") just
+# before a `/speckit:*` command expands. When the speckit skills are installed
+# globally as a plugin, the per-project `.specify/` runtime state may be absent —
+# this hook provisions it on first use so the command's scripts and templates
+# resolve. Idempotent, never blocks the command.
+#
+# Cross-agent routing is adg's responsibility: adg references this same file for
+# each runtime it supports (and lints events a target can't fire). We author one
+# base hook in Claude's native format and leave platform mapping to adg.
 
 set -u
 

--- a/plugin/hooks/ensure-specify.sh
+++ b/plugin/hooks/ensure-specify.sh
@@ -30,7 +30,7 @@ fi
 cd "$CWD" 2>/dev/null || exit 0
 
 if command -v specify >/dev/null 2>&1; then
-    if ! specify init --here --plugin --force >&2 2>&1; then
+    if ! specify init --here --plugin --force >/dev/null 2>&1; then
         echo "Spec Kit: could not provision .specify/. Run: specify init --here --plugin" >&2
     fi
 else

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptExpansion": [
+      {
+        "matcher": "speckit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-specify.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ packages = ["src/specify_cli"]
 "extensions/bug" = "specify_cli/core_pack/extensions/bug"
 # Bundled workflows (auto-installed during `specify init`)
 "workflows/speckit" = "specify_cli/core_pack/workflows/speckit"
+
+"plugin/hooks" = "specify_cli/core_pack/plugin/hooks"
 # Bundled presets (installable via `specify preset add <name>` or `specify init --preset <name>`)
 "presets/lean" = "specify_cli/core_pack/presets/lean"
 

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -488,6 +488,16 @@ def check():
     tracker.add("code-insiders", "Visual Studio Code Insiders")
     check_tool("code-insiders", tracker=tracker)
 
+    # Optional: adg CLI — only needed for `specify init --plugin` (manage core
+    # skills as a global adg plugin). Not having it is fine for normal usage.
+    from .adg_bridge import find_adg
+
+    tracker.add("adg", "adg CLI (optional — for 'init --plugin')")
+    if find_adg():
+        tracker.complete("adg", "available")
+    else:
+        tracker.skip("adg", "not installed — needed only for 'init --plugin'")
+
     console.print(tracker.render())
 
     console.print("\n[bold green]Specify CLI is ready to use![/bold green]")

--- a/src/specify_cli/_assets.py
+++ b/src/specify_cli/_assets.py
@@ -32,6 +32,27 @@ def _repo_root() -> Path:
     return Path(__file__).parent.parent.parent
 
 
+def _locate_plugin_hooks() -> Path | None:
+    """Return the path to the bundled plugin ``hooks/`` directory, or None.
+
+    Holds the Claude-native ``hooks.json`` (adg 0.4.0-beta.5+ adopts Claude's
+    hook format as the de-facto standard and routes it to Codex/Antigravity)
+    plus the hook script(s). Checks the wheel's core_pack first, then falls
+    back to the source-checkout ``plugin/hooks/`` directory.
+    """
+    core = _locate_core_pack()
+    if core is not None:
+        candidate = core / "plugin" / "hooks"
+        if (candidate / "hooks.json").is_file():
+            return candidate
+
+    candidate = _repo_root() / "plugin" / "hooks"
+    if (candidate / "hooks.json").is_file():
+        return candidate
+
+    return None
+
+
 def _locate_bundled_extension(extension_id: str) -> Path | None:
     """Return the path to a bundled extension, or None.
 

--- a/src/specify_cli/adg_bridge.py
+++ b/src/specify_cli/adg_bridge.py
@@ -12,6 +12,7 @@ adg's ``.agents/.plugin.json`` schema, keeping the two tools decoupled.
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -93,16 +94,22 @@ def _run(adg: str, args: list[str]) -> str:
 def has_global_plugin(name: str = PLUGIN_NAME, *, adg: str | None = None) -> bool:
     """Return True when a plugin named *name* is installed in the global store.
 
-    Parses ``adg plugins list --global`` text output (no ``--json`` support);
-    each plugin line begins with ``<name>@<version>``.
+    Prefers the stable ``adg plugins list --global --json`` contract; falls back
+    to parsing the human text output for older adg versions without ``--json``
+    (where each plugin line begins with ``<name>@<version>``).
     """
     adg = adg or require_adg()
-    out = _run(adg, ["plugins", "list", "--global"])
-    prefix = f"{name}@"
-    for line in out.splitlines():
-        if line.strip().startswith(prefix):
-            return True
-    return False
+    try:
+        data = json.loads(_run(adg, ["plugins", "list", "--global", "--json"]))
+        plugins = data.get("plugins", []) if isinstance(data, dict) else []
+        return any(
+            isinstance(p, dict) and p.get("name") == name for p in plugins
+        )
+    except (AdgCommandError, ValueError, TypeError):
+        # Older adg: --json rejected (non-zero) or non-JSON output → text scrape.
+        out = _run(adg, ["plugins", "list", "--global"])
+        prefix = f"{name}@"
+        return any(line.strip().startswith(prefix) for line in out.splitlines())
 
 
 def add_plugin(

--- a/src/specify_cli/adg_bridge.py
+++ b/src/specify_cli/adg_bridge.py
@@ -102,6 +102,8 @@ def has_global_plugin(name: str = PLUGIN_NAME, *, adg: str | None = None) -> boo
     try:
         data = json.loads(_run(adg, ["plugins", "list", "--global", "--json"]))
         plugins = data.get("plugins", []) if isinstance(data, dict) else []
+        if not isinstance(plugins, list):
+            plugins = []
         return any(
             isinstance(p, dict) and p.get("name") == name for p in plugins
         )

--- a/src/specify_cli/adg_bridge.py
+++ b/src/specify_cli/adg_bridge.py
@@ -1,0 +1,147 @@
+"""Bridge to the external ``adg`` CLI (Agent Directory Group).
+
+Spec Kit is the *producer* of skills; ``adg`` is the consumer/distributor.
+When ``specify init --plugin`` is used, the core speckit skills are rendered
+to a staging directory and handed to ``adg plugins import-skills`` so they
+live in a single, versioned, global plugin (``~/.agents/plugins``) instead of
+being copied into every project's ``.claude/skills``.
+
+This module only talks to ``adg`` through its CLI surface — it never touches
+adg's ``.agents/.plugin.json`` schema, keeping the two tools decoupled.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+PLUGIN_NAME = "speckit"
+ADG_INSTALL_HINT = "npm install -g @rbbtsn0w/adg"
+
+
+class AdgNotFoundError(RuntimeError):
+    """Raised when the ``adg`` CLI cannot be located on the system."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "The 'adg' CLI is required for --plugin mode but was not found.\n"
+            f"Install it with: {ADG_INSTALL_HINT}"
+        )
+
+
+class AdgCommandError(RuntimeError):
+    """Raised when an ``adg`` invocation exits non-zero."""
+
+    def __init__(self, args: list[str], returncode: int, output: str) -> None:
+        self.args = args
+        self.returncode = returncode
+        self.output = output
+        super().__init__(
+            f"adg command failed ({returncode}): {' '.join(args)}\n{output.strip()}"
+        )
+
+
+def find_adg() -> str | None:
+    """Return the path to the ``adg`` executable, or ``None`` if absent.
+
+    Looks on ``PATH`` first, then a few common locations (nvm, Homebrew)
+    that may not be exported to a subprocess environment.
+    """
+    found = shutil.which("adg")
+    if found:
+        return found
+
+    candidates = [
+        Path.home() / ".nvm" / "current" / "bin" / "adg",
+        Path("/opt/homebrew/bin/adg"),
+        Path("/usr/local/bin/adg"),
+    ]
+    # nvm keeps versioned dirs; scan them as a best effort.
+    nvm_versions = Path.home() / ".nvm" / "versions" / "node"
+    if nvm_versions.is_dir():
+        candidates.extend(sorted(nvm_versions.glob("*/bin/adg"), reverse=True))
+
+    for cand in candidates:
+        if cand.is_file():
+            return str(cand)
+    return None
+
+
+def require_adg() -> str:
+    """Return the ``adg`` path or raise :class:`AdgNotFoundError`."""
+    adg = find_adg()
+    if not adg:
+        raise AdgNotFoundError()
+    return adg
+
+
+def _run(adg: str, args: list[str]) -> str:
+    """Run ``adg <args>`` and return combined stdout, raising on failure."""
+    proc = subprocess.run(
+        [adg, *args],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise AdgCommandError(
+            [adg, *args], proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+        )
+    return proc.stdout or ""
+
+
+def has_global_plugin(name: str = PLUGIN_NAME, *, adg: str | None = None) -> bool:
+    """Return True when a plugin named *name* is installed in the global store.
+
+    Parses ``adg plugins list --global`` text output (no ``--json`` support);
+    each plugin line begins with ``<name>@<version>``.
+    """
+    adg = adg or require_adg()
+    out = _run(adg, ["plugins", "list", "--global"])
+    prefix = f"{name}@"
+    for line in out.splitlines():
+        if line.strip().startswith(prefix):
+            return True
+    return False
+
+
+def add_plugin(
+    plugin_dir: Path,
+    *,
+    as_global: bool = True,
+    target: str = "all",
+    adg: str | None = None,
+) -> str:
+    """Install a native ADG plugin source directory (skills + hooks + manifest).
+
+    Calls ``adg plugins add <plugin_dir> --all [--global] --target <target>``;
+    adg adapts it to the requested runtime(s).
+    """
+    adg = adg or require_adg()
+    args = ["plugins", "add", str(plugin_dir), "--all", "--target", target]
+    if as_global:
+        args.append("--global")
+    return _run(adg, args)
+
+
+def link(
+    names: list[str] | None = None,
+    *,
+    target: str = "all",
+    as_global: bool = True,
+    adg: str | None = None,
+) -> str:
+    """Project store plugins into a runtime (register + enable).
+
+    Calls ``adg plugins link --target <target> [names...] [--global]``.
+    ``adg plugins add`` populates the store and adapts manifests but does not
+    always register a ``[local]`` plugin into every runtime (notably Claude),
+    so this must run after :func:`add_plugin`. ``link`` is idempotent.
+    """
+    adg = adg or require_adg()
+    args = ["plugins", "link", "--target", target]
+    if as_global:
+        args.append("--global")
+    if names:
+        args.extend(names)
+    return _run(adg, args)

--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -115,6 +115,9 @@ def _run_init(integration: str, *, script_type: str, offline: bool = False) -> N
             preset=None,
             integration=integration,
             integration_options=None,
+            plugin=False,
+            plugin_out=None,
+            yes=False,
         )
     except typer.Exit as exc:
         if exc.exit_code:

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -470,8 +470,9 @@ def register(app: typer.Typer) -> None:
         elif plugin:
             # In plugin mode the runtime skills come from the adapted global
             # plugin; the integration here only drives .specify/ provisioning.
-            # Default to claude (adg's canonical target) without prompting.
-            selected_ai = "claude"
+            # Default to codex (which uses the generic AGENTS.md context file)
+            # without prompting.
+            selected_ai = "codex"
         elif not _stdin_is_interactive():
             console.print(
                 f"[dim]Non-interactive session detected: defaulting to '{DEFAULT_INIT_INTEGRATION}'. "

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -106,6 +106,8 @@ def _provision_plugin_skills(
 
     # Degrade path: no adg — produce the source tree for later pickup.
     if not adg_available:
+        if out_dir is None:
+            raise ValueError("out_dir must be provided when adg is not available")
         dest = out_dir.resolve()
         build_plugin(dest, script_type)
         tracker.complete(

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -31,6 +31,115 @@ def _stdin_is_interactive() -> bool:
     return sys.stdin.isatty()
 
 
+def _maybe_install_adg(*, yes: bool) -> bool:
+    """Offer to install the adg CLI via npm. Return True if adg is available
+    afterwards.
+
+    Interactive (TTY) prompts for consent unless *yes* forces it. Non-interactive
+    without *yes* declines silently. Needs npm; failures degrade gracefully.
+    """
+    import shutil as _shutil
+    import subprocess as _subprocess
+
+    from .. import adg_bridge
+
+    if not yes and not _stdin_is_interactive():
+        return False
+    if not yes:
+        try:
+            if not typer.confirm(
+                f"adg CLI not found. Install it now via `{adg_bridge.ADG_INSTALL_HINT}`?",
+                default=False,
+            ):
+                return False
+        except Exception:
+            return False
+    if not _shutil.which("npm"):
+        console.print("[yellow]npm not found — cannot auto-install adg.[/yellow]")
+        return False
+    console.print(f"[cyan]Installing adg…[/cyan] ({adg_bridge.ADG_INSTALL_HINT})")
+    try:
+        _subprocess.run(["npm", "install", "-g", "@rbbtsn0w/adg"], check=True)
+    except _subprocess.CalledProcessError:
+        console.print("[yellow]adg install failed.[/yellow]")
+        return False
+    return bool(adg_bridge.find_adg())
+
+
+def _provision_plugin_skills(
+    script_type: str,
+    tracker: "StepTracker",
+    *,
+    out_dir: Path | None = None,
+    adg_available: bool = True,
+) -> bool:
+    """Manage core speckit skills as a global adg plugin (plugin mode).
+
+    With adg: stateful — consume the existing global plugin, else author it
+    (``build_plugin`` → ``adg plugins add`` → ``link``). Without adg (degrade):
+    write the plugin source to *out_dir* and tell the user to finish with adg.
+    *out_dir*, when given, is a persistent target instead of a throwaway temp.
+
+    Returns True when the degraded (no-adg) path was taken.
+    """
+    import tempfile
+
+    from .. import adg_bridge
+    from ..plugin_export import PLUGIN_NAME, build_plugin
+
+    def _link_into_runtimes(adg: str) -> str:
+        """Register the global plugin into each runtime (esp. Claude).
+
+        ``adg plugins add`` adapts manifests but does not reliably register a
+        ``[local]`` plugin into Claude, so ``link`` must follow. Idempotent, so
+        it also self-heals an earlier author that never reached Claude. Failure
+        is non-fatal — .specify/ provisioning below must still proceed.
+        """
+        try:
+            adg_bridge.link([PLUGIN_NAME], target="all", as_global=True, adg=adg)
+            return ""
+        except adg_bridge.AdgCommandError:
+            return (
+                " (runtime link failed — run "
+                "`adg plugins sync --target claude speckit` manually)"
+            )
+
+    # Degrade path: no adg — produce the source tree for later pickup.
+    if not adg_available:
+        dest = out_dir.resolve()
+        build_plugin(dest, script_type)
+        tracker.complete(
+            "integration",
+            f"plugin written to {dest} — finish: adg plugins add {dest} --global",
+        )
+        return True
+
+    adg = adg_bridge.require_adg()
+    if adg_bridge.has_global_plugin(adg=adg):
+        note = _link_into_runtimes(adg)
+        tracker.complete(
+            "integration", f"skills via global adg plugin (consumed){note}"
+        )
+        return False
+
+    if out_dir is not None:
+        plugin_dir = out_dir.resolve()
+        build_plugin(plugin_dir, script_type)
+        adg_bridge.add_plugin(plugin_dir, as_global=True, adg=adg)
+        note = _link_into_runtimes(adg)
+        tracker.complete(
+            "integration", f"authored global adg plugin (source: {plugin_dir}){note}"
+        )
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "speckit-plugin"
+            build_plugin(plugin_dir, script_type)
+            adg_bridge.add_plugin(plugin_dir, as_global=True, adg=adg)
+        note = _link_into_runtimes(adg)
+        tracker.complete("integration", f"authored global adg plugin{note}")
+    return False
+
+
 def ensure_constitution_from_template(
     project_path: Path, tracker: StepTracker | None = None
 ) -> None:
@@ -133,6 +242,27 @@ def register(app: typer.Typer) -> None:
             None,
             "--integration-options",
             help='Options for the integration (e.g. --integration-options="--commands-dir .myagent/cmds")',
+        ),
+        plugin: bool = typer.Option(
+            False,
+            "--plugin",
+            help="Manage the core speckit skills as a global adg plugin instead of "
+            "writing them into the project. Lays down .specify/ as usual; on first "
+            "use it authors the global plugin via adg, afterwards it consumes it. "
+            "Requires the 'adg' CLI.",
+        ),
+        plugin_out: Path = typer.Option(
+            None,
+            "--plugin-out",
+            help="With --plugin: also write the ADG plugin source tree to this "
+            "directory. If 'adg' is unavailable, the tree is still produced here "
+            "for a later 'adg plugins add <dir> --global' (CI/offline friendly).",
+        ),
+        yes: bool = typer.Option(
+            False,
+            "--yes",
+            "-y",
+            help="Assume 'yes' for prompts (e.g. installing the adg CLI for --plugin).",
         ),
     ):
         """
@@ -268,6 +398,37 @@ def register(app: typer.Typer) -> None:
                     console.print(error_panel)
                     raise typer.Exit(1)
 
+        # --plugin needs the external adg CLI. Resolve availability up front:
+        # try an (interactive/--yes) install, then either degrade (--plugin-out)
+        # or fail fast with guidance.
+        plugin_adg_available = True
+        if plugin:
+            from .. import adg_bridge
+
+            plugin_adg_available = bool(adg_bridge.find_adg())
+            if not plugin_adg_available:
+                plugin_adg_available = _maybe_install_adg(yes=yes)
+            if not plugin_adg_available and plugin_out is None:
+                console.print()
+                console.print(
+                    Panel(
+                        "[bold]--plugin[/bold] manages the core Spec Kit skills as a global "
+                        "[cyan]adg[/cyan] plugin (shared across all your projects) instead of "
+                        "writing them into this project.\n"
+                        "It needs the [cyan]adg[/cyan] CLI, which was [red]not found[/red].\n\n"
+                        f"[bold]Install[/bold]      [cyan]{adg_bridge.ADG_INSTALL_HINT}[/cyan]  "
+                        "[dim](requires Node ≥ 22)[/dim]\n"
+                        "[bold]Or produce[/bold]    re-run with [cyan]--plugin-out <dir>[/cyan] to "
+                        "write the plugin for a later [cyan]adg plugins add[/cyan].\n"
+                        "[bold]Or skip[/bold]       re-run [cyan]specify init[/cyan] [bold]without[/bold] "
+                        "--plugin to install the skills into this project directly.",
+                        title="[yellow]adg CLI required for --plugin[/yellow]",
+                        border_style="yellow",
+                        padding=(1, 2),
+                    )
+                )
+                raise typer.Exit(1)
+
         if integration:
             if integration not in AGENT_CONFIG:
                 console.print(
@@ -275,6 +436,11 @@ def register(app: typer.Typer) -> None:
                 )
                 raise typer.Exit(1)
             selected_ai = integration
+        elif plugin:
+            # In plugin mode the runtime skills come from the adapted global
+            # plugin; the integration here only drives .specify/ provisioning.
+            # Default to claude (adg's canonical target) without prompting.
+            selected_ai = "claude"
         elif not _stdin_is_interactive():
             console.print(
                 f"[dim]Non-interactive session detected: defaulting to '{DEFAULT_INIT_INTEGRATION}'. "
@@ -407,14 +573,27 @@ def register(app: typer.Typer) -> None:
                     if extra:
                         integration_parsed_options.update(extra)
 
-                resolved_integration.setup(
-                    project_path,
-                    manifest,
-                    parsed_options=integration_parsed_options or None,
-                    script_type=selected_script,
-                    raw_options=integration_options,
-                )
-                manifest.save()
+                if plugin:
+                    # Plugin mode: do NOT write skills into the project. The core
+                    # speckit skills are managed as a global adg plugin instead.
+                    # On first use, author it; afterwards, consume it. Everything
+                    # else (.specify/, constitution, workflow, init-options) still
+                    # runs below exactly as usual.
+                    plugin_degraded = _provision_plugin_skills(
+                        selected_script,
+                        tracker,
+                        out_dir=plugin_out,
+                        adg_available=plugin_adg_available,
+                    )
+                else:
+                    resolved_integration.setup(
+                        project_path,
+                        manifest,
+                        parsed_options=integration_parsed_options or None,
+                        script_type=selected_script,
+                        raw_options=integration_options,
+                    )
+                    manifest.save()
 
                 integration_settings = _with_integration_setting(
                     {},
@@ -675,6 +854,47 @@ def register(app: typer.Typer) -> None:
                 )
                 console.print()
                 console.print(security_notice)
+
+        if plugin:
+            plugin_lines: list[str] = []
+            if not here:
+                plugin_lines.append(
+                    f"1. Go to the project folder: [cyan]cd {project_path.name}[/cyan]"
+                )
+            if plugin_degraded:
+                plugin_lines.append(
+                    "[yellow]adg was not available[/yellow], so the skills are [bold]not[/bold] "
+                    "installed yet — the plugin source was written to "
+                    f"[cyan]{plugin_out}[/cyan]."
+                )
+                plugin_lines.append(
+                    "Finish on a machine with adg: "
+                    f"[cyan]adg plugins add {plugin_out} --global[/cyan]"
+                )
+            else:
+                plugin_lines.append(
+                    "Core Spec Kit skills are managed as a global [cyan]adg[/cyan] plugin — "
+                    "they are [bold]not[/bold] copied into this project."
+                )
+                plugin_lines.append(
+                    "Invoke them in your coding agent as "
+                    "[cyan]/speckit:specify[/], [cyan]/speckit:plan[/], "
+                    "[cyan]/speckit:tasks[/], [cyan]/speckit:implement[/] …"
+                )
+            plugin_lines.append(
+                "This project's [cyan].specify/[/] runtime state is ready; "
+                "[cyan]specs/[/] is created on the first [cyan]/speckit:specify[/]."
+            )
+            console.print()
+            console.print(
+                Panel(
+                    "\n".join(plugin_lines),
+                    title="Next Steps (plugin mode)",
+                    border_style="cyan",
+                    padding=(1, 2),
+                )
+            )
+            return
 
         steps_lines = []
         if not here:

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -315,6 +315,35 @@ def register(app: typer.Typer) -> None:
             _write_integration_json,
         )
 
+        # Clean Typer OptionInfo default values when called programmatically
+        from typer.models import OptionInfo
+        if isinstance(ignore_agent_tools, OptionInfo):
+            ignore_agent_tools = False
+        if isinstance(here, OptionInfo):
+            here = False
+        if isinstance(force, OptionInfo):
+            force = False
+        if isinstance(skip_tls, OptionInfo):
+            skip_tls = False
+        if isinstance(debug, OptionInfo):
+            debug = False
+        if isinstance(github_token, OptionInfo):
+            github_token = None
+        if isinstance(offline, OptionInfo):
+            offline = False
+        if isinstance(preset, OptionInfo):
+            preset = None
+        if isinstance(integration, OptionInfo):
+            integration = None
+        if isinstance(integration_options, OptionInfo):
+            integration_options = None
+        if isinstance(plugin, OptionInfo):
+            plugin = False
+        if isinstance(plugin_out, OptionInfo):
+            plugin_out = None
+        if isinstance(yes, OptionInfo):
+            yes = False
+
         show_banner()
 
         from ..integrations import INTEGRATION_REGISTRY, get_integration

--- a/src/specify_cli/plugin_export.py
+++ b/src/specify_cli/plugin_export.py
@@ -1,0 +1,137 @@
+"""Assemble the speckit skills (and lifecycle hook) into an ADG plugin source.
+
+The producer reuses the existing ``ClaudeIntegration`` skill-rendering pipeline
+(``SkillsIntegration.setup``) against a throwaway staging root, so the emitted
+``SKILL.md`` files are byte-for-byte identical to what ``specify init`` would
+write into a project's ``.claude/skills``. The skills (plus an optional
+``hooks/`` dir and a minimal ``.agents/.plugin.json`` manifest) are laid out as
+a native ADG plugin so ``adg plugins add <dir> --global`` ingests it directly
+and fans it out to claude/codex/antigravity.
+
+Only the core command templates are produced (``list_command_templates``);
+extensions and presets stay project-local — see the project plan.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+from ._assets import get_speckit_version
+
+PLUGIN_NAME = "speckit"
+PLUGIN_DESCRIPTION = (
+    "Spec-Driven Development workflow: specify, clarify, plan, tasks, analyze, "
+    "and implement slash commands backed by deterministic scripts."
+)
+SCHEMA_VERSION = "adg.plugin/v1"
+
+
+def to_semver(version: str) -> str:
+    """Coerce a PEP 440-ish version into the strict semver adg requires.
+
+    adg's schema enforces ``MAJOR.MINOR.PATCH(-prerelease)?(+build)?``.
+    Dev/post/pre suffixes like ``0.11.4.dev0`` become ``0.11.4-dev0``.
+    Falls back to ``0.0.0`` when no MAJOR.MINOR.PATCH core is present.
+    """
+    m = re.match(r"^(\d+\.\d+\.\d+)(.*)$", version.strip())
+    if not m:
+        return "0.0.0"
+    core, rest = m.group(1), m.group(2)
+    if not rest:
+        return core
+    # Strip a leading separator (".", "-", "+") then sanitize the remainder
+    # into a valid semver prerelease segment ([0-9A-Za-z-.]).
+    pre = re.sub(r"[^0-9A-Za-z.-]", "-", rest.lstrip(".-+"))
+    return f"{core}-{pre}" if pre else core
+
+
+def produce_core_skills(skills_parent: Path, script_type: str = "sh") -> Path:
+    """Render core speckit skills into ``<skills_parent>/skills`` and return it.
+
+    Reuses ``ClaudeIntegration.setup`` on a temporary root (which emits
+    ``.claude/skills/speckit-*/SKILL.md``), then relocates the ``speckit-*``
+    directories under ``<skills_parent>/skills`` — the layout an ADG plugin
+    manifest's ``"skills": "./skills/"`` pointer expects.
+    """
+    from .integrations import get_integration
+    from .integrations.manifest import IntegrationManifest
+
+    claude = get_integration("claude")
+    if claude is None:  # pragma: no cover - claude is always registered
+        raise RuntimeError("claude integration is not available")
+
+    skills_dir = (skills_parent / "skills").resolve()
+    skills_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        staging = Path(tmp).resolve()
+        manifest = IntegrationManifest("claude", staging, version=get_speckit_version())
+        claude.setup(staging, manifest, script_type=script_type)
+        rendered = claude.skills_dest(staging)
+        # Pass the upstream-rendered skills through unchanged: their name and
+        # content (handoff cross-references to other speckit skills) are a
+        # matched set owned by spec-kit's own command-ref resolution. Any
+        # runtime namespace adaptation is adg's concern, not the producer's.
+        for child in sorted(rendered.iterdir()):
+            if child.is_dir():
+                shutil.copytree(child, skills_dir / child.name, dirs_exist_ok=True)
+
+    return skills_dir
+
+
+def build_plugin(
+    out_dir: Path,
+    script_type: str = "sh",
+    *,
+    include_hook: bool = True,
+    hook_src: Path | None = None,
+) -> Path:
+    """Assemble a native ADG plugin source tree under *out_dir*.
+
+    Produces::
+
+        out_dir/
+          .agents/.plugin.json    # plugin manifest
+          skills/speckit-*/SKILL.md
+          hooks/hooks.json        # Claude-native hook format (adg's de-facto std)
+          hooks/ensure-specify.sh # script referenced by the hook
+
+    Hooks are authored in Claude's native format (adg 0.4.0-beta.5+ adopted it
+    as the standard: Claude auto-loads ``hooks/hooks.json``, adg routes the same
+    file to Codex/Antigravity). When *include_hook* is true (default) the
+    bundled hooks dir is located via :func:`_locate_plugin_hooks` unless
+    *hook_src* overrides it. Returns *out_dir*; suitable for ``adg plugins add``.
+    """
+    from ._assets import _locate_plugin_hooks
+
+    out_dir = out_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    produce_core_skills(out_dir, script_type)
+
+    if include_hook and hook_src is None:
+        hook_src = _locate_plugin_hooks()
+
+    manifest: dict[str, object] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "name": PLUGIN_NAME,
+        "version": to_semver(get_speckit_version()),
+        "description": PLUGIN_DESCRIPTION,
+        "skills": "./skills/",
+    }
+
+    if hook_src is not None and hook_src.is_dir():
+        shutil.copytree(hook_src, out_dir / "hooks", dirs_exist_ok=True)
+        manifest["hooks"] = "./hooks/"
+
+    agents_dir = out_dir / ".agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / ".plugin.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
+    return out_dir

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -121,6 +121,45 @@ class TestInitIntegrationFlag:
         data = json.loads((project / ".specify" / "integration.json").read_text(encoding="utf-8"))
         assert data["integration"] == specify_cli.DEFAULT_INIT_INTEGRATION
 
+    def test_init_plugin_defaults_to_codex(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+        from specify_cli import app
+        import specify_cli.commands.init as init_mod
+
+        called_provision = False
+
+        def mock_provision(script_type, tracker, **kwargs):
+            nonlocal called_provision
+            called_provision = True
+            tracker.complete("integration", "mocked global plugin")
+            return False
+
+        monkeypatch.setattr(init_mod, "_provision_plugin_skills", mock_provision)
+
+        runner = CliRunner()
+        project = tmp_path / "plugin-default-test"
+        result = runner.invoke(app, [
+            "init", str(project), "--plugin", "--script", "sh", "--ignore-agent-tools",
+        ], catch_exceptions=False)
+
+        assert result.exit_code == 0, result.output
+        assert called_provision is True
+
+        data = json.loads((project / ".specify" / "integration.json").read_text(encoding="utf-8"))
+        assert data["integration"] == "codex"
+
+        opts = json.loads((project / ".specify" / "init-options.json").read_text(encoding="utf-8"))
+        assert opts["integration"] == "codex"
+        assert opts["ai"] == "codex"
+
+        import yaml as _yaml
+        ext_cfg_path = project / ".specify" / "extensions" / "agent-context" / "agent-context-config.yml"
+        assert ext_cfg_path.exists()
+        ext_cfg = _yaml.safe_load(ext_cfg_path.read_text(encoding="utf-8"))
+        assert ext_cfg["context_file"] == "AGENTS.md"
+
+        assert "Core Spec Kit skills are managed as a global adg plugin" in result.output
+
     def test_integration_copilot_auto_promotes(self, tmp_path):
         from typer.testing import CliRunner
         from specify_cli import app

--- a/tests/unit/test_adg_bridge.py
+++ b/tests/unit/test_adg_bridge.py
@@ -1,6 +1,7 @@
 """Unit tests for the adg CLI bridge."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -35,22 +36,38 @@ def _fake_run(captured, output=""):
     return _run
 
 
-def test_has_global_plugin_parses_list(monkeypatch):
+def test_has_global_plugin_uses_json(monkeypatch):
     captured: list[list[str]] = []
     runner = _fake_run(captured)
-    runner.output = (
-        "apple-skills@1.12.0   …/apple-skills  Agents: Claude\n"
-        "speckit@0.11.4        …/speckit       Agents: Claude, Codex\n"
+    runner.output = json.dumps(
+        {"plugins": [{"name": "apple-skills"}, {"name": "speckit"}]}
     )
     monkeypatch.setattr(adg_bridge, "_run", runner)
     assert adg_bridge.has_global_plugin("speckit", adg="/x/adg") is True
     assert adg_bridge.has_global_plugin("nope", adg="/x/adg") is False
-    assert captured[0] == ["/x/adg", "plugins", "list", "--global"]
+    # Prefers the stable --json contract.
+    assert captured[0] == ["/x/adg", "plugins", "list", "--global", "--json"]
+
+
+def test_has_global_plugin_text_fallback(monkeypatch):
+    # Older adg: --json call fails; must fall back to text parsing.
+    calls: list[list[str]] = []
+
+    def _run(adg, args):
+        calls.append([adg, *args])
+        if "--json" in args:
+            raise adg_bridge.AdgCommandError([adg, *args], 1, "Unknown option '--json'")
+        return "design@1.2.0   …\nspeckit@0.11.4   …\n"
+
+    monkeypatch.setattr(adg_bridge, "_run", _run)
+    assert adg_bridge.has_global_plugin("speckit", adg="/x/adg") is True
+    assert calls[0][-1] == "--json"  # tried json first
+    assert calls[1] == ["/x/adg", "plugins", "list", "--global"]  # then text
 
 
 def test_has_global_plugin_false_when_absent(monkeypatch):
     runner = _fake_run([])
-    runner.output = "design@1.2.0   …/design  Agents: Claude\n"
+    runner.output = json.dumps({"plugins": [{"name": "design"}]})
     monkeypatch.setattr(adg_bridge, "_run", runner)
     assert adg_bridge.has_global_plugin("speckit", adg="/x/adg") is False
 

--- a/tests/unit/test_adg_bridge.py
+++ b/tests/unit/test_adg_bridge.py
@@ -1,0 +1,98 @@
+"""Unit tests for the adg CLI bridge."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli import adg_bridge
+
+
+def test_find_adg_uses_path(monkeypatch):
+    monkeypatch.setattr(adg_bridge.shutil, "which", lambda _: "/usr/bin/adg")
+    assert adg_bridge.find_adg() == "/usr/bin/adg"
+
+
+def test_find_adg_missing_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setattr(adg_bridge.shutil, "which", lambda _: None)
+    # Point HOME at an empty dir so the nvm/homebrew fallbacks miss too.
+    monkeypatch.setattr(adg_bridge.Path, "home", staticmethod(lambda: tmp_path))
+    assert adg_bridge.find_adg() is None
+
+
+def test_require_adg_raises_when_missing(monkeypatch):
+    monkeypatch.setattr(adg_bridge, "find_adg", lambda: None)
+    with pytest.raises(adg_bridge.AdgNotFoundError) as exc:
+        adg_bridge.require_adg()
+    assert adg_bridge.ADG_INSTALL_HINT in str(exc.value)
+
+
+def _fake_run(captured, output=""):
+    def _run(adg, args):
+        captured.append([adg, *args])
+        return _run.output
+    _run.output = output
+    return _run
+
+
+def test_has_global_plugin_parses_list(monkeypatch):
+    captured: list[list[str]] = []
+    runner = _fake_run(captured)
+    runner.output = (
+        "apple-skills@1.12.0   …/apple-skills  Agents: Claude\n"
+        "speckit@0.11.4        …/speckit       Agents: Claude, Codex\n"
+    )
+    monkeypatch.setattr(adg_bridge, "_run", runner)
+    assert adg_bridge.has_global_plugin("speckit", adg="/x/adg") is True
+    assert adg_bridge.has_global_plugin("nope", adg="/x/adg") is False
+    assert captured[0] == ["/x/adg", "plugins", "list", "--global"]
+
+
+def test_has_global_plugin_false_when_absent(monkeypatch):
+    runner = _fake_run([])
+    runner.output = "design@1.2.0   …/design  Agents: Claude\n"
+    monkeypatch.setattr(adg_bridge, "_run", runner)
+    assert adg_bridge.has_global_plugin("speckit", adg="/x/adg") is False
+
+
+def test_add_plugin_builds_global_args(monkeypatch, tmp_path):
+    captured: list[list[str]] = []
+    monkeypatch.setattr(adg_bridge, "_run", _fake_run(captured))
+    adg_bridge.add_plugin(tmp_path, as_global=True, adg="/x/adg")
+    assert captured[0] == [
+        "/x/adg", "plugins", "add", str(tmp_path), "--all", "--target", "all", "--global",
+    ]
+
+
+def test_add_plugin_without_global(monkeypatch, tmp_path):
+    captured: list[list[str]] = []
+    monkeypatch.setattr(adg_bridge, "_run", _fake_run(captured))
+    adg_bridge.add_plugin(tmp_path, as_global=False, adg="/x/adg")
+    assert "--global" not in captured[0]
+
+
+def test_link_builds_global_args(monkeypatch):
+    captured: list[list[str]] = []
+    monkeypatch.setattr(adg_bridge, "_run", _fake_run(captured))
+    adg_bridge.link(["speckit"], target="all", as_global=True, adg="/x/adg")
+    assert captured[0] == [
+        "/x/adg", "plugins", "link", "--target", "all", "--global", "speckit",
+    ]
+
+
+def test_link_all_when_no_names(monkeypatch):
+    captured: list[list[str]] = []
+    monkeypatch.setattr(adg_bridge, "_run", _fake_run(captured))
+    adg_bridge.link(target="claude", as_global=False, adg="/x/adg")
+    assert captured[0] == ["/x/adg", "plugins", "link", "--target", "claude"]
+
+
+def test_run_raises_on_nonzero(monkeypatch):
+    class _Proc:
+        returncode = 3
+        stdout = "boom"
+        stderr = "bad"
+
+    monkeypatch.setattr(adg_bridge.subprocess, "run", lambda *a, **k: _Proc())
+    with pytest.raises(adg_bridge.AdgCommandError):
+        adg_bridge._run("/x/adg", ["plugins", "list"])

--- a/tests/unit/test_adg_bridge.py
+++ b/tests/unit/test_adg_bridge.py
@@ -18,6 +18,8 @@ def test_find_adg_missing_returns_none(monkeypatch, tmp_path):
     monkeypatch.setattr(adg_bridge.shutil, "which", lambda _: None)
     # Point HOME at an empty dir so the nvm/homebrew fallbacks miss too.
     monkeypatch.setattr(adg_bridge.Path, "home", staticmethod(lambda: tmp_path))
+    # Mock Path.is_file to simulate candidates missing as well.
+    monkeypatch.setattr(adg_bridge.Path, "is_file", lambda self: False)
     assert adg_bridge.find_adg() is None
 
 

--- a/tests/unit/test_plugin_export.py
+++ b/tests/unit/test_plugin_export.py
@@ -1,0 +1,94 @@
+"""Unit tests for the speckit→adg plugin producer."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from specify_cli.plugin_export import build_plugin, produce_core_skills, to_semver
+
+CORE_SKILLS = {
+    "speckit-analyze",
+    "speckit-checklist",
+    "speckit-clarify",
+    "speckit-constitution",
+    "speckit-converge",
+    "speckit-implement",
+    "speckit-plan",
+    "speckit-specify",
+    "speckit-tasks",
+    "speckit-taskstoissues",
+}
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("0.11.4", "0.11.4"),
+        ("0.11.4.dev0", "0.11.4-dev0"),
+        ("1.2.3-rc.1", "1.2.3-rc.1"),
+        ("1.0.0.post2", "1.0.0-post2"),
+        ("not-a-version", "0.0.0"),
+    ],
+)
+def test_to_semver(raw, expected):
+    assert to_semver(raw) == expected
+
+
+def test_produce_core_skills(tmp_path):
+    skills_dir = produce_core_skills(tmp_path, "sh")
+    assert skills_dir == (tmp_path / "skills")
+    names = {p.name for p in skills_dir.iterdir() if p.is_dir()}
+    assert names == CORE_SKILLS
+    for name in names:
+        assert (skills_dir / name / "SKILL.md").is_file()
+
+
+def test_skill_content_is_project_relative_not_plugin_root(tmp_path):
+    skills_dir = produce_core_skills(tmp_path, "sh")
+    txt = (skills_dir / "speckit-plan" / "SKILL.md").read_text(encoding="utf-8")
+    # Skills keep referencing the project's .specify/ — NOT a plugin root.
+    assert ".specify/scripts" in txt
+    assert "CLAUDE_PLUGIN_ROOT" not in txt
+    assert "SPECKIT_PLUGIN_ROOT" not in txt
+    # Claude post-processing ran (skills frontmatter injected).
+    assert "user-invocable" in txt
+
+
+def test_plugin_passes_upstream_skill_names_through(tmp_path):
+    # The producer must NOT rewrite the upstream skill name/content contract.
+    skills_dir = produce_core_skills(tmp_path, "sh")
+    md = (skills_dir / "speckit-specify" / "SKILL.md").read_text()
+    assert 'name: "speckit-specify"' in md
+
+
+def test_build_plugin_full_tree(tmp_path):
+    out = build_plugin(tmp_path / "speckit-plugin", "sh")
+    manifest = json.loads((out / ".agents" / ".plugin.json").read_text())
+    assert manifest["schemaVersion"] == "adg.plugin/v1"
+    assert manifest["name"] == "speckit"
+    assert manifest["skills"] == "./skills/"
+    assert manifest["hooks"] == "./hooks/"
+    # semver-valid version
+    assert to_semver(manifest["version"]) == manifest["version"]
+
+    # Hook authored in Claude's native format (adg's adopted de-facto standard).
+    hooks = json.loads((out / "hooks" / "hooks.json").read_text())
+    assert "UserPromptExpansion" in hooks["hooks"]
+    cmd = hooks["hooks"]["UserPromptExpansion"][0]["hooks"][0]["command"]
+    assert "${CLAUDE_PLUGIN_ROOT}/hooks/ensure-specify.sh" in cmd
+    assert not (out / ".agents" / "hooks.json").exists()  # no retired adg DSL
+
+    hook = out / "hooks" / "ensure-specify.sh"
+    assert hook.is_file()
+    assert hook.stat().st_mode & 0o111  # executable bit preserved
+
+    names = {p.name for p in (out / "skills").iterdir() if p.is_dir()}
+    assert names == CORE_SKILLS
+
+
+def test_build_plugin_without_hook(tmp_path):
+    out = build_plugin(tmp_path / "p", "sh", include_hook=False)
+    manifest = json.loads((out / ".agents" / ".plugin.json").read_text())
+    assert "hooks" not in manifest
+    assert not (out / "hooks").exists()

--- a/tests/unit/test_plugin_export.py
+++ b/tests/unit/test_plugin_export.py
@@ -58,7 +58,7 @@ def test_skill_content_is_project_relative_not_plugin_root(tmp_path):
 def test_plugin_passes_upstream_skill_names_through(tmp_path):
     # The producer must NOT rewrite the upstream skill name/content contract.
     skills_dir = produce_core_skills(tmp_path, "sh")
-    md = (skills_dir / "speckit-specify" / "SKILL.md").read_text()
+    md = (skills_dir / "speckit-specify" / "SKILL.md").read_text(encoding="utf-8")
     assert 'name: "speckit-specify"' in md
 
 
@@ -81,7 +81,9 @@ def test_build_plugin_full_tree(tmp_path):
 
     hook = out / "hooks" / "ensure-specify.sh"
     assert hook.is_file()
-    assert hook.stat().st_mode & 0o111  # executable bit preserved
+    import sys
+    if sys.platform != "win32":
+        assert hook.stat().st_mode & 0o111  # executable bit preserved
 
     names = {p.name for p in (out / "skills").iterdir() if p.is_dir()}
     assert names == CORE_SKILLS

--- a/tests/unit/test_plugin_export.py
+++ b/tests/unit/test_plugin_export.py
@@ -72,7 +72,7 @@ def test_build_plugin_full_tree(tmp_path):
     # semver-valid version
     assert to_semver(manifest["version"]) == manifest["version"]
 
-    # Hook authored in Claude's native format (adg's adopted de-facto standard).
+    # One base hook in Claude's native format; adg routes it to each runtime.
     hooks = json.loads((out / "hooks" / "hooks.json").read_text())
     assert "UserPromptExpansion" in hooks["hooks"]
     cmd = hooks["hooks"]["UserPromptExpansion"][0]["hooks"][0]["command"]

--- a/tests/unit/test_plugin_provision.py
+++ b/tests/unit/test_plugin_provision.py
@@ -1,0 +1,121 @@
+"""Unit tests for init.py plugin-mode provisioning (author/consume + link)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import specify_cli.adg_bridge as adg_bridge
+import specify_cli.commands.init as init_mod
+import specify_cli.plugin_export as plugin_export
+from specify_cli.commands.init import _maybe_install_adg, _provision_plugin_skills
+
+
+class _Tracker:
+    def __init__(self):
+        self.completed = []
+
+    def complete(self, name, msg):
+        self.completed.append((name, msg))
+
+
+def _stub_common(monkeypatch, calls):
+    monkeypatch.setattr(adg_bridge, "require_adg", lambda: "/x/adg")
+    monkeypatch.setattr(
+        adg_bridge, "add_plugin",
+        lambda *a, **k: calls.append("add") or "",
+    )
+    monkeypatch.setattr(
+        adg_bridge, "link",
+        lambda *a, **k: calls.append("link") or "",
+    )
+    monkeypatch.setattr(plugin_export, "build_plugin", lambda *a, **k: calls.append("build"))
+
+
+def test_author_branch_adds_then_links(monkeypatch):
+    calls: list[str] = []
+    _stub_common(monkeypatch, calls)
+    monkeypatch.setattr(adg_bridge, "has_global_plugin", lambda **k: False)
+    tracker = _Tracker()
+
+    _provision_plugin_skills("sh", tracker)
+
+    # Author must build, add, THEN link (link after add is the P0 fix).
+    assert calls == ["build", "add", "link"]
+    assert "authored" in tracker.completed[-1][1]
+
+
+def test_consume_branch_still_links(monkeypatch):
+    calls: list[str] = []
+    _stub_common(monkeypatch, calls)
+    monkeypatch.setattr(adg_bridge, "has_global_plugin", lambda **k: True)
+    tracker = _Tracker()
+
+    _provision_plugin_skills("sh", tracker)
+
+    # Consume must NOT re-author, but must still link (self-heal).
+    assert calls == ["link"]
+    assert "consumed" in tracker.completed[-1][1]
+
+
+def test_degrade_path_writes_out_dir_no_adg(monkeypatch, tmp_path):
+    calls: list[str] = []
+    # adg functions must NOT be called in degrade mode; build must.
+    monkeypatch.setattr(
+        adg_bridge, "add_plugin", lambda *a, **k: calls.append("add"))
+    monkeypatch.setattr(adg_bridge, "link", lambda *a, **k: calls.append("link"))
+    monkeypatch.setattr(
+        plugin_export, "build_plugin", lambda *a, **k: calls.append("build"))
+    tracker = _Tracker()
+
+    out = tmp_path / "speckit-plugin"
+    degraded = _provision_plugin_skills(
+        "sh", tracker, out_dir=out, adg_available=False
+    )
+
+    assert degraded is True
+    assert calls == ["build"]  # no add/link without adg
+    assert "adg plugins add" in tracker.completed[-1][1]
+
+
+def test_author_to_out_dir_persists(monkeypatch, tmp_path):
+    calls: list[str] = []
+    monkeypatch.setattr(adg_bridge, "require_adg", lambda: "/x/adg")
+    monkeypatch.setattr(adg_bridge, "has_global_plugin", lambda **k: False)
+    monkeypatch.setattr(
+        adg_bridge, "add_plugin",
+        lambda d, **k: calls.append(("add", Path(d))) or "")
+    monkeypatch.setattr(adg_bridge, "link", lambda *a, **k: calls.append("link") or "")
+    monkeypatch.setattr(plugin_export, "build_plugin", lambda d, *a, **k: calls.append(("build", Path(d))))
+    tracker = _Tracker()
+
+    out = tmp_path / "speckit-plugin"
+    degraded = _provision_plugin_skills(
+        "sh", tracker, out_dir=out, adg_available=True
+    )
+
+    assert degraded is False
+    # built and added at the persistent out_dir (not a temp dir)
+    assert ("build", out.resolve()) in calls
+    assert ("add", out.resolve()) in calls
+    assert "authored" in tracker.completed[-1][1]
+
+
+def test_maybe_install_adg_noninteractive_declines(monkeypatch):
+    # Non-interactive without --yes must decline early (no install attempt).
+    monkeypatch.setattr(init_mod, "_stdin_is_interactive", lambda: False)
+    assert _maybe_install_adg(yes=False) is False
+
+
+def test_link_failure_is_non_fatal(monkeypatch):
+    calls: list[str] = []
+    _stub_common(monkeypatch, calls)
+    monkeypatch.setattr(adg_bridge, "has_global_plugin", lambda **k: True)
+
+    def _boom(*a, **k):
+        raise adg_bridge.AdgCommandError(["adg", "plugins", "link"], 1, "nope")
+
+    monkeypatch.setattr(adg_bridge, "link", _boom)
+    tracker = _Tracker()
+
+    _provision_plugin_skills("sh", tracker)  # must not raise
+
+    assert "link failed" in tracker.completed[-1][1]


### PR DESCRIPTION
# Description

This PR changes the default selected_ai in `specify init --plugin` to `codex` instead of `claude`.

## Why this change?

- Under plugin mode (`--plugin`), the skills are fanned out globally by the `adg` CLI tool.
- Hardcoding the local configuration to `claude` (which uses Anthropic-specific `CLAUDE.md`) is restrictive and confusing for users running other coding agents.
- Defaulting to `codex` sets up the generic `AGENTS.md` context file and the standard `.agents/` folder structure, which is much more generic and clean.
- The control flow printed instructions have also been updated to avoid confusing warnings about local paths like `.agents/skills/`.

## Verification

- Added `test_init_plugin_defaults_to_codex` unit test inside `tests/integrations/test_cli.py` to verify this behavior end-to-end.
- Verified that all tests passed.
- Synchronized documentation in `README.md` and `docs/installation.md`.