### PR TITLE
docs(integrations): document the 'integration list --catalog' flag

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -48,6 +48,10 @@ The Specify CLI supports a wide range of AI coding agents. When you run `specify
 specify integration list
 ```
 
+| Option      | Description                                                                                  |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| `--catalog` | Browse the full catalog (built-in + community) instead of only the built-in/installed set   |
+
 Shows all available integrations, which one is currently installed, and whether each requires a CLI tool or is IDE-based.
 When multiple integrations are installed, the list marks the default integration separately from the other installed integrations.
 The list also shows whether each built-in integration is declared multi-install safe.

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -48,11 +48,11 @@ The Specify CLI supports a wide range of AI coding agents. When you run `specify
 specify integration list
 ```
 
-| Option      | Description                                                                                  |
-| ----------- | ------------------------------------------------------------------------------------------- |
-| `--catalog` | Browse the full catalog (built-in + community) instead of only the built-in/installed set   |
+| Option      | Description                                                                                                             |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--catalog` | Also browse the catalog (built-in **and** community). Community integrations that are not built in are only shown here.  |
 
-Shows all available integrations, which one is currently installed, and whether each requires a CLI tool or is IDE-based.
+Shows the built-in integrations, which one is currently installed, and whether each requires a CLI tool or is IDE-based.
 When multiple integrations are installed, the list marks the default integration separately from the other installed integrations.
 The list also shows whether each built-in integration is declared multi-install safe.
 


### PR DESCRIPTION
## What

`specify integration list` accepts a `--catalog` flag:

```python
@integration_app.command("list")
def integration_list(
    catalog: bool = typer.Option(False, "--catalog", help="Browse full catalog (built-in + community)"),
):
```

…but the **List Available Integrations** section of `docs/reference/integrations.md` documented no options, so the flag was undiscoverable from the docs (unlike `integration search` and `integration catalog add`, which both have option tables).

## Fix

Add a one-row option table documenting `--catalog`, matching the style of the sibling command sections. Docs-only.

## Verification

- Flag confirmed present in `src/specify_cli/integrations/_query_commands.py`.
- `markdownlint-cli2 docs/reference/integrations.md` → 0 errors; `git diff --check` clean.

---
🤖 Written with the assistance of Claude Code (AI). Gap self-found (flag present in code, absent from docs).