### PR TITLE
fix(shared-infra): refresh_shared_templates preserves recovered user files

### DIFF
--- a/src/specify_cli/shared_infra.py
+++ b/src/specify_cli/shared_infra.py
@@ -347,7 +347,7 @@ def refresh_shared_templates(
 
     if skipped_files:
         console.print(
-            f"[yellow]⚠[/yellow]  {len(skipped_files)} modified or untracked shared template file(s) were not updated:"
+            f"[yellow]⚠[/yellow]  {len(skipped_files)} modified, untracked, or preserved (recovered) shared template file(s) were not updated:"
         )
         for rel in skipped_files:
             console.print(f"    {rel}")

--- a/src/specify_cli/shared_infra.py
+++ b/src/specify_cli/shared_infra.py
@@ -328,7 +328,10 @@ def refresh_shared_templates(
         _ensure_safe_shared_destination(project_path, dst)
         rel = dst.relative_to(project_path).as_posix()
         if dst.exists() and not force:
-            if rel not in tracked_files or rel in modified:
+            if rel not in tracked_files or rel in modified or manifest.is_recovered(rel):
+                # Never overwrite a recovered (pre-existing user) file without
+                # --force, matching install_shared_infra's is_recovered gate
+                # (#2918). Without this, refresh clobbers user content.
                 skipped_files.append(rel)
                 continue
 

--- a/tests/integrations/test_cli.py
+++ b/tests/integrations/test_cli.py
@@ -2073,3 +2073,44 @@ class TestIntegrationCatalogDiscoveryCLI:
         assert listing.exit_code == 0, listing.output
         assert "default" in listing.output
         assert "community" in listing.output
+
+
+def test_refresh_shared_templates_preserves_recovered_user_file(tmp_path):
+    """refresh_shared_templates must not overwrite a recovered (pre-existing
+    user) template without --force, matching install_shared_infra's gate (#2918).
+    """
+    from specify_cli.shared_infra import (
+        load_speckit_manifest,
+        refresh_shared_templates,
+    )
+
+    project = tmp_path / "proj"
+    templates_dir = project / ".specify" / "templates"
+    templates_dir.mkdir(parents=True)
+    user_file = templates_dir / "spec-template.md"
+    user_file.write_text("# USER CUSTOM CONTENT\n", encoding="utf-8")
+
+    # Record the pre-existing file as recovered (its hash was adopted, not written).
+    manifest = load_speckit_manifest(project, version="test", console=_NoopConsole())
+    rel = ".specify/templates/spec-template.md"
+    manifest.record_existing(rel, recovered=True)
+    manifest.save()
+
+    # Bundled source ships a different body for the same template.
+    core_pack = tmp_path / "core-pack"
+    src = core_pack / "templates"
+    src.mkdir(parents=True)
+    (src / "spec-template.md").write_text("# BUNDLED CONTENT v2\n", encoding="utf-8")
+
+    refresh_shared_templates(
+        project,
+        version="test",
+        core_pack=core_pack,
+        repo_root=tmp_path / "unused",
+        console=_NoopConsole(),
+        invoke_separator=".",
+        force=False,
+    )
+
+    # Recovered user content must survive (fail-before: replaced by bundled body).
+    assert user_file.read_text(encoding="utf-8") == "# USER CUSTOM CONTENT\n"


### PR DESCRIPTION
## Description

`refresh_shared_templates` decides whether to skip an existing shared template using only:

```python
if dst.exists() and not force:
    if rel not in tracked_files or rel in modified:
        skipped_files.append(rel); continue
```

It never consults `manifest.is_recovered(rel)` — but `install_shared_infra` does (its `_is_managed`/is_recovered gate, added by #2918). A **recovered** file is a pre-existing user file whose on-disk hash was *adopted* via `record_existing(recovered=True)`, so it is both **tracked** and **hash-unmodified**. Both predicates above are therefore false → the file is **not** skipped → `refresh_shared_templates` overwrites the user's content with the bundled body.

Reproduced on main @ `92b7cf7`: a recovered `spec-template.md` (`# USER CUSTOM CONTENT`) is replaced with `# BUNDLED CONTENT v2` on a non-`--force` refresh — the exact data-loss class #2918 fixed for `install_shared_infra`.

### Fix

Add the `is_recovered` check to the skip predicate, mirroring `install_shared_infra`. One source file, no API change.

## Testing

New `test_refresh_shared_templates_preserves_recovered_user_file`: records a user template as recovered, points the bundled source at a different body, calls `refresh_shared_templates(force=False)`, asserts the user content survives. **Fails before** (content replaced by bundled body — verified by source-stash), **passes after**. `uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI diffed the refresh skip-predicate against install_shared_infra's is_recovered gate; I reproduced the overwrite, verified fail-before/pass-after, and reviewed the diff.