### PR TITLE
fix(templates): remove self-referencing path in plan-template.md note

### DIFF
--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -4,7 +4,7 @@
 
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
 
-**Note**: This template is filled in by the `__SPECKIT_COMMAND_PLAN__` command. See `.specify/templates/plan-template.md` for the execution workflow.
+**Note**: This template is filled in by the `__SPECKIT_COMMAND_PLAN__` command; its definition describes the execution workflow.
 
 ## Summary
 


### PR DESCRIPTION
Fixes #1148

## Root cause

The note at the top of `templates/plan-template.md` says:

> See `.specify/templates/plan-template.md` for the execution workflow.

That path is the file itself — a self-reference. The execution workflow actually lives in the plan command's definition, which the same sentence already names via the `__SPECKIT_COMMAND_PLAN__` placeholder (rendered per-agent, e.g. `/speckit.plan`).

An earlier attempt (#1342) went stale and was auto-closed; this picks the issue back up with the same intent — make the note point at the right thing without hardcoding any agent-specific path.

## Change

One line: the note now reads "This template is filled in by the `__SPECKIT_COMMAND_PLAN__` command; its definition describes the execution workflow."

## Testing

No tests pin this template's prose; the placeholder continues to render through the existing `resolve_command_refs` pipeline (shared_infra.py).