### PR TITLE
fix(agents): parse frontmatter on the --- delimiter line, not any --- substring

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -114,13 +114,24 @@ class CommandRegistrar:
         if not content.startswith("---"):
             return {}, content
 
-        # Find second ---
-        end_marker = content.find("---", 3)
-        if end_marker == -1:
+        # The closing delimiter is a line that is exactly ``---`` (a YAML
+        # document separator), not any ``---`` substring. Scanning with
+        # ``content.find("---", 3)`` stops at the first ``---`` *anywhere* —
+        # including one embedded in a frontmatter value (e.g. a description like
+        # "Separate sections with ---") or inside an indented literal block —
+        # which truncates the frontmatter and spills the remainder into the
+        # body. Match on line boundaries instead, mirroring the line-anchored
+        # scan in ``VibeIntegration._inject_frontmatter_flag``.
+        lines = content.splitlines(keepends=True)
+        end_line = next(
+            (i for i in range(1, len(lines)) if lines[i].rstrip() == "---"),
+            None,
+        )
+        if end_line is None:
             return {}, content
 
-        frontmatter_str = content[3:end_marker].strip()
-        body = content[end_marker + 3 :].strip()
+        frontmatter_str = "".join(lines[1:end_line]).strip()
+        body = "".join(lines[end_line + 1 :]).strip()
 
         try:
             frontmatter = yaml.safe_load(frontmatter_str) or {}

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1638,6 +1638,21 @@ $ARGUMENTS
         assert frontmatter == {}
         assert "Command body" in body
 
+    def test_parse_frontmatter_dash_in_value(self):
+        """A ``---`` inside a frontmatter value must not close the block early."""
+        content = """---
+description: Separate sections with --- markers
+argument-hint: "[name]"
+---
+Real body starts here.
+"""
+        registrar = CommandRegistrar()
+        frontmatter, body = registrar.parse_frontmatter(content)
+
+        assert frontmatter["description"] == "Separate sections with --- markers"
+        assert frontmatter["argument-hint"] == "[name]"
+        assert body == "Real body starts here."
+
     def test_render_frontmatter(self):
         """Test rendering frontmatter to YAML."""
         frontmatter = {


### PR DESCRIPTION
## Description

`CommandRegistrar.parse_frontmatter` finds the closing frontmatter delimiter with `content.find("---", 3)` — a raw substring search (`src/specify_cli/agents.py`). It stops at the first `---` *anywhere* after the opening, including one embedded in a frontmatter value or inside an indented YAML literal block, rather than a `---` that occupies its own line (the actual YAML document-separator).

Any command source file whose frontmatter contains `---` in a value gets a corrupted description **and** a corrupted body written into the generated agent files, silently:

```python
from specify_cli.agents import CommandRegistrar

content = """---
description: Separate sections with --- markers
argument-hint: "[name]"
---
Real body starts here.
"""
CommandRegistrar.parse_frontmatter(content)
```

- **Before:** frontmatter `{'description': 'Separate sections with'}` — description truncated, `argument-hint` silently dropped, and the rest (`markers\nargument-hint: ...\n---\n...`) spills into the body.
- **After:** `{'description': 'Separate sections with --- markers', 'argument-hint': '[name]'}` and body `Real body starts here.`

The sibling frontmatter handler in this codebase, `VibeIntegration._inject_frontmatter_flag` (`src/specify_cli/integrations/vibe/__init__.py`), already scans for a line-anchored `---`; `parse_frontmatter` was the only frontmatter reader using a substring `find`. This change makes them consistent. `parse_frontmatter` is called before rendering every command into each agent's directory (`register_commands`, extensions, and preset/core commands), so the fix covers all of those paths.

## Testing

- [x] `uv sync && uv run pytest` — `tests/test_extensions.py` + `tests/test_presets.py` → **724 passed**; no regression.
- [x] Added `test_parse_frontmatter_dash_in_value` (in `TestParseFrontmatter`), which fails on `main` (`assert 'Separate sections with' == '...--- markers'`) and passes with the fix.
- [x] `ruff check src/specify_cli/agents.py` → clean.
- Also verified the standard, no-frontmatter, unterminated-frontmatter, and indented-literal-block cases still behave correctly.

## AI Disclosure

- [ ] **No AI tools were used** in preparing this PR.
- [x] **AI tools were used** — this change was authored by an AI coding agent (Claude Code / Claude Opus 4.8) running on this account: it found the bug, wrote the repro, wrote the test, and drafted this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
