### PR TITLE
fix(workflows): reject a non-string 'command' in command-step

### DIFF
--- a/src/specify_cli/workflows/steps/command/__init__.py
+++ b/src/specify_cli/workflows/steps/command/__init__.py
@@ -30,6 +30,21 @@ class CommandStep(StepBase):
 
     def execute(self, config: dict[str, Any], context: StepContext) -> StepResult:
         command = config.get("command", "")
+        # validate() rejects a non-string 'command', but the engine does not
+        # auto-validate before execute(); an unvalidated run would pass the value
+        # to build_command_invocation() (via _try_dispatch) and crash there with a
+        # raw AttributeError (command_name.startswith(...) on a list/int/None).
+        # Fail the step with the same contract error instead, mirroring the
+        # 'input'/'options' guards below.
+        if not isinstance(command, str):
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"Command step {config.get('id', '?')!r}: 'command' must be a "
+                    f"string, got {type(command).__name__}."
+                ),
+            )
+
         input_data = config.get("input", {})
         # validate() rejects a non-mapping input, but the engine does not
         # auto-validate before execute(); a workflow that skipped validation can
@@ -178,6 +193,17 @@ class CommandStep(StepBase):
         if "command" not in config:
             errors.append(
                 f"Command step {config.get('id', '?')!r} is missing 'command' field."
+            )
+        elif not isinstance(config["command"], str):
+            # execute() passes 'command' straight to the integration's
+            # build_command_invocation(), which does command_name.startswith(...);
+            # a non-string (null, list, int) crashes there with a raw
+            # AttributeError once dispatch is attempted. Reject it at validation,
+            # mirroring the prompt-step 'prompt' and shell-step 'run' type checks.
+            # An expression like "{{ ... }}" is still a str, so it stays valid.
+            errors.append(
+                f"Command step {config.get('id', '?')!r}: 'command' must be a "
+                f"string, got {type(config['command']).__name__}."
             )
         # execute() iterates input.items() and options.update(step_options); a
         # non-mapping here would raise at run time. Validate the shape like the

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1026,6 +1026,41 @@ class TestCommandStep:
         assert res_opt.status is StepStatus.FAILED
         assert "'options' must be a mapping" in (res_opt.error or "")
 
+    def test_validate_rejects_non_string_command(self):
+        from specify_cli.workflows.steps.command import CommandStep
+
+        step = CommandStep()
+        # execute() passes 'command' to build_command_invocation(), which does
+        # command_name.startswith(...); a non-string crashes there with a raw
+        # AttributeError. validate() must report it, like prompt-step 'prompt'.
+        for bad in (None, ["a", "b"], 5, {"x": 1}):
+            errs = step.validate({"id": "c", "command": bad})
+            assert any("'command' must be a string" in e for e in errs), bad
+        # a string command (incl. an expression) is still accepted
+        assert step.validate({"id": "c", "command": "/x"}) == []
+        assert step.validate({"id": "c", "command": "{{ inputs.cmd }}"}) == []
+
+    def test_execute_non_string_command_fails_cleanly(self):
+        from unittest.mock import patch
+        from specify_cli.workflows.steps.command import CommandStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = CommandStep()
+        # The engine may skip validate(); a non-string 'command' must FAIL the
+        # step with the contract error rather than reaching _try_dispatch and
+        # crashing build_command_invocation with a raw AttributeError. Force a
+        # resolvable integration + installed CLI so, absent the guard, dispatch
+        # would actually be attempted and the crash would fire.
+        ctx = StepContext(default_integration="claude")
+        with patch("specify_cli.workflows.steps.command.shutil.which",
+                   return_value="/usr/bin/claude"):
+            for bad in (None, ["a", "b"], 5, {"x": 1}):
+                result = step.execute(
+                    {"id": "c", "command": bad, "input": {}}, ctx
+                )
+                assert result.status is StepStatus.FAILED, bad
+                assert "'command' must be a string" in (result.error or ""), bad
+
     def test_step_override_integration(self):
         from unittest.mock import patch
         from specify_cli.workflows.steps.command import CommandStep


### PR DESCRIPTION
## Summary

`CommandStep.validate` only checked that a `command` field is **present**, never its type. But the workflow engine does not auto-validate a step before calling `execute`, so on an unvalidated run a non-string `command` — `null`, a list, an int — was passed straight through `_try_dispatch` to the integration's `build_command_invocation`, which does:

```python
stem = command_name
if stem.startswith("speckit."):   # AttributeError if command_name isn't a str
```

Once a resolvable integration with an installed CLI is found, this crashes the entire workflow run with a raw `AttributeError` instead of failing just the step.

Confirmed directly:
```
['a', 'b'] -> AttributeError 'list' object has no attribute 'startswith'
None       -> AttributeError 'NoneType' object has no attribute 'startswith'
42         -> AttributeError 'int' object has no attribute 'startswith'
```

This is the same class of gap that #3582 closed for the prompt-step `prompt` field — `validate()` checked presence only while `execute()` fed the value to the CLI layer.

## Fix

Guard both paths, matching the sibling steps already in this file:

- **`validate()`** rejects a non-string `command`, mirroring prompt-step `prompt` (#3582) and shell-step `run`.
- **`execute()`** fails the step cleanly with the same contract error *before* dispatch, mirroring the existing `input`/`options` guards in `CommandStep.execute` — so an unvalidated run FAILs the step (honouring `continue_on_error`) instead of crashing the run.

An expression like `{{ inputs.cmd }}` is still a `str`, so it stays valid.

## Tests

Added to `TestCommandStep`:
- `test_validate_rejects_non_string_command` (null / list / int / dict, plus accepts a plain string and an expression)
- `test_execute_non_string_command_fails_cleanly` (patches `shutil.which` so dispatch would actually be attempted absent the guard — proving the guard prevents the crash)

Verified test-the-test: with the source fix stashed, `validate()` misses the bad value and `execute()` crashes at `build_command_invocation` with the raw `AttributeError`; with the fix, all 13 `TestCommandStep` tests pass. The 20 unrelated `test_workflows.py` failures are the pre-existing Windows symlink-guard tests that require elevation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)