### PR TITLE
fix(scripts): use ASCII [OK] marker in initialize-repo.sh (parity with PowerShell twin)

### DIFF
--- a/extensions/git/scripts/bash/initialize-repo.sh
+++ b/extensions/git/scripts/bash/initialize-repo.sh
@@ -51,4 +51,4 @@ _git_out=$(git init -q 2>&1) || { echo "[specify] Error: git init failed: $_git_
 _git_out=$(git add . 2>&1) || { echo "[specify] Error: git add failed: $_git_out" >&2; exit 1; }
 _git_out=$(git commit --allow-empty -q -m "$COMMIT_MSG" 2>&1) || { echo "[specify] Error: git commit failed: $_git_out" >&2; exit 1; }
 
-echo "✓ Git repository initialized" >&2
+echo "[OK] Git repository initialized" >&2

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -233,6 +233,10 @@ class TestInitializeRepoBash:
         result = _run_bash("initialize-repo.sh", project)
         assert result.returncode == 0, result.stderr
 
+        # Success marker is ASCII "[OK]" (matching the PowerShell twin and the
+        # sibling auto-commit scripts), not a Unicode checkmark.
+        assert "[OK]" in result.stderr
+
         # Verify git repo exists
         assert (project / ".git").exists()
 

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -233,9 +233,9 @@ class TestInitializeRepoBash:
         result = _run_bash("initialize-repo.sh", project)
         assert result.returncode == 0, result.stderr
 
-        # Success marker is ASCII "[OK]" (matching the PowerShell twin and the
-        # sibling auto-commit scripts), not a Unicode checkmark.
-        assert "[OK]" in result.stderr
+        # Success marker is the full ASCII "[OK] ..." line (matching the PowerShell
+        # twin and the sibling auto-commit scripts), not a Unicode checkmark.
+        assert "[OK] Git repository initialized" in result.stderr, result.stderr
 
         # Verify git repo exists
         assert (project / ".git").exists()


### PR DESCRIPTION
## Description

`initialize-repo.sh` printed its success line with a **Unicode checkmark**:

```bash
echo "✓ Git repository initialized" >&2
```

But its PowerShell twin and the sibling extension scripts all use the ASCII marker `[OK]`:
- `initialize-repo.ps1`: `Write-Host "[OK] Git repository initialized"`
- `auto-commit.sh`: `echo "[OK] Changes committed ..."`
- `auto-commit.ps1`: `Write-Host "[OK] Changes committed ..."`

So `initialize-repo.sh` is the lone outlier — an output-text divergence across the bash/PowerShell twins and an inconsistency among sibling extension scripts (the Unicode marker can also render as a mojibake box in consoles that aren't UTF-8).

### Fix

Use `[OK]` to match the twin and siblings. One-line change.

## Testing

- `uvx ruff check` clean.
- Extended `TestInitializeRepoBash::test_initializes_git_repo` to assert the success marker `[OK]` is present on stderr.
- The existing initialize-repo tests (git repo created, commit present, custom message) are unaffected.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI located the lone Unicode marker among the otherwise-ASCII sibling/twin scripts; I confirmed the twin and auto-commit scripts use `[OK]` and that no test depended on the checkmark, and reviewed the diff before submitting.