### PR TITLE
docs(extensions): clarify agent-context README and add config examples

### DIFF
--- a/extensions/agent-context/README.md
+++ b/extensions/agent-context/README.md
@@ -81,4 +81,4 @@ pip install pyyaml
 
 ## Issues
 
-For any other issues, please create an issue in the [official Github repo](https://github.com/github/spec-kit/issues).
+For any other issues, please create an issue in the [official GitHub repo](https://github.com/github/spec-kit/issues).

--- a/extensions/agent-context/README.md
+++ b/extensions/agent-context/README.md
@@ -11,7 +11,7 @@ It owns the lifecycle of the managed section delimited by the configurable start
 Not every Spec Kit user wants Spec Kit to write into the coding agent's context file. Keeping this behavior in a dedicated, **opt-in** extension lets users:
 
 - **Choose whether to install it at all** - `specify init` does **NOT** install it. Add it explicitly when you want Spec Kit to manage the agent context file; if it is absent or disabled, Spec Kit never creates or modifies that file (the AI context file).
-- **Customize the markers** by editing [agent-context-config.yml](./agent-context-config.yml) - the bundled scripts honor the `context_markers` value.
+- **Customize the markers** by editing `.specify/extensions/agent-context/agent-context-config.yml` ([agent-context-config.yml](./agent-context-config.yml) in this repo) - the bundled scripts honor the `context_markers` value.
 - **Synchronize multiple agent anchors** by setting `context_files` when a project intentionally uses more than one coding agent context file, such as `AGENTS.md` and `CLAUDE.md`.
 - **Refresh on demand** by running the `speckit.agent-context.update` command in your agent, or automatically through the hooks declared in [extension.yml](./extension.yml) (`after_specify`, `after_plan`).
 
@@ -44,28 +44,7 @@ While this extension is disabled (or not installed), nothing in Spec Kit creates
 
 ## Configuration
 
-All configuration flows through the extension's own config file at
-[agent-context-config.yml](./agent-context-config.yml):
-
-```yaml
-# Path to the coding agent context file managed by this extension
-context_file: CLAUDE.md
-
-# Optional list of coding agent context files to manage together.
-# When non-empty, this takes precedence over context_file.
-context_files:
-  - AGENTS.md
-  - CLAUDE.md
-
-# Delimiters for the managed Spec Kit section
-context_markers:
-  start: "<!-- SPECKIT START -->"
-  end: "<!-- SPECKIT END -->"
-```
-
-- `context_file` - the project-relative path to the coding agent context file. When empty, the bundled update scripts self-seed it by looking up the active integration's key in this extension's own `agent-context-defaults.json` map. The Specify CLI is never consulted.
-- `context_files` - optional project-relative paths to multiple coding agent context files. When non-empty, the list takes precedence over `context_file`. Absolute paths, backslash separators, and `..` path segments are rejected.
-- `context_markers.start` / `.end` - the delimiters around the managed section. Edit these to use custom markers.
+All configuration flows through the extension's own config file at [agent-context-config.yml](./agent-context-config.yml).
 
 ## Requirements
 

--- a/extensions/agent-context/README.md
+++ b/extensions/agent-context/README.md
@@ -2,29 +2,50 @@
 
 This bundled extension manages the **coding agent context/instruction file** (e.g. `CLAUDE.md`, `.github/copilot-instructions.md`, `AGENTS.md`, `GEMINI.md`, …) for the active integration.
 
-It owns the lifecycle of the managed section delimited by the configurable start/end markers (defaults: `<!-- SPECKIT START -->` / `<!-- SPECKIT END -->`).
+It owns the lifecycle of the managed section delimited by the configurable start/end markers (defaults: `<!-- SPECKIT START -->` / `<!-- SPECKIT END -->`). Everything else is untouched.
+
+> NOTE: Spec Kit itself never touches your agent context file. This extension is the only thing that does, and it's opt-in: install it if you want the block kept in sync, skip it if you'd rather manage that file yourself.
 
 ## Why an extension?
 
 Not every Spec Kit user wants Spec Kit to write into the coding agent's context file. Keeping this behavior in a dedicated, **opt-in** extension lets users:
 
-- **Choose whether to install it at all** — `specify init` does not install it. Add it explicitly when you want Spec Kit to manage the agent context file; if it is absent or disabled, Spec Kit never creates or modifies that file.
-- **Customize the markers** by editing `.specify/extensions/agent-context/agent-context-config.yml` — the bundled scripts honor the `context_markers` value.
+- **Choose whether to install it at all** - `specify init` does **NOT** install it. Add it explicitly when you want Spec Kit to manage the agent context file; if it is absent or disabled, Spec Kit never creates or modifies that file (the AI context file).
+- **Customize the markers** by editing [agent-context-config.yml](./agent-context-config.yml) - the bundled scripts honor the `context_markers` value.
 - **Synchronize multiple agent anchors** by setting `context_files` when a project intentionally uses more than one coding agent context file, such as `AGENTS.md` and `CLAUDE.md`.
-- **Refresh on demand** by running the `speckit.agent-context.update` command in your agent, or automatically through the hooks declared in `extension.yml` (`after_specify`, `after_plan`). Invoke it using your agent's slash-command separator — `/speckit.agent-context.update` for dot-separator agents or `/speckit-agent-context-update` for hyphen-separator agents (e.g. Forge, Cline).
+- **Refresh on demand** by running the `speckit.agent-context.update` command in your agent, or automatically through the hooks declared in [extension.yml](./extension.yml) (`after_specify`, `after_plan`).
+
+## Installation
+
+To install the extension, run the following command after installing Spec Kit.
+
+```bash
+specify extension add agent-context
+```
+
+## Disabling
+
+```bash
+specify extension disable agent-context
+
+# Re-enable it
+specify extension enable agent-context
+```
+
+While this extension is disabled (or not installed), nothing in Spec Kit creates, updates, or removes the managed block - the `__CONTEXT_FILE__` placeholder in any template is left as-is, and the extension's own config is never read.
 
 ## Commands
 
-The command ID below is canonical. When invoking it as a slash command, use your agent's separator: `/speckit.agent-context.update` for dot-separator agents or `/speckit-agent-context-update` for hyphen-separator agents (e.g. Forge, Cline).
-
-| Command | Description |
-|---------|-------------|
+| Command                        | Description                                                                       |
+| ------------------------------ | --------------------------------------------------------------------------------- |
 | `speckit.agent-context.update` | Refresh the managed section in the agent context file with the current plan path. |
+
+> NOTE: The command ID above is canonical. When invoking it as a slash command, use your agent's separator: `/speckit.agent-context.update` for dot-separator agents or `/speckit-agent-context-update` for hyphen-separator agents (e.g. Forge, Cline).
 
 ## Configuration
 
 All configuration flows through the extension's own config file at
-`.specify/extensions/agent-context/agent-context-config.yml`:
+[agent-context-config.yml](./agent-context-config.yml):
 
 ```yaml
 # Path to the coding agent context file managed by this extension
@@ -42,15 +63,15 @@ context_markers:
   end: "<!-- SPECKIT END -->"
 ```
 
-- `context_file` — the project-relative path to the coding agent context file. When empty, the bundled update scripts self-seed it by looking up the active integration's key in this extension's own `agent-context-defaults.json` map. The Specify CLI is never consulted.
-- `context_files` — optional project-relative paths to multiple coding agent context files. When non-empty, the list takes precedence over `context_file`. Absolute paths, backslash separators, and `..` path segments are rejected.
-- `context_markers.start` / `.end` — the delimiters around the managed section. Edit these to use custom markers.
+- `context_file` - the project-relative path to the coding agent context file. When empty, the bundled update scripts self-seed it by looking up the active integration's key in this extension's own `agent-context-defaults.json` map. The Specify CLI is never consulted.
+- `context_files` - optional project-relative paths to multiple coding agent context files. When non-empty, the list takes precedence over `context_file`. Absolute paths, backslash separators, and `..` path segments are rejected.
+- `context_markers.start` / `.end` - the delimiters around the managed section. Edit these to use custom markers.
 
 ## Requirements
 
 The bundled update scripts require **Python 3** with **PyYAML** for YAML/upsert processing (PowerShell can also use `ConvertFrom-Yaml` when available).
 
-PyYAML ships with the `specify` CLI and is normally available via the same `python3` interpreter. If a hook reports *"PyYAML is required … not available in the current Python environment"*, it means the system `python3` differs from the one used to install Spec Kit. To resolve, run:
+PyYAML ships with the `specify` CLI and is normally available via the same `python3` interpreter. If a hook reports _"PyYAML is required … not available in the current Python environment"_, it means the system `python3` differs from the one used to install Spec Kit. To resolve, run:
 
 ```bash
 pip install pyyaml
@@ -58,10 +79,6 @@ pip install pyyaml
 /path/to/speckit-python -m pip install pyyaml
 ```
 
-## Disable
+## Issues
 
-```bash
-specify extension disable agent-context
-```
-
-When disabled (or never installed), Spec Kit performs no agent context file creation, updates, or removal — the extension's bundled scripts are the only code that ever touches the managed section. The Specify CLI carries no agent-context state at all: it never reads this config, never resolves a context file, and the `__CONTEXT_FILE__` placeholder (if present in any template) is left untouched. All context-file knowledge — including the per-agent default mapping in `agent-context-defaults.json` — lives entirely within this extension, so disabling it is a complete opt-out.
+For any other issues, please create an issue in the [official Github repo](https://github.com/github/spec-kit/issues).

--- a/extensions/agent-context/README.md
+++ b/extensions/agent-context/README.md
@@ -40,7 +40,7 @@ While this extension is disabled (or not installed), nothing in Spec Kit creates
 | ------------------------------ | --------------------------------------------------------------------------------- |
 | `speckit.agent-context.update` | Refresh the managed section in the agent context file with the current plan path. |
 
-> NOTE: The command ID above is canonical. When invoking it as a slash command, use your agent's separator: `/speckit.agent-context.update` for dot-separator agents or `/speckit-agent-context-update` for hyphen-separator agents (e.g. Forge, Cline).
+> NOTE: The command ID above is canonical. Invoke it using the syntax for your integration: `/speckit.agent-context.update` for dot-command integrations; `/speckit-agent-context-update` for hyphen/skills integrations (including Forge and Cline); `$speckit-agent-context-update` for Codex or ZCode in skills mode; or `/skill:speckit-agent-context-update` for Kimi.
 
 ## Configuration
 

--- a/extensions/agent-context/README.md
+++ b/extensions/agent-context/README.md
@@ -2,7 +2,7 @@
 
 This bundled extension manages the **coding agent context/instruction file** (e.g. `CLAUDE.md`, `.github/copilot-instructions.md`, `AGENTS.md`, `GEMINI.md`, …) for the active integration.
 
-It owns the lifecycle of the managed section delimited by the configurable start/end markers (defaults: `<!-- SPECKIT START -->` / `<!-- SPECKIT END -->`). Everything else is untouched.
+It owns the lifecycle of the managed section delimited by the configurable start/end markers (defaults: `<!-- SPECKIT START -->` / `<!-- SPECKIT END -->`). For `.mdc` files, it also ensures the YAML frontmatter (the metadata block at the top of the file) contains `alwaysApply: true`. Otherwise, everything outside the managed section is untouched.
 
 > NOTE: Spec Kit itself never touches your agent context file. This extension is the only thing that does, and it's opt-in: install it if you want the block kept in sync, skip it if you'd rather manage that file yourself.
 

--- a/extensions/agent-context/README.md
+++ b/extensions/agent-context/README.md
@@ -44,7 +44,7 @@ While this extension is disabled (or not installed), nothing in Spec Kit creates
 
 ## Configuration
 
-All configuration flows through the extension's own config file at [agent-context-config.yml](./agent-context-config.yml).
+All configuration flows through the extension's own config file at `.specify/extensions/agent-context/agent-context-config.yml` ([agent-context-config.yml](./agent-context-config.yml) in the repo).
 
 ## Requirements
 

--- a/extensions/agent-context/README.md
+++ b/extensions/agent-context/README.md
@@ -10,7 +10,7 @@ It owns the lifecycle of the managed section delimited by the configurable start
 
 Not every Spec Kit user wants Spec Kit to write into the coding agent's context file. Keeping this behavior in a dedicated, **opt-in** extension lets users:
 
-- **Choose whether to install it at all** - `specify init` does **NOT** install it. Add it explicitly when you want Spec Kit to manage the agent context file; if it is absent or disabled, Spec Kit never creates or modifies that file (the AI context file).
+- **Choose whether to install it at all** - `specify init` does **not** install it. Add it explicitly when you want Spec Kit to manage the agent context file; when it is absent, the file is never modified, and when it is disabled, its automatic hooks do not run.
 - **Customize the markers** by editing `.specify/extensions/agent-context/agent-context-config.yml` ([agent-context-config.yml](./agent-context-config.yml) in this repo) - the bundled scripts honor the `context_markers` value.
 - **Synchronize multiple agent anchors** by setting `context_files` when a project intentionally uses more than one coding agent context file, such as `AGENTS.md` and `CLAUDE.md`.
 - **Refresh on demand** by running the `speckit.agent-context.update` command in your agent, or automatically through the hooks declared in [extension.yml](./extension.yml) (`after_specify`, `after_plan`).

--- a/extensions/agent-context/README.md
+++ b/extensions/agent-context/README.md
@@ -17,7 +17,7 @@ Not every Spec Kit user wants Spec Kit to write into the coding agent's context 
 
 ## Installation
 
-To install the extension, run the following command after installing Spec Kit.
+To install the extension, from the root of an initialized Spec Kit project, run:
 
 ```bash
 specify extension add agent-context

--- a/extensions/agent-context/agent-context-config.yml
+++ b/extensions/agent-context/agent-context-config.yml
@@ -14,7 +14,7 @@ context_file: ""
 context_files: []
 
 # WHAT: Markers (Delimiters) for the managed Spec Kit section. All information injected by this extension will only be done in between these markers.
-# REQUIREMENT: REQUIRED. Only change if you wish to have a custom marker name.
+# REQUIREMENT: OPTIONAL. Only change if you wish to have a custom marker name.
 # EXAMPLE:
 # context_markers:
 #   start: "<!-- AGENT SPEC KIT CONTEXT START -->"

--- a/extensions/agent-context/agent-context-config.yml
+++ b/extensions/agent-context/agent-context-config.yml
@@ -1,25 +1,25 @@
 # Coding Agent Context Extension Configuration
-# These values are populated automatically by `specify init` and
-# `specify integration use` / `specify integration install`.
+# These values are populated automatically by `specify init` and `specify integration use` / `specify integration install`.
 
-# Path (relative to the project root) to the default coding agent context file
-# managed by this extension (e.g. CLAUDE.md, AGENTS.md,
-# .github/copilot-instructions.md). Set automatically from the active
-# integration and regenerated during `specify init` or integration switches.
+# WHAT: Single Project-relative path to the main coding agent context file.
+# REQUIREMENT: OPTIONAL. If you leave this entry blank, the bundled update scripts will automatically fill this in based on the active integration's key.
 # EXAMPLE: context_file: CLAUDE.md
 context_file: ""
 
-# Optional list of project-relative coding agent context files managed by this
-# extension. When non-empty, this list takes precedence over `context_file`.
-# Use this for projects that intentionally keep multiple agent anchors in sync.
+# WHAT: List of project-relative coding agent context file paths managed by this extension. If you have both `context_file` and `context_files`, then `context_files` takes precedence.
+# REQUIREMENT: OPTIONAL. Use this if your project requires you to keep multiple agent files in sync.
 # EXAMPLE:
 # context_files:
 #   - AGENTS.md
 #   - CLAUDE.md
 context_files: []
 
-# Delimiters for the managed Spec Kit section.
-# Edit these to use custom markers.
+# WHAT: Markers (Delimiters) for the managed Spec Kit section. All information injected by this extension will only be done in between these markers.
+# REQUIREMENT: REQUIRED. Only change if you wish to have a custom marker name.
+# EXAMPLE:
+# context_markers:
+#  start: "<!-- AGENT SPEC KIT CONTEXT START -->"
+#  end: "<!-- AGENT SPEC KIT CONTEXT END -->"
 context_markers:
   start: "<!-- SPECKIT START -->"
   end: "<!-- SPECKIT END -->"

--- a/extensions/agent-context/agent-context-config.yml
+++ b/extensions/agent-context/agent-context-config.yml
@@ -1,11 +1,11 @@
 # Coding Agent Context Extension Configuration
 
-# WHAT: Single project relative path to the main coding agent context file.
+# WHAT: The single agent context file relative to the project root (the directory containing .specify/). Absolute paths, backslash separators, and `..` path segments are rejected.
 # REQUIREMENT: OPTIONAL. Use this if you want to manually specify a single context file. If you leave this entry blank, it will use the default context file for the coding agent you picked when you set up Spec Kit. See `agent-context-defaults.json` for the defaults.
 # EXAMPLE: context_file: CLAUDE.md
 context_file: ""
 
-# WHAT: List of project relative paths to the coding agent context files. If you have both `context_file` and `context_files` filled, then this (`context_files`) takes precedence.
+# WHAT: List of agent context files relative to the project root (the directory containing .specify/). If you have both `context_file` and `context_files` filled, then this (`context_files`) takes precedence. Absolute paths, backslash separators, and `..` path segments are rejected.
 # REQUIREMENT: OPTIONAL. Use this if your project requires you to keep multiple agent context files in sync.
 # EXAMPLE:
 # context_files:

--- a/extensions/agent-context/agent-context-config.yml
+++ b/extensions/agent-context/agent-context-config.yml
@@ -1,13 +1,12 @@
 # Coding Agent Context Extension Configuration
-# These values are populated automatically by `specify init` and `specify integration use` / `specify integration install`.
 
-# WHAT: Single Project-relative path to the main coding agent context file.
-# REQUIREMENT: OPTIONAL. If you leave this entry blank, the bundled update scripts will automatically fill this in based on the active integration's key.
+# WHAT: Single project relative path to the main coding agent context file.
+# REQUIREMENT: OPTIONAL. Use this if you want to manually specify a single context file. If you leave this entry blank, it will use the default context file for the coding agent you picked when you set up Spec Kit. See `agent-context-defaults.json` for the defaults.
 # EXAMPLE: context_file: CLAUDE.md
 context_file: ""
 
-# WHAT: List of project-relative coding agent context file paths managed by this extension. If you have both `context_file` and `context_files`, then `context_files` takes precedence.
-# REQUIREMENT: OPTIONAL. Use this if your project requires you to keep multiple agent files in sync.
+# WHAT: List of project relative paths to the coding agent context files. If you have both `context_file` and `context_files` filled, then this(`context_files`) takes precedence.
+# REQUIREMENT: OPTIONAL. Use this if your project requires you to keep multiple agent context files in sync.
 # EXAMPLE:
 # context_files:
 #   - AGENTS.md

--- a/extensions/agent-context/agent-context-config.yml
+++ b/extensions/agent-context/agent-context-config.yml
@@ -17,8 +17,8 @@ context_files: []
 # REQUIREMENT: REQUIRED. Only change if you wish to have a custom marker name.
 # EXAMPLE:
 # context_markers:
-#  start: "<!-- AGENT SPEC KIT CONTEXT START -->"
-#  end: "<!-- AGENT SPEC KIT CONTEXT END -->"
+#   start: "<!-- AGENT SPEC KIT CONTEXT START -->"
+#   end: "<!-- AGENT SPEC KIT CONTEXT END -->"
 context_markers:
   start: "<!-- SPECKIT START -->"
   end: "<!-- SPECKIT END -->"

--- a/extensions/agent-context/agent-context-config.yml
+++ b/extensions/agent-context/agent-context-config.yml
@@ -5,7 +5,7 @@
 # EXAMPLE: context_file: CLAUDE.md
 context_file: ""
 
-# WHAT: List of project relative paths to the coding agent context files. If you have both `context_file` and `context_files` filled, then this(`context_files`) takes precedence.
+# WHAT: List of project relative paths to the coding agent context files. If you have both `context_file` and `context_files` filled, then this (`context_files`) takes precedence.
 # REQUIREMENT: OPTIONAL. Use this if your project requires you to keep multiple agent context files in sync.
 # EXAMPLE:
 # context_files:

--- a/extensions/agent-context/agent-context-config.yml
+++ b/extensions/agent-context/agent-context-config.yml
@@ -13,7 +13,7 @@ context_file: ""
 #   - CLAUDE.md
 context_files: []
 
-# WHAT: Markers (Delimiters) for the managed Spec Kit section. All information injected by this extension will only be done in between these markers.
+# WHAT: Markers (delimiters) for the managed Spec Kit section. This extension injects information only between these markers.
 # REQUIREMENT: OPTIONAL. Only change if you wish to have a custom marker name.
 # EXAMPLE:
 # context_markers:

--- a/extensions/agent-context/agent-context-config.yml
+++ b/extensions/agent-context/agent-context-config.yml
@@ -6,11 +6,16 @@
 # managed by this extension (e.g. CLAUDE.md, AGENTS.md,
 # .github/copilot-instructions.md). Set automatically from the active
 # integration and regenerated during `specify init` or integration switches.
+# EXAMPLE: context_file: CLAUDE.md
 context_file: ""
 
 # Optional list of project-relative coding agent context files managed by this
 # extension. When non-empty, this list takes precedence over `context_file`.
 # Use this for projects that intentionally keep multiple agent anchors in sync.
+# EXAMPLE:
+# context_files:
+#   - AGENTS.md
+#   - CLAUDE.md
 context_files: []
 
 # Delimiters for the managed Spec Kit section.


### PR DESCRIPTION
## Description

Edited the `agent-context` `README.md` and `agent-context-config.yml` for clarity. Added the missing install command.

## Testing

Ran the commands on a project to ensure it's correct. No other testing are required for this.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [X] I **did** use AI assistance

AI was used to check whether there were any active PRs/issues related to this, and then to create a suggested fix for the README. However, I only used that file as a reference and made the changes to the `README.md` myself.

Please do let me know if there are changes/suggestions to be done.

