### PR TITLE
fix(integrations): hermes honors SPECKIT_INTEGRATION_HERMES_EXTRA_ARGS

### DIFF
--- a/src/specify_cli/integrations/hermes/__init__.py
+++ b/src/specify_cli/integrations/hermes/__init__.py
@@ -253,6 +253,11 @@ class HermesIntegration(SkillsIntegration):
         """
         args = [self._resolve_executable(), "chat", "-Q"]
 
+        # Operator-supplied SPECKIT_INTEGRATION_HERMES_EXTRA_ARGS go here —
+        # after the base command but before Spec Kit's canonical -m/--json/-s/-q
+        # flags — so they can't displace or clobber them (mirrors opencode).
+        self._apply_extra_args_env_var(args)
+
         if model:
             args.extend(["-m", model])
         if output_json:

--- a/tests/integrations/test_integration_hermes.py
+++ b/tests/integrations/test_integration_hermes.py
@@ -353,3 +353,38 @@ class TestHermesInitFlow:
             if "agent-context" not in d.name
         ]
         assert local_skills == [], f"Local skills dir should be empty, got: {local_skills}"
+
+
+class TestHermesBuildExecArgs:
+    """CLI dispatch argv, including the operator extra-args env hook."""
+
+    def test_build_exec_args_default_shape(self):
+        i = get_integration("hermes")
+        assert i.build_exec_args("/speckit-plan hi", output_json=True) == [
+            "hermes", "chat", "-Q", "--json", "-s", "speckit-plan", "-q", "hi",
+        ]
+
+    def test_build_exec_args_honors_extra_args(self, monkeypatch):
+        """SPECKIT_INTEGRATION_HERMES_EXTRA_ARGS is injected before the
+        canonical -m/--json/-s/-q flags (same env hook as codex/opencode/
+        devin; hermes previously skipped _apply_extra_args_env_var entirely).
+        """
+        monkeypatch.setenv(
+            "SPECKIT_INTEGRATION_HERMES_EXTRA_ARGS", "--temperature 0.2"
+        )
+        i = get_integration("hermes")
+        args = i.build_exec_args("/speckit-plan hi", output_json=True)
+        assert args == [
+            "hermes", "chat", "-Q", "--temperature", "0.2",
+            "--json", "-s", "speckit-plan", "-q", "hi",
+        ]
+        # Injected before the canonical flags so it can't displace them.
+        assert args.index("--temperature") < args.index("--json")
+        assert args.index("--temperature") < args.index("-s")
+
+    def test_build_exec_args_honors_executable_override(self, monkeypatch):
+        monkeypatch.setenv(
+            "SPECKIT_INTEGRATION_HERMES_EXECUTABLE", "/custom/hermes"
+        )
+        i = get_integration("hermes")
+        assert i.build_exec_args("/speckit-plan hi")[0] == "/custom/hermes"


### PR DESCRIPTION
## Description

`HermesIntegration.build_exec_args` routes argv[0] through `_resolve_executable()` (so the `_EXECUTABLE` override works) but never calls `_apply_extra_args_env_var()`:

```python
args = [self._resolve_executable(), "chat", "-Q"]
if model:
    args.extend(["-m", model])
...
```

So `SPECKIT_INTEGRATION_HERMES_EXTRA_ARGS` is **silently dropped** — the same class of bug fixed for `cursor-agent` in #3265. Sibling CLI-dispatch integrations (`codex`, `devin`, `opencode`) all call the hook.

### Fix

Insert `self._apply_extra_args_env_var(args)` after the base `chat -Q` command and **before** Spec Kit's canonical `-m`/`--json`/`-s`/`-q` flags, mirroring `opencode`'s placement — so operator-supplied flags can't displace or clobber the canonical ones.

## Testing

New `TestHermesBuildExecArgs` (hermes had **zero** `build_exec_args` coverage):
- default argv shape pinned;
- `test_build_exec_args_honors_extra_args`: with the env var set, `--temperature 0.2` appears **before** `--json`/`-s` (asserts both membership and insertion order). **Fails before** (tokens absent — verified by source-stash), **passes after**;
- executable-override test.

`uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI flagged hermes as another integration skipping the extra-args hook; I confirmed it, pinned insertion order in the test (per the #3265 review), verified fail-before/pass-after, and reviewed the diff.