### PR TITLE
fix(workflows): fail fan-in loudly on a non-string wait_for entry

### DIFF
--- a/src/specify_cli/workflows/steps/fan_in/__init__.py
+++ b/src/specify_cli/workflows/steps/fan_in/__init__.py
@@ -42,6 +42,28 @@ class FanInStep(StepBase):
                 output={"results": []},
             )
 
+        # A non-string entry can never match a real step id. An unhashable one
+        # (a list/dict from a YAML indentation slip like ``wait_for: [[a, b]]``)
+        # crashes the whole run at ``context.steps.get(step_id, ...)`` below with
+        # a raw TypeError; a hashable-but-non-string one (``wait_for: [123]``)
+        # silently joins an empty ``{}`` and still reports COMPLETED — the exact
+        # "silent empty result + COMPLETED" wiring bug the whole-list guard above
+        # and the engine's fan-in validation (engine.py) both reject. The engine
+        # does not auto-validate step config, so fail this step loudly on an
+        # unvalidated run too, using the engine's phrasing.
+        bad_entries = [w for w in wait_for if not isinstance(w, str)]
+        if bad_entries:
+            first = bad_entries[0]
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"Fan-in step {config.get('id', '?')!r}: 'wait_for' entries "
+                    f"must be step-id strings, got {type(first).__name__} "
+                    f"({first!r})."
+                ),
+                output={"results": []},
+            )
+
         # Collect results from referenced steps
         results = []
         for step_id in wait_for:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2784,6 +2784,34 @@ class TestFanInStep:
         assert "'wait_for' must be a list" in (result.error or "")
         assert result.output["results"] == []
 
+    @pytest.mark.parametrize("bad_entry", [["a", "b"], {"a": 1}, 123, None])
+    def test_execute_non_string_wait_for_entry_fails_loudly(self, bad_entry):
+        """A ``wait_for`` list with a non-string entry must fail the step, not
+        crash the run or silently produce a bogus join.
+
+        The whole-list guard (``test_execute_non_list_wait_for_fails_loudly``)
+        and the engine's fan-in validation both already reject the list *shape*,
+        but neither the step's ``execute`` nor the engine's runtime path guarded
+        the list's *elements*. On an unvalidated run an unhashable entry
+        (a list/dict from a YAML indentation slip like ``wait_for: [[a, b]]``)
+        crashed ``context.steps.get(entry, ...)`` with a raw TypeError, while a
+        hashable-but-non-string entry (``wait_for: [123]``) silently joined an
+        empty ``{}`` and still reported COMPLETED — the same wiring bug the
+        list-shape guard exists to prevent. Mirrors the engine's
+        ``test_non_string_wait_for_entry_is_rejected`` load-time check.
+        """
+        from specify_cli.workflows.steps.fan_in import FanInStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = FanInStep()
+        ctx = StepContext(steps={"a": {"output": {"x": 1}}})
+        # A valid entry alongside the bad one proves it is the entry, not the
+        # list, that is rejected.
+        result = step.execute({"id": "collect", "wait_for": ["a", bad_entry]}, ctx)
+        assert result.status == StepStatus.FAILED
+        assert "'wait_for' entries must be step-id strings" in (result.error or "")
+        assert result.output["results"] == []
+
     def test_validate_empty_wait_for(self):
         from specify_cli.workflows.steps.fan_in import FanInStep
 


### PR DESCRIPTION
## Summary

`FanInStep.execute` guards a non-list `wait_for` (added in #3482), and the engine's load-time validation (`engine.py`) rejects non-string `wait_for` entries. But the engine does **not** auto-validate step config before running it — the same "unvalidated run" scenario the existing non-list guard is written for — so `execute` iterated the list's *elements* raw and hit two failure modes:

- **Unhashable entry** — a list/dict from a natural YAML indentation slip like `wait_for: [[a, b]]` crashed the whole run at `context.steps.get(entry, ...)` with a raw `TypeError: cannot use 'list' as a dict key (unhashable type: 'list')`.
- **Hashable non-string entry** — `wait_for: [123]` silently joined an empty `{}` and still reported `COMPLETED` — the exact "silent empty result + COMPLETED" wiring bug that the whole-list guard and the engine's fan-in validation both exist to prevent.

This extends the `execute()` guard to reject any non-string `wait_for` entry, mirroring the sibling non-list guard directly above it and reusing the engine's own "entries must be step-id strings" phrasing for a consistent error.

## Reproduction (against current `main`)

```python
from specify_cli.workflows.steps.fan_in import FanInStep
from specify_cli.workflows.base import StepContext

step = FanInStep()
ctx = StepContext(steps={"a": {"output": {"x": 1}}})

# 1) unhashable entry -> raw TypeError takes down the run
step.execute({"id": "j", "wait_for": [["a", "b"]]}, ctx)
# TypeError: cannot use 'list' as a dict key (unhashable type: 'list')

# 2) non-string entry -> silent empty join, reported COMPLETED
r = step.execute({"id": "j", "wait_for": ["a", 123]}, ctx)
# r.status == COMPLETED, r.output["results"] == [{'x': 1}, {}]   <-- bogus {}
```

## Changes

- `src/specify_cli/workflows/steps/fan_in/__init__.py` — reject any non-string `wait_for` entry in `execute()`, failing the step cleanly with `output={"results": []}`.
- `tests/test_workflows.py` — parametrized regression test (`test_execute_non_string_wait_for_entry_fails_loudly`) covering unhashable (`list`/`dict`) and hashable-non-string (`int`/`None`) entries.

## Testing

- New test fails on the pre-fix source (raw `TypeError` for unhashable, wrong `COMPLETED` for non-string) and passes with the guard ("test-the-test" verified via `git stash`).
- All fan-in tests pass (23 selected).
- Pre-existing unrelated failures: `TestWorkflowCliAlignment` symlink/cross-project tests fail on Windows without Developer Mode/elevation — verified identical on a clean `upstream/main` tree with these changes stashed.

## Related

Same "unvalidated `execute()` crash" class as the sibling fan-in non-list guard (#3482), fan-out non-list `items`/step-template guards, the if/switch non-list branch guards (#3515), and the while/do-while non-list steps guards (#3519).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
