### PR TITLE
fix(bundler): reject host-less catalog URLs in adapters (use hostname, not netloc)

### DIFF
--- a/src/specify_cli/bundler/services/adapters.py
+++ b/src/specify_cli/bundler/services/adapters.py
@@ -75,7 +75,11 @@ def _validate_remote_url(source_id: str, url: str) -> None:
             f"Catalog '{source_id}' URL must use HTTPS (got {parsed.scheme}://). "
             "HTTP is only allowed for localhost."
         )
-    if not parsed.netloc:
+    # Check hostname, not netloc: netloc is truthy for host-less URLs like
+    # "https://:8080" or "https://user@...", so requiring netloc would let
+    # those through even though they carry no host. hostname is None in those
+    # cases. Mirrors the fix in ``specify_cli.catalogs`` (#3210).
+    if not parsed.hostname:
         raise BundlerError(
             f"Catalog '{source_id}' URL must be a valid URL with a host: {url}"
         )

--- a/tests/unit/test_bundler_adapters.py
+++ b/tests/unit/test_bundler_adapters.py
@@ -69,3 +69,30 @@ def test_http_fetch_rejects_non_https_final_url(monkeypatch):
     fetcher = adapters.make_catalog_fetcher(allow_network=True)
     with pytest.raises(BundlerError, match="must use HTTPS"):
         fetcher(_source("https://example.com/c.json"))
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://:8080",          # port only, no host
+        "https://:0",
+        "https://user@",          # userinfo only, no host
+        "https://user:pw@",
+        "https://:8080/catalog.json",
+    ],
+)
+def test_validate_remote_url_rejects_host_less_urls(url):
+    """A URL with a truthy netloc but no host (``https://:8080``,
+    ``https://user@``) must be rejected.
+
+    ``urlparse`` gives these a non-empty ``netloc`` but ``hostname is None``,
+    so a ``netloc`` check would wrongly accept them. This mirrors the fix in
+    ``specify_cli.catalogs`` (#3210), which the docstring says this validator
+    mirrors."""
+    with pytest.raises(BundlerError, match="valid URL with a host"):
+        adapters._validate_remote_url("team", url)
+
+
+def test_validate_remote_url_accepts_normal_https_url():
+    # Sanity: a real host with a port still passes.
+    adapters._validate_remote_url("team", "https://example.com:8080/c.json")


### PR DESCRIPTION
fixes #3332

## what

`_validate_remote_url` in `bundler/services/adapters.py` guarded on `parsed.netloc`, which is truthy for host-less URLs (`https://:8080`, `https://user@`) even though they carry no host — so they passed the "must be a valid URL with a host" check. the docstring says it mirrors `specify_cli.catalogs` validation, but that site was fixed to use `hostname` in #3210/#3227 and this twin was missed.

## how

check `parsed.hostname` (None for host-less URLs) instead of `parsed.netloc`, matching catalogs.py. this guard runs before any network call, so it's a pre-flight safety check.

## reproduction (fixed)

```python
_validate_remote_url("team", "https://:8080")   # before: accepted -> after: rejected
_validate_remote_url("team", "https://user@")   # before: accepted -> after: rejected
_validate_remote_url("team", "https://example.com:8080/c.json")  # still accepted
```

## tests

added parametrized regression tests for the host-less forms (`https://:8080`, `https://:0`, `https://user@`, `https://user:pw@`, `https://:8080/catalog.json`) plus a valid host+port sanity case. verified they fail on the current code and pass with the fix; the full adapters test file pas
