### PR TITLE
docs(bundles): document --integration on bundle update

### DIFF
--- a/docs/reference/bundles.md
+++ b/docs/reference/bundles.md
@@ -51,10 +51,11 @@ If the current directory is not yet a Spec Kit project, `install` initializes on
 specify bundle update [<bundle_id>]
 ```
 
-| Option       | Description                          |
-| ------------ | ------------------------------------ |
-| `--all`      | Update every installed bundle        |
-| `--offline`  | Do not access the network            |
+| Option           | Description                                                                                                            |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `--all`          | Update every installed bundle                                                                                         |
+| `--integration`  | Override the integration used when refreshing components; applied only when the project's active integration can't be determined |
+| `--offline`      | Do not access the network                                                                                             |
 
 Re-resolves a bundle and **refreshes** its components through each primitive's update path, bringing already-installed components up to the bundle's newly pinned versions while preserving primitive-level overrides (such as preset priority). Provide a bundle id, or use `--all` to update everything installed.
 


### PR DESCRIPTION
## Description

`specify bundle update` accepts an `--integration` option:

```python
@bundle_app.command("update")
def bundle_update(
    ...
    integration: str = typer.Option(None, "--integration", help="Override integration"),
    offline: bool = typer.Option(False, "--offline", ...),
)
```

(confirmed by `specify bundle update --help`). At runtime it is the integration override applied only when the project's active integration can't be detected — `active_integration=detected if detected is not None else integration`.

But the **Update Bundles** options table in `docs/reference/bundles.md` lists only `--all` and `--offline`, omitting `--integration` — even though the `install` and `init` tables in the same doc already document it. So a real, working flag is undocumented for `update`.

### Fix

Add the `--integration` row to the Update Bundles options table, describing its update-time semantics (refresh-time override, applied only when the active integration can't be determined). Docs-only change; the source is the source-of-truth.

## Testing

- `specify bundle update --help` lists `--integration` (the flag the doc now documents).
- `npx markdownlint-cli2 docs/reference/bundles.md` → 0 errors.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Opus 4.8) under my direction. AI diffed the update command's accepted options against the doc table; I confirmed the flag via `--help` and the signature, wrote the row to match its runtime semantics, ran markdownlint, and reviewed the diff before submitting.