### PR TITLE
fix(scripts): git-ext PowerShell emits the '# To persist' SPECIFY_FEATURE hint (parity)

### DIFF
--- a/extensions/git/scripts/powershell/create-new-feature-branch.ps1
+++ b/extensions/git/scripts/powershell/create-new-feature-branch.ps1
@@ -565,6 +565,12 @@ if (-not $DryRun) {
     $env:SPECIFY_FEATURE = $branchName
 }
 
+# Build the PowerShell-idiomatic persist hint, mirroring the core
+# create-new-feature.ps1 twin (and the bash/python twins of this script), which
+# all emit "# To persist in your shell: ...".
+$quotedBranchName = "'" + $branchName.Replace("'", "''") + "'"
+$featureAssignment = '$env:SPECIFY_FEATURE = ' + $quotedBranchName
+
 if ($Json) {
     $obj = [PSCustomObject]@{
         BRANCH_NAME = $branchName
@@ -581,6 +587,6 @@ if ($Json) {
     Write-Output "BRANCH_NAME: $branchName"
     Write-Output "FEATURE_NUM: $featureNum"
     if (-not $DryRun) {
-        Write-Output "SPECIFY_FEATURE environment variable set to: $branchName"
+        Write-Output "# To persist in your shell: $featureAssignment"
     }
 }

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -698,6 +698,22 @@ class TestCreateFeaturePowerShell:
         assert rt.returncode == 0, rt.stderr
         assert "HAS_GIT" not in rt.stdout
 
+    def test_persist_hint_matches_twins(self, tmp_path: Path):
+        """The non-JSON SPECIFY_FEATURE hint must use the '# To persist in your
+        shell: $env:SPECIFY_FEATURE = '<name>'' form — matching the core
+        create-new-feature.ps1 twin and the bash/python twins of this script —
+        not the old 'environment variable set to:' wording (the env var is only
+        set in this child process, so the actionable output is the persist hint)."""
+        project = _setup_project(tmp_path)
+        result = _run_pwsh(
+            "create-new-feature-branch.ps1", project,
+            "-ShortName", "persist", "Persist hint feature",
+        )
+        assert result.returncode == 0, result.stderr
+        assert "# To persist in your shell:" in result.stdout
+        assert "$env:SPECIFY_FEATURE = '001-persist'" in result.stdout
+        assert "environment variable set to:" not in result.stdout
+
     def test_help_documents_branch_prefix(self, tmp_path: Path):
         """-Help documents both template config knobs."""
         project = _setup_project(tmp_path)

--- a/tests/extensions/git/test_git_extension.py
+++ b/tests/extensions/git/test_git_extension.py
@@ -700,7 +700,7 @@ class TestCreateFeaturePowerShell:
 
     def test_persist_hint_matches_twins(self, tmp_path: Path):
         """The non-JSON SPECIFY_FEATURE hint must use the '# To persist in your
-        shell: $env:SPECIFY_FEATURE = '<name>'' form — matching the core
+        shell: $env:SPECIFY_FEATURE = '<name>' form — matching the core
         create-new-feature.ps1 twin and the bash/python twins of this script —
         not the old 'environment variable set to:' wording (the env var is only
         set in this child process, so the actionable output is the persist hint)."""


### PR DESCRIPTION
## What

The Git extension's `create-new-feature-branch.ps1` prints a non-JSON hint that diverges from **every** twin:

```
SPECIFY_FEATURE environment variable set to: 001-add-user-auth
```

Its bash twin (`create-new-feature-branch.sh`), its python twin (`create_new_feature_branch.py`), **and** the core `create-new-feature.ps1` all emit:

```
# To persist in your shell: $env:SPECIFY_FEATURE = '001-add-user-auth'
```

The old wording is also misleading: `$env:SPECIFY_FEATURE` is set only in this child process and never propagates to the agent's shell, so the actionable output is precisely the persist hint the siblings print.

## Fix

Mirror the core PowerShell twin: build `$featureAssignment = '$env:SPECIFY_FEATURE = ' + $quotedBranchName` (single-quoted, `'`-escaped) and change the output line to `# To persist in your shell: $featureAssignment`. `BRANCH_NAME`/`FEATURE_NUM` lines are untouched.

## Test

`test_persist_hint_matches_twins` (pwsh CI): the non-JSON output uses `# To persist in your shell: $env:SPECIFY_FEATURE = '001-persist'` — fails before (old wording). Verified end-to-end via `powershell.exe`:

```
BRANCH_NAME: 001-persist
FEATURE_NUM: 001
# To persist in your shell: $env:SPECIFY_FEATURE = '001-persist'
```

Merge precedent for this exact bash-parity vein on these files: #3195, #3129/#3130.

---
🤖 Written with the assistance of Claude Code (AI). Bug self-found; fix/tests verified locally (fail-before / pass-after), ruff & ASCII-only checks clean.