### PR TITLE
fix(hermes): respect $HERMES_HOME env var for profile-mode skills dir

### DIFF
--- a/src/specify_cli/integrations/hermes/__init__.py
+++ b/src/specify_cli/integrations/hermes/__init__.py
@@ -12,6 +12,7 @@ Usage::
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from shutil import rmtree
 from typing import Any
@@ -55,7 +56,12 @@ class HermesIntegration(SkillsIntegration):
 
     @staticmethod
     def _hermes_home_skills_dir() -> Path:
-        """Return ``~/.hermes/skills/`` — the global skills directory."""
+        """Return the Hermes skills directory, respecting ``$HERMES_HOME``
+        for profile-mode installations.
+        """
+        hermes_home = os.environ.get("HERMES_HOME")
+        if hermes_home:
+            return Path(hermes_home) / "skills"
         return Path.home() / ".hermes" / "skills"
 
     # -- Options -----------------------------------------------------------


### PR DESCRIPTION
## Problem

The Hermes integration hardcodes `~/.hermes/skills/` in `_hermes_home_skills_dir()`:

```python
return Path.home() / ".hermes" / "skills"
```

This breaks when Hermes runs under a non-default profile, where `$HERMES_HOME` points to `~/.hermes/profiles/<name>/` and skills live under `$HERMES_HOME/skills/`.

## Fix

Check `HERMES_HOME` env var first, fall back to `~/.hermes/skills`:

```python
hermes_home = os.environ.get("HERMES_HOME")
if hermes_home:
    return Path(hermes_home) / "skills"
return Path.home() / ".hermes" / "skills"
```

Matches Hermes internal `get_skills_dir()` → `get_hermes_home() / "skills"`.

## Testing

- `HERMES_HOME` set → skills install to profile dir, visible via `hermes skills list`
- `HERMES_HOME` unset → falls back to `~/.hermes/skills`, existing behaviour preserved