### PR TITLE
fix(integrations): exit cleanly on unbalanced quote in --integration-options (#3457)

### DIFF
--- a/src/specify_cli/integrations/_helpers.py
+++ b/src/specify_cli/integrations/_helpers.py
@@ -190,7 +190,15 @@ def _parse_integration_options(integration: Any, raw_options: str) -> dict[str, 
     """
     import shlex
     parsed: dict[str, Any] = {}
-    tokens = shlex.split(raw_options)
+    try:
+        tokens = shlex.split(raw_options)
+    except ValueError as exc:
+        # An unbalanced quote (e.g. --integration-options='--commands-dir "foo')
+        # makes shlex raise "No closing quotation". Translate it into the same
+        # clean exit-1 UX as every other bad-input path below rather than
+        # letting a raw traceback escape.
+        console.print(f"[red]Error:[/red] Could not parse integration options: {exc}.")
+        raise typer.Exit(1)
     declared_options = list(integration.options())
     declared = {opt.name.lstrip("-"): opt for opt in declared_options}
     allowed = ", ".join(sorted(opt.name for opt in declared_options))

--- a/tests/integrations/test_integration_subcommand.py
+++ b/tests/integrations/test_integration_subcommand.py
@@ -2675,6 +2675,26 @@ class TestParseIntegrationOptionsEqualsForm:
         assert result_space["commands_dir"] == "./mydir"
         assert result_equals["commands_dir"] == "./mydir"
 
+    def test_unbalanced_quote_exits_cleanly(self):
+        """An unbalanced quote must exit(1) with a message, not a raw ValueError.
+
+        shlex.split() raises ValueError("No closing quotation") on an unbalanced
+        quote; the parser must translate that into the same clean typer.Exit(1)
+        UX as unknown-option / missing-value, rather than letting the traceback
+        escape (issue #3457).
+        """
+        import typer
+
+        from specify_cli.integrations._commands import _parse_integration_options
+        from specify_cli.integrations import get_integration
+
+        integration = get_integration("generic")
+        assert integration is not None
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _parse_integration_options(integration, '--commands-dir "foo')
+        assert excinfo.value.exit_code == 1
+
 
 class TestUninstallNoManifestClearsInitOptions:
     def test_init_options_cleared_on_no_manifest_uninstall(self, tmp_path):

--- a/tests/integrations/test_integration_subcommand.py
+++ b/tests/integrations/test_integration_subcommand.py
@@ -2675,7 +2675,7 @@ class TestParseIntegrationOptionsEqualsForm:
         assert result_space["commands_dir"] == "./mydir"
         assert result_equals["commands_dir"] == "./mydir"
 
-    def test_unbalanced_quote_exits_cleanly(self):
+    def test_unbalanced_quote_exits_cleanly(self, capsys):
         """An unbalanced quote must exit(1) with a message, not a raw ValueError.
 
         shlex.split() raises ValueError("No closing quotation") on an unbalanced
@@ -2694,6 +2694,7 @@ class TestParseIntegrationOptionsEqualsForm:
         with pytest.raises(typer.Exit) as excinfo:
             _parse_integration_options(integration, '--commands-dir "foo')
         assert excinfo.value.exit_code == 1
+        assert "Error: Could not parse integration options: No closing quotation." in capsys.readouterr().out
 
 
 class TestUninstallNoManifestClearsInitOptions:


### PR DESCRIPTION
## Summary

Closes #3457. `_parse_integration_options` in `src/specify_cli/integrations/_helpers.py` called `shlex.split(raw_options)` unguarded. An unbalanced quote in the flag value made shlex raise `ValueError: No closing quotation`, so a raw traceback escaped instead of the clean `typer.Exit(1)` error every other bad-input path in this function produces (unknown option, missing value, unexpected value all print a message and exit 1).

Reachable from `specify init --integration-options=...` and every `specify integration install/switch/upgrade/migrate --integration-options=...`.

**Before:**
```
$ specify integration install generic --integration-options='--commands-dir "foo'
ValueError: No closing quotation   # raw traceback
```

**After:**
```
$ specify integration install generic --integration-options='--commands-dir "foo'
Error: Could not parse integration options: No closing quotation.
# exit 1
```

## Changes

- Wrap `shlex.split(raw_options)` in `try/except ValueError`, printing a one-line error and raising `typer.Exit(1)` — matching the loud-fail UX of the sibling bad-input branches in the same function.

## Testing

- Added `test_unbalanced_quote_exits_cleanly` under `TestParseIntegrationOptionsEqualsForm`: asserts the unbalanced-quote input raises `typer.Exit` with exit code 1.
- Test-the-test: confirmed the new test fails without the source change (raw `ValueError` propagates).
- End-to-end via `CliRunner` on the full `integration install ... --integration-options` path: exit code 1, clean message, no traceback.
- `pytest tests/integrations/test_integration_subcommand.py` → 108 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
