### PR TITLE
fix(integrations): escape control characters in goose recipe YAML renderer

### DIFF
--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -1122,6 +1122,11 @@ class TomlIntegration(IntegrationBase):
 # YamlIntegration — YAML-format agents (Goose)
 # ---------------------------------------------------------------------------
 
+# Characters a YAML literal block scalar cannot carry: C0 controls other
+# than tab/LF (a bare CR acts as a line break inside the scalar), and DEL.
+_YAML_BLOCK_SCALAR_UNSAFE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+
+
 class YamlIntegration(IntegrationBase):
     """Concrete base for integrations that use YAML recipe format.
 
@@ -1239,6 +1244,23 @@ class YamlIntegration(IntegrationBase):
             allow_unicode=True,
             default_flow_style=False,
         ).strip()
+
+        # YAML forbids C0 control characters (except tab and newline) and
+        # DEL in every scalar form, and a bare CR acts as a line break
+        # inside a block scalar. A literal block scalar emits such bytes
+        # verbatim, producing a recipe the YAML parser rejects, so fall
+        # back to an escaped double-quoted scalar for those bodies.
+        if _YAML_BLOCK_SCALAR_UNSAFE.search(body):
+            prompt_yaml = yaml.safe_dump(
+                {"prompt": body}, allow_unicode=True, default_style='"', width=float("inf")
+            ).strip()
+            lines = [
+                header_yaml,
+                prompt_yaml,
+                "",
+                f"# Source: {source_id}",
+            ]
+            return "\n".join(lines) + "\n"
 
         # Indent the body for YAML block scalar. Use an explicit indentation
         # indicator ("|2") rather than a bare "|": YAML infers a plain block

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -1238,9 +1238,9 @@ class YamlIntegration(IntegrationBase):
     def _render_yaml(cls, title: str, description: str, body: str, source_id: str) -> str:
         """Render a YAML recipe file from title, description, and body.
 
-        Produces a Goose-compatible recipe with a literal block scalar
-        for the prompt content.  Uses ``yaml.safe_dump()`` for the
-        header fields to ensure proper escaping.
+        Produces a Goose-compatible recipe with a literal block scalar for
+        normal prompt content, or an escaped quoted scalar when control
+        characters require it. Uses ``yaml.safe_dump()`` for the header fields.
         """
         header = cls._build_yaml_header(title, description)
 

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -1123,11 +1123,14 @@ class TomlIntegration(IntegrationBase):
 # ---------------------------------------------------------------------------
 
 # Characters a YAML literal block scalar cannot carry: C0 controls other
-# than tab/LF (a bare CR acts as a line break inside the scalar), DEL, and
-# the C1 range. NEL (U+0085) is YAML-printable but, like LS/PS
-# (U+2028/U+2029), YAML 1.1 treats it as a line break, which corrupts the
-# block scalar's structure just the same, so all three are included.
-_YAML_BLOCK_SCALAR_UNSAFE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f\u2028\u2029]")
+# than tab/LF (a bare CR acts as a line break inside the scalar), DEL, the
+# C1 range, lone UTF-16 surrogates, and the non-characters U+FFFE/U+FFFF.
+# NEL (U+0085) is YAML-printable but, like LS/PS (U+2028/U+2029), YAML 1.1
+# treats it as a line break, which corrupts the block scalar's structure
+# just the same, so all three are included.
+_YAML_BLOCK_SCALAR_UNSAFE = re.compile(
+    r"[\x00-\x08\x0b-\x1f\x7f-\x9f\u2028\u2029\ud800-\udfff\ufffe\uffff]"
+)
 
 
 class YamlIntegration(IntegrationBase):

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -1123,8 +1123,11 @@ class TomlIntegration(IntegrationBase):
 # ---------------------------------------------------------------------------
 
 # Characters a YAML literal block scalar cannot carry: C0 controls other
-# than tab/LF (a bare CR acts as a line break inside the scalar), and DEL.
-_YAML_BLOCK_SCALAR_UNSAFE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+# than tab/LF (a bare CR acts as a line break inside the scalar), DEL, and
+# the C1 range. NEL (U+0085) is YAML-printable but, like LS/PS
+# (U+2028/U+2029), YAML 1.1 treats it as a line break, which corrupts the
+# block scalar's structure just the same, so all three are included.
+_YAML_BLOCK_SCALAR_UNSAFE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f\u2028\u2029]")
 
 
 class YamlIntegration(IntegrationBase):

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -1252,7 +1252,7 @@ class YamlIntegration(IntegrationBase):
         # back to an escaped double-quoted scalar for those bodies.
         if _YAML_BLOCK_SCALAR_UNSAFE.search(body):
             prompt_yaml = yaml.safe_dump(
-                {"prompt": body}, allow_unicode=True, default_style='"', width=float("inf")
+                {"prompt": body}, allow_unicode=True, default_style='"', width=sys.maxsize
             ).strip()
             lines = [
                 header_yaml,

--- a/tests/integrations/test_integration_base_yaml.py
+++ b/tests/integrations/test_integration_base_yaml.py
@@ -204,11 +204,16 @@ class YamlIntegrationTests:
     def test_yaml_prompt_with_control_characters_stays_valid(self):
         """A body containing control characters must still produce parseable YAML.
 
