### PR TITLE
fix(bundle): surface a clean BundlerError on a malformed bundle download URL

### DIFF
--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -765,7 +765,16 @@ def _download_manifest(resolved, *, offline: bool):
             f"Catalog entry '{resolved.entry.id}' has no download_url; cannot resolve "
             "its manifest."
         )
-    parsed = urlparse(url)
+    # A malformed authority (e.g. an unclosed IPv6 bracket ``https://[::1``)
+    # makes urlparse raise ValueError. Surface it as the documented
+    # BundlerError, like the sibling ``_validate_remote_url``, rather than
+    # leaking a raw ValueError past the callers, which only catch BundlerError.
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        raise BundlerError(
+            f"Catalog entry '{resolved.entry.id}' has a malformed download_url: {url}"
+        ) from None
     scheme = parsed.scheme.lower()
 
     # ``file://`` URLs and bare filesystem paths (including Windows drive paths
@@ -802,8 +811,17 @@ def _download_manifest(resolved, *, offline: bool):
 def _require_https(label: str, url: str) -> None:
     from urllib.parse import urlparse
 
-    parsed = urlparse(url)
-    is_localhost = parsed.hostname in ("localhost", "127.0.0.1", "::1")
+    # urlparse / hostname access raise ValueError on a malformed authority;
+    # keep the documented BundlerError contract (older Pythons surface this via
+    # the .hostname access below rather than at the urlparse call).
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+    except ValueError:
+        raise BundlerError(
+            f"Refusing to download {label}: URL is malformed: {url}"
+        ) from None
+    is_localhost = hostname in ("localhost", "127.0.0.1", "::1")
     if parsed.scheme != "https" and not (parsed.scheme == "http" and is_localhost):
         raise BundlerError(
             f"Refusing to download {label} over non-HTTPS URL: {url}"

--- a/tests/unit/test_bundle_download_url.py
+++ b/tests/unit/test_bundle_download_url.py
@@ -1,0 +1,42 @@
+"""Unit tests for malformed download-URL handling in bundle manifest resolution."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from specify_cli.bundler import BundlerError
+from specify_cli.commands.bundle import _download_manifest, _require_https
+
+_MALFORMED_URLS = [
+    "https://[::1",  # unclosed IPv6 bracket
+    "https://[not-an-ip]/bundle.yml",
+]
+
+
+@pytest.mark.parametrize("url", _MALFORMED_URLS)
+def test_download_manifest_rejects_malformed_url_cleanly(url):
+    """A malformed download_url must raise BundlerError, not a raw ValueError.
+
+    ``urlparse`` raises ``ValueError`` on a malformed authority (e.g. an
+    unclosed IPv6 bracket). The bundle CLI commands only catch BundlerError, so
+    a raw ValueError would escape as an uncaught traceback. Sibling of the
+    guarded ``_validate_remote_url`` (adapters) and the merged #3576 fix.
+    """
+    resolved = SimpleNamespace(
+        entry=SimpleNamespace(id="mybundle", download_url=url)
+    )
+    with pytest.raises(BundlerError):
+        _download_manifest(resolved, offline=True)
+
+
+@pytest.mark.parametrize("url", _MALFORMED_URLS)
+def test_require_https_rejects_malformed_url_cleanly(url):
+    """``_require_https`` must also surface BundlerError on a malformed authority.
+
+    On older Python versions the ValueError is raised at ``.hostname`` access
+    rather than at ``urlparse``, so guarding both keeps the contract across the
+    CI Python matrix.
+    """
+    with pytest.raises(BundlerError):
+        _require_https("bundle 'x'", url)


### PR DESCRIPTION
## Description

`_download_manifest` (and its `_require_https` helper) in
`src/specify_cli/commands/bundle/__init__.py` parsed the catalog entry's
`download_url` with an **unguarded** `urlparse(url)`. A malformed authority —
e.g. an unclosed IPv6 bracket like `https://[::1` — makes `urlparse` (or
`.hostname` on older Python versions) raise a raw `ValueError`.

The three `bundle` CLI commands (`info`, `install`, `update`) wrap
`_download_manifest` in `except BundlerError` only, so that `ValueError`
escaped as an **uncaught traceback** instead of the clean error the rest of the
bundle subsystem produces.

This wraps both parse sites in the same `try/except ValueError -> BundlerError`
guard already used by the sibling `_validate_remote_url`
(`bundler/services/adapters.py`), whose comment names this exact `https://[::1`
case, and established by the merged catalog-URL fix #3576. `_require_https` is
guarded too because on older Pythons the `ValueError` surfaces at `.hostname`
rather than at `urlparse`, so both are needed to keep the contract across the
CI Python matrix.

Repro on `main` (no network reached — `offline=True`):
```python
from types import SimpleNamespace
from specify_cli.commands.bundle import _download_manifest
resolved = SimpleNamespace(entry=SimpleNamespace(id="b", download_url="https://[::1"))
_download_manifest(resolved, offline=True)   # main: ValueError: Invalid IPv6 URL
                                             # fixed: BundlerError: ... malformed download_url
```

## Testing

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

I ran the affected-area tests rather than the full (slow, integration-heavy)
suite:
- New unit test `tests/unit/test_bundle_download_url.py` (4 cases) covering both
  `_download_manifest` and `_require_https` against `https://[::1` and
  `https://[not-an-ip]/…`. It fails on `main` (raw `ValueError`) and passes with
  this change (I verified red→green by stashing the fix).
- `tests/contract/test_bundle_cli.py` + `tests/unit/test_bundler_adapters.py`
  (the direct CLI callers and the guarded sibling) — **45 passed**, no
  regression. The guard is a no-op for well-formed URLs (`urlparse` doesn't
  raise), so existing valid-URL paths are unchanged.
- `ruff check src/` clean.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

This contribution is fully AI-authored and autonomous (Claude Code, acting on
this account). An AI found the bug, wrote and ran the repro, wrote the fix and
the tests, and wrote this description; the human operator of this account did
not hand-review the diff or run the tests. The verification above is real and
re-runnable from the diff — it was just done by the AI, not a person. The fix
mirrors an existing guarded sibling rather than inventing a new pattern. If
autonomous AI contributions aren't something you want to accept, say so and
I'll close this.
