### PR TITLE
docs(workflows): gate step docstring lists the 'retry' on_reject behaviour

### DIFF
--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -26,7 +26,7 @@ class GateStep(StepBase):
     later with ``specify workflow resume``.
 
     The user's choice is stored in ``output.choice``.  ``on_reject``
-    controls abort / skip behaviour.
+    controls abort / skip / retry behaviour.
     """
 
     type_key = "gate"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2100,6 +2100,15 @@ class TestInitStep:
 class TestGateStep:
     """Test the gate step type."""
 
+    def test_docstring_lists_every_on_reject_behaviour(self):
+        # The docstring must not contradict validate()/execute(): on_reject
+        # accepts 'abort', 'skip', AND 'retry' (execute() has a dedicated
+        # retry -> PAUSED branch), but the summary omitted 'retry'.
+        from specify_cli.workflows.steps.gate import GateStep
+
+        for behaviour in ("abort", "skip", "retry"):
+            assert behaviour in GateStep.__doc__
+
     @pytest.fixture(autouse=True)
     def _non_tty_stdin_by_default(self, monkeypatch):
         # Default every gate test to a non-TTY stdin so none can drop into


### PR DESCRIPTION
## What

The `GateStep` class docstring said `on_reject` *"controls abort / skip behaviour"* — listing only two behaviours. The step actually supports three:

- `validate()` rejects any `on_reject` not in `('abort', 'skip', 'retry')`
- `execute()` has a dedicated `retry` branch (returns `PAUSED` so the next `resume` re-executes the gate), distinct from `abort` (`FAILED`) and `skip` (`COMPLETED`)

The docstring was the only place omitting `retry`, contradicting the same file's `validate()` and `execute()`.

## Fix

Docstring-only: `controls abort / skip behaviour.` → `controls abort / skip / retry behaviour.`

## Tests

`tests/test_workflows.py::TestGateStep::test_docstring_lists_every_on_reject_behaviour` — asserts all three behaviours appear in `GateStep.__doc__` (fails before the fix). `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified against the step's own `validate()` accepted set and `execute()` branches.*