### PR TITLE
fix: add trailing newline to `init-options.json` output

### DIFF
--- a/src/specify_cli/_init_options.py
+++ b/src/specify_cli/_init_options.py
@@ -14,7 +14,7 @@ def save_init_options(project_path: Path, options: dict[str, Any]) -> None:
     dest = project_path / INIT_OPTIONS_FILE
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(
-        json.dumps(options, indent=2, sort_keys=True, ensure_ascii=False),
+        json.dumps(options, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Description

`save_init_options()` in `src/specify_cli/_init_options.py` omitted a trailing newline when writing `init-options.json`. This caused `end-of-file-fixer` from `.pre-commit-config.yaml` (#3430) to flag a dirty diff on every `specify integration upgrade` run.

Appends `"\n"` to the `json.dumps()` output to match POSIX file conventions — consistent with `integration_state.py:252` which already includes the trailing newline:

| File | Has `\n`? |
|------|-----------|
| [`_init_options.py:17`](https://github.com/vincentclee/spec-kit/blob/fix/init-options-trailing-newline/src/specify_cli/_init_options.py#L17) | ✅ Fixed (this PR) |
| [`integration_state.py:252`](https://github.com/github/spec-kit/blob/f65d9f9382ffe37c86994261c2f56d258c479cf7/src/specify_cli/integration_state.py#L252) | ✅ Already correct |

Ref: https://github.com/github/spec-kit/pull/3430

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync --all-extras && uv run pytest` — `3986 passed, 110 skipped in 129.71s (0:02:09)`
- [x] Tested with a sample project — [`vincentclee/spec-kit-test`](https://github.com/vincentclee/spec-kit-test) ([`main`](https://github.com/vincentclee/spec-kit-test/tree/main) = v0.12.14 baseline, [`fix/init-options-trailing-newline`](https://github.com/vincentclee/spec-kit-test/tree/fix/init-options-trailing-newline) = verified fix — `pre-commit run --all-files` passes clean). See each branch's README for full reproduction steps.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot CLI agent (model: claude-opus-4.6, high) identified the bug, applied the fix, and ran the test suite.
