### PR TITLE
fix(bundler): dump_yaml writes literal UTF-8 (allow_unicode=True)

### DIFF
--- a/src/specify_cli/bundler/lib/yamlio.py
+++ b/src/specify_cli/bundler/lib/yamlio.py
@@ -60,7 +60,13 @@ def dump_yaml(path: Path, data: Any, *, within: Path | None = None) -> Path:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf-8") as handle:
-            yaml.safe_dump(data, handle, sort_keys=False, default_flow_style=False)
+            yaml.safe_dump(
+                data,
+                handle,
+                sort_keys=False,
+                default_flow_style=False,
+                allow_unicode=True,
+            )
     except OSError as exc:
         raise BundlerError(f"Could not write {path}: {exc}") from exc
     return path

--- a/tests/unit/test_bundler_yamlio.py
+++ b/tests/unit/test_bundler_yamlio.py
@@ -1,0 +1,26 @@
+"""Unit tests for the bundler YAML I/O helpers."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from specify_cli.bundler.lib.yamlio import dump_yaml, load_yaml
+
+
+def test_dump_yaml_preserves_unicode(tmp_path: Path):
+    # dump_yaml must write literal UTF-8, not \xNN / \uXXXX escapes, so bundle
+    # config stays human-readable — matching _utils.dump_frontmatter and the
+    # extensions/presets config writers (all allow_unicode=True).
+    path = tmp_path / "f.yml"
+    data = {"note": "café-münchen", "url": "https://例え.example"}
+    dump_yaml(path, data)
+    raw = path.read_text(encoding="utf-8")
+    assert "café-münchen" in raw
+    assert "例え" in raw
+    assert "\\x" not in raw and "\\u" not in raw
+
+
+def test_dump_yaml_round_trips_unicode(tmp_path: Path):
+    path = tmp_path / "f.yml"
+    data = {"note": "café", "city": "münchen"}
+    dump_yaml(path, data)
+    assert load_yaml(path) == data


### PR DESCRIPTION
## What

`dump_yaml` (`bundler/lib/yamlio.py`) called `yaml.safe_dump` **without** `allow_unicode=True`, so any non-ASCII content was written as `\xNN` / `\uXXXX` escape sequences instead of literal UTF-8 — e.g. `café-münchen` became `"caf\xE9-m\xFCnchen"` in the file. That's a round-trip readability loss for any bundle config carrying accented or non-Latin text.

## Why it matters

The centralized frontmatter helper `_utils.dump_frontmatter` explicitly passes `allow_unicode=True` and documents it so "no call site can silently drop" unicode, and the extensions/presets config writers (`extensions/_commands.py`, `presets/_commands.py`) all do the same. `dump_yaml` was the outlier.

## Fix

Add `allow_unicode=True` to the `safe_dump` call, matching the sibling writers.

## Tests

`tests/unit/test_bundler_yamlio.py`:
- `test_dump_yaml_preserves_unicode` — asserts literal `café-münchen` / `例え` in the output and no `\x`/`\u` escapes (fails before the fix)
- `test_dump_yaml_round_trips_unicode` — `load_yaml(dump_yaml(...))` round-trips

`ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified against the `dump_frontmatter` / extensions / presets sibling writers and confirmed fail-before/pass-after.*