### PR TITLE
fix(integrations): declare kiro-cli multi-install safe (#3471)

### DIFF
--- a/src/specify_cli/integrations/kiro_cli/__init__.py
+++ b/src/specify_cli/integrations/kiro_cli/__init__.py
@@ -26,3 +26,10 @@ class KiroCliIntegration(MarkdownIntegration):
         "args": _KIRO_ARG_FALLBACK,
         "extension": ".md",
     }
+
+    # Kiro CLI keeps everything under a static, isolated agent root
+    # (``.kiro/`` with commands in ``.kiro/prompts``) that no other
+    # integration writes to, so it is safe to install alongside others
+    # (issue #3471). The registry's multi-install-safe contract tests
+    # enforce that isolation for every integration setting this flag.
+    multi_install_safe = True

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -272,6 +272,20 @@ class TestMultiInstallSafeContracts:
                 f"these files: {sorted(overlap)}"
             )
 
+    def test_kiro_cli_is_declared_multi_install_safe(self):
+        """kiro-cli confines itself to an isolated ``.kiro/`` root that no
+        other integration touches, so it must be declared multi-install safe
+        (issue #3471).
+
+        Before the fix, co-installing kiro-cli alongside another integration
+        left ``specify integration status`` permanently in ERROR
+        (``unsafe-multi-install``) with no way to acknowledge it. The
+        parametrized isolation/manifest contracts above already exercise
+        kiro-cli once the flag is set; this pins the declaration itself so a
+        future edit cannot silently drop it and reintroduce the error.
+        """
+        assert INTEGRATION_REGISTRY["kiro-cli"].multi_install_safe is True
+
 
 class TestCatalogParity:
     """The discovery catalog must list every registered integration."""


### PR DESCRIPTION
## Summary

Fixes #3471.

`kiro-cli` keeps all of its managed files under an isolated agent root — `.kiro/` with commands in `.kiro/prompts` — that no other integration writes to. It meets every documented criterion for [multi-install safety](https://github.github.com/spec-kit/reference/integrations.html#which-integrations-are-multi-install-safe), but `KiroCliIntegration` never declared `multi_install_safe = True`.

Because of that, co-installing kiro-cli alongside any other integration (e.g. `claude`) left `specify integration status` permanently in ERROR:

```
error unsafe-multi-install: Installed integrations are not all declared multi-install safe: kiro-cli
```

`--force` on install bypasses the install-time gate but does not clear the status error, and there is no flag or config to acknowledge it — so the error is permanent as long as both integrations remain installed.

## Fix

Set `multi_install_safe = True` on `KiroCliIntegration` (one line + an explanatory comment).

`.kiro/` is unique to kiro-cli — no other integration in the registry uses that root — so declaring it safe introduces no path or manifest collisions.

## Testing

- The registry's parametrized `TestMultiInstallSafeContracts` suite now covers kiro-cli automatically: it asserts a static isolated root, pairwise-distinct agent roots and command dirs, and disjoint on-disk manifests across every safe integration. All pass with kiro-cli included.
- Added a focused regression test (`test_kiro_cli_is_declared_multi_install_safe`) that pins the declaration itself, so a future edit can't silently drop the flag and reintroduce the permanent ERROR.
- `tests/integrations/test_registry.py` (331 → 332 tests) and `tests/integrations/test_integration_subcommand.py`: **473 passed, 7 skipped** (skips pre-existing, unrelated).
- `ruff check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)