### PR TITLE
fix(integrations): agy honors SPECKIT_INTEGRATION_AGY_EXTRA_ARGS

### DIFF
--- a/src/specify_cli/integrations/agy/__init__.py
+++ b/src/specify_cli/integrations/agy/__init__.py
@@ -89,7 +89,11 @@ class AgyIntegration(SkillsIntegration):
         output_json: bool = True,
     ) -> list[str] | None:
         # agy does not support --model or JSON output; both params are ignored
-        return [self._resolve_executable(), "--print", prompt]
+        args = [self._resolve_executable(), "--print", prompt]
+        # Honor SPECKIT_INTEGRATION_AGY_EXTRA_ARGS (operator-supplied flags),
+        # appended after the positional prompt like the devin integration.
+        self._apply_extra_args_env_var(args)
+        return args
 
     def setup(
         self,

--- a/tests/integrations/test_integration_agy.py
+++ b/tests/integrations/test_integration_agy.py
@@ -81,6 +81,26 @@ class TestAgyBuildExecArgs:
         result = i.build_exec_args("my prompt", output_json=False)
         assert result == ["agy", "--print", "my prompt"]
 
+    def test_build_exec_args_honors_extra_args(self, monkeypatch):
+        """SPECKIT_INTEGRATION_AGY_EXTRA_ARGS must be appended after the prompt.
+
+        agy previously skipped _apply_extra_args_env_var entirely, so the
+        documented per-integration extra-args hook was silently ignored
+        (same class as the merged cursor-agent fix #3265).
+        """
+        from specify_cli.integrations import get_integration
+        monkeypatch.setenv("SPECKIT_INTEGRATION_AGY_EXTRA_ARGS", "--verbose")
+        i = get_integration("agy")
+        assert i.build_exec_args("my prompt") == [
+            "agy", "--print", "my prompt", "--verbose",
+        ]
+
+    def test_build_exec_args_honors_executable_override(self, monkeypatch):
+        from specify_cli.integrations import get_integration
+        monkeypatch.setenv("SPECKIT_INTEGRATION_AGY_EXECUTABLE", "/custom/agy")
+        i = get_integration("agy")
+        assert i.build_exec_args("my prompt")[0] == "/custom/agy"
+
 
 class TestAgyHookCommandNote:
     """Verify dot-to-hyphen normalization note is injected into hook sections."""


### PR DESCRIPTION
## Description

`AgyIntegration.build_exec_args` returned its argv in one line without calling `_apply_extra_args_env_var()`:

```python
# agy does not support --model or JSON output; both params are ignored
return [self._resolve_executable(), "--print", prompt]
```

So `SPECKIT_INTEGRATION_AGY_EXTRA_ARGS` was **silently dropped** — the same class of bug fixed for `cursor-agent` in #3265. (argv[0] already went through `_resolve_executable()`, so the `_EXECUTABLE` override worked; only the extra-args hook was missing.)

### Fix

Append `self._apply_extra_args_env_var(args)` after the positional prompt, matching the `devin` integration's shape (`[exe, "-p", prompt]` then hook). agy still ignores `model`/`output_json` as before.

## Testing

Added to the existing `TestAgyBuildExecArgs`:
- `test_build_exec_args_honors_extra_args`: with the env var set, argv == `['agy','--print','my prompt','--verbose']`. **Fails before** (`--verbose` absent — verified by source-stash), **passes after**;
- executable-override test.

The 3 existing tests pin the env-unset shape and stay green. `uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI flagged agy as another integration skipping the extra-args hook; I confirmed it, verified fail-before/pass-after, and reviewed the diff.