### PR TITLE
fix(workflows): command/prompt steps fail cleanly on a non-string integration

### DIFF
--- a/src/specify_cli/workflows/steps/command/__init__.py
+++ b/src/specify_cli/workflows/steps/command/__init__.py
@@ -153,7 +153,11 @@ class CommandStep(StepBase):
         not possible (integration not found, CLI not installed, or
         dispatch not supported).
         """
-        if not integration_key:
+        if not integration_key or not isinstance(integration_key, str):
+            # A non-string integration (a list/dict/expression that resolved to
+            # one) would raise TypeError: unhashable type from get_integration's
+            # dict lookup below and abort the whole run. Treat it as "not
+            # dispatchable" so execute() falls through to its FAILED StepResult.
             return None
 
         try:

--- a/src/specify_cli/workflows/steps/prompt/__init__.py
+++ b/src/specify_cli/workflows/steps/prompt/__init__.py
@@ -102,7 +102,10 @@ class PromptStep(StepBase):
         context: StepContext,
     ) -> dict[str, Any] | None:
         """Dispatch *prompt* directly through the integration CLI."""
-        if not integration_key or not prompt:
+        if not integration_key or not isinstance(integration_key, str) or not prompt:
+            # A non-string integration would raise TypeError: unhashable type
+            # from get_integration's dict lookup and abort the run; treat it as
+            # not dispatchable so execute() falls through to its FAILED result.
             return None
 
         try:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1078,6 +1078,21 @@ class TestCommandStep:
             result = step.execute(config, ctx)
         assert result.output["integration"] == "gemini"
 
+    def test_execute_non_string_integration_fails_cleanly(self):
+        """A non-string integration (e.g. a list from an expression that resolved
+        to one) must FAIL the step cleanly, not crash the run with
+        'TypeError: unhashable type: list' from get_integration's dict lookup."""
+        from specify_cli.workflows.steps.command import CommandStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = CommandStep()
+        config = {
+            "id": "s", "command": "speckit.plan",
+            "integration": ["claude"], "input": {},
+        }
+        result = step.execute(config, StepContext())
+        assert result.status == StepStatus.FAILED
+
     def test_step_override_model(self):
         from unittest.mock import patch
         from specify_cli.workflows.steps.command import CommandStep
@@ -1274,6 +1289,20 @@ class TestPromptStep:
         assert result.output["prompt"] == "Review auth.py for security issues"
         assert result.output["integration"] == "claude"
         assert result.output["dispatched"] is False
+
+    def test_execute_non_string_integration_fails_cleanly(self):
+        """A non-string integration must FAIL the step cleanly, not crash with
+        'TypeError: unhashable type: list' from get_integration's dict lookup."""
+        from specify_cli.workflows.steps.prompt import PromptStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = PromptStep()
+        config = {
+            "id": "p", "type": "prompt", "prompt": "do it",
+            "integration": ["claude"],
+        }
+        result = step.execute(config, StepContext())
+        assert result.status == StepStatus.FAILED
 
     def test_execute_with_step_integration(self):
         from unittest.mock import patch


### PR DESCRIPTION
## What

Both the `command` and `prompt` steps dispatch via `_try_dispatch`, which guarded only the falsy case before the registry lookup:

```python
if not integration_key:
    return None
...
impl = get_integration(integration_key)   # dict lookup
```

A **non-string** `integration` — a list/dict, or an expression like `integration: "{{ steps.pick.output.agents }}"` that resolves to a list — passes the falsy guard and hits `get_integration`'s dict lookup, raising **`TypeError: unhashable type: 'list'`** and aborting the entire workflow run.

## Fix

Widen the guard to also require a `str`:

```python
if not integration_key or not isinstance(integration_key, str):
    return None
```

`None` routes execution to the already-present **FAILED** `StepResult` ("Cannot dispatch … integration … not found"), so the step fails cleanly instead of crashing the run. Unconfigured `integration=None` still returns `None` as before. Applied to both `command` and `prompt` steps.

## Test

`test_execute_non_string_integration_fails_cleanly` (command + prompt): a list integration yields a `FAILED` result — fails before (`TypeError: unhashable type: 'list'`), passes after.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.