### PR TITLE
fix(git-ext): honor explicit -Number 0 in PowerShell branch creation (parity with bash)

### DIFF
--- a/extensions/git/scripts/powershell/create-new-feature-branch.ps1
+++ b/extensions/git/scripts/powershell/create-new-feature-branch.ps1
@@ -446,7 +446,10 @@ if ($env:GIT_BRANCH_NAME) {
         $branchSuffix = Get-BranchName -Description $featureDesc
     }
 
-    if ($Timestamp -and $Number -ne 0) {
+    # Warn if -Number and -Timestamp are both specified. Use ContainsKey (not
+    # `-ne 0`) so an explicit `-Number 0` is also detected, matching the bash twin's
+    # `[ -n "$BRANCH_NUMBER" ]` check.
+    if ($Timestamp -and $PSBoundParameters.ContainsKey('Number')) {
         Write-Warning "[specify] Warning: -Number is ignored when -Timestamp is used"
         $Number = 0
     }
@@ -456,7 +459,10 @@ if ($env:GIT_BRANCH_NAME) {
         $branchName = New-BranchName -FeatureNum $featureNum -BranchSuffix $branchSuffix
     } else {
         $branchScopePrefix = Get-BranchScopePrefix -Template $branchTemplate -BranchSuffix $branchSuffix
-        if ($Number -eq 0) {
+        # Auto-detect the next number only when -Number was not supplied; an
+        # explicit value (including 0) is honored, matching the bash twin's
+        # `[ -z "$BRANCH_NUMBER" ]` check.
+        if (-not $PSBoundParameters.ContainsKey('Number')) {
             if ($DryRun -and $hasGit) {
                 $Number = Get-NextBranchNumber -SpecsDir $specsDir -SkipFetch -ScopePrefix $branchScopePrefix
             } elseif ($DryRun) {

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -638,6 +638,21 @@ class TestCreateFeatureBash:
         assert result.returncode != 0
         assert "requires updated Spec Kit core scripts" in result.stderr
 
+    def test_explicit_number_zero_is_honored(self, tmp_path: Path):
+        """An explicit --number 0 is honored (yields 000), not treated as
+        'auto-detect'. Pins the canonical behavior the PowerShell twin must
+        mirror; the empty-string check (`[ -z "$BRANCH_NUMBER" ]`) already
+        distinguishes an unset flag from a supplied 0."""
+        project = _setup_project(tmp_path)
+        result = _run_bash(
+            "create-new-feature-branch.sh", project,
+            "--json", "--dry-run", "--number", "0", "--short-name", "zero", "Zero feature",
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert data["BRANCH_NAME"] == "000-zero"
+        assert data["FEATURE_NUM"] == "000"
+
 
 @pytest.mark.skipif(not HAS_PWSH, reason="pwsh not available")
 class TestCreateFeaturePowerShell:
@@ -941,6 +956,23 @@ class TestCreateFeaturePowerShell:
         )
         assert result.returncode != 0
         assert "requires updated Spec Kit core scripts" in result.stderr
+
+    def test_explicit_number_zero_is_honored(self, tmp_path: Path):
+        """An explicit -Number 0 is honored (yields 000), matching the bash twin's
+        --number 0. Regression guard: -Number defaults to 0, so a bare `-eq 0`
+        check cannot tell an unset flag from a supplied 0 and would silently
+        auto-detect instead. Uses PSBoundParameters.ContainsKey('Number')."""
+        project = _setup_project(tmp_path)
+        result = _run_pwsh(
+            "create-new-feature-branch.ps1", project,
+            "-Json", "-DryRun", "-Number", "0", "-ShortName", "zero", "Zero feature",
+        )
+        assert result.returncode == 0, result.stderr
+        json_line = [ln for ln in result.stdout.splitlines() if ln.strip().startswith("{")]
+        assert json_line, f"No JSON in output: {result.stdout}"
+        data = json.loads(json_line[-1])
+        assert data["BRANCH_NAME"] == "000-zero"
+        assert data["FEATURE_NUM"] == "000"
 
 
 # ── auto-commit.sh Tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The git extension's PowerShell branch-creation script silently ignored an explicit `-Number 0`. Because `-Number` is declared with a default of `0`, the guards `if ($Timestamp -and $Number -ne 0)` and `if ($Number -eq 0)` could not tell an **unset** flag apart from a user passing `-Number 0`. A user asking for branch `000-...` was routed into auto-detection and got the next sequential number instead.

This mirrors the same fix already landed for the **core** script in #3196 (`scripts/powershell/create-new-feature.ps1`) — the git-extension twin (`extensions/git/scripts/powershell/create-new-feature-branch.ps1`) still carried the bug.

## Changes

- Replace both `-eq 0` / `-ne 0` checks with `$PSBoundParameters.ContainsKey('Number')`, which tests whether the flag was actually supplied — mirroring the bash twin's empty-string sentinel (`BRANCH_NUMBER=""`, `[ -z "$BRANCH_NUMBER" ]` / `[ -n "$BRANCH_NUMBER" ]`).
- Add a parity regression test to **both** `TestCreateFeatureBash` and `TestCreateFeaturePowerShell` asserting `--number 0` / `-Number 0` yields `000-zero` / `FEATURE_NUM=000`.

```powershell
# Before: -Number 0 auto-detected the next number (e.g. 003-zero)
# After:  -Number 0 is honored → 000-zero
./create-new-feature-branch.ps1 -DryRun -Number 0 -ShortName zero "Zero feature"
```

## Testing

Verified both twins manually (pwsh Core / real Git-for-Windows bash are gated by `HAS_PWSH` / `requires_bash` in CI):

| Case | Bash | PowerShell |
| --- | --- | --- |
| `-Number 0` | `000-zero` | `000-zero` |
| `-Number 5` | — | `005-five` |
| auto-detect (existing `001` spec) | `001-auto` | `001-auto` (parity) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)