### PR TITLE
fix(workflows): reject a non-string prompt in prompt-step validate()

### DIFF
--- a/src/specify_cli/workflows/steps/prompt/__init__.py
+++ b/src/specify_cli/workflows/steps/prompt/__init__.py
@@ -160,4 +160,16 @@ class PromptStep(StepBase):
             errors.append(
                 f"Prompt step {config.get('id', '?')!r} is missing 'prompt' field."
             )
+        elif not isinstance(config["prompt"], str):
+            # execute() str()-coerces prompt and dispatches it to the
+            # integration CLI, so a null or list 'prompt' would send the Python
+            # repr ('None', "['review', 'this']") to the model as instructions —
+            # silently wrong, with no error. Reject non-strings at validation,
+            # mirroring the shell-step 'run' and command-step input/options type
+            # checks. An expression like "{{ ... }}" is still a str, so it stays
+            # valid.
+            errors.append(
+                f"Prompt step {config.get('id', '?')!r}: 'prompt' must be a "
+                f"string, got {type(config['prompt']).__name__}."
+            )
         return errors

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1336,11 +1336,36 @@ class TestPromptStep:
         errors = step.validate({"id": "test"})
         assert any("missing 'prompt'" in e for e in errors)
 
+    @pytest.mark.parametrize("bad_prompt", [None, ["review", "this"], 42, {"a": 1}])
+    def test_validate_rejects_non_string_prompt(self, bad_prompt):
+        """A non-string 'prompt' must be rejected at validation.
+
+        execute() str()-coerces prompt and dispatches it to the integration
+        CLI, so a null or list prompt would otherwise send the Python repr to
+        the model as instructions — silently wrong. Mirrors the shell-step
+        'run' type check.
+        """
+        from specify_cli.workflows.steps.prompt import PromptStep
+
+        step = PromptStep()
+        errors = step.validate({"id": "p", "prompt": bad_prompt})
+        assert any("'prompt' must be a string" in e for e in errors)
+
     def test_validate_valid(self):
         from specify_cli.workflows.steps.prompt import PromptStep
 
         step = PromptStep()
         errors = step.validate({"id": "test", "prompt": "do something"})
+        assert errors == []
+
+    def test_validate_accepts_expression_prompt(self):
+        """A '{{ ... }}' expression prompt is a str, so it stays valid."""
+        from specify_cli.workflows.steps.prompt import PromptStep
+
+        step = PromptStep()
+        errors = step.validate(
+            {"id": "p", "prompt": "Review {{ inputs.file }}"}
+        )
         assert errors == []
 
 


### PR DESCRIPTION
## Summary

`PromptStep.execute` str()-coerces `config['prompt']` and dispatches the result to the integration CLI as the model's instructions:

```python
prompt = evaluate_expression(prompt_template, context)
if not isinstance(prompt, str):
    prompt = str(prompt)   # <-- a list/None/int becomes its Python repr
```

But `PromptStep.validate` only checked that `prompt` was **present**, not that it was a **string** — the exact parity gap the sibling `ShellStep` already closes for its `run` field (which cites "the command-step input/options and gate options type checks" as precedent).

So a YAML authoring slip like `prompt: [review, this]` or a bare `prompt:` (YAML null) passed validation, then `execute` sent the Python repr (`"['review', 'this']"`, `"None"`) to the LLM verbatim — silently wrong instructions, no error, and a `COMPLETED` status. The engine does not auto-validate step config (`load_workflow` explicitly defers validation to `validate_workflow()`/`engine.validate()`), so validation is the only place this surfaces before dispatch.

## Fix

Extend `validate` to reject any non-string `prompt`, mirroring the shell-step `run` and command-step `input`/`options` type checks:

```python
elif not isinstance(config["prompt"], str):
    errors.append(
        f"Prompt step {config.get('id', '?')!r}: 'prompt' must be a "
        f"string, got {type(config['prompt']).__name__}."
    )
```

A `{{ ... }}` expression is still a `str`, so it stays valid.

## Testing

- Adds `test_validate_rejects_non_string_prompt` (parametrized over null/list/int/dict), mirroring `TestShellStep::test_validate_rejects_non_string_run`.
- Adds `test_validate_accepts_expression_prompt` to confirm an expression prompt still validates.
- Full `TestPromptStep` + validation suite passes (85 selected, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
