### PR TITLE
fix(integrations): cline hook note collapses onto instruction at EOF

### DIFF
--- a/src/specify_cli/integrations/cline/__init__.py
+++ b/src/specify_cli/integrations/cline/__init__.py
@@ -96,7 +96,11 @@ class ClineIntegration(MarkdownIntegration):
         def repl(m: re.Match[str]) -> str:
             indent = m.group(1)
             instruction = m.group(2)
-            eol = m.group(3)
+            # ``eol`` is empty when the regex matched via ``$`` because the
+            # instruction was the final line of a file with no trailing
+            # newline. Default to ``\n`` so the note never collapses onto
+            # the same line as the instruction.
+            eol = m.group(3) or "\n"
             return (
                 indent
                 + _HOOK_COMMAND_NOTE.rstrip("\n")

--- a/tests/integrations/test_integration_cline.py
+++ b/tests/integrations/test_integration_cline.py
@@ -90,6 +90,22 @@ class TestClineIntegration(MarkdownIntegrationTests):
         assert "replace dots (`.`) with hyphens (`-`)" in injected
         assert "- For each executable hook, output the following:" in injected
 
+    def test_cline_hook_instruction_injection_no_trailing_newline(self):
+        """Note must not collapse onto the instruction line when the
+        instruction is the final line with no trailing newline.
+
+        The injection regex matches the end-of-line via ``(\\r\\n|\\n|$)``, so
+        the captured ``eol`` is empty on a file's last line that lacks a
+        trailing newline. Without an ``or "\\n"`` fallback the note text and
+        the instruction are emitted on the same line.
+        """
+        cline = get_integration("cline")
+        content = "- For each executable hook, output the following:"  # no trailing \n
+        injected = cline._inject_hook_command_note(content)
+        assert "replace dots (`.`) with hyphens (`-`)" in injected
+        # Instruction stays on its own line rather than being mashed onto the note.
+        assert "\n- For each executable hook, output the following:" in injected
+
     # -- Overrides for MarkdownIntegrationTests ---------------------------
 
     def test_setup_creates_files(self, tmp_path):


### PR DESCRIPTION
## Description

`ClineIntegration._inject_hook_command_note()` inserts a dot-to-hyphen note before the hook-output instruction. Its regex matches the line terminator with an alternation that includes `$`:

```python
r"(?m)^(\s*)(- For each executable hook, output the following[^\r\n]*)(\r\n|\n|$)"
```

When the instruction is the **final line of a file with no trailing newline**, the third group (`eol`) captures the empty string. The integration then emits:

```python
eol = m.group(3)          # ""  on a trailing-newline-less last line
return indent + NOTE.rstrip("\n") + eol + indent + instruction + eol
```

so the note text and the instruction are concatenated onto a **single line** (e.g. `...replace dots with hyphens.- For each executable hook...`).

The sibling `agy` integration already guards this exact case with `eol = m.group(3) or "\n"` and an explanatory comment — `cline` is the lone outlier.

### Fix

Default `eol` to `"\n"` when empty, mirroring the `agy` twin verbatim (same one-line guard + comment).

## Testing

- New `test_cline_hook_instruction_injection_no_trailing_newline`: feeds the instruction with no trailing newline and asserts the instruction stays on its own line (`"\n- For each executable hook..."`). **Fails before** (note mashed onto the instruction), **passes after**.
- `uvx ruff check` clean; the two cline hook-injection tests pass.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI spotted the `agy`-vs-`cline` parity gap; I confirmed the empty-`eol` collapse, verified the fail-before/pass-after test, and reviewed the diff before submitting.