### PR TITLE
fix(workflows): match gate reject option case-insensitively

### DIFF
--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -73,7 +73,14 @@ class GateStep(StepBase):
         choice = self._prompt(self._compose_prompt(message, show_file), options)
         output["choice"] = choice
 
-        if choice in ("reject", "abort"):
+        # Match rejection case-insensitively. ``_prompt`` echoes the option's
+        # original casing, and ``validate`` accepts a reject option
+        # case-insensitively (``o.lower() in {"reject", "abort"}``), so a gate
+        # authored as ``options: [Approve, Reject]`` passes validation. Comparing
+        # ``choice`` case-sensitively here would then treat a ``Reject`` pick as
+        # approval and silently skip the abort — the reject path must agree with
+        # the check that let the option through.
+        if choice.lower() in ("reject", "abort"):
             if on_reject == "abort":
                 output["aborted"] = True
                 return StepResult(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3977,6 +3977,48 @@ steps:
         assert state.status == RunStatus.ABORTED
         assert "should-not-run" not in state.step_results
 
+    def test_gate_reject_matches_case_insensitively(
+        self, project_dir, monkeypatch
+    ):
+        """A capitalised reject option (`options: [Approve, Reject]`) still
+        aborts the run. `validate` accepts a reject choice case-insensitively,
+        so the runtime reject check must agree — a case-sensitive comparison
+        would treat the echoed `Reject` as approval and silently run
+        downstream steps.
+        """
+        from specify_cli.workflows.engine import WorkflowDefinition, WorkflowEngine
+        from specify_cli.workflows.base import RunStatus
+        from specify_cli.workflows.steps.gate import GateStep
+
+        # `_prompt` echoes the option's original casing, so the operator
+        # picking "Reject" hands `execute` the capitalised string.
+        _force_gate_stdin(monkeypatch, tty=True)
+        monkeypatch.setattr(
+            GateStep, "_prompt", staticmethod(lambda _msg, _opts: "Reject")
+        )
+
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "gate-reject-case"
+  name: "Gate Reject Case"
+  version: "1.0.0"
+steps:
+  - id: gate-step
+    type: gate
+    message: "Approve?"
+    options: [Approve, Reject]
+    on_reject: abort
+  - id: should-not-run
+    type: shell
+    run: "echo nope"
+""")
+        engine = WorkflowEngine(project_dir)
+        state = engine.execute(definition)
+
+        assert state.status == RunStatus.ABORTED
+        assert "should-not-run" not in state.step_results
+
     def test_validation_rejects_non_bool_continue_on_error(self):
         """`continue_on_error` must be a literal boolean; coerced
         strings like `"true"` are rejected at validation time so


### PR DESCRIPTION
## Summary

A gate step authored with capitalised options — e.g. `options: [Approve, Reject]` — passes `validate()` but never aborts on rejection. Picking **Reject** silently falls through to the approval path and runs downstream steps.

## Root cause

`validate()` accepts a reject option **case-insensitively**:

```python
reject_choices = {"reject", "abort"}
if not any(o.lower() in reject_choices for o in options):
    errors.append(...)
```

So `Reject` is a valid reject option and the workflow validates fine. But `_prompt` echoes the option's **original casing**, and `execute()` compared it **case-sensitively**:

```python
if choice in ("reject", "abort"):   # "Reject" != "reject" → False
```

The two checks disagree: validation lets `Reject` through as a reject option, then the runtime treats the same `Reject` pick as approval. `on_reject: abort` is silently skipped and downstream steps run.

## Fix

Lower-case `choice` before the reject comparison so the runtime agrees with the validation that admitted the option:

```python
if choice.lower() in ("reject", "abort"):
```

## Test

`test_gate_reject_matches_case_insensitively` drives a gate with `options: [Approve, Reject]`, forces a TTY, stubs `_prompt` to return the capitalised `"Reject"`, and asserts the run reaches `RunStatus.ABORTED` and the downstream step never executes. Fails before the fix, passes after.

All 26 `test_workflows.py` gate tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
