### PR TITLE
fix(bundler): order bundle members by canonical POSIX arcname (reproducible builds)

### DIFF
--- a/src/specify_cli/bundler/services/packager.py
+++ b/src/specify_cli/bundler/services/packager.py
@@ -142,4 +142,10 @@ def _collect_files(
                 # Skip symlinked files to avoid escaping the bundle directory.
                 continue
             collected.append(path)
-    return sorted(collected)
+    # Order by the canonical POSIX arcname (the same key build_bundle uses to
+    # NAME each member), not by pathlib.Path comparison. Path ordering is
+    # platform-dependent (Windows folds case and uses backslash separators),
+    # which would lay out zip members differently across build hosts and break
+    # the byte-for-byte reproducible-build guarantee even though the member
+    # names are identical.
+    return sorted(collected, key=lambda p: p.relative_to(bundle_dir).as_posix())

--- a/tests/unit/test_bundler_packager.py
+++ b/tests/unit/test_bundler_packager.py
@@ -73,6 +73,23 @@ def test_build_is_deterministic(tmp_path: Path):
     assert first.artifact_path.read_bytes() == second.artifact_path.read_bytes()
 
 
+def test_member_order_is_platform_independent(tmp_path: Path):
+    # Members must be laid out in canonical POSIX-arcname order (the same key
+    # build_bundle uses to NAME them), not pathlib.Path order — which folds case
+    # on Windows and would otherwise reorder members across build hosts, breaking
+    # the byte-for-byte reproducibility guarantee. Mixed-case names make the
+    # difference observable: Path order on Windows groups differently than the
+    # canonical string sort.
+    bundle = _make_bundle(
+        tmp_path / "b",
+        extra_files={"Zeta.txt": "z", "apple.txt": "a", "Foo.txt": "f", "bar.txt": "b"},
+    )
+    result = build_bundle(bundle, output_dir=tmp_path / "out")
+    with zipfile.ZipFile(result.artifact_path) as archive:
+        names = archive.namelist()
+    assert names == sorted(names)
+
+
 def test_output_dir_inside_bundle_excludes_prior_artifacts(tmp_path: Path):
     bundle = _make_bundle(tmp_path / "b", extra_files={"a.txt": "a"})
     out_dir = bundle / "dist"


### PR DESCRIPTION
## What

`_collect_files` returned `sorted(collected)` — i.e. `pathlib.Path` comparison order. That ordering is **platform-dependent**: on Windows `PurePath` compares case-folded with backslash separators, while on Linux/macOS it compares the case-preserving forward-slash string.

But the zip member **names** are the canonical POSIX arcnames (`build_bundle`: `file_path.relative_to(bundle_dir).as_posix()`), which are platform-independent. So member *order* was derived from a platform-dependent key while member *names* were canonical — the same bundle built on Windows vs Linux/macOS produced archives whose members were laid out in different order, i.e. **not byte-for-byte identical across build hosts**. That contradicts the packager's stated reproducible-build guarantee (fixed timestamps + canonical 0644/0755 modes; `test_build_is_deterministic` asserts "byte-for-byte reproducible").

## Fix

Order by the **same canonical POSIX-arcname key** used to name the members:

```python
return sorted(collected, key=lambda p: p.relative_to(bundle_dir).as_posix())
```

## Tests

`tests/unit/test_bundler_packager.py::test_member_order_is_platform_independent` — builds a bundle with mixed-case sibling files and asserts `archive.namelist() == sorted(archive.namelist())`. Fails before the fix on Windows (Path order groups case differently: `apple.txt` sorts before `Foo.txt`); passes after. CI's `windows-latest` matrix exercises this. All existing packager tests (incl. `test_build_is_deterministic`) still pass. `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified the arcname key matches `build_bundle`'s naming, and confirmed fail-before on Windows / pass-after.*