### PR TITLE
fix(auth): Azure DevOps az-CLI token returns None on undecodable output instead of crashing

### DIFF
--- a/src/specify_cli/authentication/azure_devops.py
+++ b/src/specify_cli/authentication/azure_devops.py
@@ -76,7 +76,17 @@ class AzureDevOpsAuth(AuthProvider):
             payload = _json.loads(result.stdout)
             token = payload.get("accessToken", "").strip()
             return token or None
-        except (OSError, subprocess.TimeoutExpired, _json.JSONDecodeError, KeyError):
+        except (
+            OSError,
+            subprocess.TimeoutExpired,
+            _json.JSONDecodeError,
+            UnicodeDecodeError,
+            KeyError,
+        ):
+            # UnicodeDecodeError: text=True decodes az stdout with the locale
+            # encoding, which raises (not a JSONDecodeError) if the output isn't
+            # decodable — this helper's contract is to return None on any
+            # failure, never to propagate.
             return None
 
     @staticmethod

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -502,6 +502,19 @@ class TestAzureDevOpsAuth:
         with patch("specify_cli.authentication.azure_devops.subprocess.run", side_effect=OSError("not found")):
             assert AzureDevOpsAuth().resolve_token(entry) is None
 
+    def test_resolve_token_azure_cli_undecodable_output_returns_none(self):
+        """Undecodable az output returns None, not a crash. With text=True,
+        subprocess.run decodes stdout with the locale encoding and raises
+        UnicodeDecodeError (not a JSONDecodeError) when it can't — the helper's
+        contract is to return None on any failure."""
+        from unittest.mock import patch
+        entry = AuthConfigEntry(
+            hosts=("dev.azure.com",), provider="azure-devops", auth="azure-cli",
+        )
+        boom = UnicodeDecodeError("utf-8", b"\xff\xfe", 0, 1, "invalid start byte")
+        with patch("specify_cli.authentication.azure_devops.subprocess.run", side_effect=boom):
+            assert AzureDevOpsAuth().resolve_token(entry) is None
+
     def test_resolve_token_azure_ad_success(self, monkeypatch):
         """azure-ad acquires token via OAuth2 client credentials."""
         from unittest.mock import patch, MagicMock


### PR DESCRIPTION
## What

`AzureDevOpsAuth._acquire_via_az_cli` runs `az account get-access-token` with `text=True`, then parses the JSON:

```python
result = subprocess.run([...], capture_output=True, text=True, ...)
...
payload = _json.loads(result.stdout)
...
except (OSError, subprocess.TimeoutExpired, _json.JSONDecodeError, KeyError):
    return None
```

With `text=True`, `subprocess.run` decodes stdout using the **locale encoding**, so if `az` emits bytes that aren't decodable there it raises `UnicodeDecodeError` *inside* `run()` — before `json.loads` ever runs. `UnicodeDecodeError` is a `ValueError` sibling but **not** a `JSONDecodeError`, so it isn't caught and it crashes a helper whose entire contract is to return `str | None`.

## Fix

Add `UnicodeDecodeError` to the except tuple so undecodable output degrades to `None` like every other failure mode. One-token change; direction unambiguous given the `str | None` return contract and the sibling encoding guards elsewhere in the codebase.

## Test

`test_resolve_token_azure_cli_undecodable_output_returns_none` patches `subprocess.run` to raise `UnicodeDecodeError` and asserts `resolve_token(...) is None` — fails before (the error propagated), passes after.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.