### PR TITLE
fix(integrations): escape Rich markup in --integration-options error messages

### DIFF
--- a/src/specify_cli/integrations/_helpers.py
+++ b/src/specify_cli/integrations/_helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 import typer
+from rich.markup import escape
 
 from .._agent_config import SCRIPT_TYPE_CHOICES
 from .._console import console
@@ -206,7 +207,7 @@ def _parse_integration_options(integration: Any, raw_options: str) -> dict[str, 
     while i < len(tokens):
         token = tokens[i]
         if not token.startswith("-"):
-            console.print(f"[red]Error:[/red] Unexpected integration option value '{token}'.")
+            console.print(f"[red]Error:[/red] Unexpected integration option value '{escape(token)}'.")
             if allowed:
                 console.print(f"Allowed options: {allowed}")
             raise typer.Exit(1)
@@ -217,7 +218,7 @@ def _parse_integration_options(integration: Any, raw_options: str) -> dict[str, 
             name, value = name.split("=", 1)
         opt = declared.get(name)
         if not opt:
-            console.print(f"[red]Error:[/red] Unknown integration option '{token}'.")
+            console.print(f"[red]Error:[/red] Unknown integration option '{escape(token)}'.")
             if allowed:
                 console.print(f"Allowed options: {allowed}")
             raise typer.Exit(1)

--- a/tests/integrations/test_integration_subcommand.py
+++ b/tests/integrations/test_integration_subcommand.py
@@ -2733,6 +2733,30 @@ class TestParseIntegrationOptionsEqualsForm:
         assert excinfo.value.exit_code == 1
         assert "Error: Could not parse integration options: No closing quotation." in capsys.readouterr().out
 
+    def test_bad_option_token_with_rich_markup_exits_cleanly(self):
+        """A bad option token carrying Rich markup must exit cleanly, not crash.
+
+        The token is user-controlled and gets interpolated into console.print.
+        A value like '[/red]foo' parses fine through shlex but is an unexpected
+        value / unknown option — and an unbalanced Rich tag would raise
+        rich.errors.MarkupError inside console.print, leaking a traceback
+        instead of the intended typer.Exit(1). The token must be escaped."""
+        import typer
+
+        from specify_cli.integrations._commands import _parse_integration_options
+        from specify_cli.integrations import get_integration
+
+        integration = get_integration("generic")
+        assert integration is not None
+
+        # Unexpected value token carrying markup.
+        with pytest.raises(typer.Exit):
+            _parse_integration_options(integration, "[/red]foo")
+
+        # Unknown option token carrying markup.
+        with pytest.raises(typer.Exit):
+            _parse_integration_options(integration, "--[/red]bad")
+
 
 class TestUninstallNoManifestClearsInitOptions:
     def test_init_options_cleared_on_no_manifest_uninstall(self, tmp_path):

--- a/tests/integrations/test_integration_subcommand.py
+++ b/tests/integrations/test_integration_subcommand.py
@@ -2757,6 +2757,31 @@ class TestParseIntegrationOptionsEqualsForm:
         with pytest.raises(typer.Exit):
             _parse_integration_options(integration, "--[/red]bad")
 
+    def test_malformed_quoting_with_rich_markup_exits_cleanly(self):
+        """A malformed value carrying Rich markup must still exit cleanly.
+
+        raw_options is user-controlled. A value like '--commands-dir "[/red]foo'
+        first trips the shlex ValueError path, but the error message then
+        interpolates the raw value into console.print — an unbalanced Rich tag
+        such as '[/red]' would raise rich.errors.MarkupError there and leak a
+        traceback anyway. The value must be escaped so the clean typer.Exit
+        survives."""
+        import typer
+
+        from specify_cli.integrations._commands import _parse_integration_options
+        from specify_cli.integrations import get_integration
+
+        integration = get_integration("generic")
+        assert integration is not None
+
+        # Unbalanced quote (shlex path) + markup injection in one value.
+        with pytest.raises(typer.Exit):
+            _parse_integration_options(integration, '--commands-dir "[/red]foo')
+
+        # Markup injection in a token that parses but is unexpected/unknown.
+        with pytest.raises(typer.Exit):
+            _parse_integration_options(integration, "[/red]foo")
+
 
 class TestUninstallNoManifestClearsInitOptions:
     def test_init_options_cleared_on_no_manifest_uninstall(self, tmp_path):

--- a/tests/integrations/test_integration_subcommand.py
+++ b/tests/integrations/test_integration_subcommand.py
@@ -2757,31 +2757,6 @@ class TestParseIntegrationOptionsEqualsForm:
         with pytest.raises(typer.Exit):
             _parse_integration_options(integration, "--[/red]bad")
 
-    def test_malformed_quoting_with_rich_markup_exits_cleanly(self):
-        """A malformed value carrying Rich markup must still exit cleanly.
-
-        raw_options is user-controlled. A value like '--commands-dir "[/red]foo'
-        first trips the shlex ValueError path, but the error message then
-        interpolates the raw value into console.print — an unbalanced Rich tag
-        such as '[/red]' would raise rich.errors.MarkupError there and leak a
-        traceback anyway. The value must be escaped so the clean typer.Exit
-        survives."""
-        import typer
-
-        from specify_cli.integrations._commands import _parse_integration_options
-        from specify_cli.integrations import get_integration
-
-        integration = get_integration("generic")
-        assert integration is not None
-
-        # Unbalanced quote (shlex path) + markup injection in one value.
-        with pytest.raises(typer.Exit):
-            _parse_integration_options(integration, '--commands-dir "[/red]foo')
-
-        # Markup injection in a token that parses but is unexpected/unknown.
-        with pytest.raises(typer.Exit):
-            _parse_integration_options(integration, "[/red]foo")
-
 
 class TestUninstallNoManifestClearsInitOptions:
     def test_init_options_cleared_on_no_manifest_uninstall(self, tmp_path):


### PR DESCRIPTION
Follow-up hardening to #3457 (the unbalanced-quote crash, since fixed on `main`).

`_parse_integration_options` interpolated user-controlled option tokens straight into `console.print` in two branches:

- the **unexpected value** branch — a token that does not start with `-`;
- the **unknown option** branch — a token that starts with `-` but is not declared.

Because `console.print` parses Rich markup, a token carrying an unbalanced tag (e.g. `[/red]foo` or `--[/red]bad`) raises `rich.errors.MarkupError` and leaks a traceback instead of the clean `typer.Exit(1)` every other bad-input path produces.

**fix:** wrap both token values in `rich.markup.escape(...)` before printing, so malformed markup is shown literally and the command still exits 1.

**scope note:** the `shlex.split` `ValueError` conversion for #3457 is already on `main`; this PR does not re-introduce it. The only production change here is the markup escaping of the two token prints.

Added `test_bad_option_token_with_rich_markup_exits_cleanly`, which asserts a clean `typer.Exit` for both the unexpected-value (`[/red]foo`) and unknown-option (`--[/red]bad`) branches; it fails on the pre-escape code (raw `MarkupError`) and passes with the fix. The existing `test_unbalanced_quote_exits_cleanly` continues to cover the shlex path.