### PR TITLE
fix(integrations): declare PiIntegration multi_install_safe

### DIFF
--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -276,6 +276,7 @@ The currently declared multi-install safe integrations are:
 | `kilocode` | `.kilocode/workflows` |
 | `kiro-cli` | `.kiro/prompts` |
 | `omp` | `.omp/commands` |
+| `pi` | `.pi/prompts` |
 | `qodercli` | `.qoder/commands` |
 | `qwen` | `.qwen/commands` |
 | `shai` | `.shai/commands` |

--- a/src/specify_cli/integrations/pi/__init__.py
+++ b/src/specify_cli/integrations/pi/__init__.py
@@ -18,3 +18,4 @@ class PiIntegration(MarkdownIntegration):
         "args": "$ARGUMENTS",
         "extension": ".md",
     }
+    multi_install_safe = True

--- a/tests/integrations/test_integration_pi.py
+++ b/tests/integrations/test_integration_pi.py
@@ -1,5 +1,7 @@
 """Tests for PiIntegration."""
 
+from specify_cli.integrations import get_integration
+
 from .test_integration_base_markdown import MarkdownIntegrationTests
 
 
@@ -8,3 +10,9 @@ class TestPiIntegration(MarkdownIntegrationTests):
     FOLDER = ".pi/"
     COMMANDS_SUBDIR = "prompts"
     REGISTRAR_DIR = ".pi/prompts"
+
+    def test_multi_install_safe(self):
+        # Pi writes only to its isolated, static root .pi/prompts, disjoint from
+        # every other integration, so it must be co-install safe (mirrors
+        # qwen/shai/qodercli and the kiro-cli #3471 precedent).
+        assert get_integration(self.KEY).multi_install_safe is True


### PR DESCRIPTION
## What

`PiIntegration` writes only to its isolated, static root `.pi/prompts` — disjoint from every other integration — yet never declared `multi_install_safe`, so it inherited the `IntegrationBase` default `False`.

## Why it matters

Like the merged kiro-cli fix #3471, an isolated-but-undeclared integration leaves `specify integration status` in a permanent `unsafe-multi-install` ERROR state when pi is co-installed alongside another agent, with no acknowledgment path. Pi meets none of the documented exclusion criteria (no shared command dir, no dynamic path, no merged settings). Every sibling isolated `MarkdownIntegration` got the flag in the #2389 rollout; pi was skipped.

## Fix

Add `multi_install_safe = True`, mirroring `qwen`/`shai`/`qodercli` and the kiro-cli #3471 precedent.

## Tests

`test_integration_pi.py::TestPiIntegration::test_multi_install_safe` (fails before the fix). The parametrized registry isolation contracts auto-include pi once the flag is set and pass — `.pi/prompts` is isolated and its manifest disjoint. `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified `.pi/` is unique across all integrations and the isolation contracts pass with the flag set.*