### PR TITLE
fix(integrations): skip Windows Store python3 alias stub in resolve_python_interpreter

### DIFF
--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -593,12 +593,19 @@ class IntegrationBase(ABC):
 
     @staticmethod
     def _interpreter_runs(path: str) -> bool:
-        """Return True when *path* executes as a Python interpreter."""
+        """Return True when *path* executes as a Python interpreter.
+
+        Runs isolated (``-I``) without ``site`` (``-S``) and discards
+        I/O so the probe is a fast liveness check that cannot trigger
+        ``sitecustomize``/user startup hooks.
+        """
         try:
             return (
                 subprocess.run(
-                    [path, "-c", ""],
-                    capture_output=True,
+                    [path, "-I", "-S", "-c", ""],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                     timeout=15,
                 ).returncode
                 == 0

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -17,6 +17,7 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 from abc import ABC
 from dataclasses import dataclass
@@ -576,9 +577,34 @@ class IntegrationBase(ABC):
                 if candidate.exists():
                     return relative
         for name in ("python3", "python"):
-            if shutil.which(name):
-                return name
+            found = shutil.which(name)
+            if not found:
+                continue
+            # On Windows, python3/python on PATH may be the Microsoft
+            # Store App Execution Alias stub: it exists but only prints
+            # an installer hint and exits non-zero, so existence is not
+            # enough (see #3304 for the same defect in the sh scripts).
+            if sys.platform == "win32" and not IntegrationBase._interpreter_runs(
+                found
+            ):
+                continue
+            return name
         return sys.executable or "python3"
+
+    @staticmethod
+    def _interpreter_runs(path: str) -> bool:
+        """Return True when *path* executes as a Python interpreter."""
+        try:
+            return (
+                subprocess.run(
+                    [path, "-c", ""],
+                    capture_output=True,
+                    timeout=15,
+                ).returncode
+                == 0
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
 
     @staticmethod
     def process_template(
@@ -1058,7 +1084,6 @@ class TomlIntegration(IntegrationBase):
 # ---------------------------------------------------------------------------
 # YamlIntegration — YAML-format agents (Goose)
 # ---------------------------------------------------------------------------
-
 
 class YamlIntegration(IntegrationBase):
     """Concrete base for integrations that use YAML recipe format.

--- a/tests/integrations/test_base.py
+++ b/tests/integrations/test_base.py
@@ -306,9 +306,12 @@ class TestResolveCommandRefs:
 class TestResolvePythonInterpreter:
     def test_returns_python_on_path(self, monkeypatch):
         # Positive: when python3 is on PATH it is preferred over python.
+        # Pin a POSIX platform so the Windows stub probe (tested separately
+        # below) does not reject the fake PATH entries on Windows CI.
         def fake_which(name):
             return f"/usr/bin/{name}" if name in ("python3", "python") else None
 
+        monkeypatch.setattr("specify_cli.integrations.base.sys.platform", "linux")
         monkeypatch.setattr(
             "specify_cli.integrations.base.shutil.which", fake_which
         )
@@ -318,6 +321,7 @@ class TestResolvePythonInterpreter:
         def fake_which(name):
             return "/usr/bin/python" if name == "python" else None
 
+        monkeypatch.setattr("specify_cli.integrations.base.sys.platform", "linux")
         monkeypatch.setattr(
             "specify_cli.integrations.base.shutil.which", fake_which
         )
@@ -369,6 +373,7 @@ class TestResolvePythonInterpreter:
 
     def test_ignores_missing_venv(self, monkeypatch, tmp_path):
         # Negative: no venv directory -> PATH resolution is used instead.
+        monkeypatch.setattr("specify_cli.integrations.base.sys.platform", "linux")
         monkeypatch.setattr(
             "specify_cli.integrations.base.shutil.which",
             lambda name: "/usr/bin/python3" if name == "python3" else None,
@@ -456,6 +461,7 @@ class TestProcessTemplatePyScriptType:
     def test_py_prefixes_interpreter(self, monkeypatch):
         # Positive: py script type prefixes a resolved interpreter and the
         # script path is rewritten to the .specify location.
+        monkeypatch.setattr("specify_cli.integrations.base.sys.platform", "linux")
         monkeypatch.setattr(
             "specify_cli.integrations.base.shutil.which",
             lambda name: "/usr/bin/python3" if name == "python3" else None,

--- a/tests/integrations/test_base.py
+++ b/tests/integrations/test_base.py
@@ -375,6 +375,72 @@ class TestResolvePythonInterpreter:
         )
         assert IntegrationBase.resolve_python_interpreter(tmp_path) == "python3"
 
+    def test_windows_skips_store_alias_stub(self, monkeypatch):
+        # On Windows, python3 on PATH may be the Microsoft Store App
+        # Execution Alias stub: it exists but only prints an installer
+        # hint and exits non-zero. Existence is not enough; the
+        # interpreter must actually run (mirrors #3304 for the CLI).
+        monkeypatch.setattr("specify_cli.integrations.base.sys.platform", "win32")
+        monkeypatch.setattr(
+            "specify_cli.integrations.base.shutil.which",
+            lambda name: f"C:\\WindowsApps\\{name}.exe"
+            if name in ("python3", "python")
+            else None,
+        )
+        monkeypatch.setattr(
+            IntegrationBase, "_interpreter_runs", staticmethod(lambda path: False)
+        )
+        monkeypatch.setattr(
+            "specify_cli.integrations.base.sys.executable", "C:\\Python\\python.exe"
+        )
+        result = IntegrationBase.resolve_python_interpreter()
+        assert result == "C:\\Python\\python.exe"
+
+    def test_windows_keeps_working_interpreter(self, monkeypatch):
+        # Positive: a real python3 on Windows PATH passes the run check.
+        monkeypatch.setattr("specify_cli.integrations.base.sys.platform", "win32")
+        monkeypatch.setattr(
+            "specify_cli.integrations.base.shutil.which",
+            lambda name: f"C:\\Python\\{name}.exe" if name == "python3" else None,
+        )
+        monkeypatch.setattr(
+            IntegrationBase, "_interpreter_runs", staticmethod(lambda path: True)
+        )
+        assert IntegrationBase.resolve_python_interpreter() == "python3"
+
+    def test_windows_stub_python3_falls_through_to_working_python(self, monkeypatch):
+        # python3 is the stub but python is a real install: pick python.
+        monkeypatch.setattr("specify_cli.integrations.base.sys.platform", "win32")
+        monkeypatch.setattr(
+            "specify_cli.integrations.base.shutil.which",
+            lambda name: f"C:\\somewhere\\{name}.exe"
+            if name in ("python3", "python")
+            else None,
+        )
+        monkeypatch.setattr(
+            IntegrationBase,
+            "_interpreter_runs",
+            staticmethod(lambda path: path.endswith("python.exe")),
+        )
+        assert IntegrationBase.resolve_python_interpreter() == "python"
+
+    def test_posix_does_not_spawn_run_check(self, monkeypatch):
+        # Non-Windows platforms have no App Execution Alias; existence
+        # on PATH stays sufficient and no subprocess is spawned.
+        monkeypatch.setattr("specify_cli.integrations.base.sys.platform", "linux")
+        monkeypatch.setattr(
+            "specify_cli.integrations.base.shutil.which",
+            lambda name: "/usr/bin/python3" if name == "python3" else None,
+        )
+
+        def boom(path):
+            raise AssertionError("run check must not execute on POSIX")
+
+        monkeypatch.setattr(
+            IntegrationBase, "_interpreter_runs", staticmethod(boom)
+        )
+        assert IntegrationBase.resolve_python_interpreter() == "python3"
+
 
 class TestProcessTemplatePyScriptType:
     CONTENT = (


### PR DESCRIPTION
## Description

Fixes #3383

`IntegrationBase.resolve_python_interpreter` picked `python3`/`python` by existence on `PATH` (`shutil.which`). On stock Windows, `python3` resolves to the Microsoft Store App Execution Alias stub, which exists but only prints an installer hint and exits non-zero. Every generated `{SCRIPT}` invocation for the `py` script type was therefore broken on that machine state, while the guaranteed-live `sys.executable` fallback sat unreached.

**Root cause:** the same existence-vs-runtime defect #3304 documents for the sh scripts (assessed valid, severity medium there); the fixes in #3312 and #3320 covered `common.sh` but not this Python resolver.

**Fix:** on Windows only, verify the found interpreter with a `[path, "-c", ""]` run before accepting it, and fall through to the next candidate (then `sys.executable`) when it fails. POSIX has no App Execution Alias, so it keeps the plain existence check and spawns nothing — a regression test asserts that. The run check lives in a small `_interpreter_runs` helper with a timeout and OSError guard.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` — 3776 passed, 105 skipped
- [ ] Tested with a sample project (if applicable)

Four regression tests in `TestResolvePythonInterpreter`: stub rejected → `sys.executable`, working interpreter accepted, stub `python3` falling through to a working `python`, and POSIX never spawning the run check. The first three fail on `main`.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Bug found, patch and tests written with GitHub Copilot CLI; reproduction and full test suite run and verified locally by me. I do not have a Windows machine in this environment; the Windows behavior is covered by the monkeypatched tests and matches the machine state documented in #3304.
