### PR TITLE
fix(scripts): warn when spec template is missing in create-new-feature.ps1 (parity with bash)

### DIFF
--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -211,6 +211,10 @@ if (-not $DryRun) {
             $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
             [System.IO.File]::WriteAllText($specFile, $content, $utf8NoBom)
         } else {
+            # Match the bash twin (create-new-feature.sh): warn on stderr that no
+            # spec template was found before creating an empty spec file, so the
+            # missing-template signal is not silently swallowed on Windows.
+            [Console]::Error.WriteLine("Warning: Spec template not found; created empty spec file")
             New-Item -ItemType File -Path $specFile -Force | Out-Null
         }
     }

--- a/tests/test_timestamp_branches.py
+++ b/tests/test_timestamp_branches.py
@@ -332,6 +332,27 @@ class TestSequentialBranchPowerShell:
         assert data["FEATURE_NUM"] == "000"
         assert data["BRANCH_NAME"] == "000-zero"
 
+    @pytest.mark.skipif(not _has_pwsh(), reason="pwsh not installed")
+    def test_missing_spec_template_warns_matching_bash(self, ps_git_repo: Path):
+        """When no spec template can be resolved, create-new-feature.ps1 must warn on
+        stderr (and still create an empty spec file), matching the bash twin's
+        'Warning: Spec template not found; created empty spec file'. Before the fix
+        PowerShell created the empty file silently."""
+        # Remove the template the fixture installs so resolution finds nothing.
+        (ps_git_repo / ".specify" / "templates" / "spec-template.md").unlink()
+        script = ps_git_repo / "scripts" / "powershell" / "create-new-feature.ps1"
+        result = subprocess.run(
+            ["pwsh", "-NoProfile", "-File", str(script),
+             "-Json", "-ShortName", "no-tmpl", "No template feature"],
+            cwd=ps_git_repo, capture_output=True, text=True, encoding="utf-8",
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Spec template not found" in result.stderr
+        # stdout stays parseable JSON and the empty spec file is still created.
+        data = json.loads(result.stdout)
+        spec_file = Path(data["SPEC_FILE"])
+        assert spec_file.is_file()
+
 
 # ── check_feature_branch Tests ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Description

When no spec template can be resolved, the bash `create-new-feature.sh` warns before falling back to an empty spec:

```bash
else
    echo "Warning: Spec template not found; created empty spec file" >&2
    touch "$SPEC_FILE"
fi
```

The PowerShell twin `create-new-feature.ps1` created the empty file **silently** (no warning), so on Windows a missing or broken template tree gave the user no signal:

```powershell
} else {
    New-Item -ItemType File -Path $specFile -Force | Out-Null
}
```

### Fix

Emit the same warning on stderr before creating the empty spec file, matching the bash wording and stream (keeps stdout/JSON output pure). One source file.

## Testing

- `uvx ruff check` clean; `tests/test_ps1_encoding.py` green (edited `.ps1` stays ASCII / PowerShell 5.1-safe).
- New `TestSequentialBranchPowerShell::test_missing_spec_template_warns_matching_bash`: with no resolvable template, asserts `Spec template not found` on stderr, stdout still parseable JSON, and the empty spec file created. **Fails before** this change (PowerShell was silent), passes after.
- Verified end-to-end with Windows PowerShell 5.1: the warning lands on stderr while stdout stays pure JSON.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI located the missing-template warning divergence across the bash/PowerShell twins and drafted the fix plus a regression test; I verified the bash wording/stream and confirmed the warning lands on stderr with stdout staying pure JSON under Windows PowerShell 5.1, and reviewed the diff before submitting.