### PR TITLE
docs: document integration catalog subcommands

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -154,7 +154,7 @@ list, or records no installed integrations.
 
 ## Catalog Management
 
-Integration catalogs control where `search` and `install` look for integrations. Catalogs are checked in priority order.
+Integration catalogs control where the discovery commands (`search` and `info`) look for integrations. Catalogs are checked in priority order.
 
 ### List Catalogs
 
@@ -162,7 +162,7 @@ Integration catalogs control where `search` and `install` look for integrations.
 specify integration catalog list
 ```
 
-Shows the active catalog sources. Project-level sources are removable; built-in sources are shown for reference.
+Shows the active catalog sources. Project-level sources (when configured) are removable by index; otherwise the active sources are shown as non-removable.
 
 ### Add a Catalog
 

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -152,6 +152,47 @@ is `null` when no installed integration set can be evaluated, such as when the
 integration state is missing, unreadable, lacks a valid recorded integration
 list, or records no installed integrations.
 
+## Catalog Management
+
+Integration catalogs control where `search` and `install` look for integrations. Catalogs are checked in priority order.
+
+### List Catalogs
+
+```bash
+specify integration catalog list
+```
+
+Shows the active catalog sources. Project-level sources are removable; built-in sources are shown for reference.
+
+### Add a Catalog
+
+```bash
+specify integration catalog add <url>
+```
+
+| Option          | Description                   |
+| --------------- | ----------------------------- |
+| `--name <name>` | Optional name for the catalog |
+
+Adds a custom catalog URL to the project's `.specify/integration-catalogs.yml`. The URL must use HTTPS (except `http://localhost`, `http://127.0.0.1`, or `http://[::1]` for local testing).
+
+### Remove a Catalog
+
+```bash
+specify integration catalog remove <index>
+```
+
+Removes a project catalog source by its 0-based index in `catalog list`.
+
+### Catalog Resolution Order
+
+Catalogs are resolved in this order (first match wins):
+
+1. **Environment variable** — `SPECKIT_INTEGRATION_CATALOG_URL` overrides all catalogs
+2. **Project config** — `.specify/integration-catalogs.yml`
+3. **User config** — `~/.specify/integration-catalogs.yml`
+4. **Built-in defaults** — official catalog + community catalog
+
 ## Integration-Specific Options
 
 Some integrations accept additional options via `--integration-options`:


### PR DESCRIPTION
closes #3205

`docs/reference/integrations.md` did not mention the `catalog` subcommand group at all, even though it is registered in code (`src/specify_cli/__init__.py:1277`) and the extension/preset/workflow references all document their catalog equivalents.

this adds a Catalog Management section covering:

- `specify integration catalog list` (`__init__.py:2556`)
- `specify integration catalog add <url> [--name]` (`__init__.py:2611`)
- `specify integration catalog remove <index>` (`__init__.py:2643`)
- resolution order (env `SPECKIT_INTEGRATION_CATALOG_URL` -> project -> user -> built-in), matching the code in `src/specify_cli/integrations/catalog.py`

structure mirrors the existing Catalog Management section in `docs/reference/workflows.md`. docs-only change, no code touched. separate from #3174 (which covers search/info/scaffold).

---

note: i used an ai assistant to help investigate and write this up.