### PR TITLE
docs: align README hero tagline with docs/index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <div align="center">
     <img src="./media/logo_large.webp" alt="Spec Kit Logo" width="200" height="200"/>
     <h1>🌱 Spec Kit</h1>
-    <h3><em>Build high-quality software faster.</em></h3>
+    <h3><em>Define what to build before building it — with any AI coding agent.</em></h3>
 </div>
 
 <p align="center">
-    <strong>An open source toolkit that allows you to focus on product scenarios and predictable outcomes instead of vibe coding every piece from scratch.</strong>
+    <strong>An open source toolkit for building high-quality software with any AI coding agent — a ready-to-use spec-driven process (or bring your own), endlessly extensible, community-driven, and built for your whole organization.</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Aligns the README hero section with the docs landing page (`docs/index.md`) so the project's positioning is consistent across both surfaces.

- **Hero tagline** now matches the docs landing hero: _"Define what to build before building it — with any AI coding agent."_
- **Subtitle** rewritten to reflect the docs' four-pillar positioning — a ready-to-use spec-driven process (or bring your own), endlessly extensible, community-driven, and built for your whole organization — rather than framing everything around SDD.

## Rationale

The previous README tagline ("Build high-quality software faster.") and subtitle diverged from how `docs/index.md` positions the project. The docs present SDD as the ready-to-use *default* process that can be tuned or replaced entirely, alongside agent-agnosticism, extensibility, and org-readiness. This change brings the README in line with that framing.

---
Opened on behalf of @mnriem by GitHub Copilot (model: Claude Opus 4.8).