### PR TITLE
fix(workflows): make pipe-filter detection quote-aware in expression evaluator

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -230,11 +230,13 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
     if expr[:1] in ("'", '"') and expr.find(expr[0], 1) == len(expr) - 1:
         return expr[1:-1]
 
-    # Handle pipe filters
-    if "|" in expr:
-        parts = expr.split("|", 1)
-        value = _evaluate_simple_expression(parts[0].strip(), namespace)
-        filter_expr = parts[1].strip()
+    # Handle pipe filters. Detect the pipe at the top level only, so a literal
+    # '|' inside a quoted operand (e.g. `inputs.x == 'a|b'`) or nested brackets is
+    # not mistaken for a filter separator — mirroring the operator parsing below.
+    pipe_idx = _find_top_level(expr, "|")
+    if pipe_idx != -1:
+        value = _evaluate_simple_expression(expr[:pipe_idx].strip(), namespace)
+        filter_expr = expr[pipe_idx + 1:].strip()
 
         # `from_json` is strict: it takes no arguments and tolerates no
         # trailing tokens. Match on the leading filter name and require the

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -322,6 +322,27 @@ class TestExpressions:
         assert evaluate_expression("{{ inputs.a == 9 or inputs.b == 2 }}", plain) is True
         assert evaluate_expression("{{ inputs.missing | default('a and b') }}", plain) == "a and b"
 
+    def test_pipe_detection_is_quote_aware(self):
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        # A literal '|' inside a quoted operand must not be treated as a filter
+        # pipe: the comparison applies to the whole string.
+        ctx = StepContext(inputs={"x": "a|b"})
+        assert evaluate_expression("{{ inputs.x == 'a|b' }}", ctx) is True
+        assert evaluate_expression("{{ inputs.x == 'a|b' }}", StepContext(inputs={"x": "z"})) is False
+        # membership against a literal containing a pipe
+        assert evaluate_expression("{{ 'a|b' in inputs.s }}", StepContext(inputs={"s": "x a|b y"})) is True
+        # a single quoted literal containing pipes is preserved
+        assert evaluate_expression("{{ 'a|b|c' }}", StepContext()) == "a|b|c"
+
+        # Regression: real filters still work, including a pipe inside a filter arg.
+        ctx2 = StepContext(inputs={"items": ["a", "b"], "s": "xabz"})
+        assert evaluate_expression("{{ inputs.missing | default('y') }}", ctx2) == "y"
+        assert evaluate_expression('{{ inputs.items | join("-") }}', ctx2) == "a-b"
+        assert evaluate_expression("{{ inputs.s | contains('ab') }}", ctx2) is True
+        assert evaluate_expression("{{ inputs.missing | default('a|b') }}", ctx2) == "a|b"
+
     def test_filter_default(self):
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext


### PR DESCRIPTION
## Description

The simple-expression evaluator detected a filter pipe with a naive substring check:

```python
if "|" in expr:
    parts = expr.split("|", 1)
```

So a literal `|` **inside a quoted operand** was mistaken for a filter separator. For example `{{ inputs.x == 'a|b' }}` split into `inputs.x == 'a` and `b'`, then tried to parse `b'` as a filter and raised a spurious `ValueError: unknown filter` instead of comparing the string.

This is the same class of bug as the operator-splitting fix in #3197 (which added the quote/bracket-aware `_find_top_level` helper) — the pipe check was the one branch left using a naive split.

### Fix

Detect the pipe with `_find_top_level(expr, "|")` so only a **top-level** pipe (outside quotes/brackets) is treated as a filter separator. A `|` inside a quoted operand now falls through to normal operator/literal parsing.

## Testing

- `uvx ruff check` clean; full `TestExpressions` passes (31 tests).
- New `test_pipe_detection_is_quote_aware`: `inputs.x == 'a|b'`, membership against a pipe-containing literal, and a single `'a|b|c'` literal all parse correctly — **fails before** (spurious ValueError), passes after. Regression guards confirm real filters still work, including a pipe inside a filter argument (`default('a|b')`).
- Verified each case against the real evaluator on current main.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI identified the lone non-quote-aware pipe split (sibling of #3197) and reused the existing `_find_top_level` helper; I reproduced the spurious ValueError against the real evaluator, confirmed filters (including pipe-in-argument) still work, and reviewed the diff before submitting.