### PR TITLE
fix(init): show hyphenated /speckit-<name> in Next Steps for Forge projects

### DIFF
--- a/src/specify_cli/commands/init.py
+++ b/src/specify_cli/commands/init.py
@@ -700,6 +700,7 @@ def register(app: typer.Typer) -> None:
         zed_skill_mode = selected_ai == "zed" and _is_skills_integration
         grok_skill_mode = selected_ai == "grok" and _is_skills_integration
         cline_skill_mode = selected_ai == "cline"
+        forge_skill_mode = selected_ai == "forge"
         bob_skill_mode = selected_ai == "bob" and _is_skills_integration
         native_skill_mode = (
             codex_skill_mode
@@ -776,6 +777,7 @@ def register(app: typer.Typer) -> None:
             if (
                 _is_slash_skills_agent(selected_ai, _ai_skills_enabled)
                 or cline_skill_mode
+                or forge_skill_mode
             ):
                 return f"/speckit-{name}"
             return f"/speckit.{name}"

--- a/tests/integrations/test_integration_forge.py
+++ b/tests/integrations/test_integration_forge.py
@@ -475,3 +475,39 @@ class TestForgeCommandRegistrar:
             "Found '/speckit.specify' (dot notation) in generated Forge git.feature command body. "
             "Forge requires hyphen notation for ZSH compatibility."
         )
+
+
+class TestForgeInitNextSteps:
+    """The post-init 'Next steps' panel must show hyphenated /speckit-<name>
+    commands for Forge, since Forge only registers the hyphenated form
+    (see the generated command-file tests above)."""
+
+    def test_init_next_steps_show_hyphenated_commands(self, tmp_path):
+        import os
+
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+
+        project = tmp_path / "forge-nextsteps"
+        project.mkdir()
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(project)
+            result = CliRunner().invoke(
+                app,
+                ["init", "--here", "--integration", "forge", "--ignore-agent-tools"],
+                catch_exceptions=False,
+            )
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0, f"init failed: {result.output}"
+        # Forge registers /speckit-<name>; the next-steps panel must match.
+        assert "/speckit-plan" in result.output, (
+            f"Expected /speckit-plan in next steps but got:\n{result.output}"
+        )
+        # Must NOT show the dotted /speckit.plan form Forge can't invoke.
+        assert "/speckit.plan" not in result.output, (
+            f"Should not show dotted /speckit.plan for Forge:\n{result.output}"
+        )


### PR DESCRIPTION
## What

The post-init **Next Steps** panel renders the recommended slash commands through the nested `_display_cmd()` in `src/specify_cli/commands/init.py`. It special-cased dollar-skills agents, `kimi`, slash-skills agents, and `cline` — but not Forge. For a Forge project `_display_cmd` fell through to:

```python
return f"/speckit.{name}"
```

printing `/speckit.constitution`, `/speckit.specify`, `/speckit.plan`, etc.

Forge only registers the **hyphenated** form `/speckit-<name>` (via `format_forge_command_name` / `ForgeIntegration.build_command_invocation`; the generated Forge command-file tests in `test_integration_forge.py` already assert dot-notation must not appear). So the panel instructed Forge users to run commands that don't exist under the dotted name.

## Fix

Add `forge_skill_mode = selected_ai == "forge"` alongside the existing `cline_skill_mode`, and include it in the hyphenated-slash condition — mirroring exactly how Cline (also a non-skills markdown agent with hyphenated commands) is handled. Other agents are unaffected.

## Tests

`tests/integrations/test_integration_forge.py::TestForgeInitNextSteps` — runs `specify init --here --integration forge` and asserts the output contains `/speckit-plan` and **not** `/speckit.plan`, mirroring the existing Copilot/Grok next-steps tests.

Verified fail-before / pass-after (reverting only the source hunk makes the test fail — the panel renders the dotted `/speckit.checklist` / `/speckit.plan`). `ruff check` clean.

---
*AI-assisted: authored with Claude Code. I confirmed Forge's hyphenated registration, that Cline is the exact sibling precedent in this same closure, and verified fail-before/pass-after.*