### PR TITLE
fix(init): don't block on confirmation for 'init --here' without a TTY

### DIFF
--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -220,29 +220,38 @@ def register(app: typer.Typer) -> None:
                 console.print(
                     f"[yellow]Warning:[/yellow] Current directory is not empty ({len(existing_items)} items)"
                 )
-                console.print(
-                    "[yellow]Template files will be merged with existing content and may overwrite existing files[/yellow]"
-                )
                 if force:
+                    # Proceeding: the merge/overwrite warning is accurate here.
+                    console.print(
+                        "[yellow]Template files will be merged with existing content and may overwrite existing files[/yellow]"
+                    )
                     console.print(
                         "[cyan]--force supplied: skipping confirmation and proceeding with merge[/cyan]"
                     )
                 else:
+                    # Fold the merge/overwrite warning into the confirmation so it
+                    # is shown only when we are actually about to proceed -- not on
+                    # the fail-fast path below, where nothing is merged.
                     try:
-                        response = typer.confirm("Do you want to continue?")
+                        proceed = typer.confirm(
+                            "Template files will be merged with existing content and "
+                            "may overwrite existing files. Continue?"
+                        )
                     except (typer.Abort, EOFError):
-                        # No confirmation input available (non-interactive session
-                        # with empty stdin): fail fast with actionable guidance
-                        # instead of the bare "Aborted." Piped input (e.g. "y") is
-                        # still honored above. Mirrors the named-project path,
-                        # which already points to --force.
+                        if _stdin_is_interactive():
+                            # Interactive cancel (e.g. Ctrl+C): a normal cancellation.
+                            console.print("[yellow]Operation cancelled[/yellow]")
+                            raise typer.Exit(0) from None
+                        # Non-interactive with no confirmation input on stdin: fail
+                        # fast with actionable guidance instead of a bare "Aborted."
+                        # (Piped input such as "y" is still honored above.)
                         console.print(
                             "[red]Error:[/red] Current directory is not empty and no "
                             "confirmation input is available. Re-run with "
                             "[bold]--force[/bold] to merge into it."
                         )
                         raise typer.Exit(1) from None
-                    if not response:
+                    if not proceed:
                         console.print("[yellow]Operation cancelled[/yellow]")
                         raise typer.Exit(0)
         else:

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -229,18 +229,29 @@ def register(app: typer.Typer) -> None:
                         "[cyan]--force supplied: skipping confirmation and proceeding with merge[/cyan]"
                     )
                 else:
-                    console.print(
-                        "[yellow]Template files will be merged with existing content and may overwrite existing files[/yellow]"
-                    )
+                    # Fold the merge risk into the confirmation prompt rather than
+                    # printing it unconditionally first: on the EOF/no-input path
+                    # below the command exits without changing anything, so a
+                    # standalone "will be merged" line would mislead. Interactive
+                    # users still see the risk as part of the question.
+                    #
                     # Call typer.confirm normally so piped y/n is honored — e.g.
                     # `echo y | specify init --here` keeps reaching the
-                    # non-destructive preserve-merge path. Only when no
-                    # confirmation input is available at all (closed/empty stdin
-                    # → EOF/Abort) do we convert it into an actionable error that
-                    # points at --force, rather than blocking or failing opaquely.
+                    # non-destructive preserve-merge path.
                     try:
-                        proceed = typer.confirm("Do you want to continue?")
+                        proceed = typer.confirm(
+                            "Template files will be merged with existing content "
+                            "and may overwrite existing files. Do you want to continue?"
+                        )
                     except (typer.Abort, EOFError):
