### PR TITLE
fix(bundler): validate catalog URLs in `catalog add` (HTTPS-only, require host)

### DIFF
--- a/src/specify_cli/bundler/commands_impl/catalog_config.py
+++ b/src/specify_cli/bundler/commands_impl/catalog_config.py
@@ -156,11 +156,11 @@ def add_source(
             "Use http(s)://, file://, builtin://, or a local path."
         )
     if parsed.scheme.lower() in {"http", "https"}:
-        # Mirror specify_cli.catalogs / bundler adapters URL validation
-        # (#3209/#3210): HTTPS only (HTTP just for localhost), and check
-        # hostname, not netloc — netloc is truthy for host-less URLs like
-        # "https://:8080" or "https://user@". Validating here keeps junk out
-        # of catalogs.yaml instead of failing later at fetch time.
+        # Mirror specify_cli.catalogs._validate_catalog_url (#3209/#3210):
+        # HTTPS only (HTTP just for localhost), and check hostname, not
+        # netloc — netloc is truthy for host-less URLs like "https://:8080"
+        # or "https://user@". Validating here keeps junk out of
+        # bundle-catalogs.yml instead of failing later at fetch time.
         is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
         if parsed.scheme.lower() != "https" and not is_localhost:
             raise BundlerError(

--- a/src/specify_cli/bundler/commands_impl/catalog_config.py
+++ b/src/specify_cli/bundler/commands_impl/catalog_config.py
@@ -95,7 +95,11 @@ def _is_local_path(url: str) -> bool:
     """True when *url* denotes a local filesystem path rather than a URL."""
     if _WINDOWS_DRIVE_RE.match(url):
         return True
-    scheme = urlparse(url).scheme.lower()
+    try:
+        scheme = urlparse(url).scheme.lower()
+    except ValueError:
+        # Malformed URLs (e.g. an unclosed IPv6 bracket) are not local paths.
+        return False
     return scheme not in _REMOTE_SCHEMES
 
 
@@ -137,7 +141,10 @@ def add_source(
     url = url.strip()
     if not url:
         raise BundlerError("A catalog url is required.")
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
+    except ValueError as exc:
+        raise BundlerError(f"Invalid catalog url: '{url}'.") from exc
     if not (parsed.scheme or parsed.path):
         raise BundlerError(f"Invalid catalog url: '{url}'.")
     # Reject unsupported URL schemes (e.g. ssh://, ftp://) up front so they are
@@ -148,6 +155,20 @@ def add_source(
             f"Unsupported catalog url scheme '{parsed.scheme}://' in '{url}'. "
             "Use http(s)://, file://, builtin://, or a local path."
         )
+    if parsed.scheme.lower() in {"http", "https"}:
+        # Mirror specify_cli.catalogs / bundler adapters URL validation
+        # (#3209/#3210): HTTPS only (HTTP just for localhost), and check
+        # hostname, not netloc — netloc is truthy for host-less URLs like
+        # "https://:8080" or "https://user@". Validating here keeps junk out
+        # of catalogs.yaml instead of failing later at fetch time.
+        is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
+        if parsed.scheme.lower() != "https" and not is_localhost:
+            raise BundlerError(
+                f"Catalog url must use HTTPS (got {parsed.scheme}://). "
+                "HTTP is only allowed for localhost."
+            )
+        if not parsed.hostname:
+            raise BundlerError(f"Catalog url must be a valid URL with a host: {url}")
 
     url = _canonicalize_url(url)
     install_policy = InstallPolicy.parse(policy)

--- a/tests/unit/test_bundler_catalog_config.py
+++ b/tests/unit/test_bundler_catalog_config.py
@@ -222,3 +222,39 @@ def test_add_source_allows_local_path_with_colon(tmp_path: Path, monkeypatch):
     # A relative path containing ':' but no '://' is still a local path.
     source = cc.add_source(project, "weird:name.json", policy="install-allowed", priority=50)
     assert source.url.endswith("weird:name.json") or "weird" in source.url
+
+
+def test_add_source_rejects_plain_http_for_non_localhost(tmp_path: Path):
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+    with pytest.raises(BundlerError, match="HTTPS"):
+        cc.add_source(project, "http://example.com/catalog.json", policy="install-allowed", priority=50)
+
+
+def test_add_source_allows_http_for_localhost(tmp_path: Path):
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+    source = cc.add_source(project, "http://localhost:8080/c.json", policy="install-allowed", priority=50)
+    assert source.url == "http://localhost:8080/c.json"
+
+
+def test_add_source_rejects_host_less_remote_urls(tmp_path: Path):
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+    for url in ("https://:8080", "https://user@"):
+        with pytest.raises(BundlerError, match="host"):
+            cc.add_source(project, url, policy="install-allowed", priority=50)
+
+
+def test_add_source_wraps_invalid_ipv6_as_bundler_error(tmp_path: Path):
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+    with pytest.raises(BundlerError, match="Invalid catalog url"):
+        cc.add_source(project, "https://[::1/c.json", policy="install-allowed", priority=50)
+
+
+def test_remove_source_does_not_crash_on_invalid_ipv6(tmp_path: Path):
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+    with pytest.raises(BundlerError, match="No project-scoped catalog source"):
+        cc.remove_source(project, "https://[::1/c.json")


### PR DESCRIPTION
## Description

Fixes #3366

`specify bundle catalog add` persisted remote catalog URLs into `catalogs.yaml` without any HTTPS or host validation, and a malformed IPv6 URL (`https://[::1/c.json`) escaped the command's `except BundlerError` handler as a raw `ValueError` traceback.

**Root cause:** `add_source` in `bundler/commands_impl/catalog_config.py` is the third copy of the catalog-URL validation contract — `specify_cli.catalogs._validate_catalog_url` (#3210) and `bundler/services/adapters._validate_remote_url` (#3333) both enforce HTTPS-only (HTTP for localhost) with a `hostname` check, but the CLI entry point that actually writes the config had neither.

**Before:** `http://evil.example.com/catalog.json`, `https://:8080`, `https://user@` → `✓ Added catalog ...` (fails later at fetch time); `https://[::1/c.json` → traceback.
**After:** all four rejected with a clear `BundlerError` at add time; `file://`, `builtin://`, local paths, and `http://localhost` unaffected.

Also guarded the `urlparse` call in `_is_local_path` so `remove_source`'s canonicalization fallback doesn't crash on the same malformed input.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` — 3832 passed, 87 skipped
- [ ] Tested with a sample project (if applicable)

5 new unit tests in `tests/unit/test_bundler_catalog_config.py`: plain-HTTP rejection, localhost-HTTP allowance, host-less rejection (`https://:8080`, `https://user@`), and `BundlerError` (not `ValueError`) on malformed IPv6 for both `add_source` and `remove_source`.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Bug found, patch and tests written with GitHub Copilot CLI; all changes reviewed, and the reproduction + full test suite run and verified locally by me.
