### PR TITLE
fix(workflows): gate validate() must not crash on non-string options

### DIFF
--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -194,7 +194,14 @@ class GateStep(StepBase):
                 f"Gate step {config.get('id', '?')!r}: 'on_reject' must be "
                 f"'abort', 'skip', or 'retry'."
             )
-        if on_reject in ("abort", "retry") and isinstance(options, list):
+        # Only inspect option text when every option is a string; otherwise the
+        # `o.lower()` below would raise AttributeError on a non-string option
+        # (already reported above) and break validate_workflow's never-raise contract.
+        if (
+            on_reject in ("abort", "retry")
+            and isinstance(options, list)
+            and all(isinstance(o, str) for o in options)
+        ):
             reject_choices = {"reject", "abort"}
             if not any(o.lower() in reject_choices for o in options):
                 errors.append(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1434,6 +1434,23 @@ class TestGateStep:
         })
         assert any("on_reject" in e for e in errors)
 
+    def test_validate_non_string_options_does_not_raise(self):
+        """Non-string options with on_reject=abort/retry must be REPORTED as an
+        error, not crash: the reject-choice check calls o.lower() on each option,
+        which previously raised AttributeError on a non-string option and broke
+        validate_workflow's 'return errors, never raise' contract."""
+        from specify_cli.workflows.steps.gate import GateStep
+
+        step = GateStep()
+        # on_reject defaults to "abort", which triggers the option-text check.
+        errors = step.validate({"id": "test", "message": "Review", "options": [123]})
+        assert any("must be strings" in e for e in errors)
+        # also with an explicit retry on_reject
+        errors = step.validate(
+            {"id": "test", "message": "Review", "options": [True], "on_reject": "retry"}
+        )
+        assert any("must be strings" in e for e in errors)
+
     def test_interactive_prompt_renders_show_file(self, tmp_path, monkeypatch, capsys):
         from specify_cli.workflows.steps.gate import GateStep
         from specify_cli.workflows.base import StepContext, StepStatus


### PR DESCRIPTION
## Description

`GateStep.validate()` reports non-string `options` as an error, but then — when `on_reject` is `abort`/`retry` (`abort` is the default) — still runs the reject-choice check:

```python
if on_reject in ("abort", "retry") and isinstance(options, list):
    if not any(o.lower() in reject_choices for o in options):
```

For a non-string option (e.g. `options: [123]`), `o.lower()` raises `AttributeError: 'int' object has no attribute 'lower'`, which **escapes `validate()`** and breaks `validate_workflow`'s documented contract — *"return a list of error messages"*, never raise. A single malformed gate option crashes validation of the whole workflow instead of being reported.

### Fix

Run the option-text check only when every option is a string (the non-string case is already reported by the earlier check). One guard clause.

## Testing

- `uvx ruff check` clean; `TestGateStep` passes (14 tests).
- New `test_validate_non_string_options_does_not_raise`: `options: [123]` (default `on_reject`) and `options: [True], on_reject: retry` now **return** the "must be strings" error instead of raising. **Fails before** (AttributeError), passes after.
- Verified against the real `GateStep` on current main; valid string options still produce the correct reject-choice error.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI traced the uncaught `AttributeError` from `o.lower()` through `validate_workflow`'s never-raise contract; I reproduced the crash against the real `GateStep`, confirmed string options still validate correctly, and reviewed the diff before submitting.