### PR TITLE
fix(extensions): render hyphenated hook invocations for Forge projects

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -3608,6 +3608,7 @@ class HookExecutor:
         dollar_skill_mode = is_dollar_skills_agent(selected_ai, ai_skills_enabled)
         kimi_skill_mode = selected_ai == "kimi"
         cline_mode = selected_ai == "cline"
+        forge_mode = selected_ai == "forge"
 
         skill_name = self._skill_name_from_command(command_id)
         if dollar_skill_mode and skill_name:
@@ -3618,6 +3619,10 @@ class HookExecutor:
             from ..integrations.cline import format_cline_command_name
 
             return f"/{format_cline_command_name(command_id)}"
+        if forge_mode:
+            from ..integrations.forge import format_forge_command_name
+
+            return f"/{format_forge_command_name(command_id)}"
 
         use_slash = is_slash_skills_agent(selected_ai, ai_skills_enabled)
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -8238,6 +8238,42 @@ class TestHookInvocationRendering:
         assert execution["command"] == "my-extension.do-something"
         assert execution["invocation"] == "/speckit-my-extension-do-something"
 
+    def test_forge_hooks_render_hyphenated_invocation(self, project_dir):
+        """Forge projects should render /speckit-* invocations (like Cline)."""
+        init_options = project_dir / ".specify" / "init-options.json"
+        init_options.parent.mkdir(parents=True, exist_ok=True)
+        init_options.write_text(json.dumps({"ai": "forge"}))
+
+        hook_executor = HookExecutor(project_dir)
+        execution = hook_executor.execute_hook(
+            {
+                "extension": "test-ext",
+                "command": "speckit.tasks",
+                "optional": False,
+            }
+        )
+
+        assert execution["command"] == "speckit.tasks"
+        assert execution["invocation"] == "/speckit-tasks"
+
+    def test_forge_hooks_render_extension_command(self, project_dir):
+        """Forge projects should render /speckit-my-ext-cmd for extension hooks."""
+        init_options = project_dir / ".specify" / "init-options.json"
+        init_options.parent.mkdir(parents=True, exist_ok=True)
+        init_options.write_text(json.dumps({"ai": "forge"}))
+
+        hook_executor = HookExecutor(project_dir)
+        execution = hook_executor.execute_hook(
+            {
+                "extension": "test-ext",
+                "command": "my-extension.do-something",
+                "optional": False,
+            }
+        )
+
+        assert execution["command"] == "my-extension.do-something"
+        assert execution["invocation"] == "/speckit-my-extension-do-something"
+
     def test_non_skill_command_keeps_slash_invocation(self, project_dir):
         """Custom hook commands should keep slash invocation style."""
         init_options = project_dir / ".specify" / "init-options.json"


### PR DESCRIPTION
## What

Forge is a hyphenated slash-command agent — it registers its commands as `/speckit-<name>` (see `format_forge_command_name` and `ForgeIntegration.build_command_invocation` in `src/specify_cli/integrations/forge/__init__.py`), exactly like Cline.

But `HookExecutor._render_hook_invocation` (`src/specify_cli/extensions/__init__.py`) special-cases only dollar-skills agents, `kimi`, `cline`, and slash-skills agents. Forge matches none of them, so it fell through to:

```python
return f"/{command_id}"
```

rendering the **dotted** form — `/speckit.plan`, `/speckit.git.commit` — which Forge does not recognize as a registered command. Hook execution messages therefore told Forge users to run commands that don't exist under that name.

## Fix

Add a Forge branch mirroring the adjacent Cline branch:

```python
if forge_mode:
    from ..integrations.forge import format_forge_command_name
    return f"/{format_forge_command_name(command_id)}"
```

`format_forge_command_name` is idempotent and has the same contract as the Cline formatter already used one branch above. Non-Forge agents are unaffected.

## Tests

`tests/test_extensions.py::TestHookInvocationRendering` — two tests mirroring the existing Cline hook tests:
- `test_forge_hooks_render_hyphenated_invocation` → `speckit.tasks` renders `/speckit-tasks`
- `test_forge_hooks_render_extension_command` → `my-extension.do-something` renders `/speckit-my-extension-do-something`

Verified fail-before / pass-after (reverting only the source hunk makes both fail, rendering the dotted `/my-extension.do-something`). `ruff check` clean.

---
*AI-assisted: authored with Claude Code. I confirmed Forge's hyphenated command registration and that the Cline branch is the exact sibling precedent, and verified fail-before/pass-after.*