### PR TITLE
fix: interpolate multi-expression templates instead of returning None (#3208)

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -164,6 +164,8 @@ def _is_single_expression(stripped: str) -> bool:
     if not (stripped.startswith("{{") and stripped.endswith("}}")):
         return False
     inner = stripped[2:-2]
+    if not inner.strip():
+        return False
     quote: str | None = None
     i = 0
     n = len(inner)

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -146,6 +146,41 @@ def _build_namespace(context: Any) -> dict[str, Any]:
     return ns
 
 
+def _is_single_expression(stripped: str) -> bool:
+    """True when *stripped* is exactly one top-level ``{{ ... }}`` block.
+
+    Scans the block body for a ``}}`` that would close it early, ignoring any
+    braces inside string literals. This keeps a lone expression whose string
+    argument contains a literal ``{{`` or ``}}`` (e.g.
+    ``{{ inputs.text | contains('}}') }}``) on the typed fast path, while
+    ``{{ a }} {{ b }}`` and ``{{ a }}{{ b }}`` are correctly seen as
+    multi-expression. Mirrors the quote handling in
+    ``_split_top_level_commas``.
+
+    A regex span check cannot decide this: the pattern's non-greedy body stops
+    at the first ``}}``, so a literal ``}}`` inside a string argument would be
+    mistaken for the closing delimiter (issue #3208, follow-up review).
+    """
+    if not (stripped.startswith("{{") and stripped.endswith("}}")):
+        return False
+    inner = stripped[2:-2]
+    quote: str | None = None
+    i = 0
+    n = len(inner)
+    while i < n:
+        ch = inner[i]
+        if quote is not None:
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch == "}" and i + 1 < n and inner[i + 1] == "}":
+            # A ``}}`` outside quotes closes the first block early.
+            return False
+        i += 1
+    return True
+
+
 def _split_top_level_commas(text: str) -> list[str]:
     """Split *text* on commas that are not inside quotes or nested brackets.
 
@@ -386,23 +421,18 @@ def evaluate_expression(template: str, context: Any) -> Any:
     # Single expression: return typed value (preserving type).
     #
     # The fast path must fire only when the whole template is one ``{{ ... }}``
-    # block. ``fullmatch`` cannot decide this: the pattern's non-greedy body
-    # ``(.+?)`` is defeated by ``fullmatch``, so ``"{{ a }} {{ b }}"`` still
-    # matches with the body expanded to ``"a }} {{ b"`` -- garbage that fails
-    # resolution and returns ``None``, bypassing the ``sub()`` interpolation
-    # path that handles each expression correctly (issue #3208).
-    #
-    # Anchor a single match at the start instead and require it to consume the
-    # entire stripped string. The non-greedy body then stops at the first
-    # ``}}``: a genuine two-block template leaves a trailing ``}}`` and fails the
-    # span check, while a lone expression -- even one with a literal ``{{`` in a
-    # string argument such as ``{{ inputs.text | contains('{{') }}`` -- matches
-    # to the end and keeps its typed return value. (Counting ``{{`` would
-    # misclassify that expression as multi-block and coerce it to ``str``.)
+    # block. Neither ``fullmatch`` nor a match-span check on ``_EXPR_PATTERN``
+    # can decide this reliably: the non-greedy body stops at the first ``}}``,
+    # so ``fullmatch`` over-expands ``"{{ a }} {{ b }}"`` to garbage (returning
+    # ``None`` and bypassing interpolation, issue #3208), while a span check
+    # trips over a literal ``}}`` inside a string argument such as
+    # ``{{ inputs.text | contains('}}') }}`` and mis-routes it to interpolation
+    # (coercing its typed return to ``str``). ``_is_single_expression`` scans
+    # for a block-closing ``}}`` outside string literals, so both cases resolve
+    # correctly.
     stripped = template.strip()
-    match = _EXPR_PATTERN.match(stripped)
-    if match and match.end() == len(stripped):
-        return _evaluate_simple_expression(match.group(1).strip(), namespace)
+    if _is_single_expression(stripped):
+        return _evaluate_simple_expression(stripped[2:-2].strip(), namespace)
 
     # Multi-expression: string interpolation
     def _replacer(m: re.Match[str]) -> str:

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -383,10 +383,21 @@ def evaluate_expression(template: str, context: Any) -> Any:
 
     namespace = _build_namespace(context)
 
-    # Single expression: return typed value
-    match = _EXPR_PATTERN.fullmatch(template.strip())
-    if match:
-        return _evaluate_simple_expression(match.group(1).strip(), namespace)
+    # Single expression: return typed value (preserving type).
+    #
+    # Guard the fast path on there being exactly one ``{{`` block. The pattern
+    # uses a non-greedy body ``(.+?)``, but ``fullmatch`` defeats non-greediness:
+    # for ``"{{ a }} {{ b }}"`` it still matches, expanding the body to capture
+    # everything between the first ``{{`` and the last ``}}`` (``"a }} {{ b"``).
+    # That garbage body fails resolution and returns ``None``, bypassing the
+    # ``sub()`` interpolation path that would handle each expression correctly.
+    # Only take the typed fast path for genuine single-expression templates
+    # (issue #3208).
+    stripped = template.strip()
+    if stripped.count("{{") == 1:
+        match = _EXPR_PATTERN.fullmatch(stripped)
+        if match:
+            return _evaluate_simple_expression(match.group(1).strip(), namespace)
 
     # Multi-expression: string interpolation
     def _replacer(m: re.Match[str]) -> str:

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -385,19 +385,24 @@ def evaluate_expression(template: str, context: Any) -> Any:
 
     # Single expression: return typed value (preserving type).
     #
-    # Guard the fast path on there being exactly one ``{{`` block. The pattern
-    # uses a non-greedy body ``(.+?)``, but ``fullmatch`` defeats non-greediness:
-    # for ``"{{ a }} {{ b }}"`` it still matches, expanding the body to capture
-    # everything between the first ``{{`` and the last ``}}`` (``"a }} {{ b"``).
-    # That garbage body fails resolution and returns ``None``, bypassing the
-    # ``sub()`` interpolation path that would handle each expression correctly.
-    # Only take the typed fast path for genuine single-expression templates
-    # (issue #3208).
+    # The fast path must fire only when the whole template is one ``{{ ... }}``
+    # block. ``fullmatch`` cannot decide this: the pattern's non-greedy body
+    # ``(.+?)`` is defeated by ``fullmatch``, so ``"{{ a }} {{ b }}"`` still
+    # matches with the body expanded to ``"a }} {{ b"`` -- garbage that fails
+    # resolution and returns ``None``, bypassing the ``sub()`` interpolation
+    # path that handles each expression correctly (issue #3208).
+    #
+    # Anchor a single match at the start instead and require it to consume the
+    # entire stripped string. The non-greedy body then stops at the first
+    # ``}}``: a genuine two-block template leaves a trailing ``}}`` and fails the
+    # span check, while a lone expression -- even one with a literal ``{{`` in a
+    # string argument such as ``{{ inputs.text | contains('{{') }}`` -- matches
+    # to the end and keeps its typed return value. (Counting ``{{`` would
+    # misclassify that expression as multi-block and coerce it to ``str``.)
     stripped = template.strip()
-    if stripped.count("{{") == 1:
-        match = _EXPR_PATTERN.fullmatch(stripped)
-        if match:
-            return _evaluate_simple_expression(match.group(1).strip(), namespace)
+    match = _EXPR_PATTERN.match(stripped)
+    if match and match.end() == len(stripped):
+        return _evaluate_simple_expression(match.group(1).strip(), namespace)
 
     # Multi-expression: string interpolation
     def _replacer(m: re.Match[str]) -> str:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -227,8 +227,8 @@ class TestExpressions:
         assert result == "Feature: login done"
 
     def test_multi_expression_no_surrounding_text(self):
-"""Two expressions with no surrounding literal text must interpolate each,
-not collapse to None via the fullmatch fast path (#3208)."""
+        """Two expressions with no surrounding literal text must interpolate each,
+        not collapse to None via the fullmatch fast path (#3208)."""
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -248,15 +248,17 @@ class TestExpressions:
         assert result == "foobar"
 
     def test_single_expression_with_literal_braces_preserves_type(self):
-        """A lone expression whose string argument contains a literal ``{{``
+        """A lone expression whose string argument contains a literal ``{{`` or ``}}``
         must still take the typed fast path and return a bool, not a string
-        (the fix for #3208 must not coerce it to ``"True"``)."""
+        (the fix for #3208 must not coerce it to ``\"True\"``)."""
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext
 
         ctx = StepContext(inputs={"text": "uses {{ jinja }} syntax"})
-        result = evaluate_expression("{{ inputs.text | contains('{{') }}", ctx)
-        assert result is True
+        assert evaluate_expression("{{ inputs.text | contains('{{') }}", ctx) is True
+
+        ctx = StepContext(inputs={"text": "uses }} syntax"})
+        assert evaluate_expression("{{ inputs.text | contains('}}') }}", ctx) is True
 
     def test_comparison_equals(self):
         from specify_cli.workflows.expressions import evaluate_expression

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -227,8 +227,8 @@ class TestExpressions:
         assert result == "Feature: login done"
 
     def test_multi_expression_no_surrounding_text(self):
-        """Two adjacent expressions with no literal text must interpolate each,
-        not collapse to None via the fullmatch fast path (#3208)."""
+"""Two expressions with no surrounding literal text must interpolate each,
+not collapse to None via the fullmatch fast path (#3208)."""
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -247,6 +247,17 @@ class TestExpressions:
         result = evaluate_expression("{{ inputs.a }}{{ inputs.b }}", ctx)
         assert result == "foobar"
 
+    def test_single_expression_with_literal_braces_preserves_type(self):
+        """A lone expression whose string argument contains a literal ``{{``
+        must still take the typed fast path and return a bool, not a string
+        (the fix for #3208 must not coerce it to ``"True"``)."""
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(inputs={"text": "uses {{ jinja }} syntax"})
+        result = evaluate_expression("{{ inputs.text | contains('{{') }}", ctx)
+        assert result is True
+
     def test_comparison_equals(self):
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -226,6 +226,27 @@ class TestExpressions:
         result = evaluate_expression("Feature: {{ inputs.name }} done", ctx)
         assert result == "Feature: login done"
 
+    def test_multi_expression_no_surrounding_text(self):
+        """Two adjacent expressions with no literal text must interpolate each,
+        not collapse to None via the fullmatch fast path (#3208)."""
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(inputs={"issue": "23"}, run_id="47c5eb4b")
+        result = evaluate_expression(
+            "{{ context.run_id }} {{ inputs.issue }}", ctx
+        )
+        assert result == "47c5eb4b 23"
+
+    def test_multi_expression_adjacent_no_separator(self):
+        """Back-to-back expressions with no separator still interpolate (#3208)."""
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(inputs={"a": "foo", "b": "bar"})
+        result = evaluate_expression("{{ inputs.a }}{{ inputs.b }}", ctx)
+        assert result == "foobar"
+
     def test_comparison_equals(self):
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext


### PR DESCRIPTION
## What

`evaluate_expression` returned `None` for any template containing **two or more `{{ }}` blocks with no surrounding literal text**, e.g. `"{{ context.run_id }} {{ inputs.issue }}"`. Downstream this surfaced as the literal string `"None"` reaching commands (the reporter hit "no issue was provided" despite `issue: "23"` being in the run inputs).

Fixes #3208.

## Root cause

The single-expression fast path used `_EXPR_PATTERN.fullmatch()`, but `fullmatch` defeats the pattern's non-greedy `(.+?)` body. For `"{{ a }} {{ b }}"` it still matches, expanding the body to capture everything between the **first** `{{` and the **last** `}}` — i.e. `"a }} {{ b"`. That garbage body fails dot-path resolution and returns `None` directly, **bypassing** the `sub()` interpolation path that would have resolved each expression separately.

| Template | `fullmatch` | Result |
|---|---|---|
| `{{ inputs.issue }}` | matches, body `inputs.issue` | ✅ correct |
| `bash x "{{ inputs.issue }}"` | no match (text prefix) → `sub()` | ✅ correct |
| `{{ a }} {{ b }}` | **matches**, body `"a }} {{ b"` | ❌ **None** |

## How

Guard the fast path on `stripped.count("{{") == 1` so only genuine single-expression templates take the typed-return path; multi-expression templates fall through to the existing `sub()` interpolation, which is already correct. Single-expression type preservation is unchanged.

## Tests

Added two regression tests to `TestExpressions`:
- `test_multi_expression_no_surrounding_text` — `"{{ context.run_id }} {{ inputs.issue }}"` → `"47c5eb4b 23"`
- `test_multi_expression_adjacent_no_separator` — `"{{ inputs.a }}{{ inputs.b }}"` → `"foobar"`

Verified both **fail on `main`** (return `None`) and **pass with the fix**. All 31 `TestExpressions` tests pass; `ruff` clean. (The 5 symlink-test failures on my local Windows run pre-exist on `main` — a symlink-privilege limitation unrelated to this change; they pass on Linux CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)