### PR TITLE
fix(agents): resolve skill placeholders in Goose (yaml) command output

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -673,6 +673,12 @@ class CommandRegistrar:
                 )
                 output = self.render_toml_command(frontmatter, body, source_id)
             elif agent_config["format"] == "yaml":
+                body = self.resolve_skill_placeholders(
+                    agent_name, frontmatter, body, project_root
+                )
+                body = self._convert_argument_placeholder(
+                    body, "$ARGUMENTS", agent_config["args"]
+                )
                 output = self.render_yaml_command(
                     frontmatter, body, source_id, cmd_name
                 )

--- a/tests/integrations/test_integration_goose.py
+++ b/tests/integrations/test_integration_goose.py
@@ -36,3 +36,43 @@ class TestGooseIntegration(YamlIntegrationTests):
                 param.get("key") == "args"
                 for param in data.get("parameters", [])
             ), f"{recipe_file} uses {{{{args}}}} but does not declare args"
+
+
+class TestGooseCommandPlaceholderResolution:
+    """register_commands must resolve skill placeholders for the yaml branch.
+
+    The yaml (Goose recipe) branch previously skipped
+    resolve_skill_placeholders / _convert_argument_placeholder that the
+    markdown and toml branches apply, so extension/preset command bodies
+    kept literal {SCRIPT} / __AGENT__ / repo-relative paths.
+    """
+
+    def test_register_commands_resolves_placeholders_in_recipe(self, tmp_path):
+        from specify_cli.agents import CommandRegistrar
+
+        ext_dir = tmp_path / "extension"
+        cmd_dir = ext_dir / "commands"
+        cmd_dir.mkdir(parents=True)
+        cmd_file = cmd_dir / "example.md"
+        cmd_file.write_text(
+            "---\n"
+            "description: Placeholder command\n"
+            "scripts:\n"
+            "  sh: scripts/bash/do.sh\n"
+            "  ps: scripts/powershell/do.ps1\n"
+            "---\n\n"
+            "Run {SCRIPT} for agent __AGENT__ with $ARGUMENTS.\n",
+            encoding="utf-8",
+        )
+
+        registrar = CommandRegistrar()
+        commands = [{"name": "speckit.example", "file": "commands/example.md"}]
+        registrar.register_commands("goose", commands, "test-ext", ext_dir, tmp_path)
+
+        recipe = tmp_path / ".goose" / "recipes" / "speckit.example.yaml"
+        assert recipe.exists(), "goose recipe should be generated"
+        content = recipe.read_text(encoding="utf-8")
+        # Placeholders must be resolved, not emitted verbatim.
+        assert "{SCRIPT}" not in content
+        assert "__AGENT__" not in content
+        assert "$ARGUMENTS" not in content

--- a/tests/integrations/test_integration_goose.py
+++ b/tests/integrations/test_integration_goose.py
@@ -71,8 +71,15 @@ class TestGooseCommandPlaceholderResolution:
 
         recipe = tmp_path / ".goose" / "recipes" / "speckit.example.yaml"
         assert recipe.exists(), "goose recipe should be generated"
-        content = recipe.read_text(encoding="utf-8")
-        # Placeholders must be resolved, not emitted verbatim.
-        assert "{SCRIPT}" not in content
-        assert "__AGENT__" not in content
-        assert "$ARGUMENTS" not in content
+        # Parse the recipe and assert the prompt actually got the correct
+        # replacements — not merely that the literal tokens are absent (which
+        # a wrong-but-token-free output could also satisfy).
+        data = yaml.safe_load(recipe.read_text(encoding="utf-8"))
+        prompt = data["prompt"]
+        assert ".specify/scripts/" in prompt  # {SCRIPT} -> resolved script path
+        assert "agent goose" in prompt  # __AGENT__ -> agent name
+        assert "{{args}}" in prompt  # $ARGUMENTS -> goose args token
+        # And the raw placeholders must not survive.
+        assert "{SCRIPT}" not in prompt
+        assert "__AGENT__" not in prompt
+        assert "$ARGUMENTS" not in prompt


### PR DESCRIPTION
## Description

`CommandRegistrar.register_commands` resolves command-body placeholders — `{SCRIPT}`, `__AGENT__` (via `resolve_skill_placeholders`) and `$ARGUMENTS` (via `_convert_argument_placeholder`) — in the **markdown** and **toml** branches, but the **yaml** branch (Goose recipes) called `render_yaml_command` directly and skipped both:

```python
elif agent_config["format"] == "yaml":
    output = self.render_yaml_command(frontmatter, body, source_id, cmd_name)
```

So an extension/preset command installed for Goose kept the **literal** `{SCRIPT}`, `__AGENT__`, and unrewritten repo-relative script paths in the generated `.goose/recipes/*.yaml` prompt. Reproduced on main @ `92b7cf7`: the same command body renders correctly for `claude` (skills) and `gemini` (toml) but Goose emitted `Run {SCRIPT} for agent __AGENT__ with $ARGUMENTS.` verbatim.

### Fix

Mirror the markdown/toml branches — run `resolve_skill_placeholders` + `_convert_argument_placeholder` on `body` before `render_yaml_command`. (`body` is reassigned before the downstream alias loop, so aliases inherit the resolved text too.)

## Testing

New `TestGooseCommandPlaceholderResolution`: registers a command whose body has `{SCRIPT}`/`__AGENT__`/`$ARGUMENTS` for `goose`, then asserts the generated `.goose/recipes/speckit.example.yaml` contains **none** of the literals (they resolve to `.specify/scripts/...`, `agent goose`, `{{args}}`). **Fails before** (literals present — verified by source-stash), **passes after**. Full goose suite: 25 passed. `uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI flagged the yaml branch as the odd one out across the three format branches; I reproduced the literal-placeholder leak against the claude/gemini baselines, verified fail-before/pass-after, and reviewed the diff.