### PR TITLE
fix(extensions): apply GHES auth and resolve release assets for `extension add --from`

### DIFF
--- a/src/specify_cli/extensions/_commands.py
+++ b/src/specify_cli/extensions/_commands.py
@@ -482,6 +482,7 @@ def extension_add(
 
             elif from_url:
                 # Install from URL (ZIP file)
+                import io
                 import urllib.error
 
                 console.print(f"Downloading from {safe_url}...")
@@ -515,7 +516,7 @@ def extension_add(
                     ) as response:
                         zip_data = response.read()
 
-                    if not zip_data.startswith(b"PK"):
+                    if not zipfile.is_zipfile(io.BytesIO(zip_data)):
                         console.print(
                             f"[red]Error:[/red] {safe_url} did not return a ZIP archive "
                             f"(got {len(zip_data)} bytes). This usually means the request "

--- a/src/specify_cli/extensions/_commands.py
+++ b/src/specify_cli/extensions/_commands.py
@@ -498,10 +498,33 @@ def extension_add(
                     zip_path = Path(download_file.name)
 
                 try:
-                    from specify_cli.authentication.http import open_url as _open_url
+                    # Use the catalog's authenticated fetch so configured
+                    # credentials (incl. GitHub Enterprise Server) are applied
+                    # and GHES release-asset URLs resolve via /api/v3 — keeping
+                    # --from consistent with catalog-based installs.
+                    dl_catalog = ExtensionCatalog(project_root)
+                    download_url = from_url
+                    extra_headers = None
+                    resolved_url = dl_catalog._resolve_github_release_asset_api_url(download_url)
+                    if resolved_url:
+                        download_url = resolved_url
+                        extra_headers = {"Accept": "application/octet-stream"}
 
-                    with _open_url(from_url, timeout=60) as response:
+                    with dl_catalog._open_url(
+                        download_url, timeout=60, extra_headers=extra_headers
+                    ) as response:
                         zip_data = response.read()
+
+                    if not zip_data.startswith(b"PK"):
+                        console.print(
+                            f"[red]Error:[/red] {safe_url} did not return a ZIP archive "
+                            f"(got {len(zip_data)} bytes). This usually means the request "
+                            f"was not authenticated and a login/HTML page was returned. "
+                            f"Verify the URL is correct and that credentials for its host "
+                            f"are configured in ~/.specify/auth.json."
+                        )
+                        raise typer.Exit(1)
+
                     zip_path.write_bytes(zip_data)
 
                     # Install from downloaded ZIP

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -40,6 +40,10 @@ from specify_cli.extensions import (
     version_satisfies,
 )
 
+# Minimal valid ZIP (empty end-of-central-directory record). Passes
+# zipfile.is_zipfile() so --from download tests exercise the content guard.
+_MINIMAL_ZIP_BYTES = b"PK\x05\x06" + b"\x00" * 18
+
 
 def can_create_symlink(tmp_path: Path) -> bool:
     """Return True when the current platform/user can create file symlinks."""
@@ -5378,7 +5382,7 @@ class TestExtensionAddCLI:
         runner = CliRunner()
         with patch.object(Path, "cwd", return_value=project_dir), \
              patch("typer.confirm", return_value=True), \
-             patch("specify_cli.authentication.http.open_url", return_value=FakeResponse(b"PK\x03\x04zip-bytes")), \
+             patch("specify_cli.authentication.http.open_url", return_value=FakeResponse(_MINIMAL_ZIP_BYTES)), \
              patch.object(ExtensionManager, "install_from_zip", fake_install_from_zip), \
              patch.object(ExtensionRegistry, "get", return_value={}):
             result = runner.invoke(
@@ -5514,7 +5518,7 @@ class TestExtensionAddCLI:
                 return FakeResponse(body)
             seen["url"] = url
             seen["headers"] = extra_headers
-            return FakeResponse(b"PK\x03\x04payload")
+            return FakeResponse(_MINIMAL_ZIP_BYTES)
 
         def fake_install(self_obj, zip_path, speckit_version, priority=10, force=False):
             return SimpleNamespace(
@@ -5615,7 +5619,7 @@ class TestExtensionAddCLI:
         runner = CliRunner()
         with patch.object(Path, "cwd", return_value=project_dir), \
              patch("typer.confirm", return_value=True), \
-             patch("specify_cli.authentication.http.open_url", return_value=FakeResponse(b"PK\x03\x04zip-bytes")), \
+             patch("specify_cli.authentication.http.open_url", return_value=FakeResponse(_MINIMAL_ZIP_BYTES)), \
              patch.object(ExtensionManager, "install_from_zip", fake_install_from_zip):
             result = runner.invoke(
                 app,
@@ -5624,7 +5628,7 @@ class TestExtensionAddCLI:
             )
 
         assert result.exit_code == 0
-        assert installed["zip_bytes"] == b"PK\x03\x04zip-bytes"
+        assert installed["zip_bytes"] == _MINIMAL_ZIP_BYTES
         assert installed["zip_path"].resolve().is_relative_to(downloads_dir.resolve())
         assert installed["zip_path"].name.startswith("extension-url-download-")
         assert not installed["zip_path"].exists()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -5378,7 +5378,7 @@ class TestExtensionAddCLI:
         runner = CliRunner()
         with patch.object(Path, "cwd", return_value=project_dir), \
              patch("typer.confirm", return_value=True), \
-             patch("specify_cli.authentication.http.open_url", return_value=FakeResponse(b"zip-bytes")), \
+             patch("specify_cli.authentication.http.open_url", return_value=FakeResponse(b"PK\x03\x04zip-bytes")), \
              patch.object(ExtensionManager, "install_from_zip", fake_install_from_zip), \
              patch.object(ExtensionRegistry, "get", return_value={}):
             result = runner.invoke(
@@ -5445,6 +5445,98 @@ class TestExtensionAddCLI:
         assert result.exit_code == 1, result.output
         assert "https://example.com/[red]ext[/red].zip" in result.output
         assert "bad [red]download[/red]" in result.output
+
+    def test_add_from_url_rejects_non_zip_login_page(self, tmp_path):
+        """An HTML login page (unauthenticated fetch) must fail clearly, not BadZipFile."""
+        import io
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        class FakeResponse(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+        (project_dir / ".specify").mkdir()
+
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir), \
+             patch("typer.confirm", return_value=True), \
+             patch(
+                 "specify_cli.authentication.http.open_url",
+                 return_value=FakeResponse(b"<!DOCTYPE html><html>Sign in</html>"),
+             ), \
+             patch.object(ExtensionManager, "install_from_zip") as install:
+            result = runner.invoke(
+                app,
+                ["extension", "add", "my-ext", "--from", "https://raw.ghe.example/o/r/ext.zip"],
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code == 1, result.output
+        assert "did not return a ZIP archive" in result.output
+        install.assert_not_called()
+
+    def test_add_from_url_resolves_ghes_release_asset(self, tmp_path):
+        """A GHES release-download URL resolves to /api/v3 with octet-stream Accept."""
+        import io
+        from types import SimpleNamespace
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+        import json
+
+        class FakeResponse(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        project_dir = tmp_path / "test-project"
+        project_dir.mkdir()
+        (project_dir / ".specify").mkdir()
+        seen = {}
+
+        def fake_open_url(url, timeout=10, extra_headers=None, redirect_validator=None):
+            if "/releases/tags/" in url:
+                body = json.dumps({
+                    "assets": [{
+                        "name": "ext.zip",
+                        "url": "https://ghes.example/api/v3/repos/org/repo/releases/assets/42",
+                    }]
+                }).encode()
+                return FakeResponse(body)
+            seen["url"] = url
+            seen["headers"] = extra_headers
+            return FakeResponse(b"PK\x03\x04payload")
+
+        def fake_install(self_obj, zip_path, speckit_version, priority=10, force=False):
+            return SimpleNamespace(
+                id="x", name="X", version="1.0.0", description="", warnings=[], commands=[], hooks=[]
+            )
+
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir), \
+             patch("typer.confirm", return_value=True), \
+             patch("specify_cli.authentication.http.github_provider_hosts", return_value=("ghes.example",)), \
+             patch("specify_cli.authentication.http.open_url", side_effect=fake_open_url), \
+             patch.object(ExtensionManager, "install_from_zip", fake_install):
+            result = runner.invoke(
+                app,
+                ["extension", "add", "x", "--from",
+                 "https://ghes.example/org/repo/releases/download/v1.0/ext.zip"],
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "/api/v3/repos/org/repo/releases/assets/" in seen["url"]
+        assert seen["headers"] == {"Accept": "application/octet-stream"}
 
     @pytest.mark.parametrize(
         ("exc_type", "label"),
@@ -5523,7 +5615,7 @@ class TestExtensionAddCLI:
         runner = CliRunner()
         with patch.object(Path, "cwd", return_value=project_dir), \
              patch("typer.confirm", return_value=True), \
-             patch("specify_cli.authentication.http.open_url", return_value=FakeResponse(b"zip-bytes")), \
+             patch("specify_cli.authentication.http.open_url", return_value=FakeResponse(b"PK\x03\x04zip-bytes")), \
              patch.object(ExtensionManager, "install_from_zip", fake_install_from_zip):
             result = runner.invoke(
                 app,
@@ -5532,7 +5624,7 @@ class TestExtensionAddCLI:
             )
 
         assert result.exit_code == 0
-        assert installed["zip_bytes"] == b"zip-bytes"
+        assert installed["zip_bytes"] == b"PK\x03\x04zip-bytes"
         assert installed["zip_path"].resolve().is_relative_to(downloads_dir.resolve())
         assert installed["zip_path"].name.startswith("extension-url-download-")
         assert not installed["zip_path"].exists()


### PR DESCRIPTION
## Problem

`specify extension add <name> --from <GHES-url>` does not apply configured GHES authentication when downloading the ZIP. It received an HTML login page instead of the binary and failed with `zipfile.BadZipFile` at `install_from_zip`. Both the catalog and asset URLs return correct content when auth is applied (verified via curl with a Bearer token).

## Root cause

The `--from` path fetched the ZIP through a bare `open_url(from_url)` call — unlike the catalog download path it skipped release-asset resolution (`/releases/download/...` → `/api/v3/.../releases/assets/...`), the `Accept: application/octet-stream` header, and any content guard. On auth mismatch/401/403, `open_url` silently fell through to an unauthenticated request, got a 200 HTML login page, wrote it to disk, and `install_from_zip` raised `BadZipFile`.

## Fix

Route `--from` through `ExtensionCatalog` so it mirrors catalog installs and `preset add --from`: resolve GHES release URLs via `/api/v3` with octet-stream Accept, apply `auth.json` credentials, and reject non-ZIP content with a clear error.

## Tests

- New: HTML/login page rejected clearly (no BadZipFile).
- New: GHES release URL resolved to /api/v3 with octet-stream.
- Updated existing --from fixtures to valid ZIP magic. Suite: 324 passed.

Assisted-by: GitHub Copilot (model: Claude Opus 4.8, supervised)