### PR TITLE
fix(extensions/git): reject negative -Number in create-new-feature-branch.ps1

### DIFF
--- a/extensions/git/scripts/powershell/create-new-feature-branch.ps1
+++ b/extensions/git/scripts/powershell/create-new-feature-branch.ps1
@@ -41,6 +41,16 @@ if ($Help) {
     exit 0
 }
 
+# -Number is [long], so PowerShell binds "-5" as -5 rather than rejecting it
+# the way the bash/Python twins do (`^[0-9]+$`). A negative value would format
+# via '{0:000}' to e.g. "-005" and produce a branch name starting with "-",
+# which git refuses (refs cannot begin with a dash). Reject it here, before the
+# description check, matching the bash twin's parse-time validation order.
+if ($Number -lt 0) {
+    Write-Error 'Error: --number must be a non-negative integer'
+    exit 1
+}
+
 if (-not $FeatureDescription -or $FeatureDescription.Count -eq 0) {
     Write-Error "Usage: ./create-new-feature-branch.ps1 [-Json] [-DryRun] [-AllowExistingBranch] [-ShortName <name>] [-Number N] [-Timestamp] <feature description>"
     exit 1

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -653,6 +653,19 @@ class TestCreateFeatureBash:
         assert data["BRANCH_NAME"] == "000-zero"
         assert data["FEATURE_NUM"] == "000"
 
+    def test_negative_number_rejected(self, tmp_path: Path):
+        """A negative --number is rejected. Pins the canonical behavior the
+        PowerShell twin must mirror; a negative value would otherwise format to
+        e.g. '-005' and produce a branch name starting with '-', which git
+        refuses (refs cannot begin with a dash)."""
+        project = _setup_project(tmp_path)
+        result = _run_bash(
+            "create-new-feature-branch.sh", project,
+            "--json", "--dry-run", "--number", "-5", "--short-name", "neg", "Negative feature",
+        )
+        assert result.returncode != 0
+        assert "--number must be a non-negative integer" in result.stderr
+
 
 @pytest.mark.skipif(not HAS_PWSH, reason="pwsh not available")
 class TestCreateFeaturePowerShell:
@@ -973,6 +986,21 @@ class TestCreateFeaturePowerShell:
         data = json.loads(json_line[-1])
         assert data["BRANCH_NAME"] == "000-zero"
         assert data["FEATURE_NUM"] == "000"
+
+    def test_negative_number_rejected(self, tmp_path: Path):
+        """A negative -Number is rejected, matching the bash/Python twins'
+        '--number must be a non-negative integer'. Regression guard: -Number is
+        [long], so PowerShell binds '-5' as -5 rather than rejecting it the way
+        the twins' `^[0-9]+$` check does; the value would then format via
+        '{0:000}' to '-005' and yield a branch name starting with '-', which
+        git refuses (refs cannot begin with a dash)."""
+        project = _setup_project(tmp_path)
+        result = _run_pwsh(
+            "create-new-feature-branch.ps1", project,
+            "-Json", "-DryRun", "-Number", "-5", "-ShortName", "neg", "Negative feature",
+        )
+        assert result.returncode != 0
+        assert "--number must be a non-negative integer" in result.stderr
 
 
 # ── auto-commit.sh Tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The `create-new-feature-branch` script has three twins (bash, PowerShell, Python). The bash and Python twins validate `--number` against `^[0-9]+$` and reject a negative value with:

```
Error: --number must be a non-negative integer
```

The **PowerShell** twin declares the parameter as `[long]$Number`, so PowerShell binds `-5` as the integer `-5` instead of rejecting it. That value then formats via `'{0:000}'` to `-005` and produces a branch name starting with a dash — e.g. `-005-my-feature` — which git refuses (refs cannot begin with `-`). The user gets a confusing late `git` failure instead of the twins' clear, early error.

## Fix

- Guard for `$Number -lt 0` up front (before the empty-description check, matching the bash twin's parse-time validation order) and emit the identical error message.
- An explicit `-Number 0` is still honored (`-lt 0`, not `-le 0`), preserving the #3412 fix.

## Tests

Added matching negative-number parity tests to both the bash and PowerShell create-feature suites, mirroring the existing `test_explicit_number_zero_is_honored` pair.

Verified manually on Windows PowerShell 5.1:
- `-Number -5` → exit 1, `Error: --number must be a non-negative integer`
- `-Number 5` → `005-...` (regression: valid numbers still work)
- `-Number 0` → `000-...` (regression: #3412 behavior preserved)

Same PowerShell-parity bug class as #3412 (`-Number 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)