### PR TITLE
fix(bundler): reject a top-level non-mapping bundle-catalogs.yml in _merge_config

### DIFF
--- a/src/specify_cli/bundler/commands_impl/catalog_config.py
+++ b/src/specify_cli/bundler/commands_impl/catalog_config.py
@@ -41,12 +41,11 @@ def _read(project_root: Path) -> list[dict]:
     if not path.exists():
         return []
     # ``load_yaml`` returns ``{}`` only for an empty document and the raw parse
-    # otherwise, so a falsy non-mapping (``[]``/``false``/``0``/``''``) is caught
-    # by the isinstance guard below and raised like a truthy one, staying
-    # consistent with the other reader of this file (models/catalog._merge_config).
+    # otherwise, so a non-mapping top level — a falsy ``[]``/``false``/``0``/``''``
+    # or an explicit null (``load_yaml`` -> ``None``) — is caught by the isinstance
+    # guard below and raised like a truthy one, staying consistent with the other
+    # reader of this file (models/catalog._merge_config).
     data = load_yaml(path)
-    if data is None:
-        return []
     if not isinstance(data, dict):
         raise BundlerError(
             f"Malformed catalog config at {path}: expected a mapping at the top "

--- a/src/specify_cli/bundler/commands_impl/catalog_config.py
+++ b/src/specify_cli/bundler/commands_impl/catalog_config.py
@@ -10,8 +10,10 @@ from pathlib import Path
 from urllib.parse import urlparse
 import re
 
+import yaml
+
 from .. import BundlerError
-from ..lib.yamlio import dump_yaml, ensure_within, load_yaml
+from ..lib.yamlio import dump_yaml, ensure_within
 from ..models.catalog import (
     CONFIG_FILENAME,
     BUILTIN_DEFAULT_STACK,
@@ -40,7 +42,17 @@ def _read(project_root: Path) -> list[dict]:
     path = ensure_within(project_root, _config_path(project_root))
     if not path.exists():
         return []
-    data = load_yaml(path)
+    # Parse the RAW document, not the shared ``load_yaml`` (whose ``… or {}``
+    # coerces a falsy top-level value to ``{}``): an empty document is a no-op,
+    # but a falsy non-mapping (``[]``/``false``/``0``/``''``) is malformed and
+    # must raise like a truthy one, staying consistent with the other reader of
+    # this file (models/catalog._merge_config).
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise BundlerError(f"Invalid YAML in {path}: {exc}") from exc
+    except OSError as exc:
+        raise BundlerError(f"Could not read {path}: {exc}") from exc
     if data is None:
         return []
     if not isinstance(data, dict):

--- a/src/specify_cli/bundler/commands_impl/catalog_config.py
+++ b/src/specify_cli/bundler/commands_impl/catalog_config.py
@@ -10,10 +10,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 import re
 
-import yaml
-
 from .. import BundlerError
-from ..lib.yamlio import dump_yaml, ensure_within
+from ..lib.yamlio import dump_yaml, ensure_within, load_yaml
 from ..models.catalog import (
     CONFIG_FILENAME,
     BUILTIN_DEFAULT_STACK,
@@ -42,17 +40,11 @@ def _read(project_root: Path) -> list[dict]:
     path = ensure_within(project_root, _config_path(project_root))
     if not path.exists():
         return []
-    # Parse the RAW document, not the shared ``load_yaml`` (whose ``… or {}``
-    # coerces a falsy top-level value to ``{}``): an empty document is a no-op,
-    # but a falsy non-mapping (``[]``/``false``/``0``/``''``) is malformed and
-    # must raise like a truthy one, staying consistent with the other reader of
-    # this file (models/catalog._merge_config).
-    try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    except yaml.YAMLError as exc:
-        raise BundlerError(f"Invalid YAML in {path}: {exc}") from exc
-    except OSError as exc:
-        raise BundlerError(f"Could not read {path}: {exc}") from exc
+    # ``load_yaml`` returns ``{}`` only for an empty document and the raw parse
+    # otherwise, so a falsy non-mapping (``[]``/``false``/``0``/``''``) is caught
+    # by the isinstance guard below and raised like a truthy one, staying
+    # consistent with the other reader of this file (models/catalog._merge_config).
+    data = load_yaml(path)
     if data is None:
         return []
     if not isinstance(data, dict):

--- a/src/specify_cli/bundler/lib/yamlio.py
+++ b/src/specify_cli/bundler/lib/yamlio.py
@@ -39,17 +39,25 @@ def ensure_within(root: Path, candidate: Path) -> Path:
 
 
 def load_yaml(path: Path) -> Any:
-    """Parse a YAML file, returning ``{}`` for an empty document."""
+    """Parse a YAML file, returning ``{}`` for an empty document.
+
+    Only an *empty* document (``yaml.safe_load`` -> ``None``) becomes ``{}``.
+    A non-empty document is returned exactly as parsed — including a falsy
+    non-mapping such as ``[]``, ``false``, ``0``, or ``''`` — so callers can
+    validate the top-level shape (e.g. reject a non-mapping config) instead of
+    having it silently coerced to an empty mapping.
+    """
     path = Path(path)
     if not path.exists():
         raise BundlerError(f"File not found: {path}")
     try:
         with path.open("r", encoding="utf-8") as handle:
-            return yaml.safe_load(handle) or {}
+            data = yaml.safe_load(handle)
     except yaml.YAMLError as exc:
         raise BundlerError(f"Invalid YAML in {path}: {exc}") from exc
     except OSError as exc:
         raise BundlerError(f"Could not read {path}: {exc}") from exc
+    return {} if data is None else data
 
 
 def dump_yaml(path: Path, data: Any, *, within: Path | None = None) -> Path:

--- a/src/specify_cli/bundler/lib/yamlio.py
+++ b/src/specify_cli/bundler/lib/yamlio.py
@@ -39,25 +39,35 @@ def ensure_within(root: Path, candidate: Path) -> Path:
 
 
 def load_yaml(path: Path) -> Any:
-    """Parse a YAML file, returning ``{}`` for an empty document.
+    """Parse a YAML file, returning ``{}`` only for an *empty* document.
 
-    Only an *empty* document (``yaml.safe_load`` -> ``None``) becomes ``{}``.
-    A non-empty document is returned exactly as parsed — including a falsy
-    non-mapping such as ``[]``, ``false``, ``0``, or ``''`` — so callers can
-    validate the top-level shape (e.g. reject a non-mapping config) instead of
-    having it silently coerced to an empty mapping.
+    A non-empty document is returned exactly as parsed — including a
+    non-mapping such as ``[]``, ``false``, ``0``, ``''``, or an explicit null
+    (``null``/``~``) — so callers can validate the top-level shape (e.g. reject
+    a non-mapping config) instead of having it silently coerced to an empty
+    mapping.
+
+    ``yaml.safe_load`` returns ``None`` for *both* an empty document and an
+    explicit null scalar, so ``yaml.compose`` (which yields no node only for a
+    truly empty document) is used to tell them apart: an empty document becomes
+    ``{}`` while an explicit ``null``/``~`` is returned as ``None`` for the
+    caller to reject.
     """
     path = Path(path)
     if not path.exists():
         raise BundlerError(f"File not found: {path}")
     try:
-        with path.open("r", encoding="utf-8") as handle:
-            data = yaml.safe_load(handle)
-    except yaml.YAMLError as exc:
-        raise BundlerError(f"Invalid YAML in {path}: {exc}") from exc
+        text = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise BundlerError(f"Could not read {path}: {exc}") from exc
-    return {} if data is None else data
+    try:
+        has_node = yaml.compose(text) is not None
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise BundlerError(f"Invalid YAML in {path}: {exc}") from exc
+    if data is None and not has_node:
+        return {}
+    return data
 
 
 def dump_yaml(path: Path, data: Any, *, within: Path | None = None) -> Path:

--- a/src/specify_cli/bundler/models/catalog.py
+++ b/src/specify_cli/bundler/models/catalog.py
@@ -11,8 +11,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from .. import BundlerError
-from ..lib.yamlio import ensure_within, load_yaml
+from ..lib.yamlio import ensure_within
 
 CONFIG_FILENAME = "bundle-catalogs.yml"
 
@@ -256,13 +258,22 @@ def load_source_stack(project_root: Path, user_config_dir: Path | None = None) -
 def _merge_config(by_id: dict[str, CatalogSource], config_path: Path, scope: Scope) -> None:
     if not config_path.exists():
         return
-    data = load_yaml(config_path)
+    # Parse the RAW document rather than the shared ``load_yaml`` helper, whose
+    # ``… or {}`` coerces a falsy top-level value to ``{}``: an empty document
+    # (``None``) is a no-op, but every non-mapping top-level — including the
+    # falsy ones ``[]``/``false``/``0``/``''`` that ``load_yaml`` would hide —
+    # is malformed and must raise, matching the sibling reader
+    # commands_impl/catalog_config._read (which does the same). #3623 already
+    # aligned the inner non-list ``catalogs`` value between the two readers.
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise BundlerError(f"Invalid YAML in {config_path}: {exc}") from exc
+    except OSError as exc:
+        raise BundlerError(f"Could not read {config_path}: {exc}") from exc
+    if data is None:
+        return
     if not isinstance(data, dict):
-        # A top-level non-mapping (a YAML list or scalar) is malformed. The
-        # sibling reader of the SAME file (commands_impl/catalog_config._read)
-        # raises here; #3623 already made the inner non-list `catalogs` value
-        # agree between the two readers, and this closes the remaining
-        # top-level-shape gap so both readers reject the same documents.
         raise BundlerError(
             f"Malformed catalog config at {config_path}: expected a mapping at "
             f"the top level, got {type(data).__name__}."

--- a/src/specify_cli/bundler/models/catalog.py
+++ b/src/specify_cli/bundler/models/catalog.py
@@ -11,10 +11,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from .. import BundlerError
-from ..lib.yamlio import ensure_within
+from ..lib.yamlio import ensure_within, load_yaml
 
 CONFIG_FILENAME = "bundle-catalogs.yml"
 
@@ -258,21 +256,12 @@ def load_source_stack(project_root: Path, user_config_dir: Path | None = None) -
 def _merge_config(by_id: dict[str, CatalogSource], config_path: Path, scope: Scope) -> None:
     if not config_path.exists():
         return
-    # Parse the RAW document rather than the shared ``load_yaml`` helper, whose
-    # ``… or {}`` coerces a falsy top-level value to ``{}``: an empty document
-    # (``None``) is a no-op, but every non-mapping top-level — including the
-    # falsy ones ``[]``/``false``/``0``/``''`` that ``load_yaml`` would hide —
-    # is malformed and must raise, matching the sibling reader
-    # commands_impl/catalog_config._read (which does the same). #3623 already
+    # ``load_yaml`` returns ``{}`` only for an empty document and the raw parse
+    # otherwise, so a non-mapping top level (a YAML list or scalar, including
+    # the falsy ``[]``/``false``/``0``/``''``) is caught here and raised —
+    # matching the sibling reader commands_impl/catalog_config._read. #3623
     # aligned the inner non-list ``catalogs`` value between the two readers.
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    except yaml.YAMLError as exc:
-        raise BundlerError(f"Invalid YAML in {config_path}: {exc}") from exc
-    except OSError as exc:
-        raise BundlerError(f"Could not read {config_path}: {exc}") from exc
-    if data is None:
-        return
+    data = load_yaml(config_path)
     if not isinstance(data, dict):
         raise BundlerError(
             f"Malformed catalog config at {config_path}: expected a mapping at "

--- a/src/specify_cli/bundler/models/catalog.py
+++ b/src/specify_cli/bundler/models/catalog.py
@@ -257,7 +257,17 @@ def _merge_config(by_id: dict[str, CatalogSource], config_path: Path, scope: Sco
     if not config_path.exists():
         return
     data = load_yaml(config_path)
-    catalogs = data.get("catalogs") if isinstance(data, dict) else None
+    if not isinstance(data, dict):
+        # A top-level non-mapping (a YAML list or scalar) is malformed. The
+        # sibling reader of the SAME file (commands_impl/catalog_config._read)
+        # raises here; #3623 already made the inner non-list `catalogs` value
+        # agree between the two readers, and this closes the remaining
+        # top-level-shape gap so both readers reject the same documents.
+        raise BundlerError(
+            f"Malformed catalog config at {config_path}: expected a mapping at "
+            f"the top level, got {type(data).__name__}."
+        )
+    catalogs = data.get("catalogs")
     if catalogs is None:
         return
     if not isinstance(catalogs, list):

--- a/tests/contract/test_catalog_schema.py
+++ b/tests/contract/test_catalog_schema.py
@@ -77,24 +77,35 @@ def test_falsy_non_list_catalogs_still_raises(tmp_path: Path, value: str):
         "false\n",     # falsy bool
         "0\n",         # falsy int
         "''\n",        # falsy empty string
+        "null\n",      # explicit null scalar (safe_load -> None, but a real node)
+        "~\n",         # explicit null scalar (alt spelling)
     ],
 )
 def test_toplevel_non_mapping_raises(tmp_path: Path, body: str):
-    """A top-level non-mapping bundle-catalogs.yml (list/scalar) must raise,
+    """A top-level non-mapping bundle-catalogs.yml (list/scalar/null) must raise,
     matching the sibling reader (catalog_config._read) — not silently fall back
     to the built-in default stack. This includes FALSY non-mappings ([], false,
-    0, ''); the shared load_yaml would coerce those to {} and hide them, so both
-    readers parse the raw document instead."""
+    0, '') and an explicit null (null/~); the shared load_yaml would coerce those
+    to {} and hide them, so it distinguishes them from a truly empty document."""
     make_project(tmp_path)
     (tmp_path / ".specify" / "bundle-catalogs.yml").write_text(body, encoding="utf-8")
     with pytest.raises(BundlerError, match="expected a mapping at the top level"):
         load_source_stack(tmp_path)
 
 
-@pytest.mark.parametrize("body", ["catalogs:\n", "catalogs: []\n"])
+@pytest.mark.parametrize(
+    "body",
+    [
+        "catalogs:\n",       # present key, null value
+        "catalogs: []\n",    # present key, empty list
+        "",                  # truly empty document
+        "# only a comment\n",  # comment-only == empty document
+    ],
+)
 def test_absent_or_empty_catalogs_is_noop(tmp_path: Path, body: str):
-    """An absent (``None``) or empty-list ``catalogs:`` is valid: it contributes
-    no project sources and falls back to the built-in default stack."""
+    """An empty document, comment-only file, or absent/empty-list ``catalogs:``
+    is valid: it contributes no project sources and falls back to the built-in
+    default stack (must not be confused with an explicit top-level null)."""
     make_project(tmp_path)
     (tmp_path / ".specify" / "bundle-catalogs.yml").write_text(body, encoding="utf-8")
     # Does not raise; still yields the built-in defaults.

--- a/tests/contract/test_catalog_schema.py
+++ b/tests/contract/test_catalog_schema.py
@@ -68,11 +68,23 @@ def test_falsy_non_list_catalogs_still_raises(tmp_path: Path, value: str):
         load_source_stack(tmp_path)
 
 
-@pytest.mark.parametrize("body", ["- a\n- b\n", "42\n"])
+@pytest.mark.parametrize(
+    "body",
+    [
+        "- a\n- b\n",  # truthy list
+        "42\n",        # truthy scalar
+        "[]\n",        # falsy list
+        "false\n",     # falsy bool
+        "0\n",         # falsy int
+        "''\n",        # falsy empty string
+    ],
+)
 def test_toplevel_non_mapping_raises(tmp_path: Path, body: str):
-    """A top-level non-mapping bundle-catalogs.yml (a YAML list or scalar) must
-    raise, matching the sibling reader (catalog_config._read) — not silently
-    fall back to the built-in default stack."""
+    """A top-level non-mapping bundle-catalogs.yml (list/scalar) must raise,
+    matching the sibling reader (catalog_config._read) — not silently fall back
+    to the built-in default stack. This includes FALSY non-mappings ([], false,
+    0, ''); the shared load_yaml would coerce those to {} and hide them, so both
+    readers parse the raw document instead."""
     make_project(tmp_path)
     (tmp_path / ".specify" / "bundle-catalogs.yml").write_text(body, encoding="utf-8")
     with pytest.raises(BundlerError, match="expected a mapping at the top level"):

--- a/tests/contract/test_catalog_schema.py
+++ b/tests/contract/test_catalog_schema.py
@@ -68,6 +68,17 @@ def test_falsy_non_list_catalogs_still_raises(tmp_path: Path, value: str):
         load_source_stack(tmp_path)
 
 
+@pytest.mark.parametrize("body", ["- a\n- b\n", "42\n"])
+def test_toplevel_non_mapping_raises(tmp_path: Path, body: str):
+    """A top-level non-mapping bundle-catalogs.yml (a YAML list or scalar) must
+    raise, matching the sibling reader (catalog_config._read) — not silently
+    fall back to the built-in default stack."""
+    make_project(tmp_path)
+    (tmp_path / ".specify" / "bundle-catalogs.yml").write_text(body, encoding="utf-8")
+    with pytest.raises(BundlerError, match="expected a mapping at the top level"):
+        load_source_stack(tmp_path)
+
+
 @pytest.mark.parametrize("body", ["catalogs:\n", "catalogs: []\n"])
 def test_absent_or_empty_catalogs_is_noop(tmp_path: Path, body: str):
     """An absent (``None``) or empty-list ``catalogs:`` is valid: it contributes

--- a/tests/unit/test_bundler_catalog_config.py
+++ b/tests/unit/test_bundler_catalog_config.py
@@ -154,6 +154,19 @@ def test_read_rejects_non_mapping_top_level(tmp_path: Path):
         cc._read(project)
 
 
+@pytest.mark.parametrize("body", ["[]\n", "false\n", "0\n", "''\n"])
+def test_read_rejects_falsy_non_mapping_top_level(tmp_path: Path, body: str):
+    # A FALSY non-mapping top level ([], false, 0, '') must raise like a truthy
+    # one. The shared load_yaml would coerce these to {} and hide them, so _read
+    # parses the raw document — staying consistent with models/catalog._merge_config.
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+    cc._config_path(project).write_text(body, encoding="utf-8")
+
+    with pytest.raises(BundlerError, match="expected a mapping at the top level"):
+        cc._read(project)
+
+
 def test_read_rejects_unknown_schema_version(tmp_path: Path):
     project = tmp_path / "proj"
     (project / ".specify").mkdir(parents=True)

--- a/tests/unit/test_bundler_catalog_config.py
+++ b/tests/unit/test_bundler_catalog_config.py
@@ -154,11 +154,12 @@ def test_read_rejects_non_mapping_top_level(tmp_path: Path):
         cc._read(project)
 
 
-@pytest.mark.parametrize("body", ["[]\n", "false\n", "0\n", "''\n"])
+@pytest.mark.parametrize("body", ["[]\n", "false\n", "0\n", "''\n", "null\n", "~\n"])
 def test_read_rejects_falsy_non_mapping_top_level(tmp_path: Path, body: str):
-    # A FALSY non-mapping top level ([], false, 0, '') must raise like a truthy
-    # one. The shared load_yaml would coerce these to {} and hide them, so _read
-    # parses the raw document — staying consistent with models/catalog._merge_config.
+    # A FALSY non-mapping top level ([], false, 0, '') OR an explicit null
+    # (null/~) must raise like a truthy one. safe_load coerces these to
+    # None/{}, so load_yaml distinguishes them from a truly empty document —
+    # staying consistent with models/catalog._merge_config.
     project = tmp_path / "proj"
     (project / ".specify").mkdir(parents=True)
     cc._config_path(project).write_text(body, encoding="utf-8")


### PR DESCRIPTION
## What

`_merge_config` silently ignored a **top-level non-mapping** `bundle-catalogs.yml` (a YAML list or scalar): `data.get("catalogs") if isinstance(data, dict) else None` made a list/scalar document fall through to `None` → early return → the built-in default stack, with no error.

The sibling reader of the **same file** — `commands_impl/catalog_config._read` — raises `"expected a mapping at the top level"` for exactly those documents. Merged PR #3623 already made the inner non-list `catalogs` value agree between the two readers; this closes the remaining top-level-shape gap so both readers reject the same malformed input.

## Fix

Add an explicit top-level mapping guard mirroring `_read`:

```python
if not isinstance(data, dict):
    raise BundlerError(f"Malformed catalog config at {config_path}: expected a mapping at the top level, got {type(data).__name__}.")
```

An empty file (`load_yaml` coerces to `{}`), absent `catalogs`, and `catalogs: []` all remain no-ops.

## Tests

`tests/contract/test_catalog_schema.py::test_toplevel_non_mapping_raises` (parametrized over a top-level list and a scalar) — both raise after the fix, silently return the default stack before it. Regression tests confirm absent/empty `catalogs` still yield the built-in defaults. `ruff` clean; all 23 contract tests pass.

---
*AI-assisted: authored with Claude Code. Verified the message/behavior matches the `_read` sibling and confirmed fail-before/pass-after.*