### PR TITLE
Fix duplicate step numbering in specify command

### DIFF
--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -139,9 +139,9 @@ Given that feature description, do this:
     7. Identify Key Entities (if data involved)
     8. Return: SUCCESS (spec ready for planning)
 
-6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+7. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
 
-7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+8. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
 
    a. **Create Spec Quality Checklist**: Generate a checklist file at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md` using the checklist template structure with these validation items:
 

--- a/tests/test_specify_template_numbering.py
+++ b/tests/test_specify_template_numbering.py
@@ -1,0 +1,44 @@
+"""Regression tests for top-level step numbering in specify.md."""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SPECIFY_TEMPLATE = REPO_ROOT / "templates" / "commands" / "specify.md"
+
+
+def _main_execution_ordinals(text: str) -> list[int]:
+    """Extract ordinals from the first top-level numbered list."""
+    ordinals: list[int] = []
+
+    for line in text.splitlines():
+        match = re.match(r"^(\d+)\. ", line)
+        if not match:
+            continue
+
+        ordinal = int(match.group(1))
+        if not ordinals:
+            if ordinal == 1:
+                ordinals.append(ordinal)
+        elif ordinal == 1:
+            break
+        else:
+            ordinals.append(ordinal)
+
+    return ordinals
+
+
+def test_main_execution_list_has_no_duplicate_ordinals():
+    """The main execution list must not reuse a step number."""
+    ordinals = _main_execution_ordinals(SPECIFY_TEMPLATE.read_text(encoding="utf-8"))
+    duplicates = {ordinal for ordinal in ordinals if ordinals.count(ordinal) > 1}
+
+    assert not duplicates, f"Duplicate top-level ordinals found: {sorted(duplicates)}"
+
+
+def test_main_execution_list_is_sequential():
+    """The main execution list must run from 1 through N without gaps."""
+    ordinals = _main_execution_ordinals(SPECIFY_TEMPLATE.read_text(encoding="utf-8"))
+
+    assert ordinals, "Could not find the main execution list in specify.md"
+    assert ordinals == list(range(1, len(ordinals) + 1))

--- a/tests/test_specify_template_numbering.py
+++ b/tests/test_specify_template_numbering.py
@@ -5,27 +5,22 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 SPECIFY_TEMPLATE = REPO_ROOT / "templates" / "commands" / "specify.md"
+MAIN_LIST_START = "Given that feature description, do this:"
+MAIN_LIST_END = "## Mandatory Post-Execution Hooks"
 
 
 def _main_execution_ordinals(text: str) -> list[int]:
-    """Extract ordinals from the first top-level numbered list."""
-    ordinals: list[int] = []
+    """Extract top-level ordinals from the main execution flow."""
+    _, start, execution_flow = text.partition(MAIN_LIST_START)
+    execution_flow, end, _ = execution_flow.partition(MAIN_LIST_END)
+    if not start or not end:
+        return []
 
-    for line in text.splitlines():
-        match = re.match(r"^(\d+)\. ", line)
-        if not match:
-            continue
-
-        ordinal = int(match.group(1))
-        if not ordinals:
-            if ordinal == 1:
-                ordinals.append(ordinal)
-        elif ordinal == 1:
-            break
-        else:
-            ordinals.append(ordinal)
-
-    return ordinals
+    return [
+        int(match.group(1))
+        for line in execution_flow.splitlines()
+        if (match := re.match(r"^(\d+)\. ", line))
+    ]
 
 
 def test_main_execution_list_has_no_duplicate_ordinals():
@@ -41,4 +36,4 @@ def test_main_execution_list_is_sequential():
     ordinals = _main_execution_ordinals(SPECIFY_TEMPLATE.read_text(encoding="utf-8"))
 
     assert ordinals, "Could not find the main execution list in specify.md"
-    assert ordinals == list(range(1, len(ordinals) + 1))
+    assert ordinals == list(range(1, 9))


### PR DESCRIPTION
## Description

The Specify command's main execution flow reused step 6, leaving the specification-writing and quality-validation phases structurally misnumbered. This renumbers the flow sequentially through step 8 and adds regression coverage that rejects duplicate, missing, or non-sequential top-level ordinals.

Preset overrides are unchanged because they do not embed the affected core execution flow.

## Testing

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Targeted test: `.venv/bin/python -m pytest tests/test_specify_template_numbering.py -q` (2 passed).

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot (GPT-5.6 Sol) autonomously investigated the issue, implemented the template and regression-test changes, and prepared this pull request on behalf of @BenBtg.

Fixes: #2407