### PR TITLE
Update Workflow Preset to v1.3.11

### DIFF
--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -670,11 +670,11 @@
     "workflow-preset": {
       "name": "Workflow Preset",
       "id": "workflow-preset",
-      "version": "1.3.2",
-      "description": "Behavior-first specification, design artifacts, and agent-native handoff orchestration.",
+      "version": "1.3.11",
+      "description": "Behavior-first specification, design artifacts, and agent-native handoff orchestration",
       "author": "bigsmartben",
       "repository": "https://github.com/bigsmartben/spec-kit-workflow-preset",
-      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/releases/download/v1.3.2/spec-kit-workflow-preset-v1.3.2.zip",
+      "download_url": "https://github.com/bigsmartben/spec-kit-workflow-preset/releases/download/v1.3.11/spec-kit-workflow-preset-v1.3.11.zip",
       "homepage": "https://github.com/bigsmartben/spec-kit-workflow-preset",
       "documentation": "https://github.com/bigsmartben/spec-kit-workflow-preset/blob/main/README.md",
       "license": "MIT",
@@ -693,7 +693,7 @@
         "handoff"
       ],
       "created_at": "2026-05-27T00:00:00Z",
-      "updated_at": "2026-06-03T00:00:00Z"
+      "updated_at": "2026-06-25T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## Description

Submission route: pr-template

Updates the `workflow-preset` community preset catalog entry from v1.3.2 to v1.3.11.

Source repository: https://github.com/bigsmartben/spec-kit-workflow-preset
Source version: v1.3.11
Source commit: 06d28ce4e0b53f4391cd4d11c49fc3eac2513172
Download URL: https://github.com/bigsmartben/spec-kit-workflow-preset/releases/download/v1.3.11/spec-kit-workflow-preset-v1.3.11.zip
Changed catalog type: preset

## Testing

- [ ] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Validation evidence:
- `Get-Content presets\catalog.community.json | ConvertFrom-Json`
- `git diff --check`
- `curl.exe -L --fail --head` for the download URL
- catalog/bundler tests: 35 passed, 1 deselected

The deselected test requires Windows symlink privileges and failed locally with WinError 1314 before deselection.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Prepared by Codex (model: GPT-5) on behalf of @bigsmartben. Codex performed the catalog update, validation commands, commit, branch push, and PR creation.
