### PR TITLE
fix(catalogs): 'priority: .inf' yields a clean validation error instead of crashing

### DIFF
--- a/src/specify_cli/catalogs.py
+++ b/src/specify_cli/catalogs.py
@@ -149,7 +149,10 @@ class CatalogStackBase:
                 )
             try:
                 priority = int(raw_priority)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError: int(float("inf")) — a YAML ``priority: .inf``
+                # would otherwise escape as an uncaught traceback instead of the
+                # clean validation error.
                 raise self._validation_error(
                     f"Invalid catalog config {config_path}: "
                     f"Invalid priority for catalog '{item.get('name', idx + 1)}': "

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -2231,7 +2231,10 @@ class PresetCatalog:
                 )
             try:
                 priority = int(raw_priority)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError: int(float("inf")) — a YAML ``priority: .inf``
+                # would otherwise escape as an uncaught traceback instead of the
+                # clean validation error (mirrors catalogs.py).
                 raise PresetValidationError(
                     f"Invalid priority for catalog '{item.get('name', idx + 1)}': "
                     f"expected integer, got {raw_priority!r}"

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -4542,6 +4542,36 @@ class TestCatalogStack:
             catalog.get_active_catalogs()
         assert str(config_path) in str(exc_info.value)
 
+    def test_load_catalog_config_rejects_infinite_priority(self, temp_dir):
+        """A ``priority: .inf`` yields a clean validation error, not an uncaught
+        OverflowError from int(float('inf'))."""
+        import yaml as yaml_module
+
+        project_dir = self._make_project(temp_dir)
+        config_path = project_dir / ".specify" / "extension-catalogs.yml"
+        config_path.write_text(
+            yaml_module.dump(
+                {
+                    "catalogs": [
+                        {
+                            "name": "inf-priority",
+                            "url": "https://example.com/catalog.json",
+                            "priority": float("inf"),
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        catalog = ExtensionCatalog(project_dir)
+
+        with pytest.raises(
+            ValidationError, match="Invalid priority|expected integer"
+        ) as exc_info:
+            catalog.get_active_catalogs()
+        assert str(config_path) in str(exc_info.value)
+
     def test_load_catalog_config_defaults_blank_names(self, temp_dir):
         """Blank and null names normalize by valid catalog order."""
         import yaml as yaml_module

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -2659,6 +2659,24 @@ class TestPresetCatalogMultiCatalog:
         with pytest.raises(PresetValidationError, match="Invalid priority|expected integer"):
             catalog._load_catalog_config(config_path)
 
+    def test_load_catalog_config_rejects_infinite_priority(self, project_dir):
+        """A ``priority: .inf`` yields a clean validation error, not an uncaught
+        OverflowError from int(float('inf'))."""
+        config_path = project_dir / ".specify" / "preset-catalogs.yml"
+        config_path.write_text(yaml.dump({
+            "catalogs": [
+                {
+                    "name": "inf-priority",
+                    "url": "https://example.com/catalog.json",
+                    "priority": float("inf"),
+                }
+            ]
+        }))
+
+        catalog = PresetCatalog(project_dir)
+        with pytest.raises(PresetValidationError, match="Invalid priority|expected integer"):
+            catalog._load_catalog_config(config_path)
+
     def test_load_catalog_config_install_allowed_string(self, project_dir):
         """Test that install_allowed accepts string values."""
         config_path = project_dir / ".specify" / "preset-catalogs.yml"


### PR DESCRIPTION
## What

A catalog config with `priority: .inf` crashed with an uncaught `OverflowError: cannot convert float infinity to integer`, because the priority parsers coerce with `int()` inside `except (TypeError, ValueError)` — and `int(float("inf"))` raises `OverflowError`, which isn't in that tuple. (The `bool`-is-int case was already guarded.)

## Fix

Add `OverflowError` to the except tuple in the affected priority loaders:

- `catalogs.py` — `CatalogStackBase._load_catalog_config`, which backs the **extensions** and **integrations** catalogs.
- `presets/__init__.py` — `PresetCatalog._load_catalog_config` (the preset catalog has its **own** loader, not the base one), which was the remaining gap.

> Scope note: the **workflow / step** catalog loaders live in `workflows/catalog.py` and are handled in a separate PR (#3526). This PR covers the base loader (extensions + integrations) and the preset loader.

## Test

Each affected loader gets a `priority: .inf` regression test mirroring the existing `rejects_boolean_priority` — fails before (`OverflowError`), passes after (clean `…ValidationError`).

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.