### PR TITLE
fix(integrations): declare LingmaIntegration multi_install_safe

### DIFF
--- a/src/specify_cli/integrations/lingma/__init__.py
+++ b/src/specify_cli/integrations/lingma/__init__.py
@@ -27,6 +27,7 @@ class LingmaIntegration(SkillsIntegration):
         "args": "$ARGUMENTS",
         "extension": "/SKILL.md",
     }
+    multi_install_safe = True
 
     @classmethod
     def options(cls) -> list[IntegrationOption]:

--- a/tests/integrations/test_integration_lingma.py
+++ b/tests/integrations/test_integration_lingma.py
@@ -1,5 +1,7 @@
 """Tests for LingmaIntegration."""
 
+from specify_cli.integrations import get_integration
+
 from .test_integration_base_skills import SkillsIntegrationTests
 
 
@@ -8,3 +10,9 @@ class TestLingmaIntegration(SkillsIntegrationTests):
     FOLDER = ".lingma/"
     COMMANDS_SUBDIR = "skills"
     REGISTRAR_DIR = ".lingma/skills"
+
+    def test_multi_install_safe(self):
+        # Lingma writes only to its isolated, static root .lingma/skills,
+        # disjoint from every other integration, so it must be co-install safe
+        # (mirrors trae/zcode and the kiro-cli #3471 precedent).
+        assert get_integration(self.KEY).multi_install_safe is True


### PR DESCRIPTION
## What

`LingmaIntegration` writes only to its isolated, static root `.lingma/skills` — disjoint from every other integration — yet never declared `multi_install_safe`, so it inherited the `IntegrationBase` default `False`.

## Why it matters

Like the merged kiro-cli fix #3471, an isolated-but-undeclared integration leaves `specify integration status` in a permanent `unsafe-multi-install` ERROR state when lingma is co-installed alongside another agent, with no acknowledgment path. `trae` and `zcode` — structurally identical `SkillsIntegration`s (IDE, `install_url=None`, `requires_cli=False`, only a `--skills` option) — both declare the flag.

## Fix

Add `multi_install_safe = True`, mirroring `trae`/`zcode` and the kiro-cli #3471 precedent.

## Tests

`test_integration_lingma.py::TestLingmaIntegration::test_multi_install_safe` (fails before the fix). The parametrized registry isolation contracts auto-include lingma once the flag is set and pass — `.lingma/skills` is isolated and its manifest disjoint. `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified `.lingma/` is unique across all integrations and the isolation contracts pass with the flag set.*