### PR TITLE
docs(installation): document the 'py' (Python) script type

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,6 +92,7 @@ Force a specific script type:
 ```bash
 specify init <project_name> --script sh
 specify init <project_name> --script ps
+specify init <project_name> --script py
 ```
 
 ### Ignore Agent Tools Check
@@ -131,6 +132,7 @@ Scripts are installed into a variant subdirectory matching the chosen script typ
 
 - `.specify/scripts/bash/` — contains `.sh` scripts (default on Linux/macOS)
 - `.specify/scripts/powershell/` — contains `.ps1` scripts (default on Windows)
+- `.specify/scripts/python/` — contains `.py` scripts (chosen with `--script py`; also installs the platform shell fallback)
 
 ## Troubleshooting
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -77,9 +77,9 @@ specify init <project_name> --integration pi
 specify init <project_name> --integration omp
 ```
 
-### Specify Script Type (Shell vs PowerShell)
+### Specify Script Type (Shell, PowerShell, or Python)
 
-All automation scripts now have both Bash (`.sh`) and PowerShell (`.ps1`) variants.
+Automation scripts are available as Bash (`.sh`), PowerShell (`.ps1`), and Python (`.py`) variants.
 
 Auto behavior:
 


### PR DESCRIPTION
## What

The installation guide's **Specify Script Type** section documented only two script types (`sh`, `ps`) in its force-example block, and the installed-variant list mentioned only `.specify/scripts/bash/` and `.specify/scripts/powershell/`. The CLI actually supports a third:

- `src/specify_cli/_agent_config.py` → `SCRIPT_TYPE_CHOICES = {"sh": ..., "ps": ..., "py": "Python"}`
- `src/specify_cli/commands/init.py` → `--script` help: *"Script type to use: sh, ps, or py"*
- `src/specify_cli/shared_infra.py` (~L407) → `script_type == "py"` installs `variant_dirs = ("python", <platform shell>)`, i.e. a `python/` directory plus the platform shell fallback.

## Fix

Two additions to `docs/installation.md`:
- a `specify init <project_name> --script py` force example, and
- a `.specify/scripts/python/` bullet in the installed-variant list.

Docs-only. `markdownlint-cli2` reports no new issues on the added lines (the two pre-existing `MD049` findings at line 9 are unrelated and untouched).

---
*AI-assisted: authored with Claude Code. I verified `py` against `SCRIPT_TYPE_CHOICES`, the `--script` option help, and the `shared_infra.py` variant-dir mapping.*