### PR TITLE
fix(bundle): reject file:// / local download_url — catalog URLs are HTTPS-only

### DIFF
--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -782,13 +782,18 @@ def _download_manifest(resolved, *, offline: bool):
             "'specify bundle install <path-to-bundle.yml | bundle-dir | .zip>'."
         )
 
+    # Validate the scheme/host *before* the offline gate so an invalid or
+    # non-HTTPS download_url reports the real problem in every mode, rather
+    # than a misleading "Network access disabled" under --offline.
+    # (_download_remote_manifest re-checks this, but only once network access
+    # is permitted.) HTTPS-only, http allowed for localhost.
+    _require_https(f"bundle '{resolved.entry.id}'", url)
+
     if offline:
         raise BundlerError(
             f"Network access disabled; cannot download bundle '{resolved.entry.id}' "
             f"from {url}."
         )
-    # HTTPS-only (http for localhost) is enforced by _require_https inside
-    # _download_remote_manifest, matching the other catalog systems.
     return _download_remote_manifest(resolved.entry.id, url)
 
 

--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -766,7 +766,17 @@ def _download_manifest(resolved, *, offline: bool):
     # On Windows an absolute path like ``C:\bundle.yml`` parses with a
     # single-letter ``scheme``; treat it as a local file, not a URL scheme.
     if scheme in ("", "file") or re.match(r"^[A-Za-z]:[\\/]", url):
-        local = Path(parsed.path if scheme == "file" else url)
+        if scheme == "file":
+            # Raw ``parsed.path`` keeps the leading slash of ``file:///C:/x``
+            # (yielding ``\C:\x`` on Windows) and skips percent-decoding
+            # (``my%20bundles``). Reuse the adapters helper that already
+            # handles drive letters, UNC hosts, and percent-encoding for
+            # catalog ``file://`` URLs.
+            from ...bundler.services.adapters import _file_url_to_path
+
+            local = _file_url_to_path(parsed)
+        else:
+            local = Path(url)
         manifest = _local_manifest_source(str(local))
         if manifest is None:
             raise BundlerError(f"Bundle manifest not found: {local}")

--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -746,11 +746,16 @@ def _resolve_manifest_path(path: Path | None) -> Path:
 def _download_manifest(resolved, *, offline: bool):
     """Resolve a bundle's manifest from its catalog ``download_url``.
 
-    Local/``file://`` URLs always work offline and may point at a ``.zip``
-    artifact, a bundle directory, or a ``bundle.yml`` (handled by
-    :func:`_local_manifest_source`). Remote ``https://`` URLs are fetched with
-    the shared authenticated, redirect-validated HTTP client, and only when not
-    ``--offline``.
+    Catalog ``download_url``s are HTTPS-only (``http`` allowed for localhost),
+    matching the extensions/presets/workflows catalog systems. Remote URLs are
+    fetched with the shared authenticated, redirect-validated HTTP client, and
+    only when not ``--offline``.
+
+    Local and ``file://`` sources are intentionally not resolved here: to
+    install a bundle from disk, pass the path positionally
+    (``specify bundle install ./path/to/bundle.yml`` — a bundle directory or a
+    ``.zip`` artifact also works), which :func:`_local_manifest_source` handles
+    before catalog resolution and which never touches ``download_url``.
     """
     from urllib.parse import urlparse
 
@@ -763,36 +768,28 @@ def _download_manifest(resolved, *, offline: bool):
     parsed = urlparse(url)
     scheme = parsed.scheme.lower()
 
-    # On Windows an absolute path like ``C:\bundle.yml`` parses with a
-    # single-letter ``scheme``; treat it as a local file, not a URL scheme.
+    # ``file://`` URLs and bare filesystem paths (including Windows drive paths
+    # like ``C:\bundle.yml``, which urlparse reads as a single-letter scheme)
+    # are not valid catalog download URLs. Catalog URLs are HTTPS-only across
+    # every catalog system; installing from disk is done by passing the path
+    # positionally, which never reaches URL resolution. Give an actionable
+    # error rather than accepting a scheme the rest of the codebase rejects.
     if scheme in ("", "file") or re.match(r"^[A-Za-z]:[\\/]", url):
-        if scheme == "file":
-            # Raw ``parsed.path`` keeps the leading slash of ``file:///C:/x``
-            # (yielding ``\C:\x`` on Windows) and skips percent-decoding
-            # (``my%20bundles``). Reuse the adapters helper that already
-            # handles drive letters, UNC hosts, and percent-encoding for
-            # catalog ``file://`` URLs.
-            from ...bundler.services.adapters import _file_url_to_path
+        raise BundlerError(
+            f"Catalog entry '{resolved.entry.id}' has a local/file:// download_url "
+            f"({url}); catalog download URLs must be HTTPS (http for localhost). "
+            "To install a bundle from disk, pass the path directly: "
+            "'specify bundle install <path-to-bundle.yml | bundle-dir | .zip>'."
+        )
 
-            local = _file_url_to_path(parsed)
-        else:
-            local = Path(url)
-        manifest = _local_manifest_source(str(local))
-        if manifest is None:
-            raise BundlerError(f"Bundle manifest not found: {local}")
-        return manifest
-
-    if scheme in ("http", "https"):
-        if offline:
-            raise BundlerError(
-                f"Network access disabled; cannot download bundle '{resolved.entry.id}' "
-                f"from {url}."
-            )
-        return _download_remote_manifest(resolved.entry.id, url)
-
-    raise BundlerError(
-        f"Unsupported download_url scheme for bundle '{resolved.entry.id}': {url}"
-    )
+    if offline:
+        raise BundlerError(
+            f"Network access disabled; cannot download bundle '{resolved.entry.id}' "
+            f"from {url}."
+        )
+    # HTTPS-only (http for localhost) is enforced by _require_https inside
+    # _download_remote_manifest, matching the other catalog systems.
+    return _download_remote_manifest(resolved.entry.id, url)
 
 
 def _require_https(label: str, url: str) -> None:

--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -776,8 +776,10 @@ def _download_manifest(resolved, *, offline: bool):
     # error rather than accepting a scheme the rest of the codebase rejects.
     if scheme in ("", "file") or re.match(r"^[A-Za-z]:[\\/]", url):
         raise BundlerError(
-            f"Catalog entry '{resolved.entry.id}' has a local/file:// download_url "
-            f"({url}); catalog download URLs must be HTTPS (http for localhost). "
+            f"Catalog entry '{resolved.entry.id}' has a non-HTTP(S) download_url "
+            f"({url}); catalog download URLs must be HTTPS (http for localhost) — "
+            "a file:// URL, a local filesystem path, or a scheme-less value "
+            "(e.g. 'example.com/bundle.zip') is not accepted. "
             "To install a bundle from disk, pass the path directly: "
             "'specify bundle install <path-to-bundle.yml | bundle-dir | .zip>'."
         )

--- a/tests/contract/test_bundle_cli.py
+++ b/tests/contract/test_bundle_cli.py
@@ -175,7 +175,23 @@ def test_build_produces_artifact(project: Path):
     assert len(artifacts) == 1
 
 
-def test_info_expands_full_component_set(project: Path):
+def _mock_manifest_download(monkeypatch, source_path: Path) -> None:
+    """Mock the HTTPS manifest fetch to return a locally-authored manifest.
+
+    Catalog ``download_url``s are HTTPS-only, so ``info`` tests can no longer
+    point one at a local file. Patch ``_download_manifest`` to return the
+    manifest parsed from *source_path* (a bundle.yml or a .zip artifact),
+    exercising ``info``'s expansion without a network call.
+    """
+    from specify_cli.commands.bundle import _local_manifest_source
+
+    monkeypatch.setattr(
+        "specify_cli.commands.bundle._download_manifest",
+        lambda resolved, *, offline: _local_manifest_source(str(source_path)),
+    )
+
+
+def test_info_expands_full_component_set(project: Path, monkeypatch):
     bundle_dir = project / "src-bundle"
     bundle_dir.mkdir()
     (bundle_dir / "bundle.yml").write_text(
@@ -183,13 +199,14 @@ def test_info_expands_full_component_set(project: Path):
     )
     catalog = project / "local-catalog.json"
     entry = catalog_entry_dict(
-        "demo-bundle", download_url=str(bundle_dir / "bundle.yml")
+        "demo-bundle", download_url="https://example.com/demo-bundle.zip"
     )
     write_catalog_file(catalog, {"demo-bundle": entry})
     added = runner.invoke(
         app, ["bundle", "catalog", "add", str(catalog), "--id", "local"]
     )
     assert added.exit_code == 0, added.output
+    _mock_manifest_download(monkeypatch, bundle_dir / "bundle.yml")
 
     result = runner.invoke(app, ["bundle", "info", "demo-bundle", "--json", "--offline"])
     assert result.exit_code == 0, result.output
@@ -207,7 +224,7 @@ def test_info_expands_full_component_set(project: Path):
     assert "Trust" in text.output
 
 
-def test_info_expands_discovery_only_bundle(project: Path):
+def test_info_expands_discovery_only_bundle(project: Path, monkeypatch):
     # Discovery-only bundles must still be fully inspectable via `info`;
     # only `install` is refused for them.
     bundle_dir = project / "disc-bundle"
@@ -217,7 +234,7 @@ def test_info_expands_discovery_only_bundle(project: Path):
     )
     catalog = project / "disc-catalog.json"
     entry = catalog_entry_dict(
-        "demo-bundle", download_url=str(bundle_dir / "bundle.yml")
+        "demo-bundle", download_url="https://example.com/demo-bundle.zip"
     )
     write_catalog_file(catalog, {"demo-bundle": entry})
     config = {
@@ -230,6 +247,7 @@ def test_info_expands_discovery_only_bundle(project: Path):
     (project / ".specify" / "bundle-catalogs.yml").write_text(
         yaml.safe_dump(config), encoding="utf-8"
     )
+    _mock_manifest_download(monkeypatch, bundle_dir / "bundle.yml")
     result = runner.invoke(app, ["bundle", "info", "demo-bundle", "--json", "--offline"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
@@ -237,8 +255,9 @@ def test_info_expands_discovery_only_bundle(project: Path):
     assert ("extensions", "ext-a") in components
 
 
-def test_info_resolves_local_zip_download_url(project: Path):
-    # A local .zip artifact as download_url is extracted to read bundle.yml.
+def test_info_expands_zip_sourced_bundle(project: Path, monkeypatch):
+    # A .zip artifact is extracted to read bundle.yml; info expands it. (The
+    # download itself is HTTPS-only now and mocked here — see contract note.)
     bundle_dir = project / "zip-src"
     bundle_dir.mkdir()
     (bundle_dir / "bundle.yml").write_text(
@@ -249,12 +268,15 @@ def test_info_resolves_local_zip_download_url(project: Path):
     catalog = project / "zip-catalog.json"
     write_catalog_file(
         catalog,
-        {"demo-bundle": catalog_entry_dict("demo-bundle", download_url=str(artifact))},
+        {"demo-bundle": catalog_entry_dict(
+            "demo-bundle", download_url="https://example.com/demo-bundle.zip"
+        )},
     )
     added = runner.invoke(
         app, ["bundle", "catalog", "add", str(catalog), "--id", "local"]
     )
     assert added.exit_code == 0, added.output
+    _mock_manifest_download(monkeypatch, artifact)
     result = runner.invoke(app, ["bundle", "info", "demo-bundle", "--json", "--offline"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)

--- a/tests/integration/test_bundler_local_install.py
+++ b/tests/integration/test_bundler_local_install.py
@@ -154,3 +154,20 @@ def test_local_install_still_resolves_via_positional_path(tmp_path: Path):
     manifest = _local_manifest_source(str(manifest_path))
     assert manifest is not None
     assert manifest.bundle.id == "demo-bundle"
+
+
+def test_download_manifest_rejects_non_https_url_even_offline(tmp_path: Path):
+    """A non-HTTPS download_url must report the HTTPS problem, not a misleading
+    'Network access disabled', even under --offline (scheme is validated before
+    the offline gate)."""
+    from types import SimpleNamespace
+
+    from specify_cli.commands.bundle import _download_manifest
+
+    resolved = SimpleNamespace(
+        entry=SimpleNamespace(
+            id="demo-bundle", download_url="http://example.com/bundle.zip"
+        )
+    )
+    with pytest.raises(BundlerError, match="HTTPS"):
+        _download_manifest(resolved, offline=True)

--- a/tests/integration/test_bundler_local_install.py
+++ b/tests/integration/test_bundler_local_install.py
@@ -112,3 +112,40 @@ def test_install_bundled_extension_from_zip_offline(tmp_path: Path):
         assert not ExtensionManager(project).registry.is_installed("agent-context")
     finally:
         os.chdir(previous)
+
+
+def test_download_manifest_resolves_file_url(tmp_path: Path):
+    """A catalog ``file://`` download_url must resolve to the manifest.
+
+    ``Path(parsed.path)`` kept the leading slash of ``file:///C:/x``
+    (yielding a ``/C:/x``-style path on Windows, which never exists) and skipped
+    percent-decoding, so ``my%20bundles`` stayed encoded on every OS.
+    The space in the directory name below makes the failure reproduce on
+    POSIX CI too, not just Windows.
+    """
+    from types import SimpleNamespace
+
+    from specify_cli.commands.bundle import _download_manifest
+
+    manifest_path = write_manifest(tmp_path / "my bundles")
+    resolved = SimpleNamespace(
+        entry=SimpleNamespace(id="demo-bundle", download_url=manifest_path.as_uri())
+    )
+
+    manifest = _download_manifest(resolved, offline=True)
+    assert manifest.bundle.id == "demo-bundle"
+
+
+def test_download_manifest_bare_windows_path_still_resolves(tmp_path: Path):
+    """The non-URL branch (bare absolute path) keeps working unchanged."""
+    from types import SimpleNamespace
+
+    from specify_cli.commands.bundle import _download_manifest
+
+    manifest_path = write_manifest(tmp_path / "plain")
+    resolved = SimpleNamespace(
+        entry=SimpleNamespace(id="demo-bundle", download_url=str(manifest_path))
+    )
+
+    manifest = _download_manifest(resolved, offline=True)
+    assert manifest.bundle.id == "demo-bundle"

--- a/tests/integration/test_bundler_local_install.py
+++ b/tests/integration/test_bundler_local_install.py
@@ -114,14 +114,10 @@ def test_install_bundled_extension_from_zip_offline(tmp_path: Path):
         os.chdir(previous)
 
 
-def test_download_manifest_resolves_file_url(tmp_path: Path):
-    """A catalog ``file://`` download_url must resolve to the manifest.
-
-    ``Path(parsed.path)`` kept the leading slash of ``file:///C:/x``
-    (yielding a ``/C:/x``-style path on Windows, which never exists) and skipped
-    percent-decoding, so ``my%20bundles`` stayed encoded on every OS.
-    The space in the directory name below makes the failure reproduce on
-    POSIX CI too, not just Windows.
+def test_download_manifest_rejects_file_url(tmp_path: Path):
+    """A catalog ``file://`` download_url is rejected — catalog URLs are
+    HTTPS-only, matching extensions/presets/workflows. Disk installs go through
+    the positional path (see the local-source tests above), not download_url.
     """
     from types import SimpleNamespace
 
@@ -132,12 +128,12 @@ def test_download_manifest_resolves_file_url(tmp_path: Path):
         entry=SimpleNamespace(id="demo-bundle", download_url=manifest_path.as_uri())
     )
 
-    manifest = _download_manifest(resolved, offline=True)
-    assert manifest.bundle.id == "demo-bundle"
+    with pytest.raises(BundlerError, match="bundle install"):
+        _download_manifest(resolved, offline=True)
 
 
-def test_download_manifest_bare_windows_path_still_resolves(tmp_path: Path):
-    """The non-URL branch (bare absolute path) keeps working unchanged."""
+def test_download_manifest_rejects_bare_path(tmp_path: Path):
+    """A bare filesystem path download_url is likewise rejected."""
     from types import SimpleNamespace
 
     from specify_cli.commands.bundle import _download_manifest
@@ -147,5 +143,14 @@ def test_download_manifest_bare_windows_path_still_resolves(tmp_path: Path):
         entry=SimpleNamespace(id="demo-bundle", download_url=str(manifest_path))
     )
 
-    manifest = _download_manifest(resolved, offline=True)
+    with pytest.raises(BundlerError, match="bundle install"):
+        _download_manifest(resolved, offline=True)
+
+
+def test_local_install_still_resolves_via_positional_path(tmp_path: Path):
+    """The supported local route — a positional path, not a download_url —
+    still resolves the manifest via _local_manifest_source."""
+    manifest_path = write_manifest(tmp_path / "my bundles")
+    manifest = _local_manifest_source(str(manifest_path))
+    assert manifest is not None
     assert manifest.bundle.id == "demo-bundle"


### PR DESCRIPTION
## Description

A catalog entry's `download_url` accepted `file://` and bare filesystem paths, diverging from the rest of the codebase. Per maintainer review, the correct fix is to **remove** that path (not repair it): catalog `download_url`s are **HTTPS-only** (http for localhost), matching the extensions/presets/workflows catalog systems. Installing a bundle from disk goes through the **positional path** — `specify bundle install ./path/to/bundle.yml` (a bundle dir or `.zip` also works) — handled by `_local_manifest_source` *before* catalog resolution, which never touches `download_url`.

Originally reported as a Windows-drive / percent-encoding bug in `_download_manifest` (it built the local path from raw `parsed.path`); that diagnosis was correct, but rather than repair the `file://` branch we drop it, since `file://` in a catalog `download_url` was never intended.

### Changes
- `_download_manifest`: reject `file://` and bare-path `download_url`s with an actionable error pointing at the positional install; route everything else through `_download_remote_manifest` (HTTPS-only via `_require_https`). HTTPS/host is validated **before** the offline gate so an invalid scheme reports the real problem in every mode (not a misleading "Network access disabled").
- Docstring updated to state the HTTPS-only contract.

### Testing
- `_download_manifest` now **rejects** a `file://` and a bare-path `download_url` (was: resolved) — see `test_download_manifest_rejects_file_url` / `test_download_manifest_rejects_bare_path`; a non-HTTPS URL is rejected with the HTTPS error even offline (`test_download_manifest_rejects_non_https_url_even_offline`).
- `test_local_install_still_resolves_via_positional_path` proves the supported disk route still works.
- The three `bundle info` contract tests were migrated off local `download_url`s onto an HTTPS entry with a mocked manifest fetch. Full `test_bundle_cli.py` + `test_bundler_local_install.py`: 40 passed, ruff clean.

### Catalog-system parity
Audited all four systems: extensions, presets, and workflows already enforce HTTPS on both catalog and per-entry download URLs; bundle's `_download_manifest` was the lone gap, now closed — so all four are consistent.

## AI Disclosure

- [x] I used AI assistance (Claude Code, under my direction). AI implemented the pivot + migrated the affected tests; I verified the full contract/local-install suites locally and reviewed the diff.