### PR TITLE
fix(extensions): preserve keep-config leftover on reinstall (data loss)

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1472,9 +1472,27 @@ class ExtensionManager:
         # path, which uses .backup/ rather than an in-place leftover.
         for name, (data, mode, atime, mtime) in preserved_configs.items():
             dest_cfg = dest_dir / name
+            # Never write *through* a symlink (or a non-regular-file) at this
+            # path: if dest_cfg is a symlink — copied with symlinks=True, or
+            # swapped in by a racing process between the copytree above and
+            # here — write_bytes() would follow it and clobber an arbitrary
+            # target outside the extension dir. Drop any non-regular entry
+            # first so write_bytes() always creates a fresh regular file.
+            try:
+                if dest_cfg.is_symlink():
+                    dest_cfg.unlink()  # remove the link itself, never follow it
+                elif dest_cfg.is_dir():
+                    shutil.rmtree(dest_cfg)
+            except OSError:
+                continue  # can't make the path safe — skip rather than clobber
             dest_cfg.write_bytes(data)
+            # Restore mode and timestamps independently: a failure to set one
+            # must not prevent the other, since either can succeed on its own.
             try:
                 os.chmod(dest_cfg, mode & 0o7777)  # permission bits only
+            except OSError:
+                pass
+            try:
                 os.utime(dest_cfg, (atime, mtime))  # and timestamps
             except OSError:
                 pass

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1344,23 +1344,56 @@ class ExtensionManager:
         return True
 
     @staticmethod
-    def _atomic_restore_config(
-        dest: Path, data: bytes, mode: int, atime: float, mtime: float
-    ) -> None:
-        """Restore a preserved config to *dest* atomically (temp file + os.replace).
+    def _reset_dir(path: Path) -> None:
+        """Remove whatever occupies *path* so a fresh directory can take its place.
 
