### PR TITLE
fix(integrations): declare OmpIntegration multi_install_safe

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -275,6 +275,7 @@ The currently declared multi-install safe integrations are:
 | `junie` | `.junie/commands` |
 | `kilocode` | `.kilocode/workflows` |
 | `kiro-cli` | `.kiro/prompts` |
+| `omp` | `.omp/commands` |
 | `qodercli` | `.qoder/commands` |
 | `qwen` | `.qwen/commands` |
 | `shai` | `.shai/commands` |

--- a/src/specify_cli/integrations/omp/__init__.py
+++ b/src/specify_cli/integrations/omp/__init__.py
@@ -20,6 +20,7 @@ class OmpIntegration(MarkdownIntegration):
         "args": "$ARGUMENTS",
         "extension": ".md",
     }
+    multi_install_safe = True
 
     def build_exec_args(
         self,

--- a/tests/integrations/test_integration_omp.py
+++ b/tests/integrations/test_integration_omp.py
@@ -11,6 +11,12 @@ class TestOmpIntegration(MarkdownIntegrationTests):
     COMMANDS_SUBDIR = "commands"
     REGISTRAR_DIR = ".omp/commands"
 
+    def test_multi_install_safe(self):
+        # Omp writes only to its isolated, static root .omp/commands, disjoint
+        # from every other integration, so it must be co-install safe (mirrors
+        # qwen/shai/qodercli and the kiro-cli #3471 precedent).
+        assert get_integration(self.KEY).multi_install_safe is True
+
     def test_build_exec_args_uses_omp_json_mode(self):
         i = get_integration(self.KEY)
 


### PR DESCRIPTION
## What

`OmpIntegration` is a plain `MarkdownIntegration` whose files live only under its isolated, static root `.omp/commands/` — disjoint from every other integration. But it never declared `multi_install_safe`, so it inherited the `IntegrationBase` default `False`.

## Why it matters

Per the isolation policy (and the merged kiro-cli fix #3471), an integration that is fully isolated but *not* declared safe leaves `specify integration status` in a permanent `unsafe-multi-install` ERROR state whenever omp is co-installed alongside another agent — with no acknowledgment path. Omp meets none of the documented exclusion criteria (it doesn't share a command dir, needs no dynamic path, merges no shared settings).

## Fix

Add `multi_install_safe = True`, mirroring the isolated `MarkdownIntegration` cohort (`qwen`, `shai`, `qodercli`, `junie`, `kilocode`) and the kiro-cli #3471 precedent. One-line class attribute.

## Tests

`tests/integrations/test_integration_omp.py::TestOmpIntegration::test_multi_install_safe` — asserts the flag (fails before the fix). The parametrized registry isolation contracts (`test_registry.py`) auto-include omp once the flag is set and all pass — `.omp/commands` is isolated and its manifest disjoint from every other safe integration. `ruff` clean.

---
*AI-assisted: authored with Claude Code. I verified `.omp/` is unique across all integrations and that the full registry isolation contracts pass with the flag set.*