### PR TITLE
fix(workflows): fail switch step on non-mapping cases instead of crashing

### DIFF
--- a/src/specify_cli/workflows/steps/switch/__init__.py
+++ b/src/specify_cli/workflows/steps/switch/__init__.py
@@ -26,6 +26,20 @@ class SwitchStep(StepBase):
         str_value = str(value) if value is not None else ""
 
         cases = config.get("cases", {})
+        if not isinstance(cases, dict):
+            # The engine does not auto-validate step config, so an unvalidated
+            # run with a non-mapping ``cases`` (a list/scalar authoring mistake)
+            # would otherwise raise AttributeError from ``.items()`` below and
+            # crash the whole run. Fail this step loudly instead, mirroring the
+            # fan-out step's non-list ``items`` handling.
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"Switch step {config.get('id', '?')!r}: 'cases' must be a "
+                    f"mapping, got {type(cases).__name__}."
+                ),
+                output={"matched_case": None, "expression_value": value},
+            )
         for case_key, case_steps in cases.items():
             if str(case_key) == str_value:
                 return StepResult(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2052,6 +2052,35 @@ class TestSwitchStep:
         assert result.output["matched_case"] == "__default__"
         assert result.next_steps == []
 
+    def test_execute_non_dict_cases_fails_loudly(self):
+        """A non-mapping ``cases`` must fail the step, not crash the run.
+
+        ``validate`` rejects a non-dict ``cases``, but the engine's
+        ``execute()`` does not auto-validate (see ``WorkflowEngine.load_workflow``
+        docstring). Before the guard, ``execute`` called ``cases.items()`` on the
+        raw value, so an unvalidated run with a list/scalar ``cases`` raised
+        AttributeError and took down the whole run instead of failing this step.
+        Mirrors the fan-out step's non-list ``items`` handling.
+        """
+        from specify_cli.workflows.steps.switch import SwitchStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = SwitchStep()
+        ctx = StepContext(steps={"review": {"output": {"choice": "approve"}}})
+        for bad_cases in (["approve"], "approve", 5):
+            result = step.execute(
+                {
+                    "id": "route",
+                    "expression": "{{ steps.review.output.choice }}",
+                    "cases": bad_cases,
+                },
+                ctx,
+            )
+            assert result.status == StepStatus.FAILED
+            assert "'cases' must be a mapping" in (result.error or "")
+            # expression is still evaluated, so its value is surfaced for context.
+            assert result.output["expression_value"] == "approve"
+
     def test_validate_missing_expression(self):
         from specify_cli.workflows.steps.switch import SwitchStep
 


### PR DESCRIPTION
## Summary

`SwitchStep.validate()` already rejects a non-mapping `cases`, but the engine's `execute()` path does **not** auto-validate — `WorkflowEngine.load_workflow`'s docstring explicitly notes the returned definition is "not yet validated; call `validate_workflow()` or `engine.validate()` separately."

On such an unvalidated run, `SwitchStep.execute` iterated the raw value with `cases.items()`, so a list or scalar `cases` (an easy authoring mistake) raised `AttributeError`. The engine calls `step_impl.execute()` with no surrounding try/except, so that exception **took down the entire run** rather than failing just the step.

```python
>>> SwitchStep().execute({"id": "sw", "expression": "x", "cases": ["a", "b"]}, ctx)
AttributeError: 'list' object has no attribute 'items'
```

## Fix

Guard `execute` to return a `FAILED` `StepResult` naming the type error instead of crashing — mirroring the existing fan-out step behavior for a non-list `items` (`test_execute_non_list_items_fails_loudly`) and the "report validation errors instead of crashing" direction of #3421. The expression is still evaluated first, so its value is surfaced in the step output for downstream context.

This is the same bug class as the recent `max_iterations` / `timeout` / fan-in `output` guards: a validator catches the bad value, but the runtime path crashes on it when validation is skipped.

## Testing

- Added `TestSwitchStep::test_execute_non_dict_cases_fails_loudly` (list, str, int `cases`).
- Full `tests/test_workflows.py` passes except the 11 pre-existing Windows symlink-guard tests, which fail identically on a clean base (require elevation on Windows).
- `ruff check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
