### PR TITLE
fix: reject host-less catalog URLs in base and preset validators (#3209)

### DIFF
--- a/src/specify_cli/catalogs.py
+++ b/src/specify_cli/catalogs.py
@@ -78,7 +78,11 @@ class CatalogStackBase:
                 f"Catalog URL must use HTTPS (got {parsed.scheme}://). "
                 "HTTP is only allowed for localhost."
             )
-        if not parsed.netloc:
+        # Use .hostname (not .netloc) so host-less URLs like "https://:8080"
+        # (port only) or "https://user@" (userinfo only) are rejected: netloc
+        # is truthy for those even though there is no host. This matches the
+        # workflow/step/bundler catalog validators (issue #3209).
+        if not parsed.hostname:
             raise cls._error("Catalog URL must be a valid URL with a host.")
 
     def _load_catalog_config(self, config_path: Path) -> list[CatalogEntry] | None:

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -1861,7 +1861,11 @@ class PresetCatalog:
                 f"Catalog URL must use HTTPS (got {parsed.scheme}://). "
                 "HTTP is only allowed for localhost."
             )
-        if not parsed.netloc:
+        # Use .hostname (not .netloc) so host-less URLs like "https://:8080"
+        # (port only) or "https://user@" (userinfo only) are rejected: netloc
+        # is truthy for those even though there is no host. This matches the
+        # workflow/step/bundler catalog validators (issue #3209).
+        if not parsed.hostname:
             raise PresetValidationError(
                 "Catalog URL must be a valid URL with a host."
             )

--- a/tests/integrations/test_integration_catalog.py
+++ b/tests/integrations/test_integration_catalog.py
@@ -67,6 +67,20 @@ class TestCatalogURLValidation:
         with pytest.raises(IntegrationCatalogError, match="valid URL"):
             IntegrationCatalog._validate_catalog_url("https:///no-host")
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://:8080",          # port only, no host
+            "https://:8080/catalog.json",
+            "https://user@",          # userinfo only, no host
+            "https://user:pass@",
+        ],
+    )
+    def test_hostless_url_rejected(self, url):
+        """netloc is truthy for these but there is no host (#3209)."""
+        with pytest.raises(IntegrationCatalogError, match="valid URL"):
+            IntegrationCatalog._validate_catalog_url(url)
+
 
 # ---------------------------------------------------------------------------
 # IntegrationCatalog — active catalogs

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1424,6 +1424,21 @@ class TestPresetCatalog:
         catalog._validate_catalog_url("http://localhost:8080/catalog.json")
         catalog._validate_catalog_url("http://127.0.0.1:8080/catalog.json")
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://:8080",          # port only, no host
+            "https://:8080/catalog.json",
+            "https://user@",          # userinfo only, no host
+            "https://user:pass@",
+        ],
+    )
+    def test_validate_catalog_url_hostless_rejected(self, project_dir, url):
+        """Host-less URLs (netloc truthy but no host) are rejected (#3209)."""
+        catalog = PresetCatalog(project_dir)
+        with pytest.raises(PresetValidationError, match="valid URL with a host"):
+            catalog._validate_catalog_url(url)
+
     def test_env_var_catalog_url(self, project_dir, monkeypatch):
         """Test catalog URL from environment variable."""
         monkeypatch.setenv("SPECKIT_PRESET_CATALOG_URL", "https://custom.example.com/catalog.json")


### PR DESCRIPTION
## What

Two catalog URL validators rejected host-less URLs incorrectly because they checked `parsed.netloc` instead of `parsed.hostname`. `netloc` is truthy for URLs like `https://:8080` (port only) or `https://user@` (userinfo only), which have **no host** — so they slipped past validation even though the error message promises "a valid URL with a host". The bad URL was then accepted and only failed later with a confusing fetch error.

Fixes #3209.

## How

Switch both stragglers to `parsed.hostname` (which is `None` for these inputs), aligning them with the sibling validators that already do this correctly:

- `src/specify_cli/catalogs.py` — `CatalogStackBase._validate_catalog_url` (inherited by `IntegrationCatalog`)
- `src/specify_cli/presets/__init__.py` — `PresetCatalog._validate_catalog_url`

The workflow (`workflows/catalog.py`), step, and bundler (`bundler/commands_impl/catalog_config.py`) validators already check `.hostname` — the bundler even documents *why*. This is purely an alignment fix; HTTPS/localhost behavior is unchanged.

```python
from urllib.parse import urlparse
p = urlparse("https://:8080")
print(bool(p.netloc), p.hostname)   # True None  <- netloc truthy, no host
```

## Tests

Added parametrized regression tests for **both** validators covering port-only (`https://:8080`, `https://:8080/catalog.json`) and userinfo-only (`https://user@`, `https://user:pass@`) URLs:

- `tests/integrations/test_integration_catalog.py::TestCatalogURLValidation::test_hostless_url_rejected`
- `tests/test_presets.py::TestPresetCatalog::test_validate_catalog_url_hostless_rejected`

Verified the new tests **fail on `main`** (host-less URLs wrongly accepted) and **pass with the fix**. Existing HTTPS / HTTP-rejected / localhost-allowed / missing-host tests still pass. `ruff` clean