### PR TITLE
fix(workflows): list-literal expression ignores trailing/empty commas

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -535,6 +535,10 @@ def _evaluate_simple_expression(expr: str, namespace: dict[str, Any]) -> Any:
         items = [
             _evaluate_simple_expression(i.strip(), namespace)
             for i in _split_top_level_commas(inner)
+            # Drop empty segments from trailing/leading/double commas ([1, 2,] ->
+            # [1, 2], not [1, 2, None]). An intentional empty-string element
+            # ('') strips to "''" (truthy), so ['', 'a'] is preserved.
+            if i.strip()
         ]
         return items
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -404,6 +404,17 @@ class TestExpressions:
         assert evaluate_expression('{{ [["a", "b"], "c"] }}', ctx) == [["a", "b"], "c"]
         assert evaluate_expression("{{ [[1, 2], [3, 4]] }}", ctx) == [[1, 2], [3, 4]]
 
+    def test_list_literal_ignores_trailing_and_empty_commas(self):
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext()
+        # A trailing comma must not append a spurious None element.
+        assert evaluate_expression("{{ [1, 2,] }}", ctx) == [1, 2]
+        assert evaluate_expression("{{ [1,, 2] }}", ctx) == [1, 2]
+        # …but an intentional empty-string element is still preserved.
+        assert evaluate_expression("{{ ['', 'a'] }}", ctx) == ["", "a"]
+
     def test_operator_splitting_is_quote_aware(self):
         from specify_cli.workflows.expressions import (
             evaluate_condition,


### PR DESCRIPTION
## What

A workflow list-literal expression with a trailing comma evaluates to a list with a spurious `None`:

```
{{ [1, 2,] }}   ->  [1, 2, None]      (expected [1, 2])
```

`_split_top_level_commas("1, 2,")` returns `['1', ' 2', '']`; the empty segment flows through `_evaluate_simple_expression('')`, which resolves as an empty dot-path to `None`. Leading/double commas hit the same path. This silently widens membership tests (`{{ x in [a, b,] }}`) and renders a stray `None` in joins. Python and Jinja2 both tolerate trailing commas.

## Fix

Drop whitespace-empty segments from the comprehension (`if i.strip()`). An **intentional** empty-string element is preserved, because its segment strips to `"''"` (truthy) — `['', 'a']` still yields `['', 'a']`. This completes the quoted-comma handling added in #3134.

## Test

`test_list_literal_ignores_trailing_and_empty_commas`: `[1, 2,]` and `[1,, 2]` → `[1, 2]`; `['', 'a']` → `['', 'a']` — fails before (trailing `None`), passes after.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff clean.