### PR TITLE
fix(auth): return no matches, not raw ValueError, for a malformed URL

### DIFF
--- a/src/specify_cli/authentication/config.py
+++ b/src/specify_cli/authentication/config.py
@@ -196,7 +196,15 @@ def find_entries_for_url(
     url: str, entries: list[AuthConfigEntry]
 ) -> list[AuthConfigEntry]:
     """Return entries whose ``hosts`` match the hostname of *url*."""
-    hostname = (urlparse(url).hostname or "").lower()
+    # A malformed authority (e.g. an unterminated IPv6 bracket "https://[::1")
+    # makes urlparse/hostname raise ValueError. Treat that the same as a
+    # host-less URL: no entry can match, so return no matches rather than
+    # leaking a raw ValueError out of the shared HTTP client (build_request /
+    # open_url call this before any URL validation).
+    try:
+        hostname = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return []
     if not hostname:
         return []
     return [

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -315,6 +315,20 @@ class TestFindEntriesForUrl:
     def test_empty_url_returns_empty(self):
         assert find_entries_for_url("", [_github_entry()]) == []
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://[::1",                 # unterminated ipv6 bracket
+            "https://[not-an-ip]/file",     # bracketed non-ip host
+        ],
+    )
+    def test_malformed_url_returns_empty(self, url):
+        # A malformed authority makes urlparse/hostname raise ValueError.
+        # Since no entry can match such a URL, this must return no matches
+        # (like a host-less URL) rather than leaking a raw ValueError out of
+        # the shared HTTP client.
+        assert find_entries_for_url(url, [_github_entry()]) == []
+
     def test_empty_entries_returns_empty(self):
         assert find_entries_for_url("https://github.com/org/repo", []) == []
 


### PR DESCRIPTION
fixes #3436

`find_entries_for_url` did `(urlparse(url).hostname or "").lower()` unguarded. a malformed authority (unterminated ipv6 bracket `https://[::1`, bracketed non-ip host `https://[not-an-ip]`) makes urlparse/hostname raise `ValueError`, so a raw ValueError leaked instead of the empty list the function already returns for a host-less url. this is the first step of the shared http client (`build_request` / `open_url` call it before any url validation), so it can surface out of catalog/extension/preset fetches.

**fix:** wrap the parse + hostname access; on `ValueError` return no matches, exactly like the host-less case just below it (no auth entry can match a url with no usable host anyway).

added a regression test (`test_malformed_url_returns_empty`) over an unterminated bracket and a bracketed non-ip host. i confirmed it fails on the pre-fix code by stashing the source and re-running (raw ValueError leaks); the auth suite passes with the fix.

same bug class as #3210 and the recent bundler/catalog validator fixes.

