### PR TITLE
fix(workflows): harden catalog.py against mis-shaped registry & non-string fields

### DIFF
--- a/src/specify_cli/workflows/catalog.py
+++ b/src/specify_cli/workflows/catalog.py
@@ -76,8 +76,16 @@ class WorkflowRegistry:
         if self.registry_path.exists():
             try:
                 with open(self.registry_path, encoding="utf-8") as f:
-                    return json.load(f)
-            except (json.JSONDecodeError, ValueError):
+                    data = json.load(f)
+                # Validate shape: must be a dict with a dict "workflows" field,
+                # otherwise every method that indexes data["workflows"] crashes.
+                # Mirrors StepRegistry._load.
+                if not isinstance(data, dict):
+                    return {"schema_version": self.SCHEMA_VERSION, "workflows": {}}
+                if not isinstance(data.get("workflows"), dict):
+                    data["workflows"] = {}
+                return data
+            except (json.JSONDecodeError, ValueError, OSError, UnicodeError):
                 # Corrupted registry file — reset to default
                 return {"schema_version": self.SCHEMA_VERSION, "workflows": {}}
         return {"schema_version": self.SCHEMA_VERSION, "workflows": {}}
@@ -438,9 +446,9 @@ class WorkflowCatalog:
                 q = query.lower()
                 searchable = " ".join(
                     [
-                        wf_data.get("name", ""),
-                        wf_data.get("description", ""),
-                        wf_data.get("id", ""),
+                        str(wf_data.get("name") or ""),
+                        str(wf_data.get("description") or ""),
+                        str(wf_data.get("id") or ""),
                     ]
                 ).lower()
                 if q not in searchable:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -4761,11 +4761,14 @@ class TestWorkflowRegistry:
         reg_path.write_text(bad_content, encoding="utf-8")
 
         registry = WorkflowRegistry(project_dir)
-        assert registry.data == {"schema_version": "1.0", "workflows": {}}
+        assert registry.data == {
+            "schema_version": WorkflowRegistry.SCHEMA_VERSION,
+            "workflows": {},
+        }
         # None of these should raise on the recovered-default shape.
         assert registry.is_installed("x") is False
         assert registry.get("x") is None
-        assert registry.list() == {} or registry.list() == []
+        assert registry.list() == {}  # list() always returns a dict
         registry.remove("x")
         registry.add("x", {"name": "X"})
         assert registry.is_installed("x")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -4746,11 +4746,55 @@ class TestWorkflowRegistry:
         registry2 = WorkflowRegistry(project_dir)
         assert registry2.is_installed("test-wf")
 
+    @pytest.mark.parametrize("bad_content", ["[]", '{"schema_version": "1.0"}'])
+    def test_load_tolerates_misshaped_registry(self, project_dir, bad_content):
+        """A JSON-valid but mis-shaped registry file must not crash every method.
+
+        A list root, or a dict lacking a 'workflows' mapping, previously made
+        is_installed/get/list/remove/add raise TypeError/KeyError. Mirrors the
+        shape guard StepRegistry._load already has.
+        """
+        from specify_cli.workflows.catalog import WorkflowRegistry
+
+        reg_path = project_dir / ".specify" / "workflows" / "workflow-registry.json"
+        reg_path.parent.mkdir(parents=True, exist_ok=True)
+        reg_path.write_text(bad_content, encoding="utf-8")
+
+        registry = WorkflowRegistry(project_dir)
+        assert registry.data == {"schema_version": "1.0", "workflows": {}}
+        # None of these should raise on the recovered-default shape.
+        assert registry.is_installed("x") is False
+        assert registry.get("x") is None
+        assert registry.list() == {} or registry.list() == []
+        registry.remove("x")
+        registry.add("x", {"name": "X"})
+        assert registry.is_installed("x")
+
 
 # ===== Workflow Catalog Tests =====
 
 class TestWorkflowCatalog:
     """Test WorkflowCatalog catalog resolution."""
+
+    def test_search_with_non_string_fields(self, project_dir, monkeypatch):
+        """Non-string workflow fields (null/int name/description) must not
+        raise TypeError in search — StepCatalog.search already coerces these."""
+        from specify_cli.workflows.catalog import WorkflowCatalog
+
+        catalog = WorkflowCatalog(project_dir)
+        monkeypatch.setattr(catalog, "_get_merged_workflows", lambda **kw: {
+            "42": {
+                "id": 42,
+                "name": None,
+                "description": 99,
+                "_catalog_name": "test",
+                "_install_allowed": True,
+            },
+        })
+
+        assert len(catalog.search()) == 1
+        assert len(catalog.search(query="42")) == 1
+        assert len(catalog.search(query="missing")) == 0
 
     def test_default_catalogs(self, project_dir, monkeypatch):
         from specify_cli.workflows.catalog import WorkflowCatalog


### PR DESCRIPTION
## Description

Two robustness gaps in `workflows/catalog.py` where the `Workflow*` classes diverge from their `Step*` siblings, which already guard both cases:

**1. `WorkflowRegistry._load` returns `json.load()` verbatim.** A JSON-valid but mis-shaped registry file crashes every method that indexes `data["workflows"]`:
- `workflow-registry.json` = `[]` → `is_installed`/`get`/`list`/`remove`/`add` raise `TypeError: list indices must be integers`;
- = `{"schema_version": "1.0"}` (no `workflows` key) → `KeyError: 'workflows'`.

`StepRegistry._load` already validates the shape (dict root + dict `steps`) and resets to default. Reproduced on main @ `92b7cf7`.

**2. `WorkflowCatalog.search` joins `name`/`description`/`id` without coercion.** A catalog entry with a null or non-string field raises `TypeError: sequence item 0: expected str instance, NoneType found`. `StepCatalog.search` already coerces with `str(... or "")` — and has a regression test for exactly this; `WorkflowCatalog.search` was the outlier.

### Fix

Mirror the siblings: validate the registry shape in `_load` (+ widen the except tuple to `OSError`/`UnicodeError`), and coerce the search fields with `str(wf_data.get(...) or "")`.

## Testing

- `test_load_tolerates_misshaped_registry` (parametrized `[]` / no-`workflows`): registry recovers to the default shape and all methods run. **Fails before** (TypeError/KeyError).
- `test_search_with_non_string_fields` (WorkflowCatalog, mirrors the existing StepCatalog test): null/int fields no longer raise. **Fails before** (TypeError).
- Both **verified fail-before via source-stash**; `TestWorkflowRegistry` + the new catalog test pass; `uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI diffed the Workflow* classes against their Step* siblings; I reproduced both crashes, verified fail-before/pass-after, and reviewed the diff.