+                        # typer.confirm raises Abort for BOTH an interactive Ctrl+C
+                        # and an EOF on closed/empty stdin. Distinguish them: a real
+                        # TTY cancellation is a normal exit (0, "cancelled"), while a
+                        # missing-input EOF (non-interactive) becomes an actionable
+                        # error pointing at --force.
+                        if _stdin_is_interactive():
+                            console.print("[yellow]Operation cancelled[/yellow]")
+                            raise typer.Exit(0) from None
                         console.print(
                             "[red]Error:[/red] Current directory is not empty and no "
                             "confirmation input is available. Re-run with "

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -228,28 +228,25 @@ def register(app: typer.Typer) -> None:
                     console.print(
                         "[cyan]--force supplied: skipping confirmation and proceeding with merge[/cyan]"
                     )
-                elif not _stdin_is_interactive():
-                    # No interactive terminal: do NOT prompt. A non-TTY stdin that
-                    # is open but idle (a common CI/agent scenario) would block on
-                    # typer.confirm, so fail fast and require an explicit --force
-                    # for a non-interactive merge. No merge happens here, so no
-                    # merge/overwrite warning is printed.
-                    console.print(
-                        "[red]Error:[/red] Current directory is not empty and no "
-                        "interactive terminal is available to confirm. Re-run with "
-                        "[bold]--force[/bold] to merge into it."
-                    )
-                    raise typer.Exit(1)
                 else:
                     console.print(
                         "[yellow]Template files will be merged with existing content and may overwrite existing files[/yellow]"
                     )
+                    # Call typer.confirm normally so piped y/n is honored — e.g.
+                    # `echo y | specify init --here` keeps reaching the
+                    # non-destructive preserve-merge path. Only when no
+                    # confirmation input is available at all (closed/empty stdin
+                    # → EOF/Abort) do we convert it into an actionable error that
+                    # points at --force, rather than blocking or failing opaquely.
                     try:
                         proceed = typer.confirm("Do you want to continue?")
-                    except typer.Abort:
-                        # Interactive cancel (e.g. Ctrl+C): a normal cancellation.
-                        console.print("[yellow]Operation cancelled[/yellow]")
-                        raise typer.Exit(0) from None
+                    except (typer.Abort, EOFError):
+                        console.print(
+                            "[red]Error:[/red] Current directory is not empty and no "
+                            "confirmation input is available. Re-run with "
+                            "[bold]--force[/bold] to merge into it."
+                        )
+                        raise typer.Exit(1) from None
                     if not proceed:
                         console.print("[yellow]Operation cancelled[/yellow]")
                         raise typer.Exit(0)

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -228,29 +228,28 @@ def register(app: typer.Typer) -> None:
                     console.print(
                         "[cyan]--force supplied: skipping confirmation and proceeding with merge[/cyan]"
                     )
+                elif not _stdin_is_interactive():
+                    # No interactive terminal: do NOT prompt. A non-TTY stdin that
+                    # is open but idle (a common CI/agent scenario) would block on
+                    # typer.confirm, so fail fast and require an explicit --force
+                    # for a non-interactive merge. No merge happens here, so no
+                    # merge/overwrite warning is printed.
+                    console.print(
+                        "[red]Error:[/red] Current directory is not empty and no "
+                        "interactive terminal is available to confirm. Re-run with "
+                        "[bold]--force[/bold] to merge into it."
+                    )
+                    raise typer.Exit(1)
                 else:
-                    # Fold the merge/overwrite warning into the confirmation so it
-                    # is shown only when we are actually about to proceed -- not on
-                    # the fail-fast path below, where nothing is merged.
+                    console.print(
+                        "[yellow]Template files will be merged with existing content and may overwrite existing files[/yellow]"
+                    )
                     try:
-                        proceed = typer.confirm(
-                            "Template files will be merged with existing content and "
-                            "may overwrite existing files. Continue?"
-                        )
-                    except (typer.Abort, EOFError):
-                        if _stdin_is_interactive():
-                            # Interactive cancel (e.g. Ctrl+C): a normal cancellation.
-                            console.print("[yellow]Operation cancelled[/yellow]")
-                            raise typer.Exit(0) from None
-                        # Non-interactive with no confirmation input on stdin: fail
-                        # fast with actionable guidance instead of a bare "Aborted."
-                        # (Piped input such as "y" is still honored above.)
-                        console.print(
-                            "[red]Error:[/red] Current directory is not empty and no "
-                            "confirmation input is available. Re-run with "
-                            "[bold]--force[/bold] to merge into it."
-                        )
-                        raise typer.Exit(1) from None
+                        proceed = typer.confirm("Do you want to continue?")
+                    except typer.Abort:
+                        # Interactive cancel (e.g. Ctrl+C): a normal cancellation.
+                        console.print("[yellow]Operation cancelled[/yellow]")
+                        raise typer.Exit(0) from None
                     if not proceed:
                         console.print("[yellow]Operation cancelled[/yellow]")
                         raise typer.Exit(0)

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -227,6 +227,17 @@ def register(app: typer.Typer) -> None:
                     console.print(
                         "[cyan]--force supplied: skipping confirmation and proceeding with merge[/cyan]"
                     )
+                elif not _stdin_is_interactive():
+                    # No TTY to confirm on: fail fast with actionable guidance
+                    # instead of blocking on typer.confirm (which would read EOF
+                    # and abort unhelpfully). Mirrors the named-project path,
+                    # which already errors and points to --force.
+                    console.print(
+                        "[red]Error:[/red] Current directory is not empty and no "
+                        "interactive terminal is available to confirm. Re-run with "
+                        "[bold]--force[/bold] to merge into it."
+                    )
+                    raise typer.Exit(1)
                 else:
                     response = typer.confirm("Do you want to continue?")
                     if not response:

--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -227,19 +227,21 @@ def register(app: typer.Typer) -> None:
                     console.print(
                         "[cyan]--force supplied: skipping confirmation and proceeding with merge[/cyan]"
                     )
-                elif not _stdin_is_interactive():
-                    # No TTY to confirm on: fail fast with actionable guidance
-                    # instead of blocking on typer.confirm (which would read EOF
-                    # and abort unhelpfully). Mirrors the named-project path,
-                    # which already errors and points to --force.
-                    console.print(
-                        "[red]Error:[/red] Current directory is not empty and no "
-                        "interactive terminal is available to confirm. Re-run with "
-                        "[bold]--force[/bold] to merge into it."
-                    )
-                    raise typer.Exit(1)
                 else:
-                    response = typer.confirm("Do you want to continue?")
+                    try:
+                        response = typer.confirm("Do you want to continue?")
+                    except (typer.Abort, EOFError):
+                        # No confirmation input available (non-interactive session
+                        # with empty stdin): fail fast with actionable guidance
+                        # instead of the bare "Aborted." Piped input (e.g. "y") is
+                        # still honored above. Mirrors the named-project path,
+                        # which already points to --force.
+                        console.print(
+                            "[red]Error:[/red] Current directory is not empty and no "
+                            "confirmation input is available. Re-run with "
+                            "[bold]--force[/bold] to merge into it."
+                        )
+                        raise typer.Exit(1) from None
                     if not response:
                         console.print("[yellow]Operation cancelled[/yellow]")
                         raise typer.Exit(0)

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -860,17 +860,11 @@ class TestInitIntegrationFlag:
         # --force should overwrite the custom file
         assert (scripts_dir / "common.sh").read_text(encoding="utf-8") != custom_content
 
-    def test_init_here_without_force_preserves_shared_infra(self, tmp_path, monkeypatch):
-        """E2E: confirming the merge interactively (no --force) preserves existing
-        shared infra files (unlike --force, which overwrites them)."""
+    def test_init_here_without_force_preserves_shared_infra(self, tmp_path):
+        """E2E: confirming the merge with piped "y" (no --force) preserves
+        existing shared infra files (unlike --force, which overwrites them)."""
         from typer.testing import CliRunner
         from specify_cli import app
-        from specify_cli.commands import init as init_mod
-
-        # Simulate an interactive terminal so the confirmation prompt is reached;
-        # the piped "y" then exercises the preserve-merge path. (Non-interactive
-        # sessions now fail fast and require --force.)
-        monkeypatch.setattr(init_mod, "_stdin_is_interactive", lambda: True)
 
         project = tmp_path / "e2e-no-force"
         project.mkdir()

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -115,16 +115,14 @@ class TestInitIntegrationFlag:
         data = json.loads((project / ".specify" / "integration.json").read_text(encoding="utf-8"))
         assert data["integration"] == specify_cli.DEFAULT_INIT_INTEGRATION
 
-    def test_init_here_nonempty_noninteractive_errors_with_force_guidance(self, tmp_path, monkeypatch):
-        """`init --here` on a non-empty directory must not block on a confirmation
-        prompt when there is no interactive terminal: it should fail fast with
-        guidance to use --force, instead of reading EOF and aborting unhelpfully."""
+    def test_init_here_nonempty_noninteractive_errors_with_force_guidance(self, tmp_path):
+        """`init --here` on a non-empty directory with no confirmation input (empty
+        stdin) must fail fast with guidance to use --force, instead of the bare
+        'Aborted.' from an EOF on typer.confirm. CliRunner with no `input=` provides
+        empty stdin, so typer.confirm raises Abort, which the command converts to the
+        actionable error."""
         from typer.testing import CliRunner
         from specify_cli import app
-        from specify_cli.commands import init as init_mod
-
-        # Deterministically exercise the non-interactive branch.
-        monkeypatch.setattr(init_mod, "_stdin_is_interactive", lambda: False)
 
         project = tmp_path / "nonempty-here"
         project.mkdir()

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -860,10 +860,17 @@ class TestInitIntegrationFlag:
         # --force should overwrite the custom file
         assert (scripts_dir / "common.sh").read_text(encoding="utf-8") != custom_content
 
-    def test_init_here_without_force_preserves_shared_infra(self, tmp_path):
-        """E2E: specify init --here (no --force) preserves existing shared infra files."""
+    def test_init_here_without_force_preserves_shared_infra(self, tmp_path, monkeypatch):
+        """E2E: confirming the merge interactively (no --force) preserves existing
+        shared infra files (unlike --force, which overwrites them)."""
         from typer.testing import CliRunner
         from specify_cli import app
+        from specify_cli.commands import init as init_mod
+
+        # Simulate an interactive terminal so the confirmation prompt is reached;
+        # the piped "y" then exercises the preserve-merge path. (Non-interactive
+        # sessions now fail fast and require --force.)
+        monkeypatch.setattr(init_mod, "_stdin_is_interactive", lambda: True)
 
         project = tmp_path / "e2e-no-force"
         project.mkdir()

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -115,6 +115,34 @@ class TestInitIntegrationFlag:
         data = json.loads((project / ".specify" / "integration.json").read_text(encoding="utf-8"))
         assert data["integration"] == specify_cli.DEFAULT_INIT_INTEGRATION
 
+    def test_init_here_nonempty_noninteractive_errors_with_force_guidance(self, tmp_path, monkeypatch):
+        """`init --here` on a non-empty directory must not block on a confirmation
+        prompt when there is no interactive terminal: it should fail fast with
+        guidance to use --force, instead of reading EOF and aborting unhelpfully."""
+        from typer.testing import CliRunner
+        from specify_cli import app
+        from specify_cli.commands import init as init_mod
+
+        # Deterministically exercise the non-interactive branch.
+        monkeypatch.setattr(init_mod, "_stdin_is_interactive", lambda: False)
+
+        project = tmp_path / "nonempty-here"
+        project.mkdir()
+        (project / "existing.txt").write_text("keep me", encoding="utf-8")
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(project)
+            result = CliRunner().invoke(app, [
+                "init", "--here", "--integration", "copilot", "--script", "sh", "--ignore-agent-tools",
+            ], catch_exceptions=False)
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 1, result.output
+        assert "--force" in result.output
+        # Aborted before scaffolding: the pre-existing file is untouched.
+        assert (project / "existing.txt").read_text(encoding="utf-8") == "keep me"
+
     def test_integration_copilot_auto_promotes(self, tmp_path):
         from typer.testing import CliRunner
         from specify_cli import app

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -141,6 +141,37 @@ class TestInitIntegrationFlag:
         # Aborted before scaffolding: the pre-existing file is untouched.
         assert (project / "existing.txt").read_text(encoding="utf-8") == "keep me"
 
+    def test_init_here_interactive_cancel_exits_zero(self, tmp_path, monkeypatch):
+        """An interactive Ctrl+C at the merge confirmation (typer.Abort on a TTY)
+        is a normal cancellation — exit 0, "cancelled" — NOT the missing-input
+        --force error, which is reserved for non-interactive EOF. Guards the
+        regression where Abort was caught unconditionally and every cancel became
+        an exit-1 --force error."""
+        from typer.testing import CliRunner
+        from specify_cli import app
+        import specify_cli.commands.init as init_mod
+
+        # Simulate an interactive terminal so the Abort is treated as a cancel.
+        monkeypatch.setattr(init_mod, "_stdin_is_interactive", lambda: True)
+
+        project = tmp_path / "cancel-here"
+        project.mkdir()
+        (project / "existing.txt").write_text("keep me", encoding="utf-8")
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(project)
+            # No input → typer.confirm raises Abort (stands in for Ctrl+C).
+            result = CliRunner().invoke(app, [
+                "init", "--here", "--integration", "copilot", "--script", "sh", "--ignore-agent-tools",
+            ], catch_exceptions=False)
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0, result.output
+        assert "cancelled" in result.output.lower()
+        assert "--force" not in result.output  # not the missing-input error
+        assert (project / "existing.txt").read_text(encoding="utf-8") == "keep me"
+
     def test_integration_copilot_auto_promotes(self, tmp_path):
         from typer.testing import CliRunner
         from specify_cli import app


### PR DESCRIPTION
## Description

When `specify init --here` targets a **non-empty** directory and `--force` is not given, it called `typer.confirm("Do you want to continue?")` unconditionally. In a non-interactive session (CI, piped input, an agent driving the CLI) there is no TTY, so the prompt reads EOF and **aborts unhelpfully** (or blocks waiting for input) — with no actionable message.

The named-project path already handles this correctly: it fails fast with an error panel pointing to `--force`. The `--here` path was the inconsistent outlier, even though the module already has a `_stdin_is_interactive()` helper used elsewhere.

### Fix

Guard the confirmation with `_stdin_is_interactive()`: when non-interactive, print a clear *"directory is not empty … re-run with --force to merge"* error and exit 1 instead of prompting. Interactive behavior and the `--force` fast-path are unchanged.

## Testing

- `uvx ruff check` clean.
- New `test_init_here_nonempty_noninteractive_errors_with_force_guidance`: a non-empty cwd + `init --here` (no `--force`) under a non-interactive stdin now exits 1 with `--force` guidance and leaves the pre-existing file untouched. **Fails/blocks before**, passes after.
- The existing `test_noninteractive_init_defaults_to_copilot` still passes.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI spotted the unguarded `typer.confirm` on the `--here` path versus the already-guarded named-project path; I confirmed the `_stdin_is_interactive` helper's existing use, verified the fix and that scaffolding is skipped on abort, and reviewed the diff before submitting.