### PR TITLE
fix(scripts): resolve invoke_separator by parse success, not python3 availability (#3304)

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -318,13 +318,14 @@ PY
                                 if (c=="{") depth++
                                 else if (c=="}") { depth--; if (depth==0) break }
                             }
-                            if (match(obj, /"invoke_separator"[ \t\r\n]*:[ \t\r\n]*"[.-]"/)) {
+                            if (match(obj, /"invoke_separator"[ \t\r\n]*:[ \t\r\n]*"[-.]"/)) {
                                 tok=substr(obj,RSTART,RLENGTH); s=substr(tok,length(tok)-1,1)
                                 if (s=="." || s=="-") sep=s
                             }
                         }
                     }
                     print sep
+                }
             ' "$integration_json" 2>/dev/null)
             case "$awk_separator" in
                 "."|"-") separator="$awk_separator" ;;

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -303,15 +303,28 @@ PY
                 END {
                     key=keyval(doc,"default_integration"); if (key=="") key=keyval(doc,"integration")
                     sep="."
-                    if (key!="" && match(doc, "\"" key "\"[ \t\r\n]*:[ \t\r\n]*[{]")) {
-                        rest=substr(doc, RSTART+RLENGTH-1)
-                        if (match(rest, /"invoke_separator"[ \t\r\n]*:[ \t\r\n]*"[.-]"/)) {
-                            tok=substr(rest,RSTART,RLENGTH); s=substr(tok,length(tok)-1,1)
-                            if (s=="." || s=="-") sep=s
+                    if (key!="") {
+                        settings=doc
+                        if (match(doc, /"integration_settings"[ \t\r\n]*:[ \t\r\n]*[{]/)) {
+                            settings=substr(doc, RSTART+RLENGTH-1)
+                        }
+                        if (match(settings, "\"" key "\"[ \t\r\n]*:[ \t\r\n]*[{]")) {
+                            start=RSTART+RLENGTH-1
+                            depth=0
+                            obj=""
+                            for (i=start; i<=length(settings); i++) {
+                                c=substr(settings,i,1)
+                                obj=obj c
+                                if (c=="{") depth++
+                                else if (c=="}") { depth--; if (depth==0) break }
+                            }
+                            if (match(obj, /"invoke_separator"[ \t\r\n]*:[ \t\r\n]*"[.-]"/)) {
+                                tok=substr(obj,RSTART,RLENGTH); s=substr(tok,length(tok)-1,1)
+                                if (s=="." || s=="-") sep=s
+                            }
                         }
                     }
                     print sep
-                }
             ' "$integration_json" 2>/dev/null)
             case "$awk_separator" in
                 "."|"-") separator="$awk_separator" ;;

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -235,21 +235,29 @@ get_invoke_separator() {
 
     local integration_json="$repo_root/.specify/integration.json"
     local separator="."
-    local parsed_with_jq=0
+    local parsed=0
 
     if [[ -f "$integration_json" ]]; then
+        # Try parsers in order (jq -> python3 -> awk), falling through on
+        # failure. Selection is by *parse success*, not mere availability: on
+        # Windows `python3` commonly resolves to the Microsoft Store App
+        # Execution Alias stub, which passes `command -v` but fails at runtime
+        # (exit 49). An availability-gated branch would pick python3, swallow
+        # its failure, and — because this function historically had no text
+        # fallback — silently return "." even for `-`-separator integrations
+        # (e.g. forge, cline), yielding wrong command hints (issue #3304).
         if command -v jq >/dev/null 2>&1; then
             local jq_separator
             if jq_separator=$(jq -r '(.default_integration // .integration // "") as $k | if $k == "" then "." else (.integration_settings[$k].invoke_separator // ".") end' "$integration_json" 2>/dev/null); then
-                parsed_with_jq=1
                 case "$jq_separator" in
-                    "."|"-") separator="$jq_separator" ;;
+                    "."|"-") separator="$jq_separator"; parsed=1 ;;
                 esac
             fi
         fi
 
-        if [[ "$parsed_with_jq" -eq 0 ]] && command -v python3 >/dev/null 2>&1; then
-            if separator=$(python3 - "$integration_json" <<'PY' 2>/dev/null
+        if [[ "$parsed" -eq 0 ]] && command -v python3 >/dev/null 2>&1; then
+            local py_separator
+            if py_separator=$(python3 - "$integration_json" <<'PY' 2>/dev/null
 import json
 import sys
 
@@ -265,16 +273,49 @@ try:
             separator = entry["invoke_separator"]
     print(separator)
 except Exception:
-    print(".")
+    sys.exit(1)
 PY
 ); then
-                case "$separator" in
-                    "."|"-") ;;
-                    *) separator="." ;;
+                case "$py_separator" in
+                    "."|"-") separator="$py_separator"; parsed=1 ;;
                 esac
