### PR TITLE
chore: align CI Python matrix with devguide lifecycle + fix bash 3.2 portability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Run ruff check
         run: uvx ruff check src/
@@ -30,8 +30,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -59,6 +59,13 @@ case "$(uname -s 2>/dev/null || true)" in
 esac
 
 # Parse extension config once; emit context files as JSON, followed by marker strings.
+#
+# NOTE (bash 3.2 / macOS portability): the embedded Python heredocs below run
+# inside $(...) command substitution. bash 3.2 (the system /bin/bash on macOS)
+# mis-parses a single-quote/apostrophe in a heredoc body nested in $(...),
+# failing with "unexpected EOF while looking for matching `''". Keep these
+# $(...)-nested heredoc bodies free of apostrophes (use double quotes in Python
+# string literals and avoid contractions in comments).
 if ! _raw_opts="$("$_python" - "$EXT_CONFIG" "$_case_insensitive_context_files" "$PROJECT_ROOT" <<'PY'
 import json
 import sys
@@ -115,7 +122,8 @@ if not context_files:
 if not context_files:
     # Self-seed: the agent-context extension owns its lifecycle, so when its
     # own config declares no target it derives one from the active integration
-    # recorded in init-options.json, using the extension's OWN bundled mapping
+    # recorded in init-options.json, using the OWN bundled mapping of the
+    # agent-context extension
     # (agent-context-defaults.json). This is independent of the Specify CLI by
     # design — nothing here imports specify_cli.
     project_root = sys.argv[3] if len(sys.argv) > 3 else "."
@@ -144,7 +152,7 @@ if not context_files:
         except Exception:
             print(
                 "agent-context: unable to read %s; cannot self-seed the context "
-                "file. Set 'context_file' in the extension config." % defaults_path,
+                "file. Set context_file in the extension config." % defaults_path,
                 file=sys.stderr,
             )
             mapping = {}
@@ -152,7 +160,7 @@ if not context_files:
         if not context_files:
             print(
                 "agent-context: no default context file is known for integration "
-                "'%s'. Set 'context_file' in the extension config to choose one."
+                "%s. Set context_file in the extension config to choose one."
                 % integration_key,
                 file=sys.stderr,
             )

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -120,12 +120,11 @@ if isinstance(raw_files, list):
 if not context_files:
     add_context_file(get_str(data, "context_file"))
 if not context_files:
-    # Self-seed: the agent-context extension owns its lifecycle, so when its
-    # own config declares no target it derives one from the active integration
-    # recorded in init-options.json, using the OWN bundled mapping of the
-    # agent-context extension
-    # (agent-context-defaults.json). This is independent of the Specify CLI by
-    # design — nothing here imports specify_cli.
+    # Self-seed: the agent-context extension manages its own lifecycle, so when
+    # its config declares no target, it derives one from the active integration
+    # recorded in init-options.json, mapped through the bundled
+    # agent-context-defaults.json file. This is independent of the Specify CLI
+    # by design; nothing here imports specify_cli.
     project_root = sys.argv[3] if len(sys.argv) > 3 else "."
     integration_key = ""
     try:

