### PR TITLE
fix(workflows): workflow add detects local YAML files case-insensitively

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -1555,7 +1555,7 @@ def workflow_add(
     # precedence over --from so a URL that would be ignored is never fetched.
     if dev:
         dev_path = Path(source).expanduser()
-        if dev_path.is_file() and dev_path.suffix in (".yml", ".yaml"):
+        if dev_path.is_file() and dev_path.suffix.lower() in (".yml", ".yaml"):
             _validate_and_install_local(dev_path, str(dev_path))
             return
         if dev_path.is_dir():
@@ -1714,7 +1714,7 @@ def workflow_add(
     # Try as a local file/directory
     source_path = Path(source)
     if source_path.exists():
-        if source_path.is_file() and source_path.suffix in (".yml", ".yaml"):
+        if source_path.is_file() and source_path.suffix.lower() in (".yml", ".yaml"):
             _validate_and_install_local(source_path, str(source_path))
             return
         elif source_path.is_dir():

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -7499,6 +7499,63 @@ class TestWorkflowRemoveGuard:
         assert "[stage]permissiondenied" in output_compact
         assert "[reg]diskfull" in output_compact
 
+
+class TestWorkflowAddCaseInsensitiveSuffix:
+    """`workflow add` must detect a local YAML file case-insensitively, matching
+    `workflow run` (_commands.py:workflow_run) and the engine loader
+    (engine.py:WorkflowEngine.load_workflow), which both use `.suffix.lower()`.
+    Without it, `workflow run Sample.YAML` works but `workflow add Sample.YAML`
+    fails — an add/run inconsistency for an uppercase extension."""
+
+    def test_plain_path_accepts_uppercase_extension(self, temp_dir, monkeypatch, sample_workflow_yaml):
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        (temp_dir / ".specify" / "workflows").mkdir(parents=True)
+        src = temp_dir / "Sample.YAML"
+        src.write_text(sample_workflow_yaml, encoding="utf-8")
+
+        monkeypatch.chdir(temp_dir)
+        result = CliRunner().invoke(app, ["workflow", "add", str(src)])
+
+        # Before the fix: `.suffix in (...)` is case-sensitive, so ".YAML" is not
+        # recognized as a local file; the path falls through to catalog lookup
+        # and fails. After the fix it installs like the lowercase happy path.
+        assert result.exit_code == 0, result.output
+        assert "installed" in result.output
+
+    def test_dev_path_accepts_uppercase_extension(self, temp_dir, monkeypatch, sample_workflow_yaml):
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        (temp_dir / ".specify" / "workflows").mkdir(parents=True)
+        src = temp_dir / "Sample.YAML"
+        src.write_text(sample_workflow_yaml, encoding="utf-8")
+
+        monkeypatch.chdir(temp_dir)
+        result = CliRunner().invoke(app, ["workflow", "add", "--dev", str(src)])
+
+        # Before the fix the --dev branch rejects ".YAML" with
+        # "--dev source must be a workflow YAML file ...".
+        assert result.exit_code == 0, result.output
+        assert "installed" in result.output
+
+    def test_lowercase_extension_still_installs(self, temp_dir, monkeypatch, sample_workflow_yaml):
+        """Happy path (lowercase .yml) is unchanged by the case-normalization."""
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        (temp_dir / ".specify" / "workflows").mkdir(parents=True)
+        src = temp_dir / "sample.yml"
+        src.write_text(sample_workflow_yaml, encoding="utf-8")
+
+        monkeypatch.chdir(temp_dir)
+        result = CliRunner().invoke(app, ["workflow", "add", str(src)])
+
+        assert result.exit_code == 0, result.output
+        assert "installed" in result.output
+
+
 class TestWorkflowAddSymlinkGuard:
     def test_add_malformed_ipv6_url_exits_cleanly(self, temp_dir, monkeypatch):
         """A malformed IPv6 URL must produce a clean error, not a ValueError traceback."""


### PR DESCRIPTION
## What

`specify workflow add` gated its two local-file branches on a **case-sensitive** extension check — `.suffix in (".yml", ".yaml")` — at both the `--dev` branch (`src/specify_cli/workflows/_commands.py`) and the plain local-path branch. Every other YAML-file detector in the CLI normalizes case first:

- `workflow run` → `source_path.suffix.lower() in (".yml", ".yaml")`
- `WorkflowEngine.load_workflow` → `path.suffix.lower() in (".yml", ".yaml")`

## Why it matters

An add/run inconsistency for uppercase extensions (e.g. `Sample.YAML`, `wf.YML`):

- `specify workflow run Sample.YAML` **loads** the file (case-insensitive), but
- `specify workflow add Sample.YAML` does **not** recognize it as a local workflow:
  - the `--dev` branch rejects it with *"--dev source must be a workflow YAML file or a directory containing workflow.yml"*
  - the plain path falls through to a catalog lookup and fails with *"not found in catalog"*

`Path("x.YAML").suffix` preserves case regardless of filesystem, so the mismatch isn't masked on case-insensitive systems.

## Fix

Add `.lower()` to both suffix reads so `workflow add` matches `workflow run` and the engine loader. The lowercase happy path is unchanged (2-line source change).

## Tests

`tests/test_workflows.py::TestWorkflowAddCaseInsensitiveSuffix`:
- `test_plain_path_accepts_uppercase_extension` — `workflow add Sample.YAML` installs (fails before the fix with "not found in catalog")
- `test_dev_path_accepts_uppercase_extension` — `workflow add --dev Sample.YAML` installs (fails before with the "--dev source must be…" error)
- `test_lowercase_extension_still_installs` — happy-path regression guard

Verified fail-before / pass-after (reverting only the source hunk makes the two uppercase tests fail with the exact errors above). `ruff check` clean.

---
*AI-assisted: authored with Claude Code. I reviewed the change, verified it against the `workflow run` / `load_workflow` siblings, and confirmed the fail-before/pass-after behavior.*