### PR TITLE
fix(templates): correct phase numbering in plan.md

### DIFF
--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -68,7 +68,6 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Evaluate gates (ERROR if violations unjustified)
    - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Constitution Check post-design
 
 ## Mandatory Post-Execution Hooks
@@ -107,7 +106,7 @@ Check if `.specify/extensions.yml` exists in the project root.
 
 ## Completion Report
 
-Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+Command ends after Phase 1 design. Report branch, IMPL_PLAN path, and generated artifacts.
 
 ## Phases
 


### PR DESCRIPTION
Fixes #1036

## Root cause

`templates/commands/plan.md` drifted out of sync with its own Phases section:

- The outline listed **two bullets labeled Phase 1**. The second one ("Update agent context by running the agent script") is a leftover from before the agent-context extension existed: core no longer ships an agent script, and the update now runs via the extension's `after_plan` hook (`extensions/agent-context/extension.yml`).
- The completion report said the command ends after **"Phase 2 planning"**, but the Phases section only defines Phase 0 and Phase 1. Phase 2 (tasks.md) belongs to `speckit.tasks`, exactly as `templates/plan-template.md` already states ("NOT created by plan").

## Change

- Drop the stale duplicate "Phase 1: Update agent context" bullet.
- "Command ends after Phase 2 planning" → "Command ends after Phase 1 design".

Two-line diff, no behavior change beyond removing contradictory instructions to the agent.

## Testing

No tests pin this template's prose. Full suite untouched by the change.