### PR TITLE
fix(workflows): StepRegistry.add tolerates a corrupted non-dict existing entry

### DIFF
--- a/src/specify_cli/workflows/catalog.py
+++ b/src/specify_cli/workflows/catalog.py
@@ -882,7 +882,11 @@ class StepRegistry:
         import copy
         from datetime import datetime, timezone
 
-        existing = self.data["steps"].get(step_id, {})
+        raw_existing = self.data["steps"].get(step_id)
+        # Corrupted-but-parseable registries may hold non-dict entries; treat
+        # them as absent rather than crashing on existing.get() (mirrors
+        # WorkflowRegistry.add).
+        existing = raw_existing if isinstance(raw_existing, dict) else {}
         metadata_to_store = copy.deepcopy(metadata)
         metadata_to_store["installed_at"] = existing.get(
             "installed_at", datetime.now(timezone.utc).isoformat()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -9739,6 +9739,17 @@ steps:
         registry.add("align-wf", {"version": "1.0.0", "source": "catalog"})
         assert registry.get("align-wf")["version"] == "1.0.0"
 
+    def test_step_registry_add_survives_non_dict_existing_entry(self, project_dir):
+        """StepRegistry.add must treat a corrupted non-dict existing entry as
+        absent rather than crash on existing.get() (parity with
+        WorkflowRegistry.add)."""
+        from specify_cli.workflows.catalog import StepRegistry
+
+        registry = StepRegistry(project_dir)
+        registry.data["steps"]["my-step"] = "corrupted"
+        registry.add("my-step", {"version": "1.0.0"})
+        assert registry.get("my-step")["version"] == "1.0.0"
+
     @pytest.mark.parametrize(
         "contents",
         [


### PR DESCRIPTION
## What

`StepRegistry.add` reads the existing entry then calls `.get()` on it:

```python
existing = self.data["steps"].get(step_id, {})
metadata_to_store["installed_at"] = existing.get("installed_at", ...)   # AttributeError if existing is a str/list/int
```

A corrupted-but-parseable registry — e.g. `{"steps": {"foo": "corrupted"}}`, which `_load()` accepts because it validates only the top-level dict and that `steps` is a dict — makes `add()` raise `AttributeError: 'str' object has no attribute 'get'`.

Its sibling `WorkflowRegistry.add` was hardened for exactly this in #3419 (`existing = raw_existing if isinstance(raw_existing, dict) else {}`); `StepRegistry.add` was left unguarded — a same-file parity gap.

## Fix

Mirror the WorkflowRegistry guard so a non-dict existing entry is treated as absent.

## Test

`test_step_registry_add_survives_non_dict_existing_entry` (a 1:1 copy of the WorkflowRegistry sibling test): a `"corrupted"` string entry no longer crashes `add()` — fails before (`AttributeError`), passes after.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.