### PR TITLE
fix(integrations): Cline overrides post_process_command_content (correct hook name)

### DIFF
--- a/src/specify_cli/integrations/cline/__init__.py
+++ b/src/specify_cli/integrations/cline/__init__.py
@@ -138,8 +138,14 @@ class ClineIntegration(MarkdownIntegration):
             content,
         )
 
-    def post_process_content(self, content: str) -> str:
-        """Apply Cline-specific transformations to command content."""
+    def post_process_command_content(self, content: str) -> str:
+        """Apply Cline-specific transformations to command content.
+
+        Overrides the ``IntegrationBase`` hook of the same name so that
+        ``CommandRegistrar.register_commands()`` (which dispatches to
+        ``post_process_command_content``) applies these transforms to
+        extension/preset command files too, not just core commands.
+        """
         updated = self._inject_hook_command_note(content)
         updated = self._rewrite_handoff_references(updated)
         return updated
@@ -169,7 +175,7 @@ class ClineIntegration(MarkdownIntegration):
             content_bytes = path.read_bytes()
             content = content_bytes.decode("utf-8")
 
-            updated = self.post_process_content(content)
+            updated = self.post_process_command_content(content)
 
             if updated != content:
                 path.write_bytes(updated.encode("utf-8"))

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -243,3 +243,34 @@ class TestRegressionPlainTemplate:
         assert output_file.exists(), f"Output file missing for {agent}"
         content = output_file.read_text(encoding="utf-8")
         assert body_text.strip() in content, f"Body text missing in {agent} output"
+
+
+class TestClineRealPostProcess:
+    """Cline's real command-content transforms (hook-command note + handoff
+    dot->hyphen rewrite) must run for extension/preset commands registered via
+    CommandRegistrar. This exercises the REAL method (not a monkeypatched
+    marker), so it fails if Cline's override does not match the base hook name
+    the registrar dispatches to (post_process_command_content)."""
+
+    def test_cline_transforms_applied_via_registrar(
+        self, tmp_path, registrar, ext_dir
+    ):
+        ext, cmd_dir = ext_dir
+        body = (
+            "- For each executable hook, output the following:\n"
+            "agent: speckit.foo\n"
+        )
+        _write_cmd(cmd_dir, body=body)
+
+        commands = [{"name": "speckit.test.review", "file": "commands/review.md"}]
+        registrar.register_commands("cline", commands, "test-ext", ext, tmp_path)
+
+        outputs = list((tmp_path / ".clinerules" / "workflows").rglob("*.md"))
+        assert outputs, "no cline command file was written"
+        content = outputs[0].read_text(encoding="utf-8")
+
+        # _inject_hook_command_note fired (its note text contains "replace dots")
+        assert "replace dots" in content
+        # _rewrite_handoff_references rewrote the dotted agent handoff
+        assert "agent: speckit-foo" in content
+        assert "agent: speckit.foo" not in content


### PR DESCRIPTION
## What

`ClineIntegration` defined its command-content transform as `post_process_content`, but the overridable base hook is `IntegrationBase.post_process_command_content` — the method `CommandRegistrar.register_commands()` dispatches to (`agents.py:813` and `:877`) for every non-skills integration.

Because the names differed, Cline's method never overrode the base hook. For **extension/preset** command files registered via `CommandRegistrar`, the registrar therefore ran the base **no-op**, so those files never received Cline's dot-to-hyphen **hook-command note** (`_inject_hook_command_note`) — the note instructing the agent to replace dots with hyphens when invoking hook commands.

(Cline's own `setup()` still works because it calls the method directly. And handoff references are already hyphenated independently by the registrar's `_hyphenate_body_refs`, so that transform was unaffected — renaming just makes Cline's own copy run too, harmlessly, since both are idempotent.)

## Fix

Rename `post_process_content` → `post_process_command_content` (matching the base hook and the `post_process_skill_content` exact-name-override convention used by claude/copilot/agy/kimi/droid/vibe), and update the single internal caller in `setup()`. No test referenced the old name.

## Tests

`tests/test_post_process.py::TestClineRealPostProcess::test_cline_transforms_applied_via_registrar` — registers an extension command through `CommandRegistrar` and asserts Cline's **real** transform ran (the hook-command note's "replace dots" text is present). Fails before the fix (note absent — the base no-op ran); passes after. `ruff` clean; all 11 post-process tests pass.

---
*AI-assisted: authored with Claude Code. I traced the registrar dispatch (`post_process_command_content` at agents.py:813/877), confirmed the exact-name-override convention across sibling integrations, and verified via fail-before that the hook-command note is missing without the rename.*