### PR TITLE
fix: fall back to feature dir basename for empty CURRENT_BRANCH (#3026)

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -191,7 +191,8 @@ get_feature_paths() {
     # directory basename so CURRENT_BRANCH is a usable identifier rather than
     # an empty, misleading value (issue #3026).
     if [[ -z "$current_branch" ]]; then
-        current_branch="${feature_dir##*/}"
+        local feature_dir_trimmed="${feature_dir%/}"
+        current_branch="${feature_dir_trimmed##*/}"
     fi
 
     # Use printf '%q' to safely quote values, preventing shell injection

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -186,6 +186,14 @@ get_feature_paths() {
         return 1
     fi
 
+    # When no branch context exists (no SPECIFY_FEATURE, feature resolved via
+    # SPECIFY_FEATURE_DIRECTORY or feature.json), fall back to the feature
+    # directory basename so CURRENT_BRANCH is a usable identifier rather than
+    # an empty, misleading value (issue #3026).
+    if [[ -z "$current_branch" ]]; then
+        current_branch="${feature_dir##*/}"
+    fi
+
     # Use printf '%q' to safely quote values, preventing shell injection
     # via crafted branch names or paths containing special characters
     printf 'REPO_ROOT=%q\n' "$repo_root"

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -187,7 +187,8 @@ function Get-FeaturePathsEnv {
     # directory basename so CURRENT_BRANCH is a usable identifier rather than
     # an empty, misleading value (issue #3026).
     if (-not $currentBranch) {
-        $currentBranch = Split-Path -Leaf $featureDir
+        $featureDirTrimmed = [System.IO.Path]::TrimEndingDirectorySeparator($featureDir)
+        $currentBranch = Split-Path -Leaf $featureDirTrimmed
     }
 
     [PSCustomObject]@{

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -187,7 +187,9 @@ function Get-FeaturePathsEnv {
     # directory basename so CURRENT_BRANCH is a usable identifier rather than
     # an empty, misleading value (issue #3026).
     if (-not $currentBranch) {
-        $featureDirTrimmed = [System.IO.Path]::TrimEndingDirectorySeparator($featureDir)
+        # TrimEnd (not [Path]::TrimEndingDirectorySeparator, which is .NET Core
+        # only) keeps this working on Windows PowerShell 5.1 / .NET Framework.
+        $featureDirTrimmed = $featureDir.TrimEnd('/', '\')
         $currentBranch = Split-Path -Leaf $featureDirTrimmed
     }
 

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -182,6 +182,14 @@ function Get-FeaturePathsEnv {
         exit 1
     }
     
+    # When no branch context exists (no SPECIFY_FEATURE, feature resolved via
+    # SPECIFY_FEATURE_DIRECTORY or feature.json), fall back to the feature
+    # directory basename so CURRENT_BRANCH is a usable identifier rather than
+    # an empty, misleading value (issue #3026).
+    if (-not $currentBranch) {
+        $currentBranch = Split-Path -Leaf $featureDir
+    }
+
     [PSCustomObject]@{
         REPO_ROOT     = $repoRoot
         CURRENT_BRANCH = $currentBranch

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -122,36 +122,31 @@ def test_paths_only_succeeds_on_spec_branch(prereq_repo: Path) -> None:
 
 
 @requires_bash
-def test_current_branch_falls_back_to_feature_dir_basename(prereq_repo: Path) -> None:
-    """When no branch context exists (feature resolved from feature.json,
-    SPECIFY_FEATURE unset), BRANCH must fall back to the feature directory
-    basename instead of being emitted empty (#3026)."""
+@pytest.mark.parametrize(
+    ("use_env_var", "specify_feature", "expected_branch"),
+    [
+        (False, None, "001-my-feature"),
+        (True, None, "001-my-feature"),
+        (False, "my-explicit-branch", "my-explicit-branch"),
+    ],
+    ids=["feature_json", "env_var", "explicit_feature"],
+)
+def test_current_branch_falls_back_to_feature_dir_basename(
+    prereq_repo: Path, use_env_var: bool, specify_feature: str | None, expected_branch: str
+) -> None:
+    """With no SPECIFY_FEATURE, BRANCH falls back to the feature directory
+    basename (from feature.json or SPECIFY_FEATURE_DIRECTORY) instead of being
+    emitted empty. If SPECIFY_FEATURE is set, it remains authoritative (#3026)."""
     feat = prereq_repo / "specs" / "001-my-feature"
     feat.mkdir(parents=True, exist_ok=True)
-    _write_feature_json(prereq_repo)
-    script = prereq_repo / ".specify" / "scripts" / "bash" / "check-prerequisites.sh"
-    result = subprocess.run(
-        ["bash", str(script), "--json", "--paths-only"],
-        cwd=prereq_repo,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=_clean_env(),  # no SPECIFY_FEATURE
-    )
-    assert result.returncode == 0, result.stderr
-    data = json.loads(result.stdout)
-    assert data["BRANCH"] == "001-my-feature"
-
-
-@requires_bash
-def test_explicit_feature_still_overrides_basename(prereq_repo: Path) -> None:
-    """SPECIFY_FEATURE remains authoritative over the basename fallback (#3026)."""
-    feat = prereq_repo / "specs" / "001-my-feature"
-    feat.mkdir(parents=True, exist_ok=True)
-    _write_feature_json(prereq_repo)
-    script = prereq_repo / ".specify" / "scripts" / "bash" / "check-prerequisites.sh"
     env = _clean_env()
-    env["SPECIFY_FEATURE"] = "my-explicit-branch"
+    if specify_feature:
+        env["SPECIFY_FEATURE"] = specify_feature
+    if use_env_var:
+        env["SPECIFY_FEATURE_DIRECTORY"] = "specs/001-my-feature"
+    else:
+        _write_feature_json(prereq_repo)
+    script = prereq_repo / ".specify" / "scripts" / "bash" / "check-prerequisites.sh"
     result = subprocess.run(
         ["bash", str(script), "--json", "--paths-only"],
         cwd=prereq_repo,
@@ -162,7 +157,7 @@ def test_explicit_feature_still_overrides_basename(prereq_repo: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     data = json.loads(result.stdout)
-    assert data["BRANCH"] == "my-explicit-branch"
+    assert data["BRANCH"] == expected_branch
 
 
 @requires_bash
@@ -271,6 +266,8 @@ def test_ps_current_branch_falls_back_to_feature_dir_basename(
     assert result.returncode == 0, result.stderr
     data = json.loads(result.stdout)
     assert data["BRANCH"] == expected_branch
+
+
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_ps_paths_only_succeeds_on_spec_branch(prereq_repo: Path) -> None:
     """-PathsOnly must also work when feature.json and SPECIFY_FEATURE agree."""

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -234,14 +234,26 @@ def test_ps_paths_only_succeeds_on_non_spec_branch(prereq_repo: Path) -> None:
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
-@pytest.mark.parametrize("use_env_var", [False, True], ids=["feature_json", "env_var"])
-def test_ps_current_branch_falls_back_to_feature_dir_basename(prereq_repo: Path, use_env_var: bool) -> None:
+@pytest.mark.parametrize(
+    ("use_env_var", "specify_feature", "expected_branch"),
+    [
+        (False, None, "001-my-feature"),
+        (True, None, "001-my-feature"),
+        (False, "my-explicit-branch", "my-explicit-branch"),
+    ],
+    ids=["feature_json", "env_var", "explicit_feature"],
+)
+def test_ps_current_branch_falls_back_to_feature_dir_basename(
+    prereq_repo: Path, use_env_var: bool, specify_feature: str | None, expected_branch: str
+) -> None:
     """With no SPECIFY_FEATURE, BRANCH falls back to the feature directory
     basename (from feature.json or SPECIFY_FEATURE_DIRECTORY) instead of being
-    emitted empty (#3026)."""
+    emitted empty. If SPECIFY_FEATURE is set, it remains authoritative (#3026)."""
     feat = prereq_repo / "specs" / "001-my-feature"
     feat.mkdir(parents=True, exist_ok=True)
-    env = _clean_env()  # no SPECIFY_FEATURE
+    env = _clean_env()
+    if specify_feature:
+        env["SPECIFY_FEATURE"] = specify_feature
     if use_env_var:
         env["SPECIFY_FEATURE_DIRECTORY"] = "specs/001-my-feature"
     else:
@@ -258,8 +270,7 @@ def test_ps_current_branch_falls_back_to_feature_dir_basename(prereq_repo: Path,
     )
     assert result.returncode == 0, result.stderr
     data = json.loads(result.stdout)
-    assert data["BRANCH"] == "001-my-feature"
-
+    assert data["BRANCH"] == expected_branch
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_ps_paths_only_succeeds_on_spec_branch(prereq_repo: Path) -> None:
     """-PathsOnly must also work when feature.json and SPECIFY_FEATURE agree."""

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -234,12 +234,18 @@ def test_ps_paths_only_succeeds_on_non_spec_branch(prereq_repo: Path) -> None:
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
-def test_ps_current_branch_falls_back_to_feature_dir_basename(prereq_repo: Path) -> None:
+@pytest.mark.parametrize("use_env_var", [False, True], ids=["feature_json", "env_var"])
+def test_ps_current_branch_falls_back_to_feature_dir_basename(prereq_repo: Path, use_env_var: bool) -> None:
     """With no SPECIFY_FEATURE, BRANCH falls back to the feature directory
-    basename instead of being emitted empty (#3026)."""
+    basename (from feature.json or SPECIFY_FEATURE_DIRECTORY) instead of being
+    emitted empty (#3026)."""
     feat = prereq_repo / "specs" / "001-my-feature"
     feat.mkdir(parents=True, exist_ok=True)
-    _write_feature_json(prereq_repo)
+    env = _clean_env()  # no SPECIFY_FEATURE
+    if use_env_var:
+        env["SPECIFY_FEATURE_DIRECTORY"] = "specs/001-my-feature"
+    else:
+        _write_feature_json(prereq_repo)
     script = prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
     exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
     result = subprocess.run(
@@ -248,12 +254,11 @@ def test_ps_current_branch_falls_back_to_feature_dir_basename(prereq_repo: Path)
         capture_output=True,
         text=True,
         check=False,
-        env=_clean_env(),  # no SPECIFY_FEATURE
+        env=env,
     )
     assert result.returncode == 0, result.stderr
     data = json.loads(result.stdout)
     assert data["BRANCH"] == "001-my-feature"
-
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_ps_paths_only_succeeds_on_spec_branch(prereq_repo: Path) -> None:

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -122,6 +122,50 @@ def test_paths_only_succeeds_on_spec_branch(prereq_repo: Path) -> None:
 
 
 @requires_bash
+def test_current_branch_falls_back_to_feature_dir_basename(prereq_repo: Path) -> None:
+    """When no branch context exists (feature resolved from feature.json,
+    SPECIFY_FEATURE unset), BRANCH must fall back to the feature directory
+    basename instead of being emitted empty (#3026)."""
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True, exist_ok=True)
+    _write_feature_json(prereq_repo)
+    script = prereq_repo / ".specify" / "scripts" / "bash" / "check-prerequisites.sh"
+    result = subprocess.run(
+        ["bash", str(script), "--json", "--paths-only"],
+        cwd=prereq_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),  # no SPECIFY_FEATURE
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["BRANCH"] == "001-my-feature"
+
+
+@requires_bash
+def test_explicit_feature_still_overrides_basename(prereq_repo: Path) -> None:
+    """SPECIFY_FEATURE remains authoritative over the basename fallback (#3026)."""
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True, exist_ok=True)
+    _write_feature_json(prereq_repo)
+    script = prereq_repo / ".specify" / "scripts" / "bash" / "check-prerequisites.sh"
+    env = _clean_env()
+    env["SPECIFY_FEATURE"] = "my-explicit-branch"
+    result = subprocess.run(
+        ["bash", str(script), "--json", "--paths-only"],
+        cwd=prereq_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["BRANCH"] == "my-explicit-branch"
+
+
+@requires_bash
 def test_paths_only_text_mode_on_non_spec_branch(prereq_repo: Path) -> None:
     """--paths-only without --json must return text paths from feature.json."""
     feat = prereq_repo / "specs" / "001-my-feature"
@@ -187,6 +231,28 @@ def test_ps_paths_only_succeeds_on_non_spec_branch(prereq_repo: Path) -> None:
     assert "REPO_ROOT" in data
     assert "BRANCH" in data
     assert "FEATURE_DIR" in data
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_ps_current_branch_falls_back_to_feature_dir_basename(prereq_repo: Path) -> None:
+    """With no SPECIFY_FEATURE, BRANCH falls back to the feature directory
+    basename instead of being emitted empty (#3026)."""
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True, exist_ok=True)
+    _write_feature_json(prereq_repo)
+    script = prereq_repo / ".specify" / "scripts" / "powershell" / "check-prerequisites.ps1"
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(script), "-Json", "-PathsOnly"],
+        cwd=prereq_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),  # no SPECIFY_FEATURE
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["BRANCH"] == "001-my-feature"
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")


### PR DESCRIPTION
## What

When a feature is resolved via `SPECIFY_FEATURE_DIRECTORY` or `.specify/feature.json` **without `SPECIFY_FEATURE` set**, `get_current_branch()` returns empty, so `get_feature_paths` / `Get-FeaturePathsEnv` emitted `CURRENT_BRANCH=` (empty) / `BRANCH: ""` even though the feature directory was fully resolvable. Downstream scripts and agents that expect a non-empty identifier got misleading, silent empty output.

Fixes #3026.

## How

Fall back to the **basename of the resolved feature directory** when the branch is empty, in both resolvers:

- **bash** (`scripts/bash/common.sh`): `current_branch="${feature_dir##*/}"`
- **PowerShell** (`scripts/powershell/common.ps1`): `$currentBranch = Split-Path -Leaf $featureDir`

An explicit `SPECIFY_FEATURE` still takes precedence (it's read before this fallback), so this only fills the previously-empty case — no change for users who set the feature explicitly.

## Verification

Reproduced end-to-end (bash), with `SPECIFY_FEATURE` unset and the feature pinned in `feature.json`:

```
=== BEFORE FIX ===  BRANCH= ''
=== AFTER FIX  ===  BRANCH= '001-my-feature'
=== AFTER FIX (SPECIFY_FEATURE=my-branch override) ===  BRANCH= 'my-branch'
```

## Tests

Added regression tests (bash + PowerShell) to `tests/test_check_prerequisites_paths_only.py`:
- `(test_|test_ps_)current_branch_falls_back_to_feature_dir_basename` — `BRANCH` equals the feature dir basename when `SPECIFY_FEATURE` is unset.
- `test_explicit_feature_still_overrides_basename` — `SPECIFY_FEATURE` remains authoritative.

Verified the PowerShell test **fails on `main`** (empty `BRANCH`) and **passes with the fix**; existing paths-only tests still pass; `ruff` clean. (Bash tests run on CI; they skip on my local Windows pytest env where `bash` isn't on the pytest PATH, but I reproduced the bash behavior directly as shown above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)