### PR TITLE
fix(catalogs): raise catalog error, not raw ValueError, on a malformed URL

### DIFF
--- a/src/specify_cli/catalogs.py
+++ b/src/specify_cli/catalogs.py
@@ -71,8 +71,12 @@ class CatalogStackBase:
         """Validate that a catalog URL uses HTTPS, except localhost HTTP."""
         from urllib.parse import urlparse
 
-        parsed = urlparse(url)
-        is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname
+        except ValueError:
+            raise cls._error(f"Catalog URL is malformed: {url}") from None
+        is_localhost = hostname in ("localhost", "127.0.0.1", "::1")
         if parsed.scheme != "https" and not (parsed.scheme == "http" and is_localhost):
             raise cls._error(
                 f"Catalog URL must use HTTPS (got {parsed.scheme}://). "
@@ -81,7 +85,7 @@ class CatalogStackBase:
         # Check hostname, not netloc: netloc is truthy for host-less URLs like
         # "https://:8080" or "https://user@", so the host guarantee this error
         # promises would not actually hold. hostname is None in those cases (#3209).
-        if not parsed.hostname:
+        if not hostname:
             raise cls._error("Catalog URL must be a valid URL with a host.")
 
     def _load_catalog_config(self, config_path: Path) -> list[CatalogEntry] | None:

--- a/tests/integrations/test_integration_catalog.py
+++ b/tests/integrations/test_integration_catalog.py
@@ -84,6 +84,20 @@ class TestCatalogURLValidation:
         with pytest.raises(IntegrationCatalogError, match="valid URL"):
             IntegrationCatalog._validate_catalog_url(url)
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://[::1",                 # unclosed ipv6 bracket
+            "https://[not-an-ip]/c.json",   # bracketed non-ip host
+        ],
+    )
+    def test_malformed_url_rejected_cleanly(self, url):
+        # A malformed authority makes urlparse/hostname raise ValueError. The
+        # validator must turn that into its normal catalog error, not leak a
+        # raw ValueError to the caller.
+        with pytest.raises(IntegrationCatalogError, match="malformed"):
+            IntegrationCatalog._validate_catalog_url(url)
+
 
 # ---------------------------------------------------------------------------
 # IntegrationCatalog — active catalogs


### PR DESCRIPTION
fixes #3434

`CatalogStackBase._validate_catalog_url` read `parsed.hostname`, which raises `ValueError` on a malformed authority (unclosed ipv6 bracket `https://[::1`, bracketed non-ip host `https://[not-an-ip]`). the method's other reject paths all raise the class catalog error, so the raw ValueError leaked instead of failing cleanly. reachable via `specify integration catalog add <url>`.

twin of the bundler validator fix (#3432 / #3433).

**fix:** wrap the parse + hostname access and convert `ValueError` to the normal error via `cls._error`, then reuse the parsed hostname for the existing scheme/host checks.

added a regression test (`test_malformed_url_rejected_cleanly`) covering an unclosed ipv6 bracket and a bracketed non-ip host. i confirmed it fails on the pre-fix code by stashing the source and re-running (raw ValueError leaks); the url-validation suite passes with the fix.

