### PR TITLE
fix(extensions): restore core-command discovery broken by #3014 module move

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -26,6 +26,7 @@ import yaml
 from packaging import version as pkg_version
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
+from .._assets import _locate_core_pack, _repo_root
 from .._init_options import is_ai_skills_enabled
 from .._invocation_style import is_dollar_skills_agent, is_slash_skills_agent
 from .._utils import dump_frontmatter, relative_extension_path_violation, version_satisfies
@@ -62,11 +63,21 @@ def _load_core_command_names() -> frozenset[str]:
     Prefer the wheel-time ``core_pack`` bundle when present, and fall back to
     the source checkout when running from the repository. If neither is
     available, use the baked-in fallback set so validation still works.
+
+    Path resolution is delegated to the canonical ``_assets`` helpers
+    (``_locate_core_pack`` / ``_repo_root``), which are anchored to the package
+    root rather than this module's location. The previous bespoke
+    ``Path(__file__)`` math was correct only while this code lived at
+    ``specify_cli/extensions.py``; once it moved into the
+    ``specify_cli/extensions/`` package the relative parents fell one level
+    short, so discovery always missed the real command dirs and silently fell
+    through to ``_FALLBACK_CORE_COMMAND_NAMES`` below.
     """
-    candidate_dirs = [
-        Path(__file__).parent / "core_pack" / "commands",
-        Path(__file__).resolve().parent.parent.parent / "templates" / "commands",
-    ]
+    candidate_dirs: list[Path] = []
+    core_pack = _locate_core_pack()
+    if core_pack is not None:
+        candidate_dirs.append(core_pack / "commands")
+    candidate_dirs.append(_repo_root() / "templates" / "commands")
 
     for commands_dir in candidate_dirs:
         if not commands_dir.is_dir():

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -205,6 +205,108 @@ class TestNormalizePriority:
         assert normalize_priority(True, default=5) == 5
 
 
+# ===== Core Command Discovery Tests =====
+
+
+class TestCoreCommandDiscovery:
+    """Regression tests for dynamic core-command discovery.
+
+    ``_load_core_command_names()`` must read the bundled command templates via
+    the canonical ``_assets`` resolvers. A prior off-by-one in this module's
+    bespoke ``Path(__file__)`` math (introduced when the code moved from
+    ``specify_cli/extensions.py`` into the ``specify_cli/extensions/`` package)
+    made discovery always miss the real dirs and silently return the hardcoded
+    ``_FALLBACK_CORE_COMMAND_NAMES``. These tests pin the live-discovery
+    behaviour so the regression cannot return unnoticed.
+    """
+
+    def test_discovery_returns_real_bundled_set_not_fallback(self, monkeypatch):
+        """Discovery must read the real bundled templates, not echo the fallback.
+
+        This is the core regression guard. ``_FALLBACK_CORE_COMMAND_NAMES``
+        currently equals the real command set, so a totally dead discovery path
+        looks healthy from the outside. We temporarily swap the fallback for a
+        sentinel: live discovery still returns the real bundled names, whereas
+        the pre-fix off-by-one (which always fell through to the fallback) would
+        return the sentinel and fail this assertion.
+        """
+        import specify_cli.extensions as ext
+
+        commands_dir = Path(__file__).resolve().parent.parent / "templates" / "commands"
+        bundled = frozenset(
+            command_file.stem
+            for command_file in commands_dir.iterdir()
+            if command_file.is_file() and command_file.suffix == ".md"
+        )
+        sentinel = frozenset({"__sentinel_fallback_must_not_be_used__"})
+        monkeypatch.setattr(ext, "_FALLBACK_CORE_COMMAND_NAMES", sentinel)
+
+        result = ext._load_core_command_names()
+
+        assert result == bundled
+        assert result != sentinel
+
+    def test_discovers_commands_from_source_tree(self, tmp_path, monkeypatch):
+        """Source checkout: read ``<repo_root>/templates/commands`` via ``_repo_root``."""
+        import specify_cli.extensions as ext
+
+        commands_dir = tmp_path / "templates" / "commands"
+        commands_dir.mkdir(parents=True)
+        for stem in ("alpha", "beta", "gamma"):
+            (commands_dir / f"{stem}.md").write_text("---\n---\n", encoding="utf-8")
+        # Non-markdown files and subdirectories must be ignored.
+        (commands_dir / "README.txt").write_text("ignore me", encoding="utf-8")
+        (commands_dir / "nested").mkdir()
+
+        monkeypatch.setattr(ext, "_locate_core_pack", lambda: None)
+        monkeypatch.setattr(ext, "_repo_root", lambda: tmp_path)
+
+        # A set distinct from _FALLBACK_CORE_COMMAND_NAMES proves discovery is
+        # live rather than masked by the fallback (which equals the real set).
+        assert ext._load_core_command_names() == frozenset({"alpha", "beta", "gamma"})
+
+    def test_prefers_wheel_core_pack(self, tmp_path, monkeypatch):
+        """Wheel install: read ``<core_pack>/commands`` when ``_locate_core_pack`` resolves."""
+        import specify_cli.extensions as ext
+
+        core_pack = tmp_path / "core_pack"
+        commands_dir = core_pack / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "wheelonly.md").write_text("---\n---\n", encoding="utf-8")
+
+        monkeypatch.setattr(ext, "_locate_core_pack", lambda: core_pack)
+        # Repo-root path intentionally absent so only the core_pack branch can match.
+        monkeypatch.setattr(ext, "_repo_root", lambda: tmp_path / "missing")
+
+        assert ext._load_core_command_names() == frozenset({"wheelonly"})
+
+    def test_falls_back_when_no_command_dir_exists(self, tmp_path, monkeypatch):
+        """With neither dir present, the baked-in fallback set is returned."""
+        import specify_cli.extensions as ext
+
+        monkeypatch.setattr(ext, "_locate_core_pack", lambda: None)
+        monkeypatch.setattr(ext, "_repo_root", lambda: tmp_path / "missing")
+
+        assert ext._load_core_command_names() == ext._FALLBACK_CORE_COMMAND_NAMES
+
+    def test_fallback_matches_bundled_commands(self):
+        """The safety-net fallback must stay in lockstep with the bundled templates.
+
+        Discovery now auto-syncs, but the hardcoded fallback remains the last
+        resort and should not rot if a core command is added or removed.
+        """
+        import specify_cli.extensions as ext
+
+        commands_dir = Path(__file__).resolve().parent.parent / "templates" / "commands"
+        bundled = frozenset(
+            command_file.stem
+            for command_file in commands_dir.iterdir()
+            if command_file.is_file() and command_file.suffix == ".md"
+        )
+
+        assert ext._FALLBACK_CORE_COMMAND_NAMES == bundled
+
+
 # ===== ExtensionManifest Tests =====
 
 class TestExtensionManifest:


### PR DESCRIPTION
## What

Fix the off-by-one path resolution in `specify_cli.extensions._load_core_command_names()` so it actually discovers the bundled core command templates instead of silently returning the hardcoded fallback set. Fixes #3294.

## Why

When this code moved from `src/specify_cli/extensions.py` to `src/specify_cli/extensions/__init__.py` (#3014, `826e193`), the file went one directory deeper but the bespoke `Path(__file__)` parent counts were not updated. Both candidate dirs now resolve to non-existent paths:

- wheel -> `specify_cli/extensions/core_pack/commands` (real: `specify_cli/core_pack/commands`)
- source -> `src/templates/commands` (real: repo-root `templates/commands`)

So `_load_core_command_names()` always falls through to `_FALLBACK_CORE_COMMAND_NAMES`. It only looks healthy because the fallback currently equals the 10 real command stems. `CORE_COMMAND_NAMES` (built from this function) guards extensions against shadowing core commands (#1994); with discovery dead, that guard depends on the fallback being hand-maintained -- `converge` was manually added to it in #3001 (`0c29d89`).

Same off-by-one class @mnriem diagnosed for the presets loader (re #3086, #2826), but in a module the preset-scoped fix does not touch.

## How

- Delegate path resolution to the canonical `_assets` resolvers (`_locate_core_pack` / `_repo_root`), exactly as `presets/__init__.py` does. These are anchored to the package root, so discovery survives future module moves.
- Add `tests/test_extensions.py::TestCoreCommandDiscovery` covering the source, wheel, and fallback branches, plus a sentinel test proving discovery returns the real bundled set rather than the fallback.

## Verification

- New regression tests fail on the pre-fix code (the sentinel test fails with a clean assertion -- it returns the fallback sentinel instead of the bundled set) and pass after the fix.
- `tests/test_extensions.py`: 328 passed, 3 skipped.
- Broader relevant suites (imports, extensions, presets, integration registry/manifest): 887 passed. The only failures are 6 pre-existing Windows symlink-privilege errors in `test_manifest.py` that fail identically on the unmodified base (unrelated to this change).

## Behavior change

None for end users today (the fallback already matches the real commands). This restores the intended dynamic discovery and removes the silent manual-maintenance dependency on the fallback list.

---
*Authored with assistance from GitHub Copilot (model: Claude Opus 4.8), acting autonomously under the direction of @dhruv-15-03. Commits carry `Assisted-by:` trailers and the change is agent-generated; please review accordingly.*