### PR TITLE
fix(bundler): reject non-mapping 'integration' in a bundle manifest

### DIFF
--- a/src/specify_cli/bundler/models/manifest.py
+++ b/src/specify_cli/bundler/models/manifest.py
@@ -122,6 +122,11 @@ class BundleManifest:
 
         integration = None
         integration_raw = data.get("integration")
+        # Mirror the requires/provides guards above: a present-but-non-mapping
+        # 'integration' (e.g. a bare string "copilot") was silently dropped,
+        # leaving the bundle wrongly integration-agnostic. Reject it instead.
+        if integration_raw is not None and not isinstance(integration_raw, dict):
+            raise BundlerError("'integration' must be a mapping when present.")
         if isinstance(integration_raw, dict) and integration_raw.get("id"):
             integration = IntegrationRef(id=str(integration_raw["id"]).strip())
 

--- a/tests/contract/test_manifest_schema.py
+++ b/tests/contract/test_manifest_schema.py
@@ -124,3 +124,13 @@ def test_string_mcp_rejected_not_split_per_character():
     data["requires"]["mcp"] = "github"
     with pytest.raises(BundlerError, match="'requires.mcp' must be a list of strings"):
         BundleManifest.from_dict(data)
+
+
+def test_string_integration_rejected_not_silently_dropped():
+    # A present-but-non-mapping 'integration' (a bare string) was silently
+    # dropped, leaving the bundle wrongly integration-agnostic. Reject it like
+    # the sibling requires/provides mapping fields.
+    data = valid_manifest_dict()
+    data["integration"] = "copilot"
+    with pytest.raises(BundlerError, match="'integration' must be a mapping when present"):
+        BundleManifest.from_dict(data)


### PR DESCRIPTION
## What

`BundleManifest.from_dict` rejects a present-but-non-mapping `requires` and `provides`:

```python
if not isinstance(requires_raw, dict):
    raise BundlerError("'requires' must be a mapping when present.")
...
if not isinstance(provides, dict):
    raise BundlerError("'provides' must be a mapping when present.")
```

…but `integration` is the odd one out — a non-mapping value is **silently dropped**:

```python
integration = None
integration_raw = data.get("integration")
if isinstance(integration_raw, dict) and integration_raw.get("id"):   # bare string "copilot" fails silently
    integration = IntegrationRef(id=...)
```

So a manifest with `integration: copilot` (a common mistake — the schema wants `integration: {id: copilot}`) parses as a bundle that is wrongly **integration-agnostic** (`is_agnostic()` True), instead of surfacing the error.

## Fix

Add the same guard as its sibling mapping fields — scoped strictly to the non-mapping-present case, leaving the existing dict-with-id behavior unchanged.

## Test

`test_string_integration_rejected_not_silently_dropped`: `integration="copilot"` now raises `BundlerError("'integration' must be a mapping when present")` — fails before (silently dropped, no raise).

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.