### PR TITLE
fix(workflows): shell step validate() rejects non-string run

### DIFF
--- a/src/specify_cli/workflows/steps/shell/__init__.py
+++ b/src/specify_cli/workflows/steps/shell/__init__.py
@@ -90,6 +90,16 @@ class ShellStep(StepBase):
             errors.append(
                 f"Shell step {config.get('id', '?')!r} is missing 'run' field."
             )
+        elif not isinstance(config["run"], str):
+            # execute() str()-coerces run and invokes it under shell=True, so a
+            # null or list 'run' would run the Python repr ('None', "['echo']")
+            # as a command. Reject non-strings at validation, mirroring the
+            # command-step input/options and gate options type checks. An
+            # expression like "{{ ... }}" is still a str, so it stays valid.
+            errors.append(
+                f"Shell step {config.get('id', '?')!r}: 'run' must be a string, "
+                f"got {type(config['run']).__name__}."
+            )
         output_format = config.get("output_format")
         if output_format is not None and output_format != "json":
             errors.append(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1183,6 +1183,26 @@ class TestShellStep:
         errors = step.validate({"id": "test"})
         assert any("missing 'run'" in e for e in errors)
 
+    @pytest.mark.parametrize("bad_run", [None, ["echo", "hi"], 42])
+    def test_validate_rejects_non_string_run(self, bad_run):
+        """A non-string 'run' must be rejected at validation.
+
+        execute() str()-coerces run and invokes it under shell=True, so a
+        null or list run would otherwise run the Python repr as a command.
+        """
+        from specify_cli.workflows.steps.shell import ShellStep
+
+        step = ShellStep()
+        errors = step.validate({"id": "s", "run": bad_run})
+        assert any("'run' must be a string" in e for e in errors)
+
+    def test_validate_accepts_string_and_expression_run(self):
+        from specify_cli.workflows.steps.shell import ShellStep
+
+        step = ShellStep()
+        assert step.validate({"id": "s", "run": "echo hi"}) == []
+        assert step.validate({"id": "s", "run": "{{ steps.x.output }}"}) == []
+
 
     def test_output_format_json_exposes_data(self, tmp_path):
         from specify_cli.workflows.steps.shell import ShellStep


### PR DESCRIPTION
## Description

`ShellStep.validate()` only checks that `run` is **present**:

```python
if "run" not in config:
    errors.append("...missing 'run' field.")
```

So `run:` (null) or a GitHub-Actions-style list validates clean. `execute()` then does:

```python
run_cmd = config.get("run", "")
...
run_cmd = str(run_cmd)   # -> 'None'  or  "['echo', 'hi']"
```

and invokes that under `shell=True` — literally running the Python repr as a command. Reproduced on main @ `bba473c`: `validate({'id':'s','run':None})` and `validate({'id':'s','run':['echo','hi']})` both return `[]`, and execute then runs `'None'` / `['echo'...` (shell error "'None' is not recognized").

### Fix

Add a type check after the presence check, mirroring the command-step (#3262) and gate-options validation patterns. An expression like `{{ steps.x.output }}` is still a `str`, so expression configs stay valid.

## Testing

- `test_validate_rejects_non_string_run` parametrized over `None`, a list, and an int → all now report `'run' must be a string`. **Fails before** (validate returns `[]` — verified by source-stash), **passes after**.
- `test_validate_accepts_string_and_expression_run`: plain and `{{ ... }}` strings return `[]`.
- Full `TestShellStep`: 11 passed. `uvx ruff check` clean.

Note: open PR #3328 also edits this `validate()` (adds `timeout` validation) and the `TestShellStep` region — I placed the new checks/tests in distinct spots to minimize any textual conflict; the two changes are independent.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI flagged the validate-vs-execute type gap; I reproduced the shell-injection of the repr, verified fail-before/pass-after, and reviewed the diff.