### PR TITLE
fix(catalogs): reject host-less catalog URLs in base and preset validators

### DIFF
--- a/src/specify_cli/catalogs.py
+++ b/src/specify_cli/catalogs.py
@@ -78,7 +78,10 @@ class CatalogStackBase:
                 f"Catalog URL must use HTTPS (got {parsed.scheme}://). "
                 "HTTP is only allowed for localhost."
             )
-        if not parsed.netloc:
+        # Check hostname, not netloc: netloc is truthy for host-less URLs like
+        # "https://:8080" or "https://user@", so the host guarantee this error
+        # promises would not actually hold. hostname is None in those cases.
+        if not parsed.hostname:
             raise cls._error("Catalog URL must be a valid URL with a host.")
 
     def _load_catalog_config(self, config_path: Path) -> list[CatalogEntry] | None:

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -1861,7 +1861,10 @@ class PresetCatalog:
                 f"Catalog URL must use HTTPS (got {parsed.scheme}://). "
                 "HTTP is only allowed for localhost."
             )
-        if not parsed.netloc:
+        # Check hostname, not netloc: netloc is truthy for host-less URLs like
+        # "https://:8080" or "https://user@", so the host guarantee this error
+        # promises would not actually hold. hostname is None in those cases.
+        if not parsed.hostname:
             raise PresetValidationError(
                 "Catalog URL must be a valid URL with a host."
             )

--- a/tests/integrations/test_integration_catalog.py
+++ b/tests/integrations/test_integration_catalog.py
@@ -67,6 +67,22 @@ class TestCatalogURLValidation:
         with pytest.raises(IntegrationCatalogError, match="valid URL"):
             IntegrationCatalog._validate_catalog_url("https:///no-host")
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://:8080",       # port only, no host
+            "https://:0",          # port only, no host
+            "https://user@",       # userinfo only, no host
+            "https://user:pw@",    # userinfo only, no host
+        ],
+    )
+    def test_hostless_url_with_truthy_netloc_rejected(self, url):
+        # These have a truthy netloc (":8080", "user@") but no actual host,
+        # so a netloc-based check would wrongly accept them despite the
+        # "valid URL with a host" promise. hostname is None for all of them.
+        with pytest.raises(IntegrationCatalogError, match="valid URL"):
+            IntegrationCatalog._validate_catalog_url(url)
+
 
 # ---------------------------------------------------------------------------
 # IntegrationCatalog — active catalogs

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1424,6 +1424,26 @@ class TestPresetCatalog:
         catalog._validate_catalog_url("http://localhost:8080/catalog.json")
         catalog._validate_catalog_url("http://127.0.0.1:8080/catalog.json")
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://:8080",       # port only, no host
+            "https://:0",          # port only, no host
+            "https://user@",       # userinfo only, no host
+            "https://user:pw@",    # userinfo only, no host
+        ],
+    )
+    def test_validate_catalog_url_hostless_rejected(self, project_dir, url):
+        """Reject host-less URLs whose netloc is truthy but hostname is None.
+
+        ``urlparse('https://:8080').netloc`` is ``':8080'`` (truthy) but its
+        ``hostname`` is ``None``, so a netloc-based check would accept a URL
+        with no actual host, contradicting the "valid URL with a host" error.
+        """
+        catalog = PresetCatalog(project_dir)
+        with pytest.raises(PresetValidationError, match="valid URL with a host"):
+            catalog._validate_catalog_url(url)
+
     def test_env_var_catalog_url(self, project_dir, monkeypatch):
         """Test catalog URL from environment variable."""
         monkeypatch.setenv("SPECKIT_PRESET_CATALOG_URL", "https://custom.example.com/catalog.json")


### PR DESCRIPTION
closes #3209

## what

`CatalogStackBase._validate_catalog_url` (`src/specify_cli/catalogs.py`) and `PresetCatalog._validate_catalog_url` (`src/specify_cli/presets/__init__.py`) checked `parsed.netloc` to enforce "a valid URL with a host". but `netloc` is truthy for host-less URLs:

```python
urlparse("https://:8080").netloc   # ":8080"  (truthy)
urlparse("https://:8080").hostname # None
urlparse("https://user@").netloc   # "user@"  (truthy)
urlparse("https://user@").hostname # None
```

so those URLs passed validation despite having no host, contradicting the error message. switched both to `parsed.hostname`, which is `None` in exactly these cases.

## why this is the right field

the other catalog validators already do this:

- `src/specify_cli/workflows/catalog.py` (all 4 copies) check `parsed.hostname`
- `src/specify_cli/bundler/commands_impl/catalog_config.py` checks `parsed.hostname` and has a comment explaining credentials/ports/IPv6 are why `.hostname` is correct
- `src/specify_cli/presets/_commands.py` (the URL-install path) also validates on hostname

this PR aligns the two stragglers with that established pattern; no behavior change for valid URLs.

## tests

added parametrized regression tests for port-only (`https://:8080`, `https://:0`) and userinfo-only (`https://user@`, `https://user:pw@`) URLs in `tests/integrations/test_integration_catalog.py` and `tests/test_presets.py`. verified they fail on the pre-fix code (8 failures) and pass after. full preset/integration/workflow/extension suites: 1058 passed, 1 skipped.

---

note: i used an ai assistant to help investigate and write this up.