-            else
-                separator="."
             fi
+        fi
+
+        if [[ "$parsed" -eq 0 ]]; then
+            # Last-resort text fallback for environments with neither jq nor a
+            # working python3 (e.g. stock Windows + Git Bash). Reads the active
+            # integration key (default_integration, else integration) and its
+            # invoke_separator from within the integration_settings object.
+            # Handles both pretty-printed (the written form) and compact JSON.
+            # Accumulate all lines into one buffer in END rather than using
+            # gawk-only whole-file slurp (RS="^$"), so this stays portable to
+            # the BSD awk on macOS.
+            local awk_separator
+            awk_separator=$(awk '
+                function keyval(d, name,   v) {
+                    if (match(d, "\"" name "\"[ \t\r\n]*:[ \t\r\n]*\"[^\"]*\"")) {
+                        v=substr(d,RSTART,RLENGTH); sub(/^.*:[ \t\r\n]*"/,"",v); sub(/"$/,"",v); return v
+                    }
+                    return ""
+                }
+                { doc = doc $0 "\n" }
+                END {
+                    key=keyval(doc,"default_integration"); if (key=="") key=keyval(doc,"integration")
+                    sep="."
+                    if (key!="" && match(doc, "\"" key "\"[ \t\r\n]*:[ \t\r\n]*[{]")) {
+                        rest=substr(doc, RSTART+RLENGTH-1)
+                        if (match(rest, /"invoke_separator"[ \t\r\n]*:[ \t\r\n]*"[.-]"/)) {
+                            tok=substr(rest,RSTART,RLENGTH); s=substr(tok,length(tok)-1,1)
+                            if (s=="." || s=="-") sep=s
+                        }
+                    }
+                    print sep
+                }
+            ' "$integration_json" 2>/dev/null)
+            case "$awk_separator" in
+                "."|"-") separator="$awk_separator" ;;
+            esac
         fi
     fi
 

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -469,11 +469,11 @@ def test_bash_command_hint_preserves_hyphens_inside_segments(tasks_repo: Path) -
 def _install_broken_json_tool_stubs(repo: Path) -> Path:
     """Create a bin dir with `jq` and `python3` stubs that exist but fail.
 
-    Mimics stock Windows + Git Bash, where `jq` is absent and `python3`
-    resolves to the Microsoft Store App Execution Alias stub: both satisfy
-    `command -v` yet fail at runtime (the alias exits 49). Prepending this to
-    PATH forces the invoke-separator parser past jq and python3 to its awk
-    text fallback (#3304).
+    Mimics stock Windows + Git Bash, where a JSON tool may be missing or broken
+    and `python3` resolves to the Microsoft Store App Execution Alias stub: both
+    satisfy `command -v` yet fail at runtime (the alias exits 49). Prepending
+    this to PATH forces the invoke-separator parser past jq and python3 to its
+    awk text fallback (#3304).
     """
     stub_dir = repo / "_broken_bin"
     stub_dir.mkdir(exist_ok=True)

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -466,6 +466,68 @@ def test_bash_command_hint_preserves_hyphens_inside_segments(tasks_repo: Path) -
     assert result.stdout.strip() == "/speckit.jira.sync-status"
 
 
