### PR TITLE
fix(integrations): Cline dispatches hyphenated /speckit-<cmd> invocations

### DIFF
--- a/src/specify_cli/integrations/cline/__init__.py
+++ b/src/specify_cli/integrations/cline/__init__.py
@@ -77,6 +77,19 @@ class ClineIntegration(MarkdownIntegration):
         """Cline uses hyphenated filenames (e.g. speckit-git-commit.md)."""
         return format_cline_command_name(template_name) + ".md"
 
+    def build_command_invocation(self, command_name: str, args: str = "") -> str:
+        """Cline installs hyphenated slash-commands (``/speckit-<name>``), so the
+        dispatch invocation must match. The inherited MarkdownIntegration default
+        builds the dotted ``/speckit.<name>``, which references a command Cline
+        never registered. Reuse the same hyphenation as command_filename /
+        the injected frontmatter name (see ``format_cline_command_name``),
+        mirroring the forge integration.
+        """
+        invocation = "/" + format_cline_command_name(command_name)
+        if args:
+            invocation = f"{invocation} {args}"
+        return invocation
+
     def process_template(self, *args, **kwargs):
         """Ensure shared templates render Cline command references with hyphens."""
         kwargs.setdefault("invoke_separator", self.invoke_separator)

--- a/tests/integrations/test_base.py
+++ b/tests/integrations/test_base.py
@@ -236,6 +236,24 @@ class TestBuildCommandInvocation:
             == "/speckit-git-commit fix typo"
         )
 
+    def test_cline_core_command_hyphenated(self):
+        """Cline installs hyphenated slash-commands (/speckit-<name>), so the
+        dispatch invocation must be hyphenated too — not the dotted default it
+        would inherit from MarkdownIntegration."""
+        from specify_cli.integrations import get_integration
+        i = get_integration("cline")
+        assert i.build_command_invocation("speckit.plan") == "/speckit-plan"
+        assert i.build_command_invocation("plan") == "/speckit-plan"
+
+    def test_cline_extension_command_hyphenated(self):
+        from specify_cli.integrations import get_integration
+        i = get_integration("cline")
+        assert i.build_command_invocation("speckit.git.commit") == "/speckit-git-commit"
+        assert (
+            i.build_command_invocation("speckit.git.commit", "fix typo")
+            == "/speckit-git-commit fix typo"
+        )
+
 
 class TestResolveCommandRefs:
     """Tests for __SPECKIT_COMMAND_<NAME>__ placeholder resolution."""


### PR DESCRIPTION
## What

Cline installs its slash-commands with **hyphenated** names — `speckit-plan`, `speckit-git-commit` — via `format_cline_command_name` and the hyphenated `command_filename`. But `ClineIntegration` inherits `MarkdownIntegration.build_command_invocation`, which builds the **dotted** form:

```python
invocation = f"/speckit.{stem}"   # -> /speckit.plan
```

So command/workflow dispatch invokes `/speckit.plan` while the registered Cline command is `/speckit-plan` — a name Cline never registered.

## Fix

Override `build_command_invocation` in `ClineIntegration` to reuse the module's own `format_cline_command_name`, producing `/speckit-<name>` (with `.`→`-` for extension commands). This mirrors the [`ForgeIntegration` fix (#3529)](https://github.com/github/spec-kit/pull/3529) exactly — Cline was the only remaining markdown integration with `invoke_separator='-'` + hyphenated `command_filename` still lacking the override.

## Test

`test_cline_core_command_hyphenated` / `test_cline_extension_command_hyphenated` (mirroring the forge tests) assert Cline invocations are hyphenated, incl. args — fail before (dotted `/speckit.plan`, `/speckit.git.commit`), pass after.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.