### PR TITLE
fix(extensions): set-priority repairs corrupted boolean priority

### DIFF
--- a/src/specify_cli/extensions/_commands.py
+++ b/src/specify_cli/extensions/_commands.py
@@ -1566,7 +1566,14 @@ def extension_set_priority(
     raw_priority = metadata.get("priority")
     # Only skip if the stored value is already a valid int equal to requested priority
     # This ensures corrupted values (e.g., "high") get repaired even when setting to default (10)
-    if isinstance(raw_priority, int) and raw_priority == priority:
+    # A bool is an int in Python (isinstance(True, int) is True), so exclude it explicitly —
+    # mirroring normalize_priority's bool guard — otherwise a corrupted True/False priority
+    # equals 1/0 here and is never repaired.
+    if (
+        isinstance(raw_priority, int)
+        and not isinstance(raw_priority, bool)
+        and raw_priority == priority
+    ):
         console.print(f"[yellow]Extension '{_escape_markup(str(display_name))}' already has priority {priority}[/yellow]")
         raise typer.Exit(0)
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -6424,6 +6424,42 @@ class TestExtensionPriorityCLI:
         plain = strip_ansi(result.output)
         assert "already has priority 5" in plain
 
+    def test_set_priority_repairs_corrupted_bool(self, extension_dir, project_dir):
+        """A corrupted boolean priority must be repaired, not skipped.
+
+        ``isinstance(True, int)`` is True and ``True == 1`` in Python, so a
+        stored ``True`` priority would short-circuit the ``already has
+        priority 1`` skip path and never get rewritten to a real int —
+        contradicting the comment that promises corrupted values are
+        repaired. The guard must exclude bools (like normalize_priority).
+        """
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        runner = CliRunner()
+
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(
+            extension_dir, "0.1.0", register_commands=False, priority=5
+        )
+        # Inject a corrupted boolean priority (True == 1).
+        manager.registry.update("test-ext", {"priority": True})
+
+        with patch.object(Path, "cwd", return_value=project_dir):
+            result = runner.invoke(app, ["extension", "set-priority", "test-ext", "1"])
+
+        assert result.exit_code == 0, result.output
+        plain = strip_ansi(result.output)
+        # The corrupted bool must be repaired, not reported as already-set.
+        assert "already has priority" not in plain
+        assert "priority changed" in plain
+
+        # The stored value is now a real int, not a bool.
+        reloaded = ExtensionManager(project_dir).registry.get("test-ext")
+        assert reloaded["priority"] == 1
+        assert not isinstance(reloaded["priority"], bool)
+
     def test_set_priority_invalid_value(self, extension_dir, project_dir):
         """Test set-priority rejects invalid priority values."""
         from typer.testing import CliRunner


### PR DESCRIPTION
## Description

The `extension set-priority` command has a skip-if-unchanged guard whose comment promises that corrupted values get repaired:

```python
# This ensures corrupted values (e.g., "high") get repaired even when setting to default (10)
if isinstance(raw_priority, int) and raw_priority == priority:
    console.print(f"...already has priority {priority}")
    raise typer.Exit(0)
```

But in Python `isinstance(True, int)` is `True` and `True == 1` (`False == 0`). So a **corrupted boolean** priority (e.g. `True`) matches the guard when the user runs `set-priority <ext> 1`: the command reports *"already has priority 1"* and exits without rewriting the bool to a real int — the exact opposite of what the comment promises. `normalize_priority()` already guards this (`if isinstance(value, bool): return default`); this call site didn't.

### Fix

Exclude bools from the skip guard, mirroring `normalize_priority`:

```python
if (
    isinstance(raw_priority, int)
    and not isinstance(raw_priority, bool)
    and raw_priority == priority
):
```

Now a corrupted bool falls through and is repaired to a real int.

## Testing

- New `test_set_priority_repairs_corrupted_bool`: installs an extension, injects `priority: True`, runs `set-priority test-ext 1`, asserts it reports *priority changed* (not *already has priority*) and the reloaded value is `1` with `not isinstance(..., bool)`. **Fails before** (reports "already has priority 1", verified by source-stash), **passes after**.
- `TestExtensionPriorityCLI` passes (8 tests); `uvx ruff check` clean. The existing same-value test (priority 5, a real int) stays green.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI flagged the bool-is-int trap against the comment's promise; I confirmed the short-circuit, proved fail-before via source-stash, and reviewed the diff before submitting.