### PR TITLE
docs: remove stale PyPI warning from extension guide

### DIFF
--- a/extensions/EXTENSION-DEVELOPMENT-GUIDE.md
+++ b/extensions/EXTENSION-DEVELOPMENT-GUIDE.md
@@ -687,7 +687,7 @@ hooks:
 
 **Error**: `Extension requires spec-kit >=0.2.0`
 
-- **Fix**: Update spec-kit with `uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git`. The bare `specify-cli` package on PyPI is a different, unrelated project — installing it without `--from git+...` will give you a stub CLI that does not include `extension`, `preset`, or other spec-kit commands.
+- **Fix**: Upgrade Spec Kit using the [Upgrade Guide](../docs/upgrade.md). `uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git` remains available as a source-install fallback. If you installed from PyPI and want to stay on that route, follow the [PyPI upgrade guidance](../docs/install/pypi.md#upgrade).
 
 **Error**: `Command file not found`
 


### PR DESCRIPTION
## Summary
- update the extension development troubleshooting guidance for version mismatches
- remove the stale claim that PyPI `specify-cli` is unrelated
- point source-install and PyPI-install users to the existing upgrade docs

Closes #3575

## Validation
- `git diff --check -- extensions/EXTENSION-DEVELOPMENT-GUIDE.md`
- searched for stale PyPI warning phrases in the target file and relevant docs
- verified the linked upgrade docs and PyPI `#upgrade` anchor exist
