### PR TITLE
fix(integrations): guard _sha256 against unreadable managed files

### DIFF
--- a/src/specify_cli/integrations/manifest.py
+++ b/src/specify_cli/integrations/manifest.py
@@ -309,7 +309,14 @@ class IntegrationManifest:
             if abs_path.is_symlink() or not abs_path.is_file():
                 modified.append(rel)
                 continue
-            if _sha256(abs_path) != expected_hash:
+            try:
+                changed = _sha256(abs_path) != expected_hash
+            except OSError:
+                # Unreadable regular file (e.g. permission denied): treat as
+                # modified, consistent with the symlink / non-regular-file
+                # handling above, rather than letting the OSError escape.
+                changed = True
+            if changed:
                 modified.append(rel)
         return modified
 
@@ -358,9 +365,17 @@ class IntegrationManifest:
                     skipped.append(path)
                     continue
             else:
-                if not force and _sha256(path) != expected_hash:
-                    skipped.append(path)
-                    continue
+                if not force:
+                    try:
+                        matches = _sha256(path) == expected_hash
+                    except OSError:
+                        # Unreadable: can't verify it's ours, so preserve it
+                        # (mirrors the path.unlink() OSError guard below).
+                        skipped.append(path)
+                        continue
+                    if not matches:
+                        skipped.append(path)
+                        continue
             try:
                 path.unlink()
             except OSError:

--- a/tests/integrations/test_manifest.py
+++ b/tests/integrations/test_manifest.py
@@ -481,3 +481,40 @@ class TestRecordExistingNewGuards:
         m = IntegrationManifest("test", tmp_path)
         with pytest.raises(ValueError, match=r"canonical|'\.\.' segments"):
             m.record_existing("dir/../file.txt")
+
+
+class TestManifestUnreadableFile:
+    """A managed file that is unreadable (e.g. PermissionError) must not crash
+    check_modified()/uninstall() — the CLI handlers surfaced a raw traceback."""
+
+    def _mk(self, tmp_path):
+        m = IntegrationManifest("test", tmp_path)
+        m.record_file("sub/f.md", "content")
+        return m
+
+    def test_check_modified_treats_unreadable_as_modified(self, tmp_path, monkeypatch):
+        m = self._mk(tmp_path)
+
+        def raise_perm(_path):
+            raise PermissionError("unreadable")
+
+        monkeypatch.setattr(
+            "specify_cli.integrations.manifest._sha256", raise_perm
+        )
+        # Before the fix this raised PermissionError.
+        assert m.check_modified() == ["sub/f.md"]
+
+    def test_uninstall_preserves_unreadable_file(self, tmp_path, monkeypatch):
+        m = self._mk(tmp_path)
+
+        def raise_perm(_path):
+            raise PermissionError("unreadable")
+
+        monkeypatch.setattr(
+            "specify_cli.integrations.manifest._sha256", raise_perm
+        )
+        removed, skipped = m.uninstall(force=False)
+        # Can't verify ownership => preserve, don't crash and don't delete.
+        assert removed == []
+        assert (tmp_path / "sub" / "f.md") in skipped
+        assert (tmp_path / "sub" / "f.md").exists()


### PR DESCRIPTION
## Description

`manifest.py::_sha256` does an unguarded `open(path, "rb")`. Two callers invoke it on a **regular file that exists but can't be opened** (e.g. permission denied) without catching `OSError`:

- `check_modified()` (line ~312) — only symlinks/non-regular files are guarded above; a readable-looking-but-unopenable regular file lets the `OSError` escape.
- `uninstall()` (line ~361) — the sibling `path.unlink()` right below **is** wrapped in `except OSError`, but the hash read is not (asymmetric).

So `specify integration upgrade` / `uninstall` / `switch` dump a raw `PermissionError` traceback instead of handling it. Reproduced on main @ `92b7cf7`.

### Fix (single file — `manifest.py`)

- `check_modified()`: catch `OSError` and treat an unreadable file as **modified**, consistent with how symlinks / non-regular files are already appended just above.
- `uninstall()`: catch `OSError` around the hash read and treat it as **skipped/preserved** (can't verify ownership → don't delete), mirroring the existing `unlink()` `OSError` guard. The `force` short-circuit is unchanged.

## Testing

New `TestManifestUnreadableFile` — deterministic and **cross-platform** via `monkeypatch` of `_sha256` to raise `PermissionError` (no real `chmod`/symlink needed):
- `check_modified()` returns the file as modified (was: raised);
- `uninstall(force=False)` returns it in `skipped`, removes nothing, leaves it on disk (was: raised).

Both **fail-before / pass-after** (verified by source-stash). Note: 6 pre-existing symlink tests in this file fail locally on Windows (symlink privilege) — identical on clean main, unrelated to this change, and green on Linux CI.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI flagged the unguarded `_sha256` against the guarded `unlink()` sibling; I reproduced the traceback path, wrote cross-platform monkeypatch tests, verified fail-before/pass-after, and confirmed the 6 remaining failures are pre-existing Windows-symlink environment issues.