-        Writes to a sibling temp file, then ``os.replace()`` swaps it into place.
-        ``os.replace`` operates on the directory entry, so it (a) never follows a
-        symlink that may occupy *dest* — closing the check-then-use race where a
-        racing process swaps in a symlink to overwrite an external target — and
-        (b) leaves either the old file or the fully-written new one, never a
-        partial write. Mirrors ``shared_infra._write_shared_bytes``. Mode and
-        timestamps are set on the temp file (independently — either can succeed
-        on its own) so the installed file carries them from the first moment.
+        A symlink is unlinked (never followed); a real directory is rmtree'd; any
+        other entry is unlinked. Unlike ``rmtree(..., ignore_errors=True)`` this
+        surfaces failures so a caller never merges into a partially-removed or
+        still-symlinked path.
         """
+        if path.is_symlink():
+            path.unlink()
+        elif path.is_dir():
+            shutil.rmtree(path)
+        elif path.exists():
+            path.unlink()
+
+    def _atomic_restore_config(
+        self, dest: Path, data: bytes, mode: int, atime: float, mtime: float
+    ) -> None:
+        """Restore a preserved config to *dest* atomically and symlink-safely.
+
+        Two guards, both required because *dest*'s parent is a fresh copytree
+        output that a racing process could swap for a symlink:
+
+        1. Reject a symlinked ancestor of *dest* (``dest.parent`` and up, under
+           the project root) via the repo's shared safe-write guard
+           (``shared_infra._ensure_safe_shared_directory``). Without this,
+           ``mkstemp(dir=dest.parent)`` + ``os.replace`` would create and install
+           the config (possibly secrets) *inside a symlinked external target*.
+        2. Write to a sibling temp file, then ``os.replace`` swaps it into the
+           directory entry — never following a symlink that occupies the leaf
+           *dest*, and never leaving a partial write.
+
+        Mode/timestamps are set on the temp file (independently — either can
+        succeed alone) so the installed file carries them from the first moment.
+        """
+        from ..shared_infra import _ensure_safe_shared_directory
+
+        # (1) Refuse a symlinked ancestor of the destination. dest.parent must
+        # already exist (a fresh copytree dir, the backup dir, or a rollback dir
+        # recreated safely just above the call).
+        _ensure_safe_shared_directory(
+            self.project_root,
+            dest.parent,
+            create=False,
+            context="extension config directory",
+        )
+
         # os.replace cannot replace a directory with a file; clear a stray
-        # (non-symlink) directory at the path first. A symlink is handled by
-        # os.replace itself (it swaps the link entry without following it).
+        # (non-symlink) directory at the leaf first. A symlink at the leaf is
+        # handled by os.replace itself (it swaps the link entry, never follows).
         if dest.is_dir() and not dest.is_symlink():
             shutil.rmtree(dest, ignore_errors=True)
         fd, temp_name = tempfile.mkstemp(prefix=f".{dest.name}.", dir=dest.parent)
@@ -1448,6 +1481,13 @@ class ExtensionManager:
                 f"extension. Install from a copy in a different location instead."
             )
 
+        # Validate the source ignore file BEFORE any destructive step. It can
+        # raise on a malformed/invalid-UTF-8 file, and neither the --force
+        # self.remove() below nor the later rmtree must run if it does — otherwise
+        # a bad ignore file would uninstall a working extension (and drop its
+        # registry entry) before validation fails. Reused as-is at the copytree.
+        ignore_fn = self._load_extensionignore(source_dir)
+
         # Remove existing installation AFTER all validations pass so that a
         # validation failure doesn't leave the user with a half-uninstalled
         # extension (configs stranded in .backup/).
@@ -1499,21 +1539,18 @@ class ExtensionManager:
 
         # Install extension (dest_dir computed above during self-install guard).
         # Preserved configs are the ONLY surviving copy once the old extension dir
-        # is removed, so guard the whole destructive reinstall against loss at any
-        # step (a malformed source ignore file, the rmtree, copytree, or a
-        # restore):
-        #   1. Validate the source ignore file BEFORE deleting anything — it can
-        #      raise on a malformed file, and nothing is destroyed yet if it does.
+        # is removed, so guard the whole destructive reinstall against loss:
+        #   1. The source ignore file is already validated above (before any
+        #      destructive step), so a malformed one never reaches here.
         #   2. Stage a durable on-disk backup of the configs.
         #   3. Run the destructive rmtree + copytree + restore inside one block;
-        #      on ANY failure, roll the configs back into a clean dest_dir and
-        #      re-raise. The backup is removed only once the configs are provably
-        #      in place (normal success OR a completed rollback) — otherwise it is
-        #      left on disk so nothing is ever lost, even on a rollback failure.
-        # Each config write is atomic (temp file + os.replace) so it never follows
-        # a symlink that may occupy the path (see _atomic_restore_config).
-        ignore_fn = self._load_extensionignore(source_dir)
-
+        #      on ANY failure, reset dest_dir to a clean, symlink-safe directory
+        #      and roll the configs back, then re-raise. The backup is removed
+        #      only once the configs are provably in place (normal success OR a
+        #      completed rollback) — otherwise it is left on disk so nothing is
+        #      ever lost, even on a rollback failure.
+        # Each config write is atomic (temp file + os.replace) AND refuses a
+        # symlinked ancestor of the destination (see _atomic_restore_config).
         backup_dir: Path | None = None
         if preserved_configs:
             backup_dir = Path(
@@ -1534,16 +1571,29 @@ class ExtensionManager:
                 self._atomic_restore_config(dest_dir / name, data, mode, atime, mtime)
             restored_ok = True
         except Exception:
-            # Roll the configs back into a clean dest_dir from the durable backup
-            # so a failed reinstall leaves them intact, then re-raise the original.
+            # Roll the configs back into a clean, symlink-safe dest_dir from the
+            # durable backup so a failed reinstall leaves them intact, then
+            # re-raise the original error. Reset dest_dir (unlink a symlink /
+            # rmtree a real dir — surfacing failures, never ignore_errors) and
+            # recreate it under a verified non-symlink ancestor chain BEFORE
+            # copying, so recovery can never merge through a symlinked or
+            # partially-removed directory into an external target.
             if backup_dir is not None:
                 try:
-                    if dest_dir.exists():
-                        shutil.rmtree(dest_dir, ignore_errors=True)
+                    from ..shared_infra import _ensure_safe_shared_directory
+                    self._reset_dir(dest_dir)
+                    _ensure_safe_shared_directory(
+                        self.project_root,
+                        dest_dir,
+                        create=True,
+                        context="extension directory",
+                    )
                     shutil.copytree(backup_dir, dest_dir, dirs_exist_ok=True)
                     restored_ok = True
-                except OSError:
-                    restored_ok = False  # keep the backup below for recovery
+                except (OSError, ValueError):
+                    # ValueError covers SymlinkedSharedPathError (a symlinked
+                    # ancestor): leave the durable backup on disk for recovery.
+                    restored_ok = False
             raise
         finally:
             # Drop the backup only when the configs are provably in dest_dir.

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1435,11 +1435,12 @@ class ExtensionManager:
         # preserved configs and the backup-restore path never runs. Capture
         # them here and write them back after the fresh copytree, mirroring
         # the *-config filter the --force restore path uses.
-        # Capture (bytes, mode) so we can restore permissions too — config
-        # files may hold secrets (API keys), and recreating them with default
-        # perms could widen access. Mirrors the --force restore's shutil.copy2
-        # (which preserves mode/mtime).
-        preserved_configs: dict[str, tuple[bytes, int]] = {}
+        # Capture (bytes, mode, atime, mtime) so restore preserves both
+        # permissions and timestamps — truly mirroring the --force restore's
+        # shutil.copy2 (which preserves mode/mtime). Config files may hold
+        # secrets (API keys); recreating them with default perms could widen
+        # access.
+        preserved_configs: dict[str, tuple[bytes, int, float, float]] = {}
         if dest_dir.exists():
             for cfg_file in dest_dir.iterdir():
                 if (
@@ -1450,9 +1451,12 @@ class ExtensionManager:
                         or cfg_file.name.endswith("-config.local.yml")
                     )
                 ):
+                    st = cfg_file.stat()
                     preserved_configs[cfg_file.name] = (
                         cfg_file.read_bytes(),
-                        cfg_file.stat().st_mode,
+                        st.st_mode,
+                        st.st_atime,
+                        st.st_mtime,
                     )
 
         # Install extension (dest_dir computed above during self-install guard)
@@ -1463,14 +1467,15 @@ class ExtensionManager:
         shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
 
         # Restore configs preserved from a keep-config leftover (see above),
-        # preserving the original file mode. The --force backup-restore below
-        # (did_remove) still takes precedence for that path, which uses
-        # .backup/ rather than an in-place leftover.
-        for name, (data, mode) in preserved_configs.items():
+        # preserving the original file mode and timestamps. The --force
+        # backup-restore below (did_remove) still takes precedence for that
+        # path, which uses .backup/ rather than an in-place leftover.
+        for name, (data, mode, atime, mtime) in preserved_configs.items():
             dest_cfg = dest_dir / name
             dest_cfg.write_bytes(data)
             try:
                 os.chmod(dest_cfg, mode & 0o7777)  # permission bits only
+                os.utime(dest_cfg, (atime, mtime))  # and timestamps
             except OSError:
                 pass
 

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1343,6 +1343,44 @@ class ExtensionManager:
 
         return True
 
+    @staticmethod
+    def _atomic_restore_config(
+        dest: Path, data: bytes, mode: int, atime: float, mtime: float
+    ) -> None:
+        """Restore a preserved config to *dest* atomically (temp file + os.replace).
+
+        Writes to a sibling temp file, then ``os.replace()`` swaps it into place.
+        ``os.replace`` operates on the directory entry, so it (a) never follows a
+        symlink that may occupy *dest* — closing the check-then-use race where a
+        racing process swaps in a symlink to overwrite an external target — and
+        (b) leaves either the old file or the fully-written new one, never a
+        partial write. Mirrors ``shared_infra._write_shared_bytes``. Mode and
+        timestamps are set on the temp file (independently — either can succeed
+        on its own) so the installed file carries them from the first moment.
+        """
+        # os.replace cannot replace a directory with a file; clear a stray
+        # (non-symlink) directory at the path first. A symlink is handled by
+        # os.replace itself (it swaps the link entry without following it).
+        if dest.is_dir() and not dest.is_symlink():
+            shutil.rmtree(dest, ignore_errors=True)
+        fd, temp_name = tempfile.mkstemp(prefix=f".{dest.name}.", dir=dest.parent)
+        temp_path = Path(temp_name)
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(data)
+            try:
+                temp_path.chmod(mode & 0o7777)  # permission bits only
+            except OSError:
+                pass
+            try:
+                os.utime(temp_path, (atime, mtime))
+            except OSError:
+                pass
+            os.replace(temp_path, dest)
+        finally:
+            if temp_path.exists():
+                temp_path.unlink()
+
     def install_from_directory(
         self,
         source_dir: Path,
@@ -1459,43 +1497,43 @@ class ExtensionManager:
                         st.st_mtime,
                     )
 
-        # Install extension (dest_dir computed above during self-install guard)
+        # Install extension (dest_dir computed above during self-install guard).
+        # rmtree removes the only on-disk copy of the preserved configs; the sole
+        # remaining copy is in `preserved_configs` (in memory). If copytree then
+        # fails (permissions, disk full, a bad source entry), write the configs
+        # back into a clean dest_dir before re-raising so a failed reinstall never
+        # loses the user's config.
         if dest_dir.exists():
             shutil.rmtree(dest_dir)
 
         ignore_fn = self._load_extensionignore(source_dir)
-        shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
+        try:
+            shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
+        except Exception:
+            if preserved_configs:
+                if dest_dir.exists():
+                    shutil.rmtree(dest_dir, ignore_errors=True)
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                for name, (data, mode, atime, mtime) in preserved_configs.items():
+                    try:
+                        self._atomic_restore_config(
+                            dest_dir / name, data, mode, atime, mtime
+                        )
+                    except OSError:
+                        pass
+            raise
 
         # Restore configs preserved from a keep-config leftover (see above),
         # preserving the original file mode and timestamps. The --force
         # backup-restore below (did_remove) still takes precedence for that
-        # path, which uses .backup/ rather than an in-place leftover.
+        # path, which uses .backup/ rather than an in-place leftover. Each write
+        # is atomic (temp file + os.replace) so it never follows a symlink that
+        # may occupy the path (see _atomic_restore_config).
         for name, (data, mode, atime, mtime) in preserved_configs.items():
-            dest_cfg = dest_dir / name
-            # Never write *through* a symlink (or a non-regular-file) at this
-            # path: if dest_cfg is a symlink — copied with symlinks=True, or
-            # swapped in by a racing process between the copytree above and
-            # here — write_bytes() would follow it and clobber an arbitrary
-            # target outside the extension dir. Drop any non-regular entry
-            # first so write_bytes() always creates a fresh regular file.
             try:
-                if dest_cfg.is_symlink():
-                    dest_cfg.unlink()  # remove the link itself, never follow it
-                elif dest_cfg.is_dir():
-                    shutil.rmtree(dest_cfg)
+                self._atomic_restore_config(dest_dir / name, data, mode, atime, mtime)
             except OSError:
-                continue  # can't make the path safe — skip rather than clobber
-            dest_cfg.write_bytes(data)
-            # Restore mode and timestamps independently: a failure to set one
-            # must not prevent the other, since either can succeed on its own.
-            try:
-                os.chmod(dest_cfg, mode & 0o7777)  # permission bits only
-            except OSError:
-                pass
-            try:
-                os.utime(dest_cfg, (atime, mtime))  # and timestamps
-            except OSError:
-                pass
+                continue  # can't safely restore this one — skip rather than clobber
 
         # Register commands with AI agents
         registered_commands = {}

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1519,7 +1519,11 @@ class ExtensionManager:
         # secrets (API keys); recreating them with default perms could widen
         # access.
         preserved_configs: dict[str, tuple[bytes, int, float, float]] = {}
-        if dest_dir.exists():
+        # Require a REAL directory, not a symlink: iterating a symlinked dest_dir
+        # would follow the link and read arbitrary external files into
+        # preserved_configs. This path only ever legitimately captures on-disk
+        # leftover configs inside the real extension directory.
+        if dest_dir.is_dir() and not dest_dir.is_symlink():
             for cfg_file in dest_dir.iterdir():
                 if (
                     cfg_file.is_file()
@@ -1561,8 +1565,10 @@ class ExtensionManager:
 
         restored_ok = not preserved_configs
         try:
-            if dest_dir.exists():
-                shutil.rmtree(dest_dir)
+            # Reset via _reset_dir (unlink a symlink / rmtree a real dir) rather
+            # than a bare rmtree, which raises on a symlink or file at dest_dir.
+            # Handles an unexpected occupant consistently with the rollback path.
+            self._reset_dir(dest_dir)
             shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
             # Restore every preserved config. A failure here is NOT swallowed: a
             # config we promised to preserve but could not restore must fail the

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1428,12 +1428,38 @@ class ExtensionManager:
                 backup_config_dir.unlink()
             did_remove = self.remove(manifest.id)
 
+        # A prior `remove(keep_config=True)` leaves the top-level
+        # *-config.yml / *-config.local.yml in place while dropping the
+        # registry entry. A later reinstall is not a --force removal
+        # (did_remove is False), so the rmtree below would wipe those
+        # preserved configs and the backup-restore path never runs. Capture
+        # them here and write them back after the fresh copytree, mirroring
+        # the *-config filter the --force restore path uses.
+        preserved_configs: dict[str, bytes] = {}
+        if dest_dir.exists():
+            for cfg_file in dest_dir.iterdir():
+                if (
+                    cfg_file.is_file()
+                    and not cfg_file.is_symlink()
+                    and (
+                        cfg_file.name.endswith("-config.yml")
+                        or cfg_file.name.endswith("-config.local.yml")
+                    )
+                ):
+                    preserved_configs[cfg_file.name] = cfg_file.read_bytes()
+
         # Install extension (dest_dir computed above during self-install guard)
         if dest_dir.exists():
             shutil.rmtree(dest_dir)
 
         ignore_fn = self._load_extensionignore(source_dir)
         shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
+
+        # Restore configs preserved from a keep-config leftover (see above).
+        # The --force backup-restore below (did_remove) still takes precedence
+        # for that path, which uses .backup/ rather than an in-place leftover.
+        for name, data in preserved_configs.items():
+            (dest_dir / name).write_bytes(data)
 
         # Register commands with AI agents
         registered_commands = {}

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1577,24 +1577,27 @@ class ExtensionManager:
                 self._atomic_restore_config(dest_dir / name, data, mode, atime, mtime)
             restored_ok = True
         except Exception:
-            # Roll the configs back into a clean, symlink-safe dest_dir from the
-            # durable backup so a failed reinstall leaves them intact, then
-            # re-raise the original error. Reset dest_dir (unlink a symlink /
-            # rmtree a real dir — surfacing failures, never ignore_errors) and
-            # recreate it under a verified non-symlink ancestor chain BEFORE
-            # copying, so recovery can never merge through a symlinked or
-            # partially-removed directory into an external target.
+            # Roll the configs back into place from the durable backup so a failed
+            # reinstall leaves them intact, then re-raise the original error.
+            # Reset dest_dir (unlink a symlink / rmtree a real dir — surfacing
+            # failures, never ignore_errors), verify its ancestor chain is not
+            # symlinked, then ATOMICALLY MOVE the whole backup directory into
+            # place with os.replace. The backup already holds real files written
+            # via _atomic_restore_config, so moving the directory wholesale avoids
+            # copytree's copy2 following a leaf symlink raced into the recreated
+            # dest_dir and writing a preserved secret to an external target.
             if backup_dir is not None:
                 try:
                     from ..shared_infra import _ensure_safe_shared_directory
                     self._reset_dir(dest_dir)
                     _ensure_safe_shared_directory(
                         self.project_root,
-                        dest_dir,
-                        create=True,
+                        dest_dir.parent,
+                        create=False,
                         context="extension directory",
                     )
-                    shutil.copytree(backup_dir, dest_dir, dirs_exist_ok=True)
+                    os.replace(backup_dir, dest_dir)
+                    backup_dir = None  # consumed by the move; nothing to clean up
                     restored_ok = True
                 except (OSError, ValueError):
                     # ValueError covers SymlinkedSharedPathError (a symlinked
@@ -1602,7 +1605,8 @@ class ExtensionManager:
                     restored_ok = False
             raise
         finally:
-            # Drop the backup only when the configs are provably in dest_dir.
+            # Drop the backup only when the configs are provably in dest_dir
+            # (a successful move sets backup_dir to None, so nothing to clean).
             if backup_dir is not None and restored_ok and backup_dir.exists():
                 shutil.rmtree(backup_dir, ignore_errors=True)
 

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1498,42 +1498,57 @@ class ExtensionManager:
                     )
 
         # Install extension (dest_dir computed above during self-install guard).
-        # rmtree removes the only on-disk copy of the preserved configs; the sole
-        # remaining copy is in `preserved_configs` (in memory). If copytree then
-        # fails (permissions, disk full, a bad source entry), write the configs
-        # back into a clean dest_dir before re-raising so a failed reinstall never
-        # loses the user's config.
-        if dest_dir.exists():
-            shutil.rmtree(dest_dir)
-
+        # Preserved configs are the ONLY surviving copy once the old extension dir
+        # is removed, so guard the whole destructive reinstall against loss at any
+        # step (a malformed source ignore file, the rmtree, copytree, or a
+        # restore):
+        #   1. Validate the source ignore file BEFORE deleting anything — it can
+        #      raise on a malformed file, and nothing is destroyed yet if it does.
+        #   2. Stage a durable on-disk backup of the configs.
+        #   3. Run the destructive rmtree + copytree + restore inside one block;
+        #      on ANY failure, roll the configs back into a clean dest_dir and
+        #      re-raise. The backup is removed only once the configs are provably
+        #      in place (normal success OR a completed rollback) — otherwise it is
+        #      left on disk so nothing is ever lost, even on a rollback failure.
+        # Each config write is atomic (temp file + os.replace) so it never follows
+        # a symlink that may occupy the path (see _atomic_restore_config).
         ignore_fn = self._load_extensionignore(source_dir)
-        try:
-            shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
-        except Exception:
-            if preserved_configs:
-                if dest_dir.exists():
-                    shutil.rmtree(dest_dir, ignore_errors=True)
-                dest_dir.mkdir(parents=True, exist_ok=True)
-                for name, (data, mode, atime, mtime) in preserved_configs.items():
-                    try:
-                        self._atomic_restore_config(
-                            dest_dir / name, data, mode, atime, mtime
-                        )
-                    except OSError:
-                        pass
-            raise
 
-        # Restore configs preserved from a keep-config leftover (see above),
-        # preserving the original file mode and timestamps. The --force
-        # backup-restore below (did_remove) still takes precedence for that
-        # path, which uses .backup/ rather than an in-place leftover. Each write
-        # is atomic (temp file + os.replace) so it never follows a symlink that
-        # may occupy the path (see _atomic_restore_config).
-        for name, (data, mode, atime, mtime) in preserved_configs.items():
-            try:
+        backup_dir: Path | None = None
+        if preserved_configs:
+            backup_dir = Path(
+                tempfile.mkdtemp(prefix=f".{dest_dir.name}.cfgbak-", dir=dest_dir.parent)
+            )
+            for name, (data, mode, atime, mtime) in preserved_configs.items():
+                self._atomic_restore_config(backup_dir / name, data, mode, atime, mtime)
+
+        restored_ok = not preserved_configs
+        try:
+            if dest_dir.exists():
+                shutil.rmtree(dest_dir)
+            shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
+            # Restore every preserved config. A failure here is NOT swallowed: a
+            # config we promised to preserve but could not restore must fail the
+            # reinstall, not report success with the config silently missing.
+            for name, (data, mode, atime, mtime) in preserved_configs.items():
                 self._atomic_restore_config(dest_dir / name, data, mode, atime, mtime)
-            except OSError:
-                continue  # can't safely restore this one — skip rather than clobber
+            restored_ok = True
+        except Exception:
+            # Roll the configs back into a clean dest_dir from the durable backup
+            # so a failed reinstall leaves them intact, then re-raise the original.
+            if backup_dir is not None:
+                try:
+                    if dest_dir.exists():
+                        shutil.rmtree(dest_dir, ignore_errors=True)
+                    shutil.copytree(backup_dir, dest_dir, dirs_exist_ok=True)
+                    restored_ok = True
+                except OSError:
+                    restored_ok = False  # keep the backup below for recovery
+            raise
+        finally:
+            # Drop the backup only when the configs are provably in dest_dir.
+            if backup_dir is not None and restored_ok and backup_dir.exists():
+                shutil.rmtree(backup_dir, ignore_errors=True)
 
         # Register commands with AI agents
         registered_commands = {}

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1435,7 +1435,11 @@ class ExtensionManager:
         # preserved configs and the backup-restore path never runs. Capture
         # them here and write them back after the fresh copytree, mirroring
         # the *-config filter the --force restore path uses.
-        preserved_configs: dict[str, bytes] = {}
+        # Capture (bytes, mode) so we can restore permissions too — config
+        # files may hold secrets (API keys), and recreating them with default
+        # perms could widen access. Mirrors the --force restore's shutil.copy2
+        # (which preserves mode/mtime).
+        preserved_configs: dict[str, tuple[bytes, int]] = {}
         if dest_dir.exists():
             for cfg_file in dest_dir.iterdir():
                 if (
@@ -1446,7 +1450,10 @@ class ExtensionManager:
                         or cfg_file.name.endswith("-config.local.yml")
                     )
                 ):
-                    preserved_configs[cfg_file.name] = cfg_file.read_bytes()
+                    preserved_configs[cfg_file.name] = (
+                        cfg_file.read_bytes(),
+                        cfg_file.stat().st_mode,
+                    )
 
         # Install extension (dest_dir computed above during self-install guard)
         if dest_dir.exists():
@@ -1455,11 +1462,17 @@ class ExtensionManager:
         ignore_fn = self._load_extensionignore(source_dir)
         shutil.copytree(source_dir, dest_dir, ignore=ignore_fn)
 
-        # Restore configs preserved from a keep-config leftover (see above).
-        # The --force backup-restore below (did_remove) still takes precedence
-        # for that path, which uses .backup/ rather than an in-place leftover.
-        for name, data in preserved_configs.items():
-            (dest_dir / name).write_bytes(data)
+        # Restore configs preserved from a keep-config leftover (see above),
+        # preserving the original file mode. The --force backup-restore below
+        # (did_remove) still takes precedence for that path, which uses
+        # .backup/ rather than an in-place leftover.
+        for name, (data, mode) in preserved_configs.items():
+            dest_cfg = dest_dir / name
+            dest_cfg.write_bytes(data)
+            try:
+                os.chmod(dest_cfg, mode & 0o7777)  # permission bits only
+            except OSError:
+                pass
 
         # Register commands with AI agents
         registered_commands = {}

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1557,6 +1557,29 @@ class TestExtensionManager:
         assert backup_file.exists()
         assert backup_file.read_text() == "test: config"
 
+    def test_reinstall_preserves_keep_config_leftover(self, extension_dir, project_dir):
+        """A reinstall after `remove(keep_config=True)` must not wipe the
+        preserved config. remove(keep_config=True) leaves the *-config.yml in
+        place and drops the registry entry; the subsequent reinstall is not a
+        --force removal, so the unconditional rmtree used to destroy it."""
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        config_file = ext_dir / "test-ext-config.yml"
+        config_file.write_text("api_key: MY-CUSTOMIZED-VALUE")
+
+        # keep-config removal: registry entry dropped, config left in place.
+        assert manager.remove("test-ext", keep_config=True) is True
+        assert config_file.exists()
+
+        # Reinstall (no --force; registry now reports not-installed).
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        # The user's config must survive the reinstall (was silently wiped).
+        assert config_file.exists()
+        assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
+
 
 # ===== CommandRegistrar Tests =====
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1698,9 +1698,16 @@ class TestExtensionManager:
         config_file.chmod(0o600)
         assert manager.remove("test-ext", keep_config=True) is True
 
-        # Simulate a mid-reinstall failure after the old dir was removed.
+        # Fail the source→dest copytree (after the old dir is removed) but let the
+        # rollback copytree (backup→dest) succeed, so recovery can be observed.
+        real_copytree = shutil.copytree
+        calls = {"n": 0}
+
         def boom(src, dst, *args, **kwargs):
-            raise OSError("simulated disk-full during copytree")
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("simulated disk-full during copytree")
+            return real_copytree(src, dst, *args, **kwargs)
 
         monkeypatch.setattr(shutil, "copytree", boom)
 
@@ -1714,6 +1721,70 @@ class TestExtensionManager:
         assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
         if platform.system() != "Windows":
             assert config_file.stat().st_mode & 0o777 == 0o600
+
+    def test_reinstall_validates_ignore_before_deleting_config(
+        self, extension_dir, project_dir, monkeypatch
+    ):
+        """A malformed source ignore file must be detected BEFORE the destructive
+        rmtree, so a reinstall that fails on it leaves the preserved config
+        untouched (it used to be loaded only after rmtree had run)."""
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        config_file = ext_dir / "test-ext-config.yml"
+        config_file.write_text("api_key: MY-CUSTOMIZED-VALUE")
+        assert manager.remove("test-ext", keep_config=True) is True
+
+        def bad_ignore(src):
+            raise ValueError("malformed .extensionignore")
+
+        monkeypatch.setattr(manager, "_load_extensionignore", bad_ignore)
+
+        with pytest.raises(ValueError):
+            manager.install_from_directory(
+                extension_dir, "0.1.0", register_commands=False
+            )
+
+        # Nothing was deleted — the leftover config is still in place.
+        assert config_file.is_file()
+        assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
+
+    def test_reinstall_failed_config_restore_is_not_silent(
+        self, extension_dir, project_dir, monkeypatch
+    ):
+        """A restore failure after copytree must NOT be silently skipped and
+        reported as a successful install — it fails loudly, and the config is
+        rolled back from the durable backup rather than left missing."""
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        config_file = ext_dir / "test-ext-config.yml"
+        config_file.write_text("api_key: MY-CUSTOMIZED-VALUE")
+        assert manager.remove("test-ext", keep_config=True) is True
+
+        # Fail the live restore into the extension dir, but let the durable-backup
+        # staging (a ".cfgbak-" temp dir) succeed so rollback can recover.
+        real_restore = ExtensionManager._atomic_restore_config
+
+        def flaky_restore(dest, data, mode, atime, mtime):
+            if "cfgbak" not in dest.parent.name:
+                raise OSError("simulated restore failure")
+            return real_restore(dest, data, mode, atime, mtime)
+
+        monkeypatch.setattr(
+            ExtensionManager, "_atomic_restore_config", staticmethod(flaky_restore)
+        )
+
+        with pytest.raises(OSError):
+            manager.install_from_directory(
+                extension_dir, "0.1.0", register_commands=False
+            )
+
+        # Not a silent success: the config was rolled back, not lost.
+        assert config_file.is_file()
+        assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
 
 
 # ===== CommandRegistrar Tests =====

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1591,6 +1591,98 @@ class TestExtensionManager:
         if platform.system() != "Windows":
             assert config_file.stat().st_mode & 0o777 == 0o600
 
+    def test_reinstall_config_restore_does_not_follow_symlink(
+        self, extension_dir, project_dir, monkeypatch
+    ):
+        """The keep-config restore must never write *through* a symlink. If the
+        config path is a symlink at restore time (e.g. swapped in between the
+        copytree and the restore), the write must not follow it and clobber the
+        external target — it must replace the link with a fresh regular file."""
+        # Probe symlink capability (Windows usually needs privilege).
+        probe_target = project_dir / "_probe_target"
+        probe_link = project_dir / "_probe_link"
+        try:
+            probe_target.write_text("x")
+            probe_link.symlink_to(probe_target)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported in this environment")
+        finally:
+            probe_link.unlink(missing_ok=True)
+            probe_target.unlink(missing_ok=True)
+
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        config_file = ext_dir / "test-ext-config.yml"
+        config_file.write_text("api_key: MY-CUSTOMIZED-VALUE")
+
+        # keep-config removal: registry entry dropped, config left in place.
+        assert manager.remove("test-ext", keep_config=True) is True
+
+        # A victim file outside the extension dir that the symlink points at.
+        victim = project_dir / "victim.txt"
+        victim.write_text("DO-NOT-OVERWRITE")
+
+        # Simulate the config path being a symlink to the victim right after the
+        # fresh copytree (the TOCTOU / symlinks=True case the guard defends).
+        real_copytree = shutil.copytree
+
+        def copytree_then_symlink(src, dst, *args, **kwargs):
+            result = real_copytree(src, dst, *args, **kwargs)
+            link = Path(dst) / "test-ext-config.yml"
+            if link.exists() or link.is_symlink():
+                link.unlink()
+            link.symlink_to(victim)
+            return result
+
+        monkeypatch.setattr(shutil, "copytree", copytree_then_symlink)
+
+        # Reinstall: restore must drop the symlink, not follow it.
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        # The victim outside the extension dir is untouched.
+        assert victim.read_text() == "DO-NOT-OVERWRITE"
+        # The config path is now a regular file (not a symlink) with the
+        # preserved content written in place.
+        assert not config_file.is_symlink()
+        assert config_file.is_file()
+        assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
+
+    def test_reinstall_config_restore_replaces_directory_at_path(
+        self, extension_dir, project_dir, monkeypatch
+    ):
+        """Cross-platform guard check: if a directory occupies the config path at
+        restore time, write_bytes() would raise (uncaught, crashing the whole
+        reinstall). The guard must clear the directory and write a fresh regular
+        file. Exercises the same non-regular-file guard as the symlink case, but
+        needs no symlink privilege so it runs everywhere (incl. Windows)."""
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        config_file = ext_dir / "test-ext-config.yml"
+        config_file.write_text("api_key: MY-CUSTOMIZED-VALUE")
+        assert manager.remove("test-ext", keep_config=True) is True
+
+        # Simulate a directory occupying the config path right after copytree.
+        real_copytree = shutil.copytree
+
+        def copytree_then_dir(src, dst, *args, **kwargs):
+            result = real_copytree(src, dst, *args, **kwargs)
+            clash = Path(dst) / "test-ext-config.yml"
+            clash.mkdir()
+            (clash / "sentinel").write_text("stray")
+            return result
+
+        monkeypatch.setattr(shutil, "copytree", copytree_then_dir)
+
+        # Must not raise, and must restore a regular file with preserved content.
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        assert config_file.is_file()
+        assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
+
 
 # ===== CommandRegistrar Tests =====
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1683,6 +1683,38 @@ class TestExtensionManager:
         assert config_file.is_file()
         assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
 
+    def test_reinstall_config_survives_copytree_failure(
+        self, extension_dir, project_dir, monkeypatch
+    ):
+        """The preserved config is captured in memory and the old dir is removed
+        before copytree runs. If copytree fails, the config must be written back
+        (not lost) so a failed reinstall leaves the user's config intact."""
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        config_file = ext_dir / "test-ext-config.yml"
+        config_file.write_text("api_key: MY-CUSTOMIZED-VALUE")
+        config_file.chmod(0o600)
+        assert manager.remove("test-ext", keep_config=True) is True
+
+        # Simulate a mid-reinstall failure after the old dir was removed.
+        def boom(src, dst, *args, **kwargs):
+            raise OSError("simulated disk-full during copytree")
+
+        monkeypatch.setattr(shutil, "copytree", boom)
+
+        with pytest.raises(OSError):
+            manager.install_from_directory(
+                extension_dir, "0.1.0", register_commands=False
+            )
+
+        # Config recovered despite the failure (was permanently lost before).
+        assert config_file.is_file()
+        assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
+        if platform.system() != "Windows":
+            assert config_file.stat().st_mode & 0o777 == 0o600
+
 
 # ===== CommandRegistrar Tests =====
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1870,6 +1870,63 @@ class TestExtensionManager:
         assert config_file.is_file()
         assert "SECRET-VALUE" in config_file.read_text()
 
+    def test_reinstall_replaces_file_at_dest_dir(self, extension_dir, project_dir):
+        """If a non-directory (a stray file) occupies dest_dir at reinstall, the
+        main install path clears it via _reset_dir rather than crashing on
+        shutil.rmtree (which raises NotADirectoryError on a file)."""
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        # Drop the registry entry, then replace the extension dir with a file.
+        assert manager.remove("test-ext", keep_config=True) is True
+        shutil.rmtree(ext_dir)
+        ext_dir.write_text("not a directory")
+        assert ext_dir.is_file()
+
+        # Reinstall must succeed, replacing the file with a real extension dir.
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+        assert ext_dir.is_dir() and not ext_dir.is_symlink()
+        assert (ext_dir / "extension.yml").is_file()
+
+    def test_preserve_capture_ignores_symlinked_dest_dir(
+        self, extension_dir, project_dir
+    ):
+        """The preserve-config capture must not follow a symlinked dest_dir and
+        read external files into preserved_configs. Skipped without symlink
+        privilege; runs on Linux CI."""
+        probe_t = project_dir / "_pt2"
+        probe_l = project_dir / "_pl2"
+        try:
+            probe_t.mkdir()
+            probe_l.symlink_to(probe_t, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported in this environment")
+        finally:
+            if probe_l.is_symlink():
+                probe_l.unlink()
+            if probe_t.exists():
+                shutil.rmtree(probe_t, ignore_errors=True)
+
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        assert manager.remove("test-ext", keep_config=True) is True
+
+        # External dir with a config-looking file that must NOT be captured.
+        external = project_dir / "external_configs"
+        external.mkdir()
+        (external / "test-ext-config.yml").write_text("api_key: EXTERNAL-SECRET")
+        # Swap dest_dir for a symlink to the external dir.
+        shutil.rmtree(ext_dir)
+        ext_dir.symlink_to(external, target_is_directory=True)
+
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+
+        # The external secret was never captured, restored, or overwritten.
+        assert (external / "test-ext-config.yml").read_text() == "api_key: EXTERNAL-SECRET"
+        assert ext_dir.is_dir() and not ext_dir.is_symlink()
+        assert not (ext_dir / "test-ext-config.yml").exists()
+
 
 # ===== CommandRegistrar Tests =====
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1568,6 +1568,9 @@ class TestExtensionManager:
         ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
         config_file = ext_dir / "test-ext-config.yml"
         config_file.write_text("api_key: MY-CUSTOMIZED-VALUE")
+        # Restrictive perms — a config may hold secrets; the restore must not
+        # widen them (POSIX only; Windows chmod ignores group/other bits).
+        config_file.chmod(0o600)
 
         # keep-config removal: registry entry dropped, config left in place.
         assert manager.remove("test-ext", keep_config=True) is True
@@ -1579,6 +1582,9 @@ class TestExtensionManager:
         # The user's config must survive the reinstall (was silently wiped).
         assert config_file.exists()
         assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
+        # ...and keep its original (restrictive) mode, not default perms.
+        if platform.system() != "Windows":
+            assert config_file.stat().st_mode & 0o777 == 0o600
 
 
 # ===== CommandRegistrar Tests =====

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1571,6 +1571,9 @@ class TestExtensionManager:
         # Restrictive perms — a config may hold secrets; the restore must not
         # widen them (POSIX only; Windows chmod ignores group/other bits).
         config_file.chmod(0o600)
+        # Distinctive mtime to prove timestamps survive too (mirrors copy2).
+        old_mtime = 1_600_000_000
+        os.utime(config_file, (old_mtime, old_mtime))
 
         # keep-config removal: registry entry dropped, config left in place.
         assert manager.remove("test-ext", keep_config=True) is True
@@ -1582,7 +1585,9 @@ class TestExtensionManager:
         # The user's config must survive the reinstall (was silently wiped).
         assert config_file.exists()
         assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
-        # ...and keep its original (restrictive) mode, not default perms.
+        # ...and keep its original mtime (copy2-style timestamp preservation).
+        assert config_file.stat().st_mtime == old_mtime
+        # ...and its original (restrictive) mode, not default perms.
         if platform.system() != "Windows":
             assert config_file.stat().st_mode & 0o777 == 0o600
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1768,13 +1768,13 @@ class TestExtensionManager:
         # staging (a ".cfgbak-" temp dir) succeed so rollback can recover.
         real_restore = ExtensionManager._atomic_restore_config
 
-        def flaky_restore(dest, data, mode, atime, mtime):
+        def flaky_restore(self, dest, data, mode, atime, mtime):
             if "cfgbak" not in dest.parent.name:
                 raise OSError("simulated restore failure")
-            return real_restore(dest, data, mode, atime, mtime)
+            return real_restore(self, dest, data, mode, atime, mtime)
 
         monkeypatch.setattr(
-            ExtensionManager, "_atomic_restore_config", staticmethod(flaky_restore)
+            ExtensionManager, "_atomic_restore_config", flaky_restore
         )
 
         with pytest.raises(OSError):
@@ -1785,6 +1785,90 @@ class TestExtensionManager:
         # Not a silent success: the config was rolled back, not lost.
         assert config_file.is_file()
         assert "MY-CUSTOMIZED-VALUE" in config_file.read_text()
+
+    def test_reinstall_force_validates_ignore_before_removal(
+        self, extension_dir, project_dir, monkeypatch
+    ):
+        """A --force reinstall must validate the source ignore file BEFORE
+        self.remove() runs. Otherwise a malformed ignore file uninstalls a
+        working extension (dropping its files and registry entry) before the
+        validation raises. (The leftover-path test covers the non-force case.)"""
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+        assert manager.registry.is_installed("test-ext")
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        manifest_file = ext_dir / "extension.yml"
+        assert manifest_file.is_file()
+
+        def bad_ignore(src):
+            raise ValueError("malformed .extensionignore")
+
+        monkeypatch.setattr(manager, "_load_extensionignore", bad_ignore)
+
+        with pytest.raises(ValueError):
+            manager.install_from_directory(
+                extension_dir, "0.1.0", register_commands=False, force=True
+            )
+
+        # The working extension was NOT removed by the failed --force reinstall.
+        assert manager.registry.is_installed("test-ext")
+        assert manifest_file.is_file()
+
+    def test_reinstall_refuses_symlinked_dest_dir(
+        self, extension_dir, project_dir, monkeypatch
+    ):
+        """If dest_dir is swapped to a symlink after copytree, the config restore
+        must NOT create bytes (potential secrets) inside the symlinked external
+        target — the repo's ancestor guard rejects it, and rollback recreates a
+        real directory. Guards the symlinked-parent gap (leaf-only guards miss
+        it). Skipped where symlinks need privilege; runs on Linux CI."""
+        probe_t = project_dir / "_pt"
+        probe_l = project_dir / "_pl"
+        try:
+            probe_t.mkdir()
+            probe_l.symlink_to(probe_t, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported in this environment")
+        finally:
+            if probe_l.is_symlink():
+                probe_l.unlink()
+            if probe_t.exists():
+                shutil.rmtree(probe_t, ignore_errors=True)
+
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(extension_dir, "0.1.0", register_commands=False)
+        ext_dir = project_dir / ".specify" / "extensions" / "test-ext"
+        config_file = ext_dir / "test-ext-config.yml"
+        config_file.write_text("api_key: SECRET-VALUE")
+        assert manager.remove("test-ext", keep_config=True) is True
+
+        victim = project_dir / "victim_target"
+        victim.mkdir()
+
+        real_copytree = shutil.copytree
+        calls = {"n": 0}
+
+        def copytree_symlinks_destdir_first(src, dst, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Simulate a racing swap: dest_dir is a symlink to an external dir.
+                Path(dst).symlink_to(victim, target_is_directory=True)
+                return dst
+            return real_copytree(src, dst, *args, **kwargs)
+
+        monkeypatch.setattr(shutil, "copytree", copytree_symlinks_destdir_first)
+
+        with pytest.raises(Exception):
+            manager.install_from_directory(
+                extension_dir, "0.1.0", register_commands=False
+            )
+
+        # Secrets never landed in the external target.
+        assert list(victim.iterdir()) == []
+        # dest_dir is a real directory again (rollback), with the config recovered.
+        assert not ext_dir.is_symlink()
+        assert config_file.is_file()
+        assert "SECRET-VALUE" in config_file.read_text()
 
 
 # ===== CommandRegistrar Tests =====


### PR DESCRIPTION
## Description

`extension remove --keep-config` deliberately **preserves** the top-level `*-config.yml` / `*-config.local.yml` in the extension dir and drops the registry entry, so the user can reinstall and keep their configuration. But a subsequent `install_from_directory` silently destroys it:

```python
if dest_dir.exists():
    shutil.rmtree(dest_dir)   # wipes the preserved config
...
if did_remove:                # only runs on the --force path
    ...restore from .backup...
```

After a keep-config remove the registry reports **not installed**, so the reinstall is not a `--force` removal → `did_remove` is `False` → the restore block never runs → the config is gone. Reproduced on main @ `92b7cf7`: a user config (`api_key: MY-CUSTOMIZED-VALUE`) survives `remove(keep_config=True)` but is **wiped** by the next reinstall — the file doesn't even exist afterward. This is data loss that directly contradicts the feature's promise.

### Fix

Before the `rmtree`, capture any top-level `*-config.yml` / `*-config.local.yml` from the existing dest_dir (in-memory), and write them back after the fresh `copytree` — using the same `*-config` filter and symlink guard the `--force` restore path already applies. The `--force` `.backup` restore still takes precedence for that path; this only covers the in-place keep-config leftover.

## Testing

New `test_reinstall_preserves_keep_config_leftover`: install → write custom config → `remove(keep_config=True)` → reinstall (no force) → assert the custom config survives. **Fails before** (config file gone after reinstall — verified by source-stash), **passes after**. Full `tests/test_extensions.py`: **327 passed, 3 skipped** (no regressions; `keep_config=False`/.backup path unaffected). `uvx ruff check` clean.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

Found and fixed with Claude Code (Claude Fable 5) under my direction. AI traced the keep-config leftover through the reinstall path and found the restore only fires on `--force`; I reproduced the data loss, verified fail-before/pass-after and the full suite, and reviewed the diff.