### PR TITLE
docs(core): document the 'py' (Python) --script type

### DIFF
--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -12,7 +12,7 @@ specify init [<project_name>]
 | ------------------------ | ------------------------------------------------------------------------ |
 | `--integration <key>`    | AI coding agent integration to use (e.g. `copilot`, `claude`, `gemini`). See the [Integrations reference](integrations.md) for all available keys |
 | `--integration-options`  | Options for the integration (e.g. `--integration-options="--commands-dir .myagent/cmds"`) |
-| `--script sh\|ps`        | Script type: `sh` (bash/zsh) or `ps` (PowerShell)                       |
+| `--script sh\|ps\|py`    | Script type: `sh` (bash/zsh), `ps` (PowerShell), or `py` (Python)       |
 | `--here`                 | Initialize in the current directory instead of creating a new one        |
 | `--force`                | Force merge/overwrite when initializing in an existing directory         |
 | `--ignore-agent-tools`   | Skip checks for AI coding agent CLI tools                                |


### PR DESCRIPTION
## What

`specify init --script` accepts three values — `sh`, `ps`, **and `py`** — per `init.py` (`--script` help: "sh, ps, or py") and `SCRIPT_TYPE_CHOICES` in `_agent_config.py` (`{"sh", "ps", "py"}`). `specify init … --script py` scaffolds Python scripts.

But the **Core Commands** reference (`docs/reference/core.md`) — the canonical option table — listed only `--script sh|ps`, so a user following the docs never discovers `--script py`.

## Fix

Update the one option row to `--script sh|ps|py` with the Python description. Single-file, one-line docs change, kept to `core.md` to stay single-concern.

---
🤖 Written with the assistance of Claude Code (AI). Gap self-found (flag present in code + `SCRIPT_TYPE_CHOICES`, absent from docs).