### PR TITLE
fix: mark Kiro as safe for multi-install

### DIFF
--- a/src/specify_cli/integrations/kiro_cli/__init__.py
+++ b/src/specify_cli/integrations/kiro_cli/__init__.py
@@ -13,6 +13,7 @@ _KIRO_ARG_FALLBACK = "(the user will provide the argument in this conversation)"
 
 class KiroCliIntegration(MarkdownIntegration):
     key = "kiro-cli"
+    multi_install_safe = True
     config = {
         "name": "Kiro CLI",
         "folder": ".kiro/",

--- a/tests/integrations/test_integration_kiro_cli.py
+++ b/tests/integrations/test_integration_kiro_cli.py
@@ -42,6 +42,9 @@ class TestKiroCliIntegration(MarkdownIntegrationTests):
     COMMANDS_SUBDIR = "prompts"
     REGISTRAR_DIR = ".kiro/prompts"
 
+    def test_declares_multi_install_safe(self):
+        assert get_integration(self.KEY).multi_install_safe is True
+
     def test_registrar_config(self):
         """Override base assertion: kiro-cli uses a prose fallback for args
         because Kiro CLI file-based prompts do not natively substitute


### PR DESCRIPTION
## Description

Kiro writes its generated commands under the isolated `.kiro/prompts` tree, but its integration did not declare the existing multi-install safety capability. As a result, compatible co-installs were reported as permanently unsafe and required `--force`.

This change:

- marks `KiroCliIntegration` as `multi_install_safe`;
- adds a dedicated regression test so removing the declaration fails independently of the registry matrix.

Closes #3471.

## Testing

- [x] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

Additional validation:

- `uv sync --extra test`
- Kiro integration and agent-metadata tests: 51 passed
- Full `tests/integrations/test_registry.py`: 365 passed
- Multi-install safety contract subset: 290 passed
- Manual Claude + Kiro co-install without `--force`: integration status `OK`, `Multi-install safe: yes`, and no `unsafe-multi-install` finding
- Ruff on the production file and `git diff --check`: passed

The full repository test suite was not run, so that checkbox is intentionally left unchecked.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Codex (GPT-5, autonomous) analyzed the issue and repository contracts, authored the code and regression test, and ran the validations above on behalf of @NgoQuocViet2001. The operator requested this contribution but did not manually author or line-by-line review the patch.