### PR TITLE
fix(integration): preserve ai_skills on `use` for skills-mode Copilot

### DIFF
--- a/src/specify_cli/integrations/_helpers.py
+++ b/src/specify_cli/integrations/_helpers.py
@@ -252,6 +252,7 @@ def _update_init_options_for_integration(
     project_root: Path,
     integration: Any,
     script_type: str | None = None,
+    parsed_options: dict[str, Any] | None = None,
 ) -> None:
     """Update init-options.json to reflect *integration* as the active one.
 
@@ -270,7 +271,17 @@ def _update_init_options_for_integration(
     opts["speckit_version"] = _get_speckit_version()
     if script_type:
         opts["script"] = script_type
-    if isinstance(integration, SkillsIntegration) or getattr(integration, "_skills_mode", False):
+    # Skills mode is either intrinsic (SkillsIntegration), set on the instance
+    # during setup() (_skills_mode), or requested via parsed options (e.g.
+    # Copilot's --skills, persisted as parsed_options["skills"]). The latter is
+    # the only signal available on the `use` path, where no setup() runs and a
+    # fresh integration instance has _skills_mode == False (issue #3550).
+    skills_mode = (
+        isinstance(integration, SkillsIntegration)
+        or getattr(integration, "_skills_mode", False)
+        or bool((parsed_options or {}).get("skills"))
+    )
+    if skills_mode:
         opts["ai_skills"] = True
     else:
         opts.pop("ai_skills", None)
@@ -326,7 +337,9 @@ def _set_default_integration(
             ) from exc
 
     _write_integration_json(project_root, key, installed_keys, settings)
-    _update_init_options_for_integration(project_root, integration, script_type=resolved_script)
+    _update_init_options_for_integration(
+        project_root, integration, script_type=resolved_script, parsed_options=parsed_options
+    )
 
 
 def _set_default_integration_or_exit(*args: Any, **kwargs: Any) -> None:

--- a/tests/integrations/test_integration_subcommand.py
+++ b/tests/integrations/test_integration_subcommand.py
@@ -1566,6 +1566,43 @@ class TestIntegrationUse:
         assert opts["integration"] == "codex"
         assert opts["ai"] == "codex"
 
+    def test_use_preserves_copilot_skills_mode(self, tmp_path):
+        """`use` on a skills-mode Copilot keeps ``ai_skills`` (issue #3550).
+
+        Re-selecting the same skills-mode Copilot must not drop ``ai_skills``
+        from init-options.json nor regenerate extension commands in the legacy
+        ``.agent.md``/``.prompt.md`` layout.
+        """
+        project = _init_project(tmp_path, "copilot", integration_options="--skills")
+
+        opts = json.loads((project / ".specify" / "init-options.json").read_text(encoding="utf-8"))
+        assert opts.get("ai_skills") is True, "precondition: init recorded skills mode"
+
+        result = _run_in_project(project, ["extension", "add", "git"])
+        assert result.exit_code == 0, f"extension add failed: {result.output}"
+
+        # Simulate a fresh process: `use` in real life runs in its own process
+        # where the registry's Copilot instance has _skills_mode == False (it is
+        # only set during setup()). In-process test invocations otherwise reuse
+        # the singleton left in skills mode by init, masking the bug (#3550).
+        from specify_cli.integrations import get_integration
+
+        get_integration("copilot")._skills_mode = False
+
+        result = _run_in_project(project, ["integration", "use", "copilot"])
+        assert result.exit_code == 0, result.output
+
+        opts = json.loads((project / ".specify" / "init-options.json").read_text(encoding="utf-8"))
+        assert opts.get("ai_skills") is True, "ai_skills must survive `use copilot`"
+
+        # No legacy command-layout files should be regenerated for the
+        # skills-mode agent.
+        assert not (project / ".github" / "agents" / "speckit.git.feature.agent.md").exists()
+        assert not (project / ".github" / "prompts" / "speckit.git.feature.prompt.md").exists()
+        assert (
+            project / ".github" / "skills" / "speckit-git-feature" / "SKILL.md"
+        ).exists()
+
     def test_use_requires_installed_integration(self, tmp_path):
         project = _init_project(tmp_path, "claude")
         old_cwd = os.getcwd()


### PR DESCRIPTION
Closes #3550

## Problem

Running `specify integration use copilot` against a Copilot integration installed with `--integration-options "--skills"` silently dropped `"ai_skills": true` from `.specify/init-options.json`, even though `.specify/integration.json` still recorded `parsed_options.skills: true`. The two files then contradicted each other, and any skills-mode extension commands (e.g. `git`) were regenerated in the legacy `.github/agents/*.agent.md` + `.github/prompts/*.prompt.md` layout, coexisting with the existing `.github/skills/speckit-*/SKILL.md` files.

Reproduced exactly against current `main`:

```console
$ specify init proj --integration copilot --integration-options "--skills" --script sh --ignore-agent-tools
$ cd proj && specify extension add git
$ specify integration use copilot
# ai_skills removed from init-options.json; git commands duplicated in agents/ + prompts/
```

## Root cause

`_update_init_options_for_integration` (`src/specify_cli/integrations/_helpers.py`) decided `ai_skills` purely from `isinstance(integration, SkillsIntegration)` or the instance's `_skills_mode` flag. Copilot is not a `SkillsIntegration`; its skills mode lives in `parsed_options["skills"]` and only sets `_skills_mode` during `setup()`. On the `use` path no `setup()` runs, so `get_integration("copilot")` returns an instance with `_skills_mode == False`, and the already-resolved `parsed_options` were never consulted — so `ai_skills` was popped. The downstream refresh then treated Copilot as non-skills and regenerated extension commands in the legacy layout.

## Fix

- `_set_default_integration` now passes its resolved `parsed_options` into `_update_init_options_for_integration`.
- Skills mode is detected from `SkillsIntegration` **or** the instance `_skills_mode` **or** `parsed_options["skills"]` (consistent with how `init` and `command_invocation_separator` already detect it).

## Testing

- Added `test_use_preserves_copilot_skills_mode`, which follows the issue's exact sequence and asserts `ai_skills` survives and no legacy-layout files are produced. It resets the registry singleton's `_skills_mode` to faithfully simulate a fresh process — in-process test invocations otherwise reuse the singleton left in skills mode by `init`, which masks the bug. Verified the test fails without the fix and passes with it.
- `tests/integrations/test_integration_subcommand.py`, `test_integration_copilot.py`, and `test_integration_base_skills.py` all pass (162 tests).

---

This PR was authored by GitHub Copilot (model: Claude Opus 4.8) on behalf of @mnriem.