+def _install_broken_json_tool_stubs(repo: Path) -> Path:
+    """Create a bin dir with `jq` and `python3` stubs that exist but fail.
+
+    Mimics stock Windows + Git Bash, where `jq` is absent and `python3`
+    resolves to the Microsoft Store App Execution Alias stub: both satisfy
+    `command -v` yet fail at runtime (the alias exits 49). Prepending this to
+    PATH forces the invoke-separator parser past jq and python3 to its awk
+    text fallback (#3304).
+    """
+    stub_dir = repo / "_broken_bin"
+    stub_dir.mkdir(exist_ok=True)
+    for name in ("jq", "python3"):
+        stub = stub_dir / name
+        stub.write_text(
+            "#!/bin/sh\n"
+            'echo "simulated broken interpreter/tool" >&2\n'
+            "exit 49\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        stub.chmod(0o755)
+    return stub_dir
+
+
+@requires_bash
+def test_bash_command_hint_falls_back_to_awk_when_jq_and_python3_broken(
+    tasks_repo: Path,
+) -> None:
+    """Separator resolution survives a broken python3 stub with no jq (#3304).
+
+    `get_invoke_separator` historically selected python3 by availability and
+    had no text fallback, so a Windows Store python3 stub made it silently
+    return "." even for `-`-separator integrations (e.g. forge), yielding a
+    wrong hint like `/speckit.plan`. The awk fallback must recover `-`.
+    """
+    _write_integration_state(tasks_repo, "forge", "-")
+    stub_dir = _install_broken_json_tool_stubs(tasks_repo)
+
+    script = tasks_repo / ".specify" / "scripts" / "bash" / "common.sh"
+    env = _clean_env()
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; format_speckit_command "$2" "$PWD"',
+            "bash",
+            str(script),
+            "plan",
+        ],
+        cwd=tasks_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "/speckit-plan"
+
+
 @requires_bash
 def test_bash_command_hint_caches_invoke_separator_per_process(tasks_repo: Path) -> None:
     _write_integration_state(tasks_repo, "claude", "-")

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -494,7 +494,7 @@ def _install_broken_json_tool_stubs(repo: Path) -> Path:
 def test_bash_command_hint_falls_back_to_awk_when_jq_and_python3_broken(
     tasks_repo: Path,
 ) -> None:
-    """Separator resolution survives a broken python3 stub with no jq (#3304).
+    """Separator resolution survives broken jq and python3 stubs (#3304).
 
     `get_invoke_separator` historically selected python3 by availability and
     had no text fallback, so a Windows Store python3 stub made it silently


### PR DESCRIPTION
## Summary

Follow-up to #3304. The primary report and PR #3312 fix the `feature.json`
parser (`read_feature_json_feature_directory`), but the reporter explicitly
asked that **other `python3` call sites be grepped for the same pattern**.
This fixes the one remaining site that has the defect: `get_invoke_separator`.

`get_invoke_separator` in `scripts/bash/common.sh` selected its JSON parser by
tool *availability* (`command -v python3`) rather than parse *success*, and —
unlike the feature.json parser — had **no text fallback at all** after the
python3 branch. On a stock Windows machine under Git Bash (no `jq`; `python3`
resolving to the Microsoft Store App Execution Alias stub that satisfies
`command -v` but exits 49 at runtime), it silently returned `"."` even for
integrations that use a `-` separator (e.g. `forge`, `cline`).

The observable symptom is **wrong command hints in user-facing error messages**
— `check-prerequisites.sh` and `setup-tasks.sh` print e.g.
`Run /speckit.plan first` instead of the correct `/speckit-plan`.

## Changes

- **`scripts/bash/common.sh`** (`get_invoke_separator`):
  - Restructure the `jq → python3` cascade to **fall through on parse failure**,
    gated on a `parsed` success flag rather than exclusive `elif`-on-availability
    branches (mirrors the approach in #3312).
  - Make the python3 branch **signal failure** (`sys.exit(1)`) instead of
    printing `"."`, so a stub failure falls through instead of being accepted as
    a valid answer.
  - Add an **awk text fallback** for environments with neither `jq` nor a working
    `python3`. It reads the active integration key (`default_integration`, else
    `integration`) and its `invoke_separator` from within `integration_settings`.
    Portable (no gawk-only `RS="^$"` whole-file slurp, so BSD awk / macOS is
    fine) and handles both pretty-printed (the written form) and compact JSON.
    Malformed input safely defaults to `"."`.

- **`tests/test_setup_tasks.py`**: regression test that simulates the broken
  environment (`jq` + `python3` stubs that exit 49, prepended to `PATH`) and
  asserts the `-` separator is still recovered (`/speckit-plan`).

## Scope note

The other two `python3` call sites in `common.sh` (`resolve_template`,
`resolve_template_content`) already wrap the call in `if …python3…; then …
else <fallback> fi`, so a stub failure correctly falls into their unordered-scan
fallback. They are unaffected and left unchanged. This PR does not touch
`read_feature_json_feature_directory` (covered by #3312), so the two PRs are
non-overlapping.

## Verification

Reproduced on a machine that *is* the affected environment (no jq, `python3` =
Windows Store stub): before the fix `format_speckit_command plan` emits
`/speckit.plan`; after, `/speckit-plan`. Validated the parser across pretty /
compact / dot-default / empty-settings / malformed inputs, and under
`set -euo pipefail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)