### PR TITLE
fix(templates): point constitution sync checklist at installed command files

### DIFF
--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -81,7 +81,7 @@ Follow this execution flow:
    - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
    - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
    - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
-   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*`, or `speckit-<name>/SKILL.md` for skills-based layouts, e.g. in `.github/agents/`, `.github/skills/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` (dot or hyphen depending on the agent), or laid out as `speckit-<name>/SKILL.md` for skills-based integrations, e.g. in `.github/agents/`, `.github/skills/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
 5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -81,7 +81,7 @@ Follow this execution flow:
    - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
    - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
    - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
-   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` (dot or hyphen depending on the agent), or laid out as `speckit-<name>/SKILL.md` for skills-based integrations, e.g. in `.github/agents/`, `.github/skills/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` (dot or hyphen depending on the agent), or laid out as `speckit-<name>/SKILL.md` for skills-based integrations, e.g. in `.github/agents/`, `.github/skills/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (CLAUDE-only or other agent-specific names) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
 5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -81,7 +81,7 @@ Follow this execution flow:
    - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
    - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
    - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
-   - Read each installed `speckit.*` command file for your agent (including this one) — e.g. in `.github/prompts/`, `.claude/commands/`, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` depending on the agent, e.g. in `.github/prompts/`, `.claude/commands/`, a skills directory, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
 5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -81,7 +81,7 @@ Follow this execution flow:
    - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
    - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
    - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
-   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read each installed `speckit.*` command file for your agent (including this one) — e.g. in `.github/prompts/`, `.claude/commands/`, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
 5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -81,7 +81,7 @@ Follow this execution flow:
    - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
    - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
    - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
-   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` depending on the agent, e.g. in `.github/prompts/`, `.claude/commands/`, a skills directory, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` depending on the agent, e.g. in `.github/agents/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
 5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):

--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -81,7 +81,7 @@ Follow this execution flow:
    - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
    - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
    - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
-   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` depending on the agent, e.g. in `.github/agents/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*`, or `speckit-<name>/SKILL.md` for skills-based layouts, e.g. in `.github/agents/`, `.github/skills/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
 5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):


### PR DESCRIPTION
Fixes #660

## Root cause

Step 4 of the constitution command's consistency-propagation checklist tells the agent to:

> Read each command file in `.specify/templates/commands/*.md` (including this one) …

`specify init` never creates `.specify/templates/commands/` — command templates are rendered directly into the agent-specific directory (`.github/prompts/`, `.claude/commands/`, `.codex/commands/`, …). See also the assessment on #3086: keeping commands out of `.specify/templates/` is intentional, so the fix is to correct the reference, not to start copying files there.

The result today: this checklist step points at a path that does not exist in any initialized project, so the outdated-reference sweep it describes can never actually run.

## Change

One line — the step now reads the installed `speckit.*` command files for the active agent (with `.github/prompts/` and `.claude/commands/` as examples), instead of the nonexistent template path.

## Testing

No tests pin this template's prose. Verified the new strings are untouched by `CommandRegistrar.rewrite_project_relative_paths` (only bare `scripts/`, `templates/`, `memory/` prefixes are rewritten).