### PR TITLE
fix(workflows): if step execute() fails cleanly on a non-list branch

### DIFF
--- a/src/specify_cli/workflows/steps/if_then/__init__.py
+++ b/src/specify_cli/workflows/steps/if_then/__init__.py
@@ -24,9 +24,31 @@ class IfThenStep(StepBase):
         if result:
             branch_name = "then"
             branch = config.get("then", [])
+            branch_name = "then"
         else:
             branch_name = "else"
             branch = config.get("else", [])
+            branch_name = "else"
+
+        if not isinstance(branch, list):
+            # The engine does not auto-validate step config and feeds
+            # ``next_steps`` straight into ``_execute_steps``, which iterates them
+            # as step mappings. A non-list ``then``/``else`` (a single mapping or
+            # scalar authoring mistake) would otherwise be iterated element-wise
+            # — a dict yields its keys, a str its characters — and crash the whole
+            # run with AttributeError on ``.get()``. ``validate`` already rejects
+            # a non-list branch; fail this step loudly on an unvalidated run
+            # instead, mirroring the while/do-while (#3519) / switch / fan-out
+            # steps. The selected branch is always returned as next_steps, so the
+            # guard is unconditional.
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"If step {config.get('id', '?')!r}: {branch_name!r} must be a "
+                    f"list of steps, got {type(branch).__name__}."
+                ),
+                output={"condition_result": result},
+            )
 
         # The engine does not auto-validate step config (see
         # ``WorkflowEngine.load_workflow``), and it feeds ``next_steps`` straight

--- a/src/specify_cli/workflows/steps/if_then/__init__.py
+++ b/src/specify_cli/workflows/steps/if_then/__init__.py
@@ -28,32 +28,6 @@ class IfThenStep(StepBase):
             branch = config.get("else", [])
             branch_name = "else"
 
-        # ``else: null`` is the supported "no else branch" form (validate()
-        # accepts None here); normalize a selected None branch to [] so a false
-        # condition on such a config runs cleanly instead of hitting the guard.
-        if branch is None:
-            branch = []
-
-        if not isinstance(branch, list):
-            # The engine does not auto-validate step config and feeds
-            # ``next_steps`` straight into ``_execute_steps``, which iterates them
-            # as step mappings. A non-list ``then``/``else`` (a single mapping or
-            # scalar authoring mistake) would otherwise be iterated element-wise
-            # — a dict yields its keys, a str its characters — and crash the whole
-            # run with AttributeError on ``.get()``. ``validate`` already rejects
-            # a non-list branch; fail this step loudly on an unvalidated run
-            # instead, mirroring the while/do-while (#3519) / switch / fan-out
-            # steps. The selected branch is always returned as next_steps, so the
-            # guard is unconditional.
-            return StepResult(
-                status=StepStatus.FAILED,
-                error=(
-                    f"If step {config.get('id', '?')!r}: {branch_name!r} must be a "
-                    f"list of steps, got {type(branch).__name__}."
-                ),
-                output={"condition_result": result},
-            )
-
         # The engine does not auto-validate step config (see
         # ``WorkflowEngine.load_workflow``), and it feeds ``next_steps`` straight
         # into ``_execute_steps`` which iterates them as step mappings. A

--- a/src/specify_cli/workflows/steps/if_then/__init__.py
+++ b/src/specify_cli/workflows/steps/if_then/__init__.py
@@ -22,13 +22,17 @@ class IfThenStep(StepBase):
         result = evaluate_condition(condition, context)
 
         if result:
-            branch_name = "then"
             branch = config.get("then", [])
             branch_name = "then"
         else:
-            branch_name = "else"
             branch = config.get("else", [])
             branch_name = "else"
+
+        # ``else: null`` is the supported "no else branch" form (validate()
+        # accepts None here); normalize a selected None branch to [] so a false
+        # condition on such a config runs cleanly instead of hitting the guard.
+        if branch is None:
+            branch = []
 
         if not isinstance(branch, list):
             # The engine does not auto-validate step config and feeds

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2130,6 +2130,30 @@ class TestIfThenStep:
         assert result.output["condition_result"] is False
         assert result.next_steps[0]["id"] == "b"
 
+    @pytest.mark.parametrize("bad_branch", ["oops", {"a": 1}, 42])
+    def test_execute_rejects_non_list_branch(self, bad_branch):
+        """execute() fails cleanly on a non-list then/else branch. The engine
+        doesn't auto-validate step config, so a non-iterable next_steps would
+        otherwise crash the run — completing the while/do-while guard (#3519) for
+        the if step (mirrors the switch step's 'cases' guard)."""
+        from specify_cli.workflows.steps.if_then import IfThenStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = IfThenStep()
+        cond = "{{ inputs.scope == 'full' }}"
+        res_then = step.execute(
+            {"id": "i", "condition": cond, "then": bad_branch},
+            StepContext(inputs={"scope": "full"}),
+        )
+        assert res_then.status is StepStatus.FAILED
+        assert "'then' must be a list" in (res_then.error or "")
+        res_else = step.execute(
+            {"id": "i", "condition": cond, "then": [], "else": bad_branch},
+            StepContext(inputs={"scope": "backend"}),
+        )
+        assert res_else.status is StepStatus.FAILED
+        assert "'else' must be a list" in (res_else.error or "")
+
     def test_validate_missing_condition(self):
         from specify_cli.workflows.steps.if_then import IfThenStep
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2154,6 +2154,23 @@ class TestIfThenStep:
         assert res_else.status is StepStatus.FAILED
         assert "'else' must be a list" in (res_else.error or "")
 
+    def test_execute_allows_null_else_branch(self):
+        """`else: null` is the supported 'no else branch' form (validate accepts
+        it); a false condition must run cleanly (COMPLETED, no next steps), not
+        be turned into FAILED by the non-list guard."""
+        from specify_cli.workflows.steps.if_then import IfThenStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = IfThenStep()
+        result = step.execute(
+            {"id": "i", "condition": "{{ inputs.scope == 'full' }}",
+             "then": [{"id": "a", "command": "speckit.tasks"}], "else": None},
+            StepContext(inputs={"scope": "backend"}),
+        )
+        assert result.status is StepStatus.COMPLETED
+        assert result.output["condition_result"] is False
+        assert result.next_steps == []
+
     def test_validate_missing_condition(self):
         from specify_cli.workflows.steps.if_then import IfThenStep
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2171,6 +2171,21 @@ class TestIfThenStep:
         assert result.output["condition_result"] is False
         assert result.next_steps == []
 
+    def test_execute_null_then_is_failed_not_normalized(self):
+        """Only `else: null` is normalized to []; `then: null` is invalid
+        (validate() rejects it), so a true condition must FAIL, not silently
+        complete an empty branch."""
+        from specify_cli.workflows.steps.if_then import IfThenStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = IfThenStep()
+        result = step.execute(
+            {"id": "i", "condition": "{{ inputs.scope == 'full' }}", "then": None},
+            StepContext(inputs={"scope": "full"}),
+        )
+        assert result.status is StepStatus.FAILED
+        assert "'then' must be" in (result.error or "")
+
     def test_validate_missing_condition(self):
         from specify_cli.workflows.steps.if_then import IfThenStep
 


### PR DESCRIPTION
## What

`IfThenStep.execute` returns `config['then']`/`['else']` directly as `StepResult.next_steps` with no check that it's a list:

```python
branch = config.get("then", [])
return StepResult(status=COMPLETED, next_steps=branch)   # branch could be "oops" / {...} / 42
```

The engine does **not** auto-validate step config before `execute()`, so an unvalidated run with a non-list branch (a scalar or mapping authoring mistake) passes a non-iterable as `next_steps` and crashes the whole run. `validate()` catches this, but `execute()` should fail the step loudly rather than take down the run.

## Fix

Add an `isinstance(..., list)` guard returning a `FAILED` `StepResult`. This **completes the same guard #3519 added to the `while`/`do-while` steps** — whose comment already references the `if` step as a peer — and mirrors the `switch` step's `cases` guard.

> Note: this PR originally also touched `while`/`do-while`, but #3519 landed that guard for those two steps in the meantime. Rebased down to the still-missing **`if`** case only, to avoid duplicating merged work.

## Test

Parametrized `test_execute_rejects_non_list_branch` feeds a `str`/`dict`/`int` branch and asserts `FAILED` — fails before (the non-iterable `next_steps` crashed execution), passes after.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.