### PR TITLE
fix(integrations): add zed to discovery catalog.json

### DIFF
--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -299,6 +299,15 @@
       "author": "spec-kit-core",
       "repository": "https://github.com/github/spec-kit",
       "tags": ["cli", "skills", "z-ai"]
+    },
+    "zed": {
+      "id": "zed",
+      "name": "Zed",
+      "version": "1.0.0",
+      "description": "Zed editor skills-based integration",
+      "author": "spec-kit-core",
+      "repository": "https://github.com/github/spec-kit",
+      "tags": ["ide", "skills"]
     }
   }
 }

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -244,3 +244,26 @@ class TestMultiInstallSafeContracts:
                 f"{initial} and {additional} are declared multi-install safe but both manage "
                 f"these files: {sorted(initial_files & additional_files)}"
             )
+
+
+class TestCatalogParity:
+    """The discovery catalog must list every registered integration."""
+
+    def test_every_registered_integration_is_in_catalog(self):
+        """``integrations/catalog.json`` must cover every registry key.
+
+        The catalog is the discovery manifest; an integration that is
+        registered, registrar-aligned and registry-tested but missing from
+        the catalog is undiscoverable through it. ``generic`` is exempt —
+        it is the no-fixed-directory fallback, not a catalogued agent.
+        """
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        catalog = json.loads(
+            (repo_root / "integrations" / "catalog.json").read_text(encoding="utf-8")
+        )
+        catalogued = set(catalog["integrations"])
+        registered = set(INTEGRATION_REGISTRY) - {"generic"}
+        missing = sorted(registered - catalogued)
+        assert not missing, f"integrations missing from catalog.json: {missing}"


### PR DESCRIPTION
## Description

`integrations/catalog.json` is the discovery manifest for Spec Kit integrations. The `zed` integration is registered in `INTEGRATION_REGISTRY`, registrar-aligned, and covered by the registry tests — but it is the **only one of the 34 registered integrations missing from the catalog**:

```python
set(INTEGRATION_REGISTRY) - {"generic"} - set(catalog["integrations"])  # -> {'zed'}
```

So `zed` is undiscoverable through the catalog while every sibling (including the other skills-based editors) is listed.

### Fix

- Add the `"zed"` entry to `integrations/catalog.json`, mirroring the sibling skills entries (e.g. `agy`, `lingma`) — `name: "Zed"`, `description: "Zed editor skills-based integration"`, `tags: ["ide", "skills"]`, consistent with the module's own "Zed editor integration — skills-based agent" description.
- Add a `TestCatalogParity` regression test asserting every registered integration (except the `generic` fallback) appears in the catalog, so this can't silently drift again.

## Testing

- New `test_every_registered_integration_is_in_catalog`: **fails before** (`missing: ['zed']`, verified by stashing the catalog change), **passes after**.
- Full `tests/integrations/test_registry.py` passes (434 tests); `uvx ruff check` clean; catalog.json validated as well-formed JSON.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI computed the registry-vs-catalog set difference; I confirmed `zed` was the sole omission, matched the sibling entry shape, proved fail-before via stash, and reviewed the diff before submitting.