### PR TITLE
fix(workflows): fan-in validate() rejects non-mapping output

### DIFF
--- a/src/specify_cli/workflows/steps/fan_in/__init__.py
+++ b/src/specify_cli/workflows/steps/fan_in/__init__.py
@@ -58,4 +58,13 @@ class FanInStep(StepBase):
                 f"Fan-in step {config.get('id', '?')!r}: "
                 f"'wait_for' must be a non-empty list of step IDs."
             )
+        output = config.get("output")
+        if output is not None and not isinstance(output, dict):
+            # execute() silently coerces a non-mapping output to {}, so the
+            # author's declared aggregation keys would vanish with no error.
+            # Reject at validation, mirroring the command-step (#3262) fix.
+            errors.append(
+                f"Fan-in step {config.get('id', '?')!r}: 'output' must be a "
+                f"mapping of key -> expression, got {type(output).__name__}."
+            )
         return errors

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2099,6 +2099,27 @@ class TestFanInStep:
         errors = step.validate({"id": "test", "wait_for": "not-a-list"})
         assert any("non-empty list" in e for e in errors)
 
+    @pytest.mark.parametrize("bad_output", [["{{ fan_in.results }}"], "{{ x }}", 42])
+    def test_validate_rejects_non_mapping_output(self, bad_output):
+        """A non-mapping 'output' must be rejected: execute() would otherwise
+        silently coerce it to {} and drop the declared aggregation keys."""
+        from specify_cli.workflows.steps.fan_in import FanInStep
+
+        step = FanInStep()
+        errors = step.validate(
+            {"id": "j", "wait_for": ["a"], "output": bad_output}
+        )
+        assert any("'output' must be a mapping" in e for e in errors)
+
+    def test_validate_accepts_mapping_or_absent_output(self):
+        from specify_cli.workflows.steps.fan_in import FanInStep
+
+        step = FanInStep()
+        assert step.validate(
+            {"id": "j", "wait_for": ["a"], "output": {"joined": "{{ x }}"}}
+        ) == []
+        assert step.validate({"id": "j", "wait_for": ["a"]}) == []
+
 
 class TestFanOutConcurrency:
     """Fan-out honors max_concurrency (WorkflowEngine._run_fan_out)."""


### PR DESCRIPTION
## Description

`FanInStep.validate()` only validates `wait_for` — it never checks `output`. But `execute()` does:

```python
output_config = config.get("output") or {}
if not isinstance(output_config, dict):
    output_config = {}   # silent
```

So a non-mapping `output` (a YAML list or scalar) **validates clean**, then the author's declared aggregation keys are silently discarded at run time — the step returns `COMPLETED` with an empty aggregation and no diagnostic. Reproduced on main @ `bba473c`: `validate({'id':'j','wait_for':['a'],'output':['{{ x }}']})` returns `[]`.

### Fix

Reject a non-mapping `output` at validation, mirroring the command-step (#3262) non-mapping input/options fix. `execute()`'s defensive coercion is intentionally left in place for callers that skip validation.

## Testing

- `test_validate_rejects_non_mapping_output` parametrized over a list, a string, and an int → all report `'output' must be a mapping`. **Fails before** (validate returns `[]` — verified by source-stash), **passes after**.
- `test_validate_accepts_mapping_or_absent_output`: a mapping and an omitted `output` return `[]`.
- Full `TestFanInStep`: 9 passed. `uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI flagged fan-in as the remaining step with a validate-vs-execute shape gap; I reproduced the silent key-drop, verified fail-before/pass-after, and reviewed the diff.