### PR TITLE
fix(integrations): declare kiro-cli multi-install safe

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -271,6 +271,7 @@ The currently declared multi-install safe integrations are:
 | `grok` | `.grok/skills` |
 | `junie` | `.junie/commands`, `.junie/AGENTS.md` |
 | `kilocode` | `.kilocode/workflows`, `.kilocode/rules/specify-rules.md` |
+| `kiro-cli` | `.kiro/prompts` |
 | `qodercli` | `.qoder/commands`, `QODER.md` |
 | `qwen` | `.qwen/commands`, `QWEN.md` |
 | `shai` | `.shai/commands`, `SHAI.md` |

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -250,34 +250,32 @@ Spec Kit tracks one default integration in `.specify/integration.json` with `def
 
 ### Which integrations are multi-install safe?
 
-An integration is multi-install safe when it uses a static, unique agent root and command directory, stable command invocation settings, and a separate install manifest whose managed files do not overlap another safe integration. Registry tests enforce those path and manifest invariants. Shared Spec Kit templates remain aligned to the single default integration.
+An integration is multi-install safe when it uses a static, unique command directory, stable command invocation settings, and a separate install manifest whose managed files do not overlap another safe integration. Registry tests enforce those path and manifest invariants. Shared Spec Kit templates remain aligned to the single default integration.
 
-The Isolation column below lists paths Spec Kit manages for that integration (skills/commands roots and any integration-owned rule files). It is not a full inventory of every file an agent may read.
-
-**Agent-context defaults are separate.** The optional agent-context extension maps each integration to a default context file in `extensions/agent-context/agent-context-defaults.json`. Those defaults are independent of multi-install safety: several agents may share a root file such as `AGENTS.md` when the extension is enabled. Multi-install safety does not require a unique context file per safe integration.
+The Command directory column below lists the directory each integration installs its commands or skills into. The optional agent-context extension is a separate concern — it seeds a per-agent context file (for example `AGENTS.md` or `CLAUDE.md`) and is *not* multi-install safe, since several agents can map to the same context file; see the agent-context extension for details.
 
 The currently declared multi-install safe integrations are:
 
-| Key | Isolation |
-| --- | --------- |
-| `auggie` | `.augment/commands`, `.augment/rules/specify-rules.md` |
-| `claude` | `.claude/skills`, `CLAUDE.md` |
-| `cline` | `.clinerules/workflows`, `.clinerules/specify-rules.md` |
-| `codebuddy` | `.codebuddy/commands`, `CODEBUDDY.md` |
-| `codex` | `.agents/skills`, `AGENTS.md` |
-| `cursor-agent` | `.cursor/skills`, `.cursor/rules/specify-rules.mdc` |
-| `firebender` | `.firebender/commands`, `.firebender/rules/specify-rules.mdc` |
-| `gemini` | `.gemini/commands`, `GEMINI.md` |
+| Key | Command directory |
+| --- | ----------------- |
+| `auggie` | `.augment/commands` |
+| `claude` | `.claude/skills` |
+| `cline` | `.clinerules/workflows` |
+| `codebuddy` | `.codebuddy/commands` |
+| `codex` | `.agents/skills` |
+| `cursor-agent` | `.cursor/skills` |
+| `firebender` | `.firebender/commands` |
+| `gemini` | `.gemini/commands` |
 | `grok` | `.grok/skills` |
-| `junie` | `.junie/commands`, `.junie/AGENTS.md` |
-| `kilocode` | `.kilocode/workflows`, `.kilocode/rules/specify-rules.md` |
+| `junie` | `.junie/commands` |
+| `kilocode` | `.kilocode/workflows` |
 | `kiro-cli` | `.kiro/prompts` |
-| `qodercli` | `.qoder/commands`, `QODER.md` |
-| `qwen` | `.qwen/commands`, `QWEN.md` |
-| `shai` | `.shai/commands`, `SHAI.md` |
-| `tabnine` | `.tabnine/agent/commands`, `TABNINE.md` |
-| `trae` | `.trae/skills`, `.trae/rules/project_rules.md` |
-| `zcode` | `.zcode/skills`, `ZCODE.md` |
+| `qodercli` | `.qoder/commands` |
+| `qwen` | `.qwen/commands` |
+| `shai` | `.shai/commands` |
+| `tabnine` | `.tabnine/agent/commands` |
+| `trae` | `.trae/skills` |
+| `zcode` | `.zcode/skills` |
 
 Integrations that share a command directory with another integration, require dynamic install paths such as `--commands-dir`, or merge shared tool settings are not declared safe by default. They can still be installed alongside another integration with `--force`.
 

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -250,9 +250,9 @@ Spec Kit tracks one default integration in `.specify/integration.json` with `def
 
 ### Which integrations are multi-install safe?
 
-An integration is multi-install safe when it uses a static, unique command directory, stable command invocation settings, and a separate install manifest whose managed files do not overlap another safe integration. Registry tests enforce those path and manifest invariants. Shared Spec Kit templates remain aligned to the single default integration.
+An integration is multi-install safe when it uses a static, unique agent root and command directory, stable command invocation settings, and a separate install manifest whose managed files do not overlap another safe integration. Registry tests enforce those path and manifest invariants. Shared Spec Kit templates remain aligned to the single default integration.
 