--- a/extensions/git/scripts/bash/create-new-feature-branch.sh
+++ b/extensions/git/scripts/bash/create-new-feature-branch.sh
@@ -288,7 +288,7 @@ generate_branch_name() {
         if ! echo "$word" | grep -qiE "$stop_words"; then
             if [ ${#word} -ge 3 ]; then
                 meaningful_words+=("$word")
-            elif echo "$description" | grep -qw -- "$(printf '%s' "$word" | tr '[:lower:]' '[:upper:]')"; then
+            elif printf '%s' "$description" | grep -qw -- "$(printf '%s' "$word" | tr '[:lower:]' '[:upper:]')"; then
                 meaningful_words+=("$word")
             fi
         fi

--- a/extensions/git/scripts/bash/create-new-feature-branch.sh
+++ b/extensions/git/scripts/bash/create-new-feature-branch.sh
@@ -288,7 +288,7 @@ generate_branch_name() {
         if ! echo "$word" | grep -qiE "$stop_words"; then
             if [ ${#word} -ge 3 ]; then
                 meaningful_words+=("$word")
-            elif echo "$description" | grep -qw -- "${word^^}"; then
+            elif echo "$description" | grep -qw -- "$(printf '%s' "$word" | tr '[:lower:]' '[:upper:]')"; then
                 meaningful_words+=("$word")
             fi
         fi

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -152,7 +152,7 @@ generate_branch_name() {
         if ! echo "$word" | grep -qiE "$stop_words"; then
             if [ ${#word} -ge 3 ]; then
                 meaningful_words+=("$word")
-            elif echo "$description" | grep -q "\b$(printf '%s' "$word" | tr '[:lower:]' '[:upper:]')\b"; then
+            elif printf '%s' "$description" | grep -qw -- "$(printf '%s' "$word" | tr '[:lower:]' '[:upper:]')"; then
                 # Keep short words if they appear as uppercase in original (likely acronyms)
                 meaningful_words+=("$word")
             fi

--- a/scripts/bash/create-new-feature.sh
+++ b/scripts/bash/create-new-feature.sh
@@ -152,7 +152,7 @@ generate_branch_name() {
         if ! echo "$word" | grep -qiE "$stop_words"; then
             if [ ${#word} -ge 3 ]; then
                 meaningful_words+=("$word")
-            elif echo "$description" | grep -q "\b${word^^}\b"; then
+            elif echo "$description" | grep -q "\b$(printf '%s' "$word" | tr '[:lower:]' '[:upper:]')\b"; then
                 # Keep short words if they appear as uppercase in original (likely acronyms)
                 meaningful_words+=("$word")
             fi


### PR DESCRIPTION
## Summary

Aligns Spec Kit's CI Python matrix with the [Python release lifecycle](https://devguide.python.org/versions/), and fixes the bash 3.2 (macOS) portability issues this surfaced.

**Policy:**
- **Floor stays at `requires-python = ">=3.11"`** — the oldest non-EOL security release. Security-only versions (3.11, 3.12) are supported by claim and fixed reactively, not gated on a wide per-commit matrix. (No change to `pyproject.toml` — upstream already requires 3.11.)
- **Test matrix runs only the bugfix (maintenance) releases** — `3.13` and `3.14` — which are the versions most likely to surface real differences.
- **`ruff` lint job points at the latest interpreter (`3.14`)** so packaging/lint is exercised on the newest release.
- **Added `macos-latest`** to the OS matrix (now ubuntu/windows/macos × 3.13/3.14) so macOS regressions are caught.

## bash 3.2 portability fixes

Adding `macos-latest` surfaced two pre-existing incompatibilities with **bash 3.2**, which macOS still ships as the system `/bin/bash`:

1. **`update-agent-context.sh`** embeds Python heredocs inside `$(...)` command substitution. bash 3.2 mis-parses an apostrophe in a heredoc body nested in `$(...)`, failing with an `unexpected EOF` quote-matching error. Removed the apostrophes from the affected `$()`-nested heredoc body and documented the constraint inline to prevent regressions.
2. **`create-new-feature-branch.sh`** and **`create-new-feature.sh`** used the bash 4+ `${word^^}` uppercase expansion, which errors as a *bad substitution* on bash 3.2 and caused short uppercase acronyms (e.g. `GO`) to be dropped from derived branch names. Replaced with a portable `tr '[:lower:]' '[:upper:]'` pipeline.

## Validation

- Full test suite passes under **bash 3.2.57** (verified locally on macOS by forcing `bash` → `/bin/bash`).
- `shellcheck --severity=error` clean on all changed scripts.
- All `.sh` files parse under bash 3.2 (`bash -n`).

## Notes

- 3.13 enters security-only status in Oct 2026, at which point the matrix rolls to 3.14/3.15.

---
This PR was prepared by GitHub Copilot (model: Claude Opus 4.8) on behalf of @mnriem.