### PR TITLE
fix(workflows): fail gate step loudly on a malformed 'options'

### DIFF
--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -43,6 +43,35 @@ class GateStep(StepBase):
         options = config.get("options", ["approve", "reject"])
         on_reject = config.get("on_reject", "abort")
 
+        # ``validate`` rejects a non-list (or empty) ``options``, and requires
+        # every option to be a string, but the engine does not auto-validate
+        # before ``execute``. An unvalidated run with a scalar/dict/None
+        # ``options`` would otherwise reach ``_prompt`` and crash the whole run
+        # with a raw ``TypeError`` (``enumerate``/``len`` on a non-iterable) or
+        # ``KeyError`` (indexing a dict); a non-string option would crash at the
+        # ``choice.lower()`` reject check with ``AttributeError``. Fail this step
+        # loudly instead — mirroring the switch 'cases' and command 'input'
+        # guards. Checked before the non-TTY short-circuit so the error surfaces
+        # in CI too, rather than PAUSING and crashing later on interactive resume.
+        if (
+            not isinstance(options, list)
+            or not options
+            or not all(isinstance(o, str) for o in options)
+        ):
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"Gate step {config.get('id', '?')!r}: 'options' must be a "
+                    f"non-empty list of strings, got {type(options).__name__}."
+                ),
+                output={
+                    "message": message,
+                    "options": options,
+                    "on_reject": on_reject,
+                    "choice": None,
+                },
+            )
+
         show_file = config.get("show_file")
         if isinstance(show_file, str) and "{{" in show_file:
             show_file = evaluate_expression(show_file, context)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2093,6 +2093,72 @@ class TestGateStep:
         assert result.status == StepStatus.PAUSED
         assert result.output["show_file"] == "123"
 
+    @pytest.mark.parametrize(
+        "bad_options",
+        [5, {"a": "approve"}, None, [], "approve"],
+    )
+    def test_execute_non_list_options_fails_cleanly(self, monkeypatch, bad_options):
+        """A malformed ``options`` must FAIL the step, not crash the run.
+
+        ``validate`` rejects a non-list/empty ``options``, but the engine does
+        not auto-validate before ``execute``. On an interactive run a scalar/
+        dict/None ``options`` would otherwise reach ``_prompt`` and raise a raw
+        ``TypeError`` (``enumerate``/``len`` on a non-iterable) or ``KeyError``
+        (indexing a dict), crashing the whole workflow. Mirrors the switch
+        'cases' and command 'input' unvalidated-execute guards."""
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        # Force an interactive TTY so the crash-prone _prompt path is reached;
+        # input() is stubbed so a (buggy) fall-through can't block the suite.
+        _force_gate_stdin(monkeypatch, tty=True)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
+
+        step = GateStep()
+        config = {"id": "review", "message": "Review.", "options": bad_options}
+        result = step.execute(config, StepContext())
+
+        assert result.status == StepStatus.FAILED
+        assert "options" in (result.error or "")
+        assert result.output["choice"] is None
+
+    def test_execute_non_string_options_element_fails_cleanly(self, monkeypatch):
+        """A non-string option element must FAIL the step, not crash.
+
+        A non-empty list with a non-string element passes the shape check but
+        would reach the reject test ``choice.lower()`` and raise a raw
+        ``AttributeError`` at run time. ``validate`` reports "must be strings";
+        ``execute`` must fail cleanly on an unvalidated run too."""
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        _force_gate_stdin(monkeypatch, tty=True)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
+
+        step = GateStep()
+        config = {"id": "review", "message": "Review.", "options": [123, 456]}
+        result = step.execute(config, StepContext())
+
+        assert result.status == StepStatus.FAILED
+        assert "options" in (result.error or "")
+
+    def test_execute_non_list_options_fails_in_non_tty_too(self):
+        """The guard runs before the non-TTY PAUSE short-circuit.
+
+        A malformed ``options`` should surface as FAILED in CI (non-TTY) rather
+        than PAUSING and only crashing later when an operator resumes on a real
+        terminal."""
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        # Autouse fixture already forces non-TTY stdin.
+        step = GateStep()
+        config = {"id": "review", "message": "Review.", "options": 5}
+        result = step.execute(config, StepContext())
+
+        assert result.status == StepStatus.FAILED
+        assert "options" in (result.error or "")
+
 
 class TestIfThenStep:
     """Test the if/then/else step type."""


### PR DESCRIPTION
## Summary

`GateStep.validate` rejects a non-list (or empty) `options` and requires every option to be a string, but the workflow engine does **not** auto-validate a step before calling `execute`. On an unvalidated run a malformed `options` slipped straight through to the interactive prompt and took down the whole workflow:

- **scalar / dict / `None` `options`** → raw `TypeError` (`enumerate`/`len` on a non-iterable) or `KeyError` (indexing a dict) inside `_prompt`
- **empty list `[]`** → `_prompt`'s `while True:` input loop can never satisfy `1 <= n <= 0`, so it spins forever
- **non-string element** (e.g. `[123, 456]`) → passes the shape check but crashes the reject test at `choice.lower()` with `AttributeError`

This mirrors an established bug class in this repo: `validate()` correctly rejects bad input, but `execute()` (reachable on an unvalidated run) crashes on it instead of failing the step cleanly — same shape as the switch `cases` (#3481) and command `input` guards.

## Fix

Guard `execute` to return `StepStatus.FAILED` with a clear error when `options` is not a non-empty list of strings. The check runs **before** the non-TTY `PAUSED` short-circuit, so a misconfigured gate surfaces as FAILED in CI rather than pausing and only crashing later when an operator resumes on a real terminal.

## Tests

Added regression tests under `TestGateStep`:
- `test_execute_non_list_options_fails_cleanly` (parametrized over `5`, `{...}`, `None`, `[]`, `"approve"`)
- `test_execute_non_string_options_element_fails_cleanly`
- `test_execute_non_list_options_fails_in_non_tty_too`

Verified test-the-test: with the source fix stashed, the scalar cases crash and the empty-list case hangs `_prompt` forever; with the fix all 21 `TestGateStep` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)