### PR TITLE
fix(bundler): reject falsy non-mapping requires/provides in manifest from_dict

### DIFF
--- a/src/specify_cli/bundler/models/manifest.py
+++ b/src/specify_cli/bundler/models/manifest.py
@@ -111,8 +111,10 @@ class BundleManifest:
             license=str(bundle_raw.get("license", "")).strip(),
         )
 
-        requires_raw = data.get("requires") or {}
-        if not isinstance(requires_raw, dict):
+        requires_raw = data.get("requires")
+        if requires_raw is None:
+            requires_raw = {}
+        elif not isinstance(requires_raw, dict):
             raise BundlerError("'requires' must be a mapping when present.")
         requires = Requires(
             speckit_version=str(requires_raw.get("speckit_version", "")).strip(),
@@ -130,8 +132,10 @@ class BundleManifest:
         if isinstance(integration_raw, dict) and integration_raw.get("id"):
             integration = IntegrationRef(id=str(integration_raw["id"]).strip())
 
-        provides = data.get("provides") or {}
-        if not isinstance(provides, dict):
+        provides = data.get("provides")
+        if provides is None:
+            provides = {}
+        elif not isinstance(provides, dict):
             raise BundlerError("'provides' must be a mapping when present.")
 
         tags_raw = data.get("tags")

--- a/tests/contract/test_manifest_schema.py
+++ b/tests/contract/test_manifest_schema.py
@@ -134,3 +134,33 @@ def test_string_integration_rejected_not_silently_dropped():
     data["integration"] = "copilot"
     with pytest.raises(BundlerError, match="'integration' must be a mapping when present"):
         BundleManifest.from_dict(data)
+
+
+@pytest.mark.parametrize("bad", [[], "", 0, False, "extensions"])
+def test_non_mapping_provides_rejected_including_falsy(bad):
+    # `data.get("provides") or {}` coerced a FALSY non-mapping ([], '', 0, False)
+    # to {} before the type check, so a malformed manifest passed validation as
+    # a bundle that provides nothing. Only an absent/None value means "empty".
+    data = valid_manifest_dict()
+    data["provides"] = bad
+    with pytest.raises(BundlerError, match="'provides' must be a mapping when present"):
+        BundleManifest.from_dict(data)
+
+
+@pytest.mark.parametrize("bad", [[], "", 0, False, "speckit>=0.1"])
+def test_non_mapping_requires_rejected_including_falsy(bad):
+    # Same falsy-coercion hole for `requires`.
+    data = valid_manifest_dict()
+    data["requires"] = bad
+    with pytest.raises(BundlerError, match="'requires' must be a mapping when present"):
+        BundleManifest.from_dict(data)
+
+
+def test_absent_provides_and_requires_still_parse():
+    # Absent optional fields remain valid: provides defaults to empty, requires
+    # to an empty Requires — no regression from the None handling.
+    data = valid_manifest_dict()
+    data.pop("provides", None)
+    data.pop("requires", None)
+    manifest = BundleManifest.from_dict(data)
+    assert manifest.structural_errors() == []

--- a/tests/contract/test_manifest_schema.py
+++ b/tests/contract/test_manifest_schema.py
@@ -156,11 +156,12 @@ def test_non_mapping_requires_rejected_including_falsy(bad):
         BundleManifest.from_dict(data)
 
 
-def test_absent_provides_and_requires_still_parse():
-    # Absent optional fields remain valid: provides defaults to empty, requires
-    # to an empty Requires — no regression from the None handling.
+def test_absent_provides_and_requires_do_not_raise_mapping_error():
+    # Absent (None) optional mappings default to empty and must NOT trigger the
+    # "must be a mapping when present" guard — that is reserved for present
+    # non-mappings. (Structural completeness, e.g. requires.speckit_version, is
+    # a separate concern checked by structural_errors().)
     data = valid_manifest_dict()
     data.pop("provides", None)
     data.pop("requires", None)
-    manifest = BundleManifest.from_dict(data)
-    assert manifest.structural_errors() == []
+    BundleManifest.from_dict(data)  # does not raise BundlerError


### PR DESCRIPTION
## What

`BundleManifest.from_dict` used `data.get("requires") or {}` and `data.get("provides") or {}`. The `or {}` coerces a **falsy** non-mapping value (`[]`, `''`, `0`, `false`) to `{}` **before** the `isinstance` guard runs — so a malformed manifest silently passed validation as one that requires/provides nothing. Only a *truthy* non-mapping (e.g. `provides: "extensions"`) reached the guard and raised.

The sibling `integration` guard (added in #3629) already does this correctly with an explicit `is not None` check; `requires`/`provides` were the remaining holes.

## Fix

Handle `None` explicitly (default to `{}`) and reject every other non-mapping:

```python
requires_raw = data.get("requires")
if requires_raw is None:
    requires_raw = {}
elif not isinstance(requires_raw, dict):
    raise BundlerError("'requires' must be a mapping when present.")
```

…and the same for `provides`. Absent fields still parse to the empty default.

## Tests

`tests/contract/test_manifest_schema.py`:
- `test_non_mapping_provides_rejected_including_falsy` and `test_non_mapping_requires_rejected_including_falsy` — parametrized over `[]`, `''`, `0`, `False`, and a truthy string; all raise after the fix (the falsy ones passed silently before)
- `test_absent_provides_and_requires_do_not_raise_mapping_error` — absent (None) optional mappings still parse without tripping the guard

`ruff` clean; all 28 contract tests pass.

---
*AI-assisted: authored with Claude Code. Verified the falsy-coercion hole against the merged `integration` guard (#3629) and confirmed fail-before/pass-after.*