### PR TITLE
fix(bundler): reject non-list 'catalogs' in bundle-catalogs.yml with a clean error

### DIFF
--- a/src/specify_cli/bundler/models/catalog.py
+++ b/src/specify_cli/bundler/models/catalog.py
@@ -251,14 +251,18 @@ def _merge_config(by_id: dict[str, CatalogSource], config_path: Path, scope: Sco
         return
     data = load_yaml(config_path)
     catalogs = data.get("catalogs") if isinstance(data, dict) else None
-    if not catalogs:
+    if catalogs is None:
         return
     if not isinstance(catalogs, list):
-        # A non-empty scalar (``catalogs: 5``) passes the falsy check above and
-        # would raise a raw ``TypeError: 'int' object is not iterable`` from the
-        # loop below. Report the same actionable BundlerError the sibling reader
-        # of this file raises (commands_impl/catalog_config.py) so both readers
-        # of bundle-catalogs.yml agree.
+        # Treat only an absent/``None`` ``catalogs`` as "nothing to merge"; any
+        # other non-list value (``catalogs: 5``, ``false``, ``0``, ``''``,
+        # ``{}``) is a malformed config and must raise, not be silently skipped
+        # by a falsy check. Otherwise a truthy scalar would raise a raw
+        # ``TypeError: 'int' object is not iterable`` from the loop below, while
+        # falsy non-lists would be swallowed. Report the same actionable
+        # BundlerError the sibling reader of this file raises
+        # (commands_impl/catalog_config.py) so both readers of
+        # bundle-catalogs.yml agree. An empty list stays valid (loop is a no-op).
         raise BundlerError(
             f"Malformed catalog config at {config_path}: 'catalogs' must be a "
             f"list, got {type(catalogs).__name__}."

--- a/src/specify_cli/bundler/models/catalog.py
+++ b/src/specify_cli/bundler/models/catalog.py
@@ -253,6 +253,16 @@ def _merge_config(by_id: dict[str, CatalogSource], config_path: Path, scope: Sco
     catalogs = data.get("catalogs") if isinstance(data, dict) else None
     if not catalogs:
         return
+    if not isinstance(catalogs, list):
+        # A non-empty scalar (``catalogs: 5``) passes the falsy check above and
+        # would raise a raw ``TypeError: 'int' object is not iterable`` from the
+        # loop below. Report the same actionable BundlerError the sibling reader
+        # of this file raises (commands_impl/catalog_config.py) so both readers
+        # of bundle-catalogs.yml agree.
+        raise BundlerError(
+            f"Malformed catalog config at {config_path}: 'catalogs' must be a "
+            f"list, got {type(catalogs).__name__}."
+        )
     for raw in catalogs:
         src = CatalogSource.from_dict(raw, scope)
         by_id[src.id] = src

--- a/tests/contract/test_catalog_schema.py
+++ b/tests/contract/test_catalog_schema.py
@@ -43,6 +43,18 @@ def test_builtin_default_stack_when_no_config(tmp_path: Path):
     assert all(s.scope is Scope.BUILTIN for s in sources)
 
 
+def test_non_list_catalogs_raises_actionable_error(tmp_path: Path):
+    """A scalar ``catalogs:`` value raises a clean BundlerError, not a raw
+    'int object is not iterable' TypeError — matching what the sibling reader
+    (bundle catalog list) already reports for the same file."""
+    make_project(tmp_path)
+    (tmp_path / ".specify" / "bundle-catalogs.yml").write_text(
+        "catalogs: 5\n", encoding="utf-8"
+    )
+    with pytest.raises(BundlerError, match="must be a list"):
+        load_source_stack(tmp_path)
+
+
 def test_project_config_overrides_same_id(tmp_path: Path):
     make_project(tmp_path)
     config = {

--- a/tests/contract/test_catalog_schema.py
+++ b/tests/contract/test_catalog_schema.py
@@ -55,6 +55,30 @@ def test_non_list_catalogs_raises_actionable_error(tmp_path: Path):
         load_source_stack(tmp_path)
 
 
+@pytest.mark.parametrize("value", ["false", "0", "''", "{}"])
+def test_falsy_non_list_catalogs_still_raises(tmp_path: Path, value: str):
+    """A *falsy* non-list ``catalogs:`` value (false/0/''/{}) must also raise —
+    only an absent/``None`` value means "nothing to merge". A plain falsy check
+    would silently swallow these, diverging from the sibling reader."""
+    make_project(tmp_path)
+    (tmp_path / ".specify" / "bundle-catalogs.yml").write_text(
+        f"catalogs: {value}\n", encoding="utf-8"
+    )
+    with pytest.raises(BundlerError, match="must be a list"):
+        load_source_stack(tmp_path)
+
+
+@pytest.mark.parametrize("body", ["catalogs:\n", "catalogs: []\n"])
+def test_absent_or_empty_catalogs_is_noop(tmp_path: Path, body: str):
+    """An absent (``None``) or empty-list ``catalogs:`` is valid: it contributes
+    no project sources and falls back to the built-in default stack."""
+    make_project(tmp_path)
+    (tmp_path / ".specify" / "bundle-catalogs.yml").write_text(body, encoding="utf-8")
+    # Does not raise; still yields the built-in defaults.
+    sources = load_source_stack(tmp_path)
+    assert len(sources) > 0
+
+
 def test_project_config_overrides_same_id(tmp_path: Path):
     make_project(tmp_path)
     config = {


### PR DESCRIPTION
## What

`_merge_config` (the source-stack loader for `bundle-catalogs.yml`) guards only the falsy case:

```python
catalogs = data.get("catalogs") if isinstance(data, dict) else None
if not catalogs:
    return
for raw in catalogs:   # <-- raw TypeError if `catalogs` is a non-empty scalar
```

A non-empty scalar like `catalogs: 5` (or `catalogs: true`) passes the falsy check and then raises a raw **`TypeError: 'int' object is not iterable`** from the loop — escaping the module's `BundlerError` error contract.

The **sibling reader of the same file** — `commands_impl/catalog_config.py` (used by `specify bundle catalog list`) — already raises an actionable `BundlerError("Malformed catalog config … 'catalogs' must be a list …")` for the identical mis-shape. So the two readers of `bundle-catalogs.yml` diverge.

## Fix

Add the same `isinstance(catalogs, list)` guard, raising the same-shaped `BundlerError`. One file, ~3 lines (`BundlerError` already imported). Matches the shape-guard vein used across `catalogs.py`, `workflows/catalog.py`, presets, and extensions.

## Test

`catalogs: 5` now raises `BundlerError(…must be a list…)` — fails before (raw `TypeError`), passes after. Full `test_catalog_schema.py` (15) passes.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.