### PR TITLE
fix(workflows): make pipe-filter split quote/bracket-aware

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -230,11 +230,14 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
     if expr[:1] in ("'", '"') and expr.find(expr[0], 1) == len(expr) - 1:
         return expr[1:-1]
 
-    # Handle pipe filters
-    if "|" in expr:
-        parts = expr.split("|", 1)
-        value = _evaluate_simple_expression(parts[0].strip(), namespace)
-        filter_expr = parts[1].strip()
+    # Handle pipe filters. Split at the first *top-level* ``|`` so a pipe inside
+    # a quoted operand (e.g. the ``|`` in ``mode == 'read|write'``) or nested
+    # brackets is not mistaken for a filter separator. A naive ``"|" in expr``
+    # check would mis-parse such operands and raise a spurious "unknown filter".
+    pipe_idx = _find_top_level(expr, "|")
+    if pipe_idx != -1:
+        value = _evaluate_simple_expression(expr[:pipe_idx].strip(), namespace)
+        filter_expr = expr[pipe_idx + 1:].strip()
 
         # `from_json` is strict: it takes no arguments and tolerates no
         # trailing tokens. Match on the leading filter name and require the

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -322,6 +322,28 @@ class TestExpressions:
         assert evaluate_expression("{{ inputs.a == 9 or inputs.b == 2 }}", plain) is True
         assert evaluate_expression("{{ inputs.missing | default('a and b') }}", plain) == "a and b"
 
+    def test_pipe_splitting_is_quote_aware(self):
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        # A '|' INSIDE a quoted operand must not be treated as a filter
+        # separator: the comparison applies to the whole string literal.
+        # Previously this raised ValueError("unknown filter 'write'") because
+        # the pipe split was not quote-aware (unlike and/or/comparison).
+        ctx = StepContext(inputs={"mode": "read|write"})
+        assert evaluate_expression("{{ inputs.mode == 'read|write' }}", ctx) is True
+        assert evaluate_expression("{{ inputs.mode != 'a|b' }}", ctx) is True
+
+        # A single quoted literal that itself contains a pipe is preserved.
+        assert evaluate_expression("{{ 'read|write' }}", StepContext()) == "read|write"
+
+        # A pipe used as a real filter argument still works (separator is '|').
+        joined = StepContext(inputs={"tags": ["a", "b", "c"]})
+        assert evaluate_expression("{{ inputs.tags | join('|') }}", joined) == "a|b|c"
+
+        # Regression: an ordinary (top-level) filter still applies.
+        assert evaluate_expression("{{ inputs.missing | default('x') }}", StepContext()) == "x"
+
     def test_filter_default(self):
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext


### PR DESCRIPTION
closes #3260

## what

`_evaluate_simple_expression` split on the first `|` with a naive `if "|" in expr` / `expr.split("|", 1)`. unlike the and/or/in/comparison splits (which use `_find_top_level` to ignore separators inside quoted operands or nested brackets), the pipe split had no such guard. so a `|` inside a quoted string was treated as a filter pipe:

```python
evaluate_expression("{{ inputs.mode == 'read|write' }}", ctx)
# before: ValueError: unknown filter 'write'
# after:  True
```

this crashed any workflow gate/`when` condition or template comparing against a string literal containing `|`.

## fix

use `_find_top_level(expr, "|")` so only a top-level pipe starts a filter, mirroring the existing operator handling. one-spot change. as a side effect it also fixes `join('|')` (pipe as the separator argument), which previously mis-split.

## tests

added `test_pipe_splitting_is_quote_aware` in `tests/test_workflows.py`, mirroring the existing `test_operator_splitting_is_quote_aware`. verified it fails on the pre-fix code (`ValueError: unknown filter 'write'`) and passes after. full `tests/test_workflows.py`: 313 passed, 1 skipped.

note: this is separate from #3208/#3228 (which fix the multi-expression `fullmatch` path in `evaluate_expression`); this touches the pipe split in `_evaluate_simple_expression`, a different spot.

---

note: i used an ai assistant to help investigate and write this up.