### PR TITLE
docs(toc): add Bundles and Authentication to the Reference nav

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -35,6 +35,10 @@
       href: reference/presets.md
     - name: Workflows
       href: reference/workflows.md
+    - name: Bundles
+      href: reference/bundles.md
+    - name: Authentication
+      href: reference/authentication.md
 
 # Concepts
 - name: Concepts


### PR DESCRIPTION
## Description

Two Reference pages exist on disk but are missing from the Reference section of `docs/toc.yml`:

- `docs/reference/bundles.md`
- `docs/reference/authentication.md`

Since the published docs sidebar is generated from `toc.yml`, both pages are **orphaned** — reachable only via direct link or in-page cross-references, not from the navigation. Every other `docs/reference/*.md` page has a nav entry.

### Fix

Add the two missing entries to the Reference `items`:

- **Bundles** placed right after Workflows, matching the section ordering in `reference/overview.md` (…Presets → Workflows → Bundles).
- **Authentication** placed last.

Pure navigation/data addition — no code, no behavior change.

## Testing

- `docs/toc.yml` parses as valid YAML; the Reference `items` now read Overview, Core Commands, Integrations, Extensions, Presets, Workflows, **Bundles, Authentication**.
- Both new `href`s resolve to existing files under `docs/` (no broken links).

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI diffed the on-disk reference pages against the toc entries; I confirmed the two pages were orphaned, matched the overview.md ordering, verified the hrefs resolve, and reviewed the diff before submitting.