### PR TITLE
fix(workflows): fan-out max_concurrency .inf falls back to sequential instead of crashing

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -1197,9 +1197,9 @@ class WorkflowEngine:
         already flipped), so the prefix never drops the actual halting item.
 
         ``max_concurrency`` is coerced with ``int()``; a value that cannot be
-        coerced (``None``, a non-numeric string, …) or that coerces to <= 1 runs
-        sequentially, while a numeric string like ``"4"`` or a float like ``4.0``
-        is honored.
+        coerced (``None``, a non-numeric string, ``.inf``/``.nan``, …) or that
+        coerces to <= 1 runs sequentially, while a numeric string like ``"4"`` or
+        a float like ``4.0`` is honored.
         """
         if not items:
             return []
@@ -1207,7 +1207,9 @@ class WorkflowEngine:
         halting = (RunStatus.PAUSED, RunStatus.FAILED, RunStatus.ABORTED)
         try:
             workers = max(1, int(max_concurrency))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
+            # OverflowError: int(float("inf")) — a YAML ``max_concurrency: .inf``
+            # would otherwise crash the whole run instead of falling back.
             workers = 1
         # Never spin up more workers than there is work — bounds a user-controlled
         # max_concurrency from over-allocating threads.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2662,8 +2662,13 @@ class TestFanOutConcurrency:
         results, _ = self._run(tmp_path, list(range(n)), n, on_item)
         assert results == [{"seen": i} for i in range(n)]
 
-    @pytest.mark.parametrize("bad", [0, -1, None, "abc", 1.0])
+    @pytest.mark.parametrize(
+        "bad", [0, -1, None, "abc", 1.0, float("inf"), float("nan")]
+    )
     def test_invalid_max_concurrency_coerces_to_sequential(self, tmp_path, bad):
+        # float("inf") -> int() raises OverflowError (not TypeError/ValueError);
+        # it must fall back to sequential like any other uncoercible value, not
+        # crash the run.
         results, _ = self._run(tmp_path, list(range(4)), bad)
         assert results == [{"seen": i} for i in range(4)]
 


### PR DESCRIPTION
## What

A fan-out step with `max_concurrency: .inf` crashes the entire workflow run:

```
OverflowError: cannot convert float infinity to integer
```

`WorkflowEngine._run_fan_out` coerces the user-controlled `max_concurrency` with `int()` inside `except (TypeError, ValueError)`:

```python
try:
    workers = max(1, int(max_concurrency))
except (TypeError, ValueError):
    workers = 1
```

But `int(float("inf"))` raises **`OverflowError`**, which is not in that tuple — so `.inf` (a valid YAML float) escapes the guard and takes down the run, contradicting the method's own docstring ("a value that cannot be coerced … runs sequentially").

## Fix

Add `OverflowError` to the except tuple so `.inf` falls back to sequential like any other uncoercible value. (`.nan` already coerced via `ValueError`.) One-line change; direction matches the documented intent and the sibling numeric-coercion guards in this codebase (e.g. `_coerce_input`'s OverflowError handling).

## Test

Extends the existing `test_invalid_max_concurrency_coerces_to_sequential` parametrization with `float("inf")`/`float("nan")` — fails before on `inf` (OverflowError), passes after (sequential, all items in order).

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.