-The Command directory column below lists the directory each integration installs its commands or skills into. The optional agent-context extension is a separate concern — it seeds a per-agent context file (for example `AGENTS.md` or `CLAUDE.md`) and is *not* multi-install safe, since several agents can map to the same context file; see the agent-context extension for details.
+The Command directory column below lists the directory each integration installs its commands or skills into. Context-file targeting is a separate concern from integration multi-install safety: `multi_install_safe` is an integration declaration about command/skill paths, whereas the optional agent-context extension manages a per-agent context file (for example `AGENTS.md` or `CLAUDE.md`) and can even synchronize several anchors at once via its `context_files` setting. Multiple agents mapping to the same context file is expected there and does not affect whether an integration is multi-install safe; see the agent-context extension for details.
 
 The currently declared multi-install safe integrations are:
 

--- a/src/specify_cli/integrations/kiro_cli/__init__.py
+++ b/src/specify_cli/integrations/kiro_cli/__init__.py
@@ -13,7 +13,6 @@ _KIRO_ARG_FALLBACK = "(the user will provide the argument in this conversation)"
 
 class KiroCliIntegration(MarkdownIntegration):
     key = "kiro-cli"
-    multi_install_safe = True
     config = {
         "name": "Kiro CLI",
         "folder": ".kiro/",

--- a/src/specify_cli/integrations/kiro_cli/__init__.py
+++ b/src/specify_cli/integrations/kiro_cli/__init__.py
@@ -13,6 +13,14 @@ _KIRO_ARG_FALLBACK = "(the user will provide the argument in this conversation)"
 
 class KiroCliIntegration(MarkdownIntegration):
     key = "kiro-cli"
+    # Kiro CLI keeps everything under a static, isolated agent root
+    # (``.kiro/`` with commands in ``.kiro/prompts``) that no other
+    # integration writes to, so it is safe to install alongside others
+    # (issue #3471). IntegrationBase defaults this to False; declaring it
+    # True here is the actual behavior change this integration opts into.
+    # The registry's multi-install-safe contract tests enforce that
+    # isolation for every integration setting this flag.
+    multi_install_safe = True
     config = {
         "name": "Kiro CLI",
         "folder": ".kiro/",
@@ -26,10 +34,3 @@ class KiroCliIntegration(MarkdownIntegration):
         "args": _KIRO_ARG_FALLBACK,
         "extension": ".md",
     }
-
-    # Kiro CLI keeps everything under a static, isolated agent root
-    # (``.kiro/`` with commands in ``.kiro/prompts``) that no other
-    # integration writes to, so it is safe to install alongside others
-    # (issue #3471). The registry's multi-install-safe contract tests
-    # enforce that isolation for every integration setting this flag.
-    multi_install_safe = True

--- a/tests/integrations/test_integration_kiro_cli.py
+++ b/tests/integrations/test_integration_kiro_cli.py
@@ -56,16 +56,6 @@ class TestKiroCliIntegration(MarkdownIntegrationTests):
         assert i.registrar_config["format"] == "markdown"
         assert i.registrar_config["extension"] == ".md"
 
-    def test_declared_multi_install_safe(self):
-        """kiro-cli uses a fully isolated .kiro/ root, a stable "." separator,
-        and a dedicated manifest, so it must be declared multi-install safe —
-        otherwise co-installing it (e.g. alongside claude) leaves
-        `integration status` permanently in ERROR with no way to resolve it
-        (#3471). The registry contract tests enforce the actual path isolation
-        against every other safe integration."""
-        i = get_integration(self.KEY)
-        assert i.multi_install_safe is True
-
     def test_registrar_config_args_is_exact_prose_fallback(self):
         """Layer 1 — pin the exact fallback so wording drift requires a
         deliberate paired commit (production constant + test update)."""

--- a/tests/integrations/test_integration_kiro_cli.py
+++ b/tests/integrations/test_integration_kiro_cli.py
@@ -56,6 +56,16 @@ class TestKiroCliIntegration(MarkdownIntegrationTests):
         assert i.registrar_config["format"] == "markdown"
         assert i.registrar_config["extension"] == ".md"
 
+    def test_declared_multi_install_safe(self):
+        """kiro-cli uses a fully isolated .kiro/ root, a stable "." separator,
+        and a dedicated manifest, so it must be declared multi-install safe —
+        otherwise co-installing it (e.g. alongside claude) leaves
+        `integration status` permanently in ERROR with no way to resolve it
+        (#3471). The registry contract tests enforce the actual path isolation
+        against every other safe integration."""
+        i = get_integration(self.KEY)
+        assert i.multi_install_safe is True
+
     def test_registrar_config_args_is_exact_prose_fallback(self):
         """Layer 1 — pin the exact fallback so wording drift requires a
         deliberate paired commit (production constant + test update)."""


### PR DESCRIPTION
fixes #3471

kiro-cli uses a fully isolated `.kiro/` root and `.kiro/prompts` command dir, a stable `.` separator with no dynamic paths, and a dedicated install manifest — it meets every documented multi-install-safe criterion. but `multi_install_safe` was never set on `KiroCliIntegration`, so co-installing it (e.g. alongside claude) left `specify integration status` permanently in ERROR (`unsafe-multi-install`) with no way to resolve it. `--force` bypasses the install-time gate but not the status finding.

**fix:** set `multi_install_safe = True` on `KiroCliIntegration`.

i verified the isolation rather than trusting the flag: the registry contract tests in `tests/integrations/test_registry.py` auto-parametrize over every declared-safe integration and check pairwise-disjoint agent roots, command dirs, and (via a real init+install) install manifests. with kiro-cli added they still all pass (365 tests), which empirically proves `.kiro/` doesn't collide with any other safe integration.

also added an explicit `multi_install_safe is True` assertion in the kiro-cli test file (fails on the pre-fix code) and listed kiro-cli in the multi-install-safe docs table.

