### PR TITLE
fix(workflows): if-step validate accepts falsy non-list else

### DIFF
--- a/src/specify_cli/workflows/steps/if_then/__init__.py
+++ b/src/specify_cli/workflows/steps/if_then/__init__.py
@@ -47,8 +47,8 @@ class IfThenStep(StepBase):
             errors.append(
                 f"If step {config.get('id', '?')!r}: 'then' must be a list of steps."
             )
-        else_branch = config.get("else", [])
-        if else_branch and not isinstance(else_branch, list):
+        else_branch = config.get("else")
+        if else_branch is not None and not isinstance(else_branch, list):
             errors.append(
                 f"If step {config.get('id', '?')!r}: 'else' must be a list of steps."
             )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1988,6 +1988,35 @@ class TestIfThenStep:
         errors = step.validate({"id": "test", "then": []})
         assert any("missing 'condition'" in e for e in errors)
 
+    @pytest.mark.parametrize("bad_else", [False, 0, "", {}, 42])
+    def test_validate_rejects_non_list_else(self, bad_else):
+        """A non-list 'else' must be rejected even when it is falsy.
+
+        The original guard used ``if else_branch and ...`` which
+        short-circuits for falsy non-list values (False/0/''/{}), letting a
+        malformed else-branch pass validation only to be silently skipped at
+        runtime. ``then`` is already strictly validated; ``else`` must match.
+        """
+        from specify_cli.workflows.steps.if_then import IfThenStep
+
+        step = IfThenStep()
+        errors = step.validate(
+            {"id": "i", "condition": "true", "then": [], "else": bad_else}
+        )
+        assert any("'else' must be a list of steps" in e for e in errors)
+
+    @pytest.mark.parametrize("ok_else", [None, [], [{"id": "x", "command": "/y"}]])
+    def test_validate_accepts_valid_else(self, ok_else):
+        """A missing/None/list 'else' stays valid."""
+        from specify_cli.workflows.steps.if_then import IfThenStep
+
+        step = IfThenStep()
+        config = {"id": "i", "condition": "true", "then": []}
+        if ok_else is not None:
+            config["else"] = ok_else
+        errors = step.validate(config)
+        assert not any("'else'" in e for e in errors)
+
 
 class TestSwitchStep:
     """Test the switch step type."""

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2007,14 +2007,25 @@ class TestIfThenStep:
 
     @pytest.mark.parametrize("ok_else", [None, [], [{"id": "x", "command": "/y"}]])
     def test_validate_accepts_valid_else(self, ok_else):
-        """A missing/None/list 'else' stays valid."""
+        """An explicit 'else' of None or a list stays valid.
+
+        ``else`` is set explicitly here (including ``else: None``) so the
+        explicit-None case is exercised, not just the missing-key case.
+        """
         from specify_cli.workflows.steps.if_then import IfThenStep
 
         step = IfThenStep()
-        config = {"id": "i", "condition": "true", "then": []}
-        if ok_else is not None:
-            config["else"] = ok_else
-        errors = step.validate(config)
+        errors = step.validate(
+            {"id": "i", "condition": "true", "then": [], "else": ok_else}
+        )
+        assert not any("'else'" in e for e in errors)
+
+    def test_validate_accepts_missing_else(self):
+        """A missing 'else' key stays valid (no else branch)."""
+        from specify_cli.workflows.steps.if_then import IfThenStep
+
+        step = IfThenStep()
+        errors = step.validate({"id": "i", "condition": "true", "then": []})
         assert not any("'else'" in e for e in errors)
 
 


### PR DESCRIPTION
## Description

`IfThenStep.validate()` validates the `then` branch strictly (`if not isinstance(then_branch, list)`) but guards `else` with a leading truthiness check:

```python
else_branch = config.get("else", [])
if else_branch and not isinstance(else_branch, list):   # bug
    errors.append("...'else' must be a list of steps.")
```

`else_branch and ...` short-circuits whenever `else` is **falsy** — `else: false`, `else: 0`, `else: ""`, `else: {}`. Those malformed values pass validation, then at runtime `execute()` does `config.get("else", [])` and the falsy non-list branch is silently skipped (no error, no else steps run). Only a *truthy* non-list (e.g. `else: 42`) was caught.

### Fix

Switch to an `is not None` guard so `else` is validated exactly like `then` while keeping a missing/None `else` valid:

```python
else_branch = config.get("else")
if else_branch is not None and not isinstance(else_branch, list):
    errors.append("...'else' must be a list of steps.")
```

This matches the sibling `switch` `default:` / `fan_out` `step:` validation pattern.

## Testing

- New `test_validate_rejects_non_list_else` parametrizes `else` ∈ {False, 0, '', {}, 42}: the four falsy values **fail before / pass after**; 42 was already caught (regression guard).
- New `test_validate_accepts_valid_else` keeps missing/None/`[]`/list-of-steps valid.
- `TestIfThenStep` passes (11 tests); `uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI flagged the then-vs-else validation asymmetry; I confirmed the falsy short-circuit, verified fail-before/pass-after, and reviewed the diff before submitting.