### PR TITLE
docs: clarify that release tags keep the leading v prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Spec-Driven Development **flips the script** on traditional software development
 
 ### 1. Install Specify CLI
 
-Requires **[uv](https://docs.astral.sh/uv/)** ([install uv](./docs/install/uv.md)). Replace `vX.Y.Z` with the latest tag from [Releases](https://github.com/github/spec-kit/releases):
+Requires **[uv](https://docs.astral.sh/uv/)** ([install uv](./docs/install/uv.md)). Replace `vX.Y.Z` with the latest release tag from [Releases](https://github.com/github/spec-kit/releases) — keep the leading `v` (for example, `v0.12.11`, not `0.12.11`):
 
 ```bash
 uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z

--- a/docs/install/one-time.md
+++ b/docs/install/one-time.md
@@ -11,7 +11,8 @@ If you want to try Spec Kit without installing it permanently, use `uvx` to run 
 # Create a new project (latest from main)
 uvx --from git+https://github.com/github/spec-kit.git specify init <PROJECT_NAME>
 
-# Or target a specific release (replace vX.Y.Z with a tag from Releases)
+# Or target a specific release (replace vX.Y.Z with a tag from Releases;
+# keep the leading v, e.g. v0.12.11 not 0.12.11)
 uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify init <PROJECT_NAME>
 
 # Initialize in the current directory

--- a/docs/install/pipx.md
+++ b/docs/install/pipx.md
@@ -7,7 +7,8 @@
 Pin a specific release tag for stability (check [Releases](https://github.com/github/spec-kit/releases) for the latest):
 
 ```bash
-# Install a specific stable release (recommended — replace vX.Y.Z with the latest tag)
+# Install a specific stable release (recommended — replace vX.Y.Z with the
+# latest tag, keeping the leading v, e.g. v0.12.11 not 0.12.11)
 pipx install git+https://github.com/github/spec-kit.git@vX.Y.Z
 
 # Or install latest from main (may include unreleased changes)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,7 @@
 
 ### Persistent Installation (Recommended)
 
-Install once and use everywhere. Replace `vX.Y.Z` with a tag from [Releases](https://github.com/github/spec-kit/releases):
+Install once and use everywhere. Replace `vX.Y.Z` with a release tag from [Releases](https://github.com/github/spec-kit/releases) — keep the leading `v` (for example, `v0.12.11`, not `0.12.11`):
 
 > [!NOTE]
 > The command below requires **[uv](https://docs.astral.sh/uv/)**. If you see `command not found: uv`, [install uv first](./install/uv.md).


### PR DESCRIPTION
## Summary
- Clarify install docs so readers keep the leading `v` when substituting release tags (e.g. `v0.12.11`, not `0.12.11`).
- Update the same guidance in README, the installation guide, and the pipx/uvx install pages to avoid the common `couldn't find remote ref` failure.

## Test plan
- [ ] Confirm [Releases](https://github.com/github/spec-kit/releases) tags are named `vX.Y.Z`.
- [ ] Skim README + docs/installation.md wording for clarity.
- [ ] Optionally verify `uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@v0.12.11` succeeds and `@0.12.11` fails.
