### PR TITLE
fix(workflows): reject bool max_iterations in while/do-while validation

### DIFF
--- a/src/specify_cli/workflows/steps/do_while/__init__.py
+++ b/src/specify_cli/workflows/steps/do_while/__init__.py
@@ -48,7 +48,10 @@ class DoWhileStep(StepBase):
             )
         max_iter = config.get("max_iterations")
         if max_iter is not None:
-            if not isinstance(max_iter, int) or max_iter < 1:
+            # bool is a subclass of int, so isinstance(True, int) is True and
+            # True < 1 is False; reject bools explicitly so `max_iterations: true`
+            # is a type error rather than a silent single iteration.
+            if isinstance(max_iter, bool) or not isinstance(max_iter, int) or max_iter < 1:
                 errors.append(
                     f"Do-while step {config.get('id', '?')!r}: "
                     f"'max_iterations' must be an integer >= 1."

--- a/src/specify_cli/workflows/steps/while_loop/__init__.py
+++ b/src/specify_cli/workflows/steps/while_loop/__init__.py
@@ -55,7 +55,10 @@ class WhileStep(StepBase):
             )
         max_iter = config.get("max_iterations")
         if max_iter is not None:
-            if not isinstance(max_iter, int) or max_iter < 1:
+            # bool is a subclass of int, so isinstance(True, int) is True and
+            # True < 1 is False; reject bools explicitly so `max_iterations: true`
+            # is a type error rather than a silent single iteration.
+            if isinstance(max_iter, bool) or not isinstance(max_iter, int) or max_iter < 1:
                 errors.append(
                     f"While step {config.get('id', '?')!r}: "
                     f"'max_iterations' must be an integer >= 1."

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1876,11 +1876,11 @@ class TestDoWhileStep:
             {"id": "test", "condition": "{{ true }}", "max_iterations": True, "steps": []}
         )
         assert any("must be an integer >= 1" in e for e in errors)
-        # a real positive integer is still accepted.
+        # a real positive integer is fully valid (no errors at all).
         ok = step.validate(
             {"id": "test", "condition": "{{ true }}", "max_iterations": 3, "steps": []}
         )
-        assert not any("max_iterations" in e for e in ok)
+        assert ok == [], ok
 
     def test_execute_empty_steps(self):
         from specify_cli.workflows.steps.do_while import DoWhileStep

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1822,6 +1822,12 @@ class TestWhileStep:
         step = WhileStep()
         errors = step.validate({"id": "test", "condition": "{{ true }}", "max_iterations": 0, "steps": []})
         assert any("must be an integer >= 1" in e for e in errors)
+        # bool is an int subclass; `max_iterations: true` must be rejected, not
+        # silently treated as a single iteration.
+        bool_errors = step.validate(
+            {"id": "test", "condition": "{{ true }}", "max_iterations": True, "steps": []}
+        )
+        assert any("must be an integer >= 1" in e for e in bool_errors)
 
 
 class TestDoWhileStep:
@@ -1860,6 +1866,21 @@ class TestDoWhileStep:
         # Body always executes on first call regardless of condition
         assert len(result.next_steps) == 1
         assert result.output["max_iterations"] == 5
+
+    def test_validate_rejects_bool_max_iterations(self):
+        from specify_cli.workflows.steps.do_while import DoWhileStep
+
+        step = DoWhileStep()
+        # bool is an int subclass; `max_iterations: true` must be rejected.
+        errors = step.validate(
+            {"id": "test", "condition": "{{ true }}", "max_iterations": True, "steps": []}
+        )
+        assert any("must be an integer >= 1" in e for e in errors)
+        # a real positive integer is still accepted.
+        ok = step.validate(
+            {"id": "test", "condition": "{{ true }}", "max_iterations": 3, "steps": []}
+        )
+        assert not any("max_iterations" in e for e in ok)
 
     def test_execute_empty_steps(self):
         from specify_cli.workflows.steps.do_while import DoWhileStep


### PR DESCRIPTION
## Description

`WhileStep.validate()` and `DoWhileStep.validate()` check:

```python
if not isinstance(max_iter, int) or max_iter < 1:
```

Since `bool` is a subclass of `int`, `isinstance(True, int)` is `True` and `True < 1` is `False` — so `max_iterations: true` **passes validation**. It is then used as a loop bound, and `range(True) == range(1)`, so the loop silently runs **one iteration** instead of the author's intent being flagged as a type error.

This is the same bool-is-int trap already guarded against for number inputs (`_coerce_input`, #3199) and gate options.

### Fix

Reject bools explicitly in both `while` and `do-while` validators.

## Testing

- `uvx ruff check` clean; `TestWhileStep` + `TestDoWhileStep` pass (10 tests).
- Extended `test_validate_invalid_max_iterations` (while) and added `test_validate_rejects_bool_max_iterations` (do-while): `max_iterations: true` now returns the "must be an integer >= 1" error; a real positive integer is still accepted. **Fails before**, passes after.
- Verified against both real step validators on current main.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI identified the bool-is-int trap shared by both loop validators (consistent with the existing number/gate guards); I confirmed the silent single-iteration behavior and the fix on both real validators, and reviewed the diff before submitting.