### PR TITLE
fix(workflows): fail fan-in step on non-list wait_for instead of crashing

### DIFF
--- a/src/specify_cli/workflows/steps/fan_in/__init__.py
+++ b/src/specify_cli/workflows/steps/fan_in/__init__.py
@@ -24,6 +24,24 @@ class FanInStep(StepBase):
         if not isinstance(output_config, dict):
             output_config = {}
 
+        # The engine does not auto-validate step config, so an unvalidated run
+        # with a non-list ``wait_for`` reaches here raw. Iterating it then
+        # either crashes the whole run (a scalar like an int or None raises
+        # TypeError) or, worse, silently iterates a string's characters and
+        # yields a bogus join of empty results with a COMPLETED status — the
+        # exact "silent empty result + COMPLETED" wiring bug the engine's
+        # fan-in validation guards against. Fail this step loudly instead,
+        # mirroring the fan-out step's non-list ``items`` handling.
+        if not isinstance(wait_for, list):
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"Fan-in step {config.get('id', '?')!r}: 'wait_for' must be "
+                    f"a list of step IDs, got {type(wait_for).__name__}."
+                ),
+                output={"results": []},
+            )
+
         # Collect results from referenced steps
         results = []
         for step_id in wait_for:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2355,6 +2355,29 @@ class TestFanInStep:
         result = step.execute(config, ctx)
         assert result.output["results"] == [{}]
 
+    @pytest.mark.parametrize("bad_wait_for", ["stepA", 5, None, {"a": 1}])
+    def test_execute_non_list_wait_for_fails_loudly(self, bad_wait_for):
+        """A non-list ``wait_for`` must fail the step, not crash the run or
+        silently produce a bogus join.
+
+        ``validate`` rejects a non-list ``wait_for``, but the engine's
+        ``execute()`` does not auto-validate. Before the guard, ``execute``
+        iterated the raw value: a scalar (int/None) raised TypeError and took
+        down the whole run, while a string silently iterated its characters and
+        returned a join of empty results with a COMPLETED status — the exact
+        "silent empty result + COMPLETED" wiring bug the engine's fan-in
+        validation warns against. Mirrors the fan-out non-list ``items`` guard.
+        """
+        from specify_cli.workflows.steps.fan_in import FanInStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = FanInStep()
+        ctx = StepContext(steps={"a": {"output": {"x": 1}}})
+        result = step.execute({"id": "collect", "wait_for": bad_wait_for}, ctx)
+        assert result.status == StepStatus.FAILED
+        assert "'wait_for' must be a list" in (result.error or "")
+        assert result.output["results"] == []
+
     def test_validate_empty_wait_for(self):
         from specify_cli.workflows.steps.fan_in import FanInStep
 


### PR DESCRIPTION
## Summary

`FanInStep.validate()` and the engine's fan-in wiring checks both reject a non-list `wait_for`, but the engine's `execute()` path does **not** auto-validate — `WorkflowEngine.load_workflow`'s docstring notes the returned definition is "not yet validated; call `validate_workflow()` or `engine.validate()` separately."

On such an unvalidated run, `FanInStep.execute` iterated the raw value (`for step_id in wait_for`), with two bad outcomes depending on the type:

- **Scalar** (`wait_for: 5`, `wait_for: null`) → `TypeError`, which took down the whole run, since the engine calls `step_impl.execute()` with no surrounding try/except.
- **String** (`wait_for: stepA`) → silently iterated the string's *characters*, returning a join of empty results with a `COMPLETED` status:

```python
>>> FanInStep().execute({"id": "f", "wait_for": "stepA"}, ctx).output["results"]
[{}, {}, {}, {}, {}]   # one bogus empty result per character, COMPLETED
```

That silent-wrong case is exactly the "silent empty result + COMPLETED" wiring bug the engine's own fan-in validation comment (`engine.py`) warns against.

## Fix

Guard `execute` to return a `FAILED` `StepResult` naming the type error — mirroring the fan-out step's non-list `items` handling (`test_execute_non_list_items_fails_loudly`) and the switch/`max_iterations`/`timeout`/fan-in-`output` guards. A **missing** `wait_for` key still defaults to an empty list (`COMPLETED`), unchanged; the guard fires only on an explicit non-list value.

Same bug class as #3481 and prior fixes: a validator catches the bad value, but the runtime path crashes (or silently misbehaves) on it when validation is skipped.

## Testing

- Added `TestFanInStep::test_execute_non_list_wait_for_fails_loudly` (parametrized over `str`, `int`, `None`, `dict`).
- Full `tests/test_workflows.py` passes except the 11 pre-existing Windows symlink-guard tests (fail identically on a clean base; require elevation).
- `ruff check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
