### PR TITLE
fix(github-http): return None on malformed GHES port instead of raising

### DIFF
--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -127,7 +127,14 @@ def resolve_github_release_asset_api_url(
     if hostname == "github.com":
         api_base = "https://api.github.com"
     elif is_ghes:
-        authority = hostname if parsed.port is None else f"{hostname}:{parsed.port}"
+        # ``parsed.port`` raises ValueError on a malformed port (e.g.
+        # ``host:notaport``); the function's contract is to return None for
+        # anything it can't resolve, not to raise.
+        try:
+            port = parsed.port
+        except ValueError:
+            return None
+        authority = hostname if port is None else f"{hostname}:{port}"
         api_base = f"{parsed.scheme}://{authority}/api/v3"
     else:
         return None

--- a/tests/test_github_http.py
+++ b/tests/test_github_http.py
@@ -233,6 +233,23 @@ class TestResolveGitHubReleaseAssetApiUrl:
         assert result is None
         assert called == []
 
+    def test_returns_none_on_malformed_ghes_port(self):
+        """A malformed port on an allowlisted GHES host returns None, not a
+        ValueError (contract: resolve or return None, never raise)."""
+        called = []
+
+        def open_never(url, timeout=None, extra_headers=None):
+            called.append(url)
+            raise AssertionError("open_url_fn must not be called")
+
+        result = resolve_github_release_asset_api_url(
+            "https://ghes.example:notaport/o/r/releases/download/v1/ext.zip",
+            open_never,
+            github_hosts=("ghes.example",),
+        )
+        assert result is None
+        assert called == []
+
     def test_passthrough_for_unlisted_ghes_api_asset_url(self):
         """A direct GHES /api/v3 asset URL passes through even when the host is
         not allowlisted: passthrough issues no API request, and the download


### PR DESCRIPTION
## Description

`resolve_github_release_asset_api_url` is contracted to either resolve a browser release-download URL to its REST API asset URL or **return `None`** — every unresolvable case (unknown host, not-an-asset path, network error, missing asset) returns `None`. But the GHES branch builds the authority via `parsed.port`:

```python
elif is_ghes:
    authority = hostname if parsed.port is None else f"{hostname}:{parsed.port}"
```

`urllib`'s `.port` **raises `ValueError`** on a malformed port. So an allowlisted GHES host with a bad port (e.g. `https://ghes.example:notaport/...`) crashes the caller instead of returning `None`. Reproduced on main @ `92b7cf7`: `ValueError: Port could not be cast to integer value as 'notaport'`.

### Fix

Read `parsed.port` inside a `try/except ValueError: return None`, matching the function's existing graceful `return None` behavior.

## Testing

New `test_returns_none_on_malformed_ghes_port`: an allowlisted GHES host with `:notaport` returns `None` and induces **no** network call. **Fails before** (`ValueError` — verified by source-stash), **passes after**. The existing valid-port GHES test still passes (happy path unchanged). Full `test_github_http.py`: 27 passed. `uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI spotted the unguarded `parsed.port` against the function's return-None contract; I reproduced the ValueError, verified fail-before/pass-after, and reviewed the diff.