### PR TITLE
fix(presets): re-validate catalog URL after redirects (HTTPS parity/security)

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -2108,13 +2108,22 @@ class PresetCatalog:
         url: str,
         timeout: int = 10,
         extra_headers: Optional[Dict[str, str]] = None,
+        redirect_validator=None,
     ):
         """Open a URL with provider-based auth, trying each configured provider.
 
         Delegates to :func:`specify_cli.authentication.http.open_url`.
+        *redirect_validator*, when provided, is invoked as ``(old_url, new_url)``
+        before EACH redirect hop, so an HTTPS host guarantee can be enforced on
+        every intermediate URL, not just the terminal one.
         """
         from specify_cli.authentication.http import open_url
-        return open_url(url, timeout, extra_headers=extra_headers)
+        return open_url(
+            url,
+            timeout,
+            extra_headers=extra_headers,
+            redirect_validator=redirect_validator,
+        )
 
     def _resolve_github_release_asset_api_url(
         self,
@@ -2404,14 +2413,18 @@ class PresetCatalog:
                 pass
 
         try:
-            with self._open_url(entry.url, timeout=10) as response:
-                # Re-validate the URL after any redirects: _open_url follows
-                # redirects (stripping auth only on an HTTPS->HTTP downgrade), so
-                # without this an https:// catalog entry that 30x-redirects to
-                # http://attacker/... would be fetched and trusted. The catalog
-                # payload supplies each preset's download_url + sha256, so a
-                # redirected payload defeats verify_archive_sha256. Mirrors the
-                # integrations/workflows catalog fetchers.
+            # Validate EVERY redirect hop (not just the terminal URL): an
+            # https -> http -> attacker-controlled-https chain would pass a
+            # final-URL-only check while the insecure intermediate hop lets a
+            # network attacker rewrite the next redirect. redirect_validator runs
+            # before each hop; the final geturl() check is retained as a
+            # belt-and-braces guard. Mirrors bundler/services/adapters.py.
+            def _validate_redirect(_old_url: str, new_url: str) -> None:
+                self._validate_catalog_url(new_url)
+
+            with self._open_url(
+                entry.url, timeout=10, redirect_validator=_validate_redirect
+            ) as response:
                 final_url = response.geturl()
                 if final_url != entry.url:
                     self._validate_catalog_url(final_url)
@@ -2565,7 +2578,18 @@ class PresetCatalog:
                 pass
 
         try:
-            with self._open_url(catalog_url, timeout=10) as response:
+            # Same redirect hardening as _fetch_single_catalog: validate every
+            # redirect hop AND the final URL so this legacy single-catalog path
+            # is not vulnerable to an HTTPS->HTTP redirected payload either.
+            def _validate_redirect(_old_url: str, new_url: str) -> None:
+                self._validate_catalog_url(new_url)
+
+            with self._open_url(
+                catalog_url, timeout=10, redirect_validator=_validate_redirect
+            ) as response:
+                final_url = response.geturl()
+                if final_url != catalog_url:
+                    self._validate_catalog_url(final_url)
                 catalog_data = json.loads(response.read())
 
             # Validate catalog structure. Reuses the same helper as

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -2405,6 +2405,16 @@ class PresetCatalog:
 
         try:
             with self._open_url(entry.url, timeout=10) as response:
+                # Re-validate the URL after any redirects: _open_url follows
+                # redirects (stripping auth only on an HTTPS->HTTP downgrade), so
+                # without this an https:// catalog entry that 30x-redirects to
+                # http://attacker/... would be fetched and trusted. The catalog
+                # payload supplies each preset's download_url + sha256, so a
+                # redirected payload defeats verify_archive_sha256. Mirrors the
+                # integrations/workflows catalog fetchers.
+                final_url = response.geturl()
+                if final_url != entry.url:
+                    self._validate_catalog_url(final_url)
                 catalog_data = json.loads(response.read())
 
             self._validate_catalog_payload(catalog_data, entry.url)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1788,7 +1788,7 @@ class TestPresetCatalog:
             def geturl(self):
                 return "http://evil.test/catalog.json"  # downgraded via redirect
 
-        catalog._open_url = lambda url, timeout=None: _Resp()
+        catalog._open_url = lambda url, timeout=None, redirect_validator=None: _Resp()
 
         entry = PresetCatalogEntry(
             url="https://good.example/catalog.json",
@@ -1798,6 +1798,53 @@ class TestPresetCatalog:
         )
         with pytest.raises(PresetValidationError, match="HTTPS"):
             catalog._fetch_single_catalog(entry, force_refresh=True)
+
+    def test_fetch_single_catalog_validates_every_redirect_hop(self, project_dir):
+        """A redirect_validator is passed to _open_url and rejects a non-HTTPS
+        INTERMEDIATE hop — closing the https -> http -> attacker-https chain that
+        a terminal-URL-only check would miss."""
+        catalog = PresetCatalog(project_dir)
+        captured = {}
+
+        def fake_open(url, timeout=None, redirect_validator=None):
+            captured["rv"] = redirect_validator
+            # Simulate the hop urllib validates before following the redirect.
+            redirect_validator("https://good.example/catalog.json", "http://evil.test/hop")
+            raise AssertionError("redirect_validator should have raised")
+
+        catalog._open_url = fake_open
+        entry = PresetCatalogEntry(
+            url="https://good.example/catalog.json",
+            name="c",
+            priority=1,
+            install_allowed=True,
+        )
+        with pytest.raises(PresetValidationError, match="HTTPS"):
+            catalog._fetch_single_catalog(entry, force_refresh=True)
+        assert captured["rv"] is not None
+
+    def test_fetch_catalog_legacy_revalidates_redirected_url(self, project_dir):
+        """The legacy single-catalog fetch_catalog() path also rejects an
+        HTTPS -> http redirected payload (final geturl() check), matching
+        _fetch_single_catalog — it previously parsed the body with no check."""
+        catalog = PresetCatalog(project_dir)
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return json.dumps({"schema_version": "1.0", "presets": {}}).encode()
+
+            def geturl(self):
+                return "http://evil.test/catalog.json"
+
+        catalog._open_url = lambda url, timeout=None, redirect_validator=None: _Resp()
+        with pytest.raises(PresetError, match="HTTPS"):
+            catalog.fetch_catalog(force_refresh=True)
 
     @pytest.mark.parametrize(
         "payload",
@@ -1832,6 +1879,7 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(payload).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.geturl.return_value = "https://example.com/catalog.json"
         # A real urllib response reports the final URL (== request URL with no
         # redirect); the fetcher re-validates it after redirects.
         mock_response.geturl.return_value = "https://example.com/catalog.json"
@@ -1952,6 +2000,7 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(payload).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.geturl.return_value = "https://example.com/catalog.json"
 
         with patch.object(catalog, "_open_url", return_value=mock_response):
             with pytest.raises(PresetError, match="Invalid preset catalog format"):
@@ -1993,6 +2042,7 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(valid).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.geturl.return_value = "https://example.com/catalog.json"
 
         with patch.object(catalog, "_open_url", return_value=mock_response):
             result = catalog.fetch_catalog(force_refresh=False)
@@ -2031,6 +2081,7 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(valid).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.geturl.return_value = "https://example.com/catalog.json"
 
         with patch.object(catalog, "_open_url", return_value=mock_response):
             result = catalog.fetch_catalog(force_refresh=False)
@@ -2101,6 +2152,7 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(payload).encode("utf-8")
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.geturl.return_value = "https://example.com/catalog.json"
 
         # Record every ``write_text`` call's encoding kwarg so the
         # assertion observes the production writer's argument directly.

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1846,6 +1846,23 @@ class TestPresetCatalog:
         with pytest.raises(PresetError, match="HTTPS"):
             catalog.fetch_catalog(force_refresh=True)
 
+    def test_fetch_catalog_legacy_validates_every_redirect_hop(self, project_dir):
+        """The legacy fetch_catalog() path also validates every INTERMEDIATE hop
+        (not just the terminal URL): it must supply a redirect_validator that
+        rejects an insecure hop, so an https -> http -> https chain is caught."""
+        catalog = PresetCatalog(project_dir)
+        captured = {}
+
+        def fake_open(url, timeout=None, redirect_validator=None):
+            captured["rv"] = redirect_validator
+            redirect_validator(url, "http://evil.test/hop")
+            raise AssertionError("redirect_validator should have raised")
+
+        catalog._open_url = fake_open
+        with pytest.raises(PresetError, match="HTTPS"):
+            catalog.fetch_catalog(force_refresh=True)
+        assert captured["rv"] is not None
+
     @pytest.mark.parametrize(
         "payload",
         [
@@ -1879,7 +1896,6 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(payload).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
-        mock_response.geturl.return_value = "https://example.com/catalog.json"
         # A real urllib response reports the final URL (== request URL with no
         # redirect); the fetcher re-validates it after redirects.
         mock_response.geturl.return_value = "https://example.com/catalog.json"

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1766,6 +1766,39 @@ class TestPresetCatalog:
 
         assert captured["req"].get_header("Authorization") == "Bearer ghp_testtoken"
 
+    def test_fetch_single_catalog_revalidates_redirected_url(self, project_dir):
+        """An HTTPS catalog URL that redirects to http:// must be rejected AFTER
+        the redirect. _open_url follows redirects (auth stripped on downgrade),
+        so without re-validating response.geturl() the http payload would still
+        be fetched and trusted — and it supplies each preset's download_url +
+        sha256, defeating verify_archive_sha256. Parity with the
+        integrations/workflows catalog fetchers."""
+        catalog = PresetCatalog(project_dir)
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return json.dumps({"schema_version": "1.0", "presets": {}}).encode()
+
+            def geturl(self):
+                return "http://evil.test/catalog.json"  # downgraded via redirect
+
+        catalog._open_url = lambda url, timeout=None: _Resp()
+
+        entry = PresetCatalogEntry(
+            url="https://good.example/catalog.json",
+            name="c",
+            priority=1,
+            install_allowed=True,
+        )
+        with pytest.raises(PresetValidationError, match="HTTPS"):
+            catalog._fetch_single_catalog(entry, force_refresh=True)
+
     @pytest.mark.parametrize(
         "payload",
         [
@@ -1799,6 +1832,9 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(payload).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        # A real urllib response reports the final URL (== request URL with no
+        # redirect); the fetcher re-validates it after redirects.
+        mock_response.geturl.return_value = "https://example.com/catalog.json"
 
         entry = PresetCatalogEntry(
             url="https://example.com/catalog.json",
@@ -1868,6 +1904,7 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(valid).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.geturl.return_value = catalog.DEFAULT_CATALOG_URL
 
         entry = PresetCatalogEntry(
             url=catalog.DEFAULT_CATALOG_URL,
@@ -2113,6 +2150,7 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(valid).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.geturl.return_value = catalog.DEFAULT_CATALOG_URL
 
         # Simulate an unwritable cache dir: every write_text under the
         # cache directory raises PermissionError (an OSError subclass).
@@ -2165,6 +2203,7 @@ class TestPresetCatalog:
         mock_response.read.return_value = json.dumps(payload).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.geturl.return_value = "https://example.com/catalog.json"
 
         entry = PresetCatalogEntry(
             url="https://example.com/catalog.json",


### PR DESCRIPTION
## What

`PresetCatalog._fetch_single_catalog` fetched the catalog JSON and trusted it without re-validating the **post-redirect** URL:

```python
with self._open_url(entry.url, timeout=10) as response:
    catalog_data = json.loads(response.read())   # no response.geturl() check
```

`_open_url` follows redirects (stripping auth only on an HTTPS→HTTP downgrade), so an `https://` catalog `entry.url` that 30x-redirects to `http://attacker/catalog.json` is still fetched and trusted. Because the catalog payload supplies each preset's `download_url` **and** `sha256`, an attacker-controlled redirected payload defeats `verify_archive_sha256` and can drive installation of an arbitrary archive.

## Fix

Re-validate `response.geturl()` after the redirect via the existing `_validate_catalog_url`, exactly mirroring the other catalog systems:

- `integrations/catalog.py` (`final_url = resp.geturl(); if final_url != entry.url: self._validate_catalog_url(final_url)`)
- `workflows/catalog.py`, `bundler/services/adapters.py`
- and `presets/_commands.py` itself, which **already** does redirect re-validation on its `--from` download path.

This was the one preset catalog-fetch site missing the guard — clearly an oversight, not a deliberate omission.

## Test

`test_fetch_single_catalog_revalidates_redirected_url`: an HTTPS URL whose `response.geturl()` reports `http://` is rejected with `PresetValidationError` (fails before: no revalidation). Four pre-existing fetch-test mocks were completed to report `geturl()` like a real `urllib` response.

```
uv run pytest tests/test_presets.py   # 339 passed
uvx ruff check  # clean
```

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after).