### PR TITLE
docs(workflows): fix stale FanOutStep docstring claiming sequential-only execution

### DIFF
--- a/src/specify_cli/workflows/steps/fan_out/__init__.py
+++ b/src/specify_cli/workflows/steps/fan_out/__init__.py
@@ -12,9 +12,10 @@ class FanOutStep(StepBase):
     """Dispatch a step template for each item in a collection.
 
     The engine executes the nested ``step:`` template once per item,
-    setting ``context.item`` for each iteration.  Execution is
-    currently sequential; ``max_concurrency`` is accepted but not
-    enforced.
+    setting ``context.item`` for each iteration.  ``max_concurrency``
+    controls parallelism: ``<= 1`` (the default) runs items
+    sequentially, while ``> 1`` runs up to that many items concurrently
+    on a bounded thread pool (see ``WorkflowEngine._run_fan_out``).
     """
 
     type_key = "fan-out"


### PR DESCRIPTION
## What

The `FanOutStep` class docstring (`src/specify_cli/workflows/steps/fan_out/__init__.py`) still claims:

> Execution is currently sequential; `max_concurrency` is accepted but not enforced.

That has been inaccurate since **#3224** (`feat(workflows): honor max_concurrency in fan-out via a bounded thread pool`), which added a real bounded-thread-pool concurrency path to `WorkflowEngine._run_fan_out`. That PR updated `engine.py`, `base.py`, and tests, but the step's own class docstring was never updated, so it now contradicts the code.

## Fix

Update the docstring to match the engine's authoritative `_run_fan_out` docstring:

> `max_concurrency` controls parallelism: `<= 1` (the default) runs items sequentially, while `> 1` runs up to that many items concurrently on a bounded thread pool (see `WorkflowEngine._run_fan_out`).

Docstring-only change — no behavior change, no test needed. `ruff check` clean; import/docstring verified.

---
*AI-assisted: authored with Claude Code. I verified the claim against `WorkflowEngine._run_fan_out` and commit 20f4306 (#3224).*