### PR TITLE
fix(workflows): gate prompt uses isdecimal() so a superscript digit can't crash it

### DIFF
--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -168,7 +168,11 @@ class GateStep(StepBase):
             except (EOFError, KeyboardInterrupt):
                 print()
                 return options[-1]  # default to last (usually reject)
-            if raw.isdigit() and 1 <= int(raw) <= len(options):
+            # isdecimal() (not isdigit()): int() accepts exactly the decimal-digit
+            # set, whereas isdigit() also returns True for superscripts/subscripts
+            # (e.g. "²") that int() then rejects with ValueError — crashing
+            # this interactive loop.
+            if raw.isdecimal() and 1 <= int(raw) <= len(options):
                 return options[int(raw) - 1]
             # Also accept the option name directly
             if raw.lower() in [o.lower() for o in options]:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1985,6 +1985,19 @@ class TestGateStep:
         assert result.status == StepStatus.COMPLETED
         assert result.output["choice"] == "approve"
 
+    def test_interactive_prompt_rejects_non_decimal_digit(self, monkeypatch, capsys):
+        """A Unicode digit int() can't parse — e.g. the superscript '²', which
+        str.isdigit() accepts but int() rejects — must be treated as an invalid
+        choice, not crash the prompt loop with an uncaught ValueError."""
+        from specify_cli.workflows.steps.gate import GateStep
+
+        _force_gate_stdin(monkeypatch, tty=True)
+        inputs = iter(["²", "1"])  # superscript-two, then a real "1"
+        monkeypatch.setattr("builtins.input", lambda _prompt="": next(inputs))
+
+        choice = GateStep._prompt("Review the spec.", ["approve", "reject"])
+        assert choice == "approve"
+
     def test_interactive_prompt_missing_show_file_does_not_crash(
         self, tmp_path, monkeypatch, capsys
     ):


### PR DESCRIPTION
## What

The interactive `gate` step prompt parses a numeric choice like this:

```python
if raw.isdigit() and 1 <= int(raw) <= len(options):
```

`str.isdigit()` returns `True` for characters `int()` **rejects** — e.g. the superscript `²` (`'²'.isdigit()` is `True`, but `int('²')` raises `ValueError`). So entering `²` at the prompt passes the guard and then crashes the input loop with an uncaught `ValueError`.

## Fix

Use `raw.isdecimal()` — exactly the decimal-digit set `int()` accepts (`Numeric_Type=Decimal`), which excludes superscripts/subscripts while preserving every real decimal digit across scripts. Such input is now treated as an invalid choice and re-prompted. No behavior change for valid input.

## Test

`test_interactive_prompt_rejects_non_decimal_digit`: input `²` then `1` returns the first option — fails before (`ValueError`), passes after.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.