### PR TITLE
fix(extensions): hyphenate in-body command refs when rendering skills

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1081,6 +1081,13 @@ class ExtensionManager:
             body = registrar.resolve_skill_placeholders(
                 selected_ai, frontmatter, body, self.project_root, extension_id=manifest.id
             )
+            # Rewrite in-body command references (`speckit.foo.bar`) to the
+            # hyphenated skill spelling. Skills-based integrations dispatch
+            # commands as `speckit-foo-bar` skills, not `/speckit.foo.bar`
+            # slash commands, so a verbatim dotted reference is not runnable
+            # (see #3451). The skill dir name and frontmatter hook refs are
+            # already hyphenated elsewhere; the body was the missing piece.
+            body = registrar._hyphenate_body_refs(body)
 
             original_desc = frontmatter.get("description", "")
             description = original_desc or f"Extension command: {cmd_name}"

--- a/tests/test_extension_skills.py
+++ b/tests/test_extension_skills.py
@@ -103,6 +103,7 @@ def _create_extension_dir(temp_dir: Path, ext_id: str = "test-ext") -> Path:
         "# Hello Command\n"
         "\n"
         "Run this to say hello.\n"
+        f"First run /speckit.{ext_id}.world to set up.\n"
         "$ARGUMENTS\n"
     )
 
@@ -326,6 +327,28 @@ class TestExtensionSkillRegistration:
         assert "author: github-spec-kit" in content
         assert "compatibility:" in content
         assert "Run this to say hello." in content
+
+    def test_skill_body_command_refs_are_hyphenated(self, skills_project, extension_dir):
+        """In-body `speckit.x.y` references must be rewritten to the hyphenated
+        skill spelling for skills-based integrations (#3451).
+
+        Skills agents dispatch `speckit-x-y` skills, not `/speckit.x.y` slash
+        commands, so a verbatim dotted reference copied into the skill body is
+        not runnable. The skill dir name and frontmatter hook refs are already
+        hyphenated; the body was the missing piece."""
+        project_dir, skills_dir = skills_project
+        manager = ExtensionManager(project_dir)
+        manager.install_from_directory(
+            extension_dir, "0.1.0", register_commands=False
+        )
+
+        skill_file = skills_dir / "speckit-test-ext-hello" / "SKILL.md"
+        content = skill_file.read_text()
+
+        # The dotted cross-command reference must be gone from the body...
+        assert "speckit.test-ext.world" not in content
+        # ...rewritten to the hyphenated skill name.
+        assert "speckit-test-ext-world" in content
 
     def test_skill_md_has_parseable_yaml(self, skills_project, extension_dir):
         """Generated SKILL.md should contain valid, parseable YAML frontmatter."""


### PR DESCRIPTION
fixes #3451

extension command bodies were copied verbatim into generated SKILL.md files for skills-based integrations (codex, claude, etc.), so an in-body reference like `/speckit.foo.bar` kept its slash-dot spelling. skills agents dispatch `speckit-foo-bar` skills, not `/speckit.foo.bar` slash commands, so the reference was not runnable and the agent fell back to a markdown-only path (as reported in discussion #3422 with codex + spec-kit-memory-hub).

**root cause (matches the issue):** `_register_extension_skills` only ran `resolve_skill_placeholders` (script/args/`__AGENT__`/project-relative paths) and `post_process_skill_content` (which for `SkillsIntegration` only injects a hook-note), never a body-ref rewrite. the skill dir name and frontmatter hook refs were already hyphenated elsewhere; the body was the missing piece.

**fix:** apply the existing `CommandRegistrar._hyphenate_body_refs` helper in the skills render path, right after `resolve_skill_placeholders`. that helper is already used on the cline extension path (agents.py); this reuses it. skills integrations always dispatch hyphenated skills, so the rewrite is unconditionally correct there.

added a regression test: it installs an extension whose command body references a sibling command (`/speckit.test-ext.world`) and asserts the generated skill body has the dotted ref rewritten to `speckit-test-ext-world`. i confirmed it fails on the pre-fix code (the verbatim `speckit.test-ext.world` leaks into the body); the full extension-skills suite (58 tests) passes with the fix.

this covers part 1 (code) of the issue's proposed fix. i left the docs-portability note (part 2) out of this PR to keep it focused; happy to follow up if you'd like it here.

