### PR TITLE
test: pin interpreter probe so py-template render test passes on Windows

### DIFF
--- a/tests/test_command_template_py_scripts.py
+++ b/tests/test_command_template_py_scripts.py
@@ -39,6 +39,17 @@ def _pin_interpreter(monkeypatch):
         "specify_cli.integrations.base.shutil.which",
         lambda name: "/usr/bin/python3" if name == "python3" else None,
     )
+    # On Windows, ``resolve_python_interpreter`` guards the ``which`` result
+    # with a real ``_interpreter_runs`` subprocess probe (#3304). The mocked
+    # ``/usr/bin/python3`` path does not exist on a Windows runner, so the
+    # probe would fail and the resolver would fall back to ``sys.executable``
+    # (a ``...python.exe`` path), breaking the ``python3``-anchored assertion.
+    # Pin the probe to True so the interpreter token stays ``python3`` on all
+    # platforms.
+    monkeypatch.setattr(
+        "specify_cli.integrations.base.IntegrationBase._interpreter_runs",
+        staticmethod(lambda path: True),
+    )
 
 
 def test_py_templates_discovered():


### PR DESCRIPTION
## Summary

`tests/test_command_template_py_scripts.py::test_template_renders_python_invocation` fails on **Windows** runners (all 6 `py:`-scripted command templates) while passing on Linux/macOS — see [run 29023156913](https://github.com/github/spec-kit/actions/runs/29023156913/job/86135534062).

### Root cause

The `_pin_interpreter` fixture monkeypatches `shutil.which` to return `/usr/bin/python3`, intending to pin the rendered interpreter token to `python3`. But on Windows, `resolve_python_interpreter()` guards the `which()` result with a real `_interpreter_runs()` subprocess probe (added in #3304 to skip the Microsoft Store App Execution Alias stub):

```python
if sys.platform == "win32" and not IntegrationBase._interpreter_runs(found):
    continue
```

The mocked `/usr/bin/python3` path doesn't exist on a Windows runner, so the probe returns `False`, both `python3` and `python` are skipped, and the resolver falls back to `sys.executable` (e.g. `C:\hostedtoolcache\...\python.exe`). The rendered invocation then starts with a Windows `python.exe` path instead of `python3`, failing the assertion:

```python
assert re.search(r"python3 \.specify/scripts/python/\w+\.py(?: --[\w-]+)*", result)
```

### Fix

Patch `_interpreter_runs` to return `True` in the `_pin_interpreter` fixture so the resolved interpreter token stays `python3` across all platforms. This keeps the #3304 production guard fully intact — only the test's mock is made platform-independent.

## Testing

- `pytest tests/test_command_template_py_scripts.py` → 20 passed locally (macOS). The fix targets the Windows-only fallback path.

---

Opened by GitHub Copilot (model: Claude Opus 4.8) on behalf of @mnriem.
