### PR TITLE
fix(extensions): handle prefix-colliding env vars in _get_env_config

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -2758,15 +2758,24 @@ class ConfigManager:
             # Remove prefix and split into parts
             config_path = key[len(prefix) :].lower().split("_")
 
-            # Build nested dict
+            # Build nested dict. Two env vars can collide on a prefix, e.g.
+            # SPECKIT_X_CONNECTION=a and SPECKIT_X_CONNECTION_URL=b. Guard the
+            # walk so a colliding scalar is replaced by a dict (deeper/more
+            # specific vars win) instead of being indexed into — which raised
+            # TypeError ('str' object does not support item assignment) — and
+            # guard the leaf so a scalar processed after the nested var does
+            # not clobber the nested dict. Order-independent: both insertion
+            # orders yield {'connection': {'url': ...}}. Nested-wins mirrors
+            # _merge_configs' dict-preserving semantics.
             current = env_config
             for part in config_path[:-1]:
-                if part not in current:
+                if not isinstance(current.get(part), dict):
                     current[part] = {}
                 current = current[part]
 
-            # Set the final value
-            current[config_path[-1]] = value
+            # Set the final value, unless a nested dict already occupies it.
+            if not isinstance(current.get(config_path[-1]), dict):
+                current[config_path[-1]] = value
 
         return env_config
 

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -2755,8 +2755,13 @@ class ConfigManager:
             if not key.startswith(prefix):
                 continue
 
-            # Remove prefix and split into parts
-            config_path = key[len(prefix) :].lower().split("_")
+            # Remove prefix and split into parts. Drop empty components from a
+            # malformed name (e.g. ``SPECKIT_<EXT>_`` with no key, or
+            # consecutive underscores ``SPECKIT_X__Y``) so we never create an
+            # entry under an empty key.
+            config_path = [p for p in key[len(prefix) :].lower().split("_") if p]
+            if not config_path:
+                continue
 
             # Build nested dict. Two env vars can collide on a prefix, e.g.
             # SPECKIT_X_CONNECTION=a and SPECKIT_X_CONNECTION_URL=b. Guard the

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -7665,6 +7665,9 @@ class TestConfigManagerEnvPrefixCollision:
         monkeypatch.setenv("SPECKIT_TESTEXT_CONNECTION", "x")
         monkeypatch.setenv("SPECKIT_TESTEXT_CONNECTION_URL", "y")
         executor = HookExecutor(tmp_path)
-        assert executor._evaluate_condition(
-            "config.connection.url is set", "testext"
+        # Exercise the public API: before the fix the TypeError was swallowed
+        # by should_execute_hook's `except Exception: return False`, so the
+        # hook was silently disabled (False); after the fix it returns True.
+        assert executor.should_execute_hook(
+            {"condition": "config.connection.url is set", "extension": "testext"}
         ) is True

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -7671,3 +7671,13 @@ class TestConfigManagerEnvPrefixCollision:
         assert executor.should_execute_hook(
             {"condition": "config.connection.url is set", "extension": "testext"}
         ) is True
+
+    def test_malformed_env_names_ignored(self, tmp_path, monkeypatch):
+        """A name with no key (SPECKIT_X_) or empty parts (consecutive
+        underscores) must not create an entry under an empty key."""
+        monkeypatch.setenv("SPECKIT_TESTEXT_", "orphan")  # no key at all
+        monkeypatch.setenv("SPECKIT_TESTEXT_A__B", "z")   # empty middle part
+        cm = ConfigManager(tmp_path, "testext")
+        cfg = cm._get_env_config()
+        assert "" not in cfg
+        assert cfg == {"a": {"b": "z"}}

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -7628,3 +7628,43 @@ class TestConfigManagerNonMappingYaml:
         (ext_dir / "jira-config.yml").write_text("just a string\n", encoding="utf-8")
         executor = HookExecutor(tmp_path)
         assert executor._evaluate_condition("config.x is set", "jira") is False
+
+
+class TestConfigManagerEnvPrefixCollision:
+    """Prefix-colliding env vars must not crash or clobber nested config."""
+
+    def test_scalar_then_nested_yields_nested(self, tmp_path, monkeypatch):
+        """SPECKIT_X_CONNECTION=x then SPECKIT_X_CONNECTION_URL=y.
+
+        The scalar-first order previously raised TypeError ('str' object
+        does not support item assignment) when the walk indexed into 'x'.
+        """
+        monkeypatch.setenv("SPECKIT_TESTEXT_CONNECTION", "x")
+        monkeypatch.setenv("SPECKIT_TESTEXT_CONNECTION_URL", "y")
+        cm = ConfigManager(tmp_path, "testext")
+        assert cm._get_env_config() == {"connection": {"url": "y"}}
+
+    def test_nested_then_scalar_does_not_clobber(self, tmp_path, monkeypatch):
+        """Reverse order previously returned {'connection': 'x'}, losing url."""
+        monkeypatch.setenv("SPECKIT_TESTEXT_CONNECTION_URL", "y")
+        monkeypatch.setenv("SPECKIT_TESTEXT_CONNECTION", "x")
+        cm = ConfigManager(tmp_path, "testext")
+        assert cm._get_env_config() == {"connection": {"url": "y"}}
+
+    def test_colliding_env_does_not_disable_hook_condition(self, tmp_path, monkeypatch):
+        """`config.connection.url is set` must stay True under colliding env.
+
+        Before the fix the TypeError propagated into should_execute_hook's
+        blanket `except Exception: return False`, silently disabling the hook.
+        """
+        ext_dir = tmp_path / ".specify" / "extensions" / "testext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "testext-config.yml").write_text(
+            "connection:\n  url: https://example.com\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("SPECKIT_TESTEXT_CONNECTION", "x")
+        monkeypatch.setenv("SPECKIT_TESTEXT_CONNECTION_URL", "y")
+        executor = HookExecutor(tmp_path)
+        assert executor._evaluate_condition(
+            "config.connection.url is set", "testext"
+        ) is True


### PR DESCRIPTION
## Description

`ConfigManager._get_env_config` maps `SPECKIT_{EXT}_{SECTION}_{KEY}` env vars into a nested dict:

```python
current = env_config
for part in config_path[:-1]:
    if part not in current:
        current[part] = {}
    current = current[part]
current[config_path[-1]] = value
```

Two env vars can **collide on a prefix** — e.g. `SPECKIT_JIRA_CONNECTION=x` and `SPECKIT_JIRA_CONNECTION_URL=y`. Behavior then depends on `os.environ` iteration order:

- **scalar first** → the walk for `CONNECTION_URL` does `current = current['connection']` (a `str`) then `current['url'] = 'y'` → **`TypeError: 'str' object does not support item assignment`**;
- **scalar last** → `current['connection'] = 'x'` overwrites the nested dict → returns `{'connection': 'x'}`, **silently losing `connection.url`**.

Both reproduced on main @ `bba473c`. Worse: the `TypeError` propagates through `get_config()`/`has_value()` into `should_execute_hook`'s blanket `except Exception: return False`, so a colliding env var **silently disables every `config.*` hook condition** for that extension.

### Fix

Guard the walk (`if not isinstance(current.get(part), dict): current[part] = {}`) and the leaf assignment (skip when a nested dict already occupies it). A colliding scalar yields to the more-specific nested var, so the result is **order-independent** — `{'connection': {'url': ...}}` either way — matching `_merge_configs`' dict-preserving semantics.

> Design note: nested-wins was chosen for order-independence and consistency with `_merge_configs`. An alternative (skip/warn on the colliding scalar) is possible; happy to adjust if you'd prefer.

## Testing

New `TestConfigManagerEnvPrefixCollision` (3 tests, all **fail-before / pass-after** via source-stash):
- scalar-first and scalar-last both yield `{'connection': {'url': 'y'}}`;
- e2e: `HookExecutor._evaluate_condition('config.connection.url is set', ...)` stays `True` under colliding env (was silently `False`).

`uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI found the order-dependent crash/clobber and traced it into the swallowed hook exception; I reproduced both modes, verified fail-before/pass-after, and reviewed the diff.