### PR TITLE
docs(workflows): init step docstring lists the 'py' script type

### DIFF
--- a/src/specify_cli/workflows/steps/init/__init__.py
+++ b/src/specify_cli/workflows/steps/init/__init__.py
@@ -59,7 +59,7 @@ class InitStep(StepBase):
         Extra options for the integration (e.g. ``"--skills"`` or
         ``"--commands-dir .myagent/cmds"``).
     ``script``
-        Script type, ``sh`` or ``ps``.
+        Script type, ``sh``, ``ps``, or ``py``.
     ``force``
         Merge/overwrite without confirmation when the directory is not
         empty.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1935,6 +1935,14 @@ def _force_gate_stdin(monkeypatch, *, tty: bool):
 class TestInitStep:
     """Test the init step type."""
 
+    def test_docstring_lists_every_valid_script_type(self):
+        # The `script` field docstring must not contradict the step's own
+        # VALID_SCRIPT_TYPES (which includes 'py'); validate() accepts all three.
+        from specify_cli.workflows.steps.init import InitStep, VALID_SCRIPT_TYPES
+
+        for script_type in VALID_SCRIPT_TYPES:
+            assert f"``{script_type}``" in InitStep.__doc__
+
     def test_builds_here_argv_and_bootstraps(self, tmp_path):
         from specify_cli.workflows.steps.init import InitStep
         from specify_cli.workflows.base import StepContext, StepStatus


### PR DESCRIPTION
## What

The `InitStep` class docstring described the `script` field as *"Script type, `sh` or `ps`."* — but the init workflow step accepts a third value, `py`:

- `VALID_SCRIPT_TYPES = tuple(SCRIPT_TYPE_CHOICES.keys())` resolves to `('sh', 'ps', 'py')`
- `validate()` accepts any of the three and builds its error message dynamically from `VALID_SCRIPT_TYPES`
- so `script: py` passes validation and produces a valid `--script py` argv

The docstring was the only place hard-coding the stale two-value pair, contradicting the same class's `validate()` authority.

## Fix

Docstring-only: `Script type, ``sh`` or ``ps``.` → `Script type, ``sh``, ``ps``, or ``py``.`

## Tests

`tests/test_workflows.py::TestInitStep::test_docstring_lists_every_valid_script_type` — asserts every `VALID_SCRIPT_TYPES` entry appears in `InitStep.__doc__` (fails before the fix, since `py` was absent). `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified against `VALID_SCRIPT_TYPES` and the step's own `validate()`.*