### PR TITLE
fix(integrations): Forge dispatches hyphenated /speckit-<cmd> invocations

### DIFF
--- a/src/specify_cli/integrations/forge/__init__.py
+++ b/src/specify_cli/integrations/forge/__init__.py
@@ -91,6 +91,18 @@ class ForgeIntegration(MarkdownIntegration):
     }
     invoke_separator = "-"
 
+    def build_command_invocation(self, command_name: str, args: str = "") -> str:
+        """Forge installs hyphenated slash-commands (``/speckit-<name>``), so the
+        dispatch invocation must match. The inherited MarkdownIntegration default
+        builds the dotted ``/speckit.<name>``, which references a command Forge
+        never registered. Reuse the same hyphenation as the installed frontmatter
+        ``name`` (see ``format_forge_command_name``), mirroring the skills agents.
+        """
+        invocation = "/" + format_forge_command_name(command_name)
+        if args:
+            invocation = f"{invocation} {args}"
+        return invocation
+
     def setup(
         self,
         project_root: Path,

--- a/tests/integrations/test_base.py
+++ b/tests/integrations/test_base.py
@@ -216,6 +216,24 @@ class TestBuildCommandInvocation:
         i = get_integration("codex")
         assert i.build_command_invocation("speckit.git.commit", "fix typo") == "/speckit-git-commit fix typo"
 
+    def test_forge_core_command_hyphenated(self):
+        """Forge installs hyphenated slash-commands (/speckit-<name>), so the
+        dispatch invocation must be hyphenated too — not the dotted default it
+        would inherit from MarkdownIntegration."""
+        from specify_cli.integrations import get_integration
+        i = get_integration("forge")
+        assert i.build_command_invocation("speckit.plan") == "/speckit-plan"
+        assert i.build_command_invocation("plan") == "/speckit-plan"
+
+    def test_forge_extension_command_hyphenated(self):
+        from specify_cli.integrations import get_integration
+        i = get_integration("forge")
+        assert i.build_command_invocation("speckit.git.commit") == "/speckit-git-commit"
+        assert (
+            i.build_command_invocation("speckit.git.commit", "fix typo")
+            == "/speckit-git-commit fix typo"
+        )
+
 
 class TestResolveCommandRefs:
     """Tests for __SPECKIT_COMMAND_<NAME>__ placeholder resolution."""


### PR DESCRIPTION
## What

Forge installs its slash-commands with **hyphenated** names — `speckit-plan`, `speckit-git-commit` — via `format_forge_command_name` and the injected frontmatter `name` (done for ZSH/shell compatibility, as the module docstring notes).

But `ForgeIntegration` inherits `MarkdownIntegration.build_command_invocation`, which builds the **dotted** form:

```python
invocation = f"/speckit.{stem}"   # -> /speckit.plan
```

So command/workflow dispatch invokes `/speckit.plan` while the registered Forge command is `/speckit-plan` — a name Forge never registered.

## Fix

Override `build_command_invocation` in `ForgeIntegration` to reuse the module's own `format_forge_command_name`, producing `/speckit-<name>` (with `.`→`-` for extension commands like `speckit.git.commit` → `/speckit-git-commit`). This mirrors the skills agents' hyphenated `build_command_invocation` and Forge's own installed naming.

## Test

`test_forge_core_command_hyphenated` / `test_forge_extension_command_hyphenated` assert Forge invocations are hyphenated (incl. args) — fail before (dotted `/speckit.plan`, `/speckit.git.commit`), pass after.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.