### PR TITLE
fix(scripts): route 'Plan template not found' per --json in setup-plan.ps1 (parity with bash)

### DIFF
--- a/scripts/powershell/setup-plan.ps1
+++ b/scripts/powershell/setup-plan.ps1
@@ -48,7 +48,14 @@ if (Test-Path $paths.IMPL_PLAN -PathType Leaf) {
             Write-Output "Copied plan template to $($paths.IMPL_PLAN)"
         }
     } else {
-        Write-Warning "Plan template not found"
+        # Match the bash twin's wording and stream routing (stderr in -Json so
+        # stdout stays pure JSON, stdout otherwise), consistent with the sibling
+        # "Copied plan template" message above.
+        if ($Json) {
+            [Console]::Error.WriteLine("Warning: Plan template not found")
+        } else {
+            Write-Output "Warning: Plan template not found"
+        }
         # Create a basic plan file if template doesn't exist
         New-Item -ItemType File -Path $paths.IMPL_PLAN -Force | Out-Null
     }

--- a/tests/test_setup_plan_no_overwrite.py
+++ b/tests/test_setup_plan_no_overwrite.py
@@ -246,3 +246,27 @@ def test_ps_setup_plan_copied_message_on_stderr_in_json_mode(plan_repo: Path) ->
     data = json.loads(result.stdout)
     assert "IMPL_PLAN" in data
     assert "Copied plan template" in result.stderr
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_ps_setup_plan_template_not_found_warning_matches_bash(plan_repo: Path) -> None:
+    """When no plan template resolves, -Json mode must emit 'Warning: Plan template
+    not found' on stderr (matching the bash twin's wording and stream routing) while
+    keeping stdout pure JSON. Before the fix the PowerShell script used Write-Warning,
+    producing a different 'WARNING:' prefix on the warning stream instead."""
+    # Remove the template the fixture installs so resolution finds nothing.
+    (plan_repo / ".specify" / "templates" / "plan-template.md").unlink()
+    script = plan_repo / ".specify" / "scripts" / "powershell" / "setup-plan.ps1"
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(script), "-Json"],
+        cwd=plan_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert "IMPL_PLAN" in data
+    assert "Warning: Plan template not found" in result.stderr


### PR DESCRIPTION
## Description

When no plan template resolves, the bash `setup-plan.sh` emits:

```bash
if $JSON_MODE; then echo "Warning: Plan template not found" >&2
else echo "Warning: Plan template not found"; fi
```

The PowerShell twin used `Write-Warning "Plan template not found"`, which renders `WARNING: Plan template not found` on PowerShell's **warning stream** — diverging from bash in both **wording** (`WARNING:` vs `Warning:`) and **routing** (warning stream vs stderr/stdout per mode). It is also inconsistent with the sibling "Copied plan template" message in the same block, which #3198 just aligned to the per-`--json` pattern.

### Fix

Route the message the same way as bash and the sibling: `[Console]::Error.WriteLine` under `-Json` (so stdout stays pure JSON), `Write-Output` otherwise, with bash's exact wording. Completes the parity started in #3198.

## Testing

- `uvx ruff check` clean; `tests/test_ps1_encoding.py` green (`.ps1` stays ASCII).
- New `test_ps_setup_plan_template_not_found_warning_matches_bash`: with no resolvable template, `-Json` mode now emits `Warning: Plan template not found` on stderr with stdout still parseable JSON. **Fails before** (it was `WARNING:` on the warning stream), passes after.
- Verified with Windows PowerShell 5.1; existing setup-plan tests still pass.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI spotted the leftover `Write-Warning` divergence beside the `#3198`-aligned sibling; I confirmed the bash wording/stream and verified fail-before/pass-after under Windows PowerShell 5.1, and reviewed the diff before submitting.