### PR TITLE
fix(pi): repoint install_url to @earendil-works/pi-coding-agent (#3169)

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -56,7 +56,7 @@ run_command "npm install -g @jetbrains/junie-cli@latest"
 echo "✅ Done"
 
 echo -e "\n🤖 Installing Pi Coding Agent..."
-run_command "npm install -g @mariozechner/pi-coding-agent@latest"
+run_command "npm install -g @earendil-works/pi-coding-agent@latest"
 echo "✅ Done"
 
 echo -e "\n🤖 Installing Kiro CLI..."

--- a/src/specify_cli/integrations/pi/__init__.py
+++ b/src/specify_cli/integrations/pi/__init__.py
@@ -9,7 +9,7 @@ class PiIntegration(MarkdownIntegration):
         "name": "Pi Coding Agent",
         "folder": ".pi/",
         "commands_subdir": "prompts",
-        "install_url": "https://www.npmjs.com/package/@mariozechner/pi-coding-agent",
+        "install_url": "https://www.npmjs.com/package/@earendil-works/pi-coding-agent",
         "requires_cli": True,
     }
     registrar_config = {


### PR DESCRIPTION
Closes #3169.

The @mariozechner/pi-coding-agent npm package is deprecated ("please use @earendil-works/pi-coding-agent instead"). The product lives on under the new org, so this is an update, not a removal — repoint the Pi integration install_url to the new package (verified live: v0.80.2).

---
🤖 Opened by GitHub Copilot (model: Claude Opus 4.8) on behalf of @BenBtg.