### PR TITLE
fix(extensions): coerce non-mapping YAML config roots to {} in ConfigManager

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -2688,7 +2688,12 @@ class ConfigManager:
             return {}
 
         try:
-            return yaml.safe_load(file_path.read_text(encoding="utf-8")) or {}
+            data = yaml.safe_load(file_path.read_text(encoding="utf-8"))
+            # Coerce a non-mapping root (list/scalar, or None for an empty
+            # file) to {} so callers that iterate/merge the result — e.g.
+            # _merge_configs' .items() — never crash. Mirrors the same
+            # non-dict-root guard in get_project_config().
+            return data if isinstance(data, dict) else {}
         except (yaml.YAMLError, OSError, UnicodeError):
             return {}
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -31,6 +31,7 @@ from specify_cli.extensions import (
     ExtensionRegistry,
     ExtensionManager,
     CommandRegistrar,
+    ConfigManager,
     HookExecutor,
     ExtensionCatalog,
     ExtensionError,
@@ -7492,3 +7493,52 @@ def test_extension_wrapper_resolves_ghes_asset_when_host_configured(tmp_path, mo
     )
     assert resolved == "https://ghes.example/api/v3/repos/o/r/releases/assets/7"
     assert captured == ["https://ghes.example/api/v3/repos/o/r/releases/tags/v1"]
+
+
+class TestConfigManagerNonMappingYaml:
+    """A non-mapping YAML config root must not crash config/hook resolution."""
+
+    def _make(self, tmp_path, body: str):
+        ext_dir = tmp_path / ".specify" / "extensions" / "jira"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "jira-config.yml").write_text(body, encoding="utf-8")
+        return ConfigManager(tmp_path, "jira")
+
+    def test_get_config_coerces_list_root(self, tmp_path):
+        """A YAML list root previously raised AttributeError in _merge_configs."""
+        cm = self._make(tmp_path, "- foo\n- bar\n")
+        assert cm.get_config() == {}
+
+    def test_get_config_coerces_scalar_root(self, tmp_path):
+        cm = self._make(tmp_path, "just a string\n")
+        assert cm.get_config() == {}
+
+    def test_has_value_and_get_value_do_not_raise(self, tmp_path):
+        cm = self._make(tmp_path, "- foo\n")
+        assert cm.has_value("anything") is False
+        assert cm.get_value("anything") is None
+
+    def test_valid_local_config_layers_over_list_root_project_config(self, tmp_path):
+        """A malformed project config must not block a valid local config."""
+        ext_dir = tmp_path / ".specify" / "extensions" / "jira"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "jira-config.yml").write_text("- foo\n- bar\n", encoding="utf-8")
+        (ext_dir / "local-config.yml").write_text(
+            "notifications:\n  enabled: true\n", encoding="utf-8"
+        )
+        cm = ConfigManager(tmp_path, "jira")
+        assert cm.get_value("notifications.enabled") is True
+
+    def test_hook_condition_returns_false_without_raising(self, tmp_path):
+        """`config.x is set` on a scalar-root config must evaluate cleanly.
+
+        Before the fix, _merge_configs raised AttributeError and the
+        exception was swallowed by should_execute_hook, silently disabling
+        every config-based hook for the extension. Assert on
+        _evaluate_condition directly so the crash isn't masked.
+        """
+        ext_dir = tmp_path / ".specify" / "extensions" / "jira"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "jira-config.yml").write_text("just a string\n", encoding="utf-8")
+        executor = HookExecutor(tmp_path)
+        assert executor._evaluate_condition("config.x is set", "jira") is False


### PR DESCRIPTION
## Description

`ConfigManager._load_yaml_config` guards only *falsy* YAML roots:

```python
return yaml.safe_load(file_path.read_text(encoding="utf-8")) or {}
```

A **truthy non-mapping** root — a YAML list (`- foo`) or a scalar (`just a string`) — passes straight through, then `_merge_configs` does `.items()` on it:

```text
AttributeError: 'list' object has no attribute 'items'
```

reproduced on main @ `bba473c` via `ConfigManager(root, 'jira').get_config()` with a list-root `jira-config.yml`. `has_value`/`get_value` crash the same way, and — worse — `HookExecutor.should_execute_hook` wraps evaluation in a blanket `except Exception: return False`, so a malformed config file **silently disables every `config.* ` hook condition** for that extension instead of surfacing an error.

### Fix

Coerce a non-`dict` root (list/scalar, or `None` for an empty file) to `{}`, mirroring the existing non-dict-root guard already present in `get_project_config()`. One place hardens all three callers (`_get_extension_defaults`, `_get_project_config`, `_get_local_config`).

## Testing

New `TestConfigManagerNonMappingYaml` (5 tests, all **fail-before / pass-after**, verified by source-stash):
- list-root and scalar-root `get_config()` return `{}` instead of raising;
- `has_value`/`get_value` don't raise;
- a **valid** `local-config.yml` still layers over a malformed (list-root) project config;
- `HookExecutor._evaluate_condition('config.x is set', 'jira')` returns `False` cleanly (asserted directly, since `should_execute_hook` masks the exception).

`uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI traced the crash from `_load_yaml_config` through `_merge_configs` into the swallowed hook exception; I reproduced it, verified fail-before/pass-after, and reviewed the diff before submitting.