### PR TITLE
fix(integrations): catch OverflowError on a 'priority: .inf' in add/remove

### DIFF
--- a/src/specify_cli/integrations/catalog.py
+++ b/src/specify_cli/integrations/catalog.py
@@ -429,7 +429,8 @@ class IntegrationCatalog(CatalogStackBase):
                     )
                 try:
                     normalized_priority = int(raw_priority)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, OverflowError):
+                    # OverflowError: int(float("inf")) — a ``priority: .inf``.
                     raise IntegrationValidationError(
                         f"Invalid catalog entry at index {idx} in {config_path}: "
                         f"'priority' must be an integer, got "
@@ -537,7 +538,8 @@ class IntegrationCatalog(CatalogStackBase):
             else:
                 try:
                     priority = int(raw_priority)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, OverflowError):
+                    # OverflowError: int(float("inf")) — a ``priority: .inf``.
                     priority = yaml_idx + 1
             priority_pairs.append((priority, yaml_idx))
         if not priority_pairs:

--- a/tests/integrations/test_integration_catalog.py
+++ b/tests/integrations/test_integration_catalog.py
@@ -922,6 +922,57 @@ class TestCatalogSourceManagement:
         assert str(cfg_path) in message
         assert "expected a mapping" in message
 
+    def test_add_catalog_rejects_inf_priority_in_existing_entry(
+        self, tmp_path, monkeypatch
+    ):
+        # ``priority: .inf`` loads as float('inf'); int() on it raises
+        # OverflowError, which used to escape the IntegrationValidationError
+        # contract as a raw traceback (github/spec-kit#3526 fixed the sibling
+        # workflow/step loaders the same way).
+        self._isolate(tmp_path, monkeypatch)
+        cfg_path = tmp_path / ".specify" / "integration-catalogs.yml"
+        cfg_path.write_text(
+            yaml.dump(
+                {
+                    "catalogs": [
+                        {
+                            "url": "https://a.example.com/catalog.json",
+                            "priority": float("inf"),
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        cat = IntegrationCatalog(tmp_path)
+        with pytest.raises(
+            IntegrationValidationError, match="must be an integer"
+        ):
+            cat.add_catalog("https://new.example.com/catalog.json")
+
+    def test_remove_catalog_tolerates_inf_priority(self, tmp_path, monkeypatch):
+        # Building the remove display order must not crash on a ``priority:
+        # .inf`` entry; it falls back to positional order like the other
+        # non-integer priorities do.
+        self._isolate(tmp_path, monkeypatch)
+        cfg_path = tmp_path / ".specify" / "integration-catalogs.yml"
+        cfg_path.write_text(
+            yaml.dump(
+                {
+                    "catalogs": [
+                        {
+                            "url": "https://a.example.com/catalog.json",
+                            "priority": float("inf"),
+                        },
+                        {"url": "https://b.example.com/catalog.json", "priority": 2},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        cat = IntegrationCatalog(tmp_path)
+        cat.remove_catalog(0)  # must not raise OverflowError
+
     def test_add_catalog_skips_blank_url_entries(self, tmp_path, monkeypatch):
         self._isolate(tmp_path, monkeypatch)
         cfg_path = tmp_path / ".specify" / "integration-catalogs.yml"


### PR DESCRIPTION
## Description

`IntegrationCatalog.add_catalog` and `remove_catalog` re-validate the existing catalog entries' priorities inline (separately from the inherited base loader). Both did `int(raw_priority)` under `except (TypeError, ValueError)`, so a `priority: .inf` (which YAML loads as `float('inf')`) raised `OverflowError`, which neither handler catches:

```python
>>> from specify_cli.integrations.catalog import IntegrationCatalog
>>> # .specify/integration-catalogs.yml contains an entry with `priority: .inf`
>>> IntegrationCatalog(project_root).add_catalog("https://new.example.com/catalog.json")
OverflowError: cannot convert float infinity to integer   # not IntegrationValidationError
```

`add_catalog` leaked a raw traceback instead of the documented `IntegrationValidationError`, and `remove_catalog` crashed while building the display order.

This adds `OverflowError` to both handlers:
- `add_catalog` now raises `IntegrationValidationError` (fail-fast on a corrupt sibling entry, as the surrounding comment intends).
- `remove_catalog` falls back to positional order, like the other non-integer priorities there.

**Relationship to the earlier fixes:** #3525 fixed the base `CatalogStackBase._load_catalog_config` (which extensions/integrations inherit for the *load* path) and the preset loader; #3526 fixed the workflow/step loaders including their own `add_catalog`. The `IntegrationCatalog.add_catalog`/`remove_catalog` methods have their **own** inline priority parsing that neither of those touched, so this is the remaining sibling. `catch (TypeError, ValueError, OverflowError)` here mirrors both.

## Testing

- [x] `uv run pytest tests/integrations/test_integration_catalog.py` — **108 passed** (added `test_add_catalog_rejects_inf_priority_in_existing_entry` and `test_remove_catalog_tolerates_inf_priority`; both fail on `main` with `OverflowError` and pass with this change).
- [x] `uvx ruff check src/` clean.
- [ ] Full `uv run pytest` (ran the integration-catalog module; the full suite is a slow integration run).

## AI Disclosure

- [ ] I did **not** use AI assistance for this contribution.
- [x] I **did** use AI assistance for this contribution.

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI noticed that #3525/#3526 left the `IntegrationCatalog` add/remove priority parsing unpatched, reproduced the `OverflowError`, wrote the fix and the two regression tests, and wrote this description. The account holder reviews every change and is accountable for it. The fail-before/pass-after tests are real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