-        YAML forbids C0 control characters (except tab and newline) and DEL
-        in every scalar form; a literal block scalar emits them verbatim,
-        so the generated recipe failed to load. The renderer falls back to
-        an escaped double-quoted scalar for such bodies."""
-        for ch in ("\x08", "\x0c", "\x1b", "\x7f"):
+        YAML forbids C0 control characters (except tab and newline), DEL,
+        and C1 controls in every scalar form, and YAML 1.1 treats NEL
+        (U+0085), LS (U+2028) and PS (U+2029) as line breaks that corrupt a
+        literal block scalar's structure. The renderer falls back to an
+        escaped double-quoted scalar for such bodies."""
+        for ch in (
+            "\x08", "\x0c", "\x1b", "\x7f",
+            "\x80", "\x84", "\x85", "\x86", "\x9f",
+            "\u2028", "\u2029",
+        ):
             body = f"before{ch}after\nsecond line"
             rendered = YamlIntegration._render_yaml("Title", "Desc", body, "src")
             parsed = yaml.safe_load(rendered)

--- a/tests/integrations/test_integration_base_yaml.py
+++ b/tests/integrations/test_integration_base_yaml.py
@@ -201,6 +201,29 @@ class YamlIntegrationTests:
         parsed = yaml.safe_load("\n".join(yaml_lines))
         assert parsed["prompt"].rstrip("\n") == body
 
+    def test_yaml_prompt_with_control_characters_stays_valid(self):
+        """A body containing control characters must still produce parseable YAML.
+
+        YAML forbids C0 control characters (except tab and newline) and DEL
+        in every scalar form; a literal block scalar emits them verbatim,
+        so the generated recipe failed to load. The renderer falls back to
+        an escaped double-quoted scalar for such bodies."""
+        for ch in ("\x08", "\x0c", "\x1b", "\x7f"):
+            body = f"before{ch}after\nsecond line"
+            rendered = YamlIntegration._render_yaml("Title", "Desc", body, "src")
+            parsed = yaml.safe_load(rendered)
+            assert parsed["prompt"].rstrip("\n") == body, f"char {ch!r} round-trip"
+
+    def test_yaml_prompt_with_bare_carriage_return_stays_valid(self):
+        """A bare CR (not part of CRLF) must not break the generated YAML.
+
+        Inside a block scalar a lone \r acts as a line break, corrupting
+        the document structure."""
+        body = "line1\rstill line1\nline2"
+        rendered = YamlIntegration._render_yaml("Title", "Desc", body, "src")
+        parsed = yaml.safe_load(rendered)
+        assert parsed["prompt"].rstrip("\n") == body
+
     def test_plan_command_has_no_context_placeholder(self, tmp_path):
         """The generated plan command must not carry a context-file placeholder.
 

--- a/tests/integrations/test_integration_base_yaml.py
+++ b/tests/integrations/test_integration_base_yaml.py
@@ -205,14 +205,16 @@ class YamlIntegrationTests:
         """A body containing control characters must still produce parseable YAML.
 
         YAML forbids C0 control characters (except tab and newline), DEL,
-        and C1 controls in every scalar form, and YAML 1.1 treats NEL
-        (U+0085), LS (U+2028) and PS (U+2029) as line breaks that corrupt a
-        literal block scalar's structure. The renderer falls back to an
-        escaped double-quoted scalar for such bodies."""
+        C1 controls, lone surrogates and U+FFFE/U+FFFF in every scalar form,
+        and YAML 1.1 treats NEL (U+0085), LS (U+2028) and PS (U+2029) as
+        line breaks that corrupt a literal block scalar's structure. The
+        renderer falls back to an escaped double-quoted scalar for such
+        bodies."""
         for ch in (
             "\x08", "\x0c", "\x1b", "\x7f",
             "\x80", "\x84", "\x85", "\x86", "\x9f",
             "\u2028", "\u2029",
+            "\ud800", "\udfff", "\ufffe", "\uffff",
         ):
             body = f"before{ch}after\nsecond line"
             rendered = YamlIntegration._render_yaml("Title", "Desc", body, "src")


### PR DESCRIPTION
## Description

Fixes #3382

`YamlIntegration._render_yaml` writes the command body verbatim into a `|2` literal block scalar. YAML forbids C0 control characters (except tab and newline) and DEL in every scalar form, and a bare CR acts as a line break inside a block scalar, so a body containing any of these produced a goose recipe the YAML parser rejects (`unacceptable character #x0008: special characters are not allowed`).

**Root cause:** the block-scalar path has no escaping mechanism at all; there is no string form in YAML that carries these bytes raw.

**Fix:** detect block-scalar-unsafe characters with a precompiled character class and fall back to an escaped double-quoted scalar rendered by `yaml.safe_dump`, which escapes them as `\b`, `\r`, `\x7F` and so on. Bodies without such characters keep the existing readable block-scalar output byte for byte. This mirrors the fallback strategy #3341 gives the TOML renderers for the same bug class (#3340).

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` — 3776 passed, 105 skipped
- [ ] Tested with a sample project (if applicable)

Two regression tests in the shared `YamlIntegrationTests` mixin (exercised via the goose integration): control characters (`\x08`, `\x0c`, `\x1b`, `\x7f`) and a bare CR, both asserting the rendered recipe parses and the prompt round-trips. Both fail on `main`.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Bug found, patch and tests written with GitHub Copilot CLI; reproduction and full test suite run and verified locally by me.
