### PR TITLE
fix(presets): raise PresetValidationError, not raw ValueError, on malformed catalog URL

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -2074,8 +2074,12 @@ class PresetCatalog:
         """
         from urllib.parse import urlparse
 
-        parsed = urlparse(url)
-        is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
+        try:
+            parsed = urlparse(url)
+            hostname = parsed.hostname
+        except ValueError:
+            raise PresetValidationError(f"Catalog URL is malformed: {url}") from None
+        is_localhost = hostname in ("localhost", "127.0.0.1", "::1")
         if parsed.scheme != "https" and not (
             parsed.scheme == "http" and is_localhost
         ):
@@ -2086,7 +2090,7 @@ class PresetCatalog:
         # Check hostname, not netloc: netloc is truthy for host-less URLs like
         # "https://:8080" or "https://user@", so the host guarantee this error
         # promises would not actually hold. hostname is None in those cases (#3209).
-        if not parsed.hostname:
+        if not hostname:
             raise PresetValidationError(
                 "Catalog URL must be a valid URL with a host."
             )

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1634,6 +1634,18 @@ class TestPresetCatalog:
         with pytest.raises(PresetValidationError, match="valid URL with a host"):
             catalog._validate_catalog_url(url)
 
+    def test_validate_catalog_url_malformed_rejected(self, project_dir):
+        """A malformed URL raises PresetValidationError, not a raw ValueError.
+
+        ``urlparse('https://[::1').hostname`` raises ``ValueError: Invalid IPv6
+        URL`` (unterminated bracket). Without wrapping, that leaks past callers'
+        ``except PresetValidationError`` guards and crashes the CLI. Mirrors the
+        shared ``CatalogStackBase`` (#3435) and ``IntegrationCatalog`` behaviour.
+        """
+        catalog = PresetCatalog(project_dir)
+        with pytest.raises(PresetValidationError, match="malformed"):
+            catalog._validate_catalog_url("https://[::1")
+
     def test_env_var_catalog_url(self, project_dir, monkeypatch):
         """Test catalog URL from environment variable."""
         monkeypatch.setenv("SPECKIT_PRESET_CATALOG_URL", "https://custom.example.com/catalog.json")


### PR DESCRIPTION
## Description

`PresetCatalog._validate_catalog_url` leaks a raw `ValueError` on a malformed catalog URL, violating its documented `PresetValidationError` contract and crashing the CLI with a traceback.

`urlparse("https://[::1").hostname` raises `ValueError: Invalid IPv6 URL` (unterminated bracket). The preset validator accesses `.hostname` without guarding it, so the exception escapes. Callers only catch `PresetValidationError`:

- `specify preset catalog add <URL>` validates the user's `url` argument inside `except PresetValidationError`.
- `specify preset catalog list` validates URLs from `SPECKIT_PRESET_CATALOG_URL` and `.specify/preset-catalogs.yml`, again catching only `PresetValidationError`.

So a malformed URL from any of these sources crashes with a traceback instead of a clean error message.

This is the last un-updated copy of a pattern the project has already hardened elsewhere: the shared `CatalogStackBase` (#3435), `workflows` (#3484), `bundler` (#3433), and `IntegrationCatalog` all wrap this in `try/except ValueError` and re-raise their domain error. This PR mirrors the shared `CatalogStackBase` implementation exactly — wrap `urlparse` + `.hostname`, re-raise as `PresetValidationError("Catalog URL is malformed: ...")`, and read the local `hostname` in the host check.

Before:
```
$ python -c "from specify_cli.presets import PresetCatalog; from pathlib import Path; PresetCatalog(Path('.'))._validate_catalog_url('https://[::1')"
ValueError: Invalid IPv6 URL      # leaks past callers' except PresetValidationError
```
After: raises `PresetValidationError: Catalog URL is malformed: https://[::1`.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (not applicable — pure validation logic)

Added `test_validate_catalog_url_malformed_rejected` to `tests/test_presets.py`, mirroring `IntegrationCatalog`'s existing `test_malformed_url_rejected_cleanly`. It is **red on `main`** (raw `ValueError`) and **green** with the fix. `tests/test_presets.py` passes (365), preset-scoped suite passes (376), and `uvx ruff check src/` is clean. The valid / host-less / non-HTTPS control cases are unchanged.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

**Correcting this disclosure** — the original wording credited the human operator with work an AI actually did, which understates the extent and would lead you to apply less scrutiny than you should. The accurate version:

This contribution is **fully AI-authored and autonomous** (Claude Code, acting on this account). An AI found the leak, reproduced it against `main`, wrote the failing regression test first, mirrored the shared `CatalogStackBase` fix, ran the preset test suites and `ruff check`, reviewed the diff, and wrote this description. **The human operator of this account did not hand-review the diff or personally run the tests.**

What that means for your review, stated plainly against your "what we're looking for" list:
- **Disclosure** — this, in full.
- **Testing** — real and verifiable, but done by the AI, not a human: bare repro against `main` before any fix, regression test red→green (mirroring `IntegrationCatalog`'s `test_malformed_url_rejected_cleanly`), `test_presets.py` 365 passed, preset-scoped 376 passed, `uvx ruff check src/` clean. You can re-run all of it from the diff.
- **Rationale** — the four sibling call sites (#3435 / #3484 / #3433 / IntegrationCatalog) were already hardened for exactly this; presets is the one that was missed. That's the whole argument, and it's checkable against the repo rather than something you have to take on faith.
- **Human understanding** — this is where I can't tick your box honestly. Please review it as unsupervised AI output. If that's not a contribution you want regardless of the testing, say so and I'll close it, no hard feelings.

