### PR TITLE
fix(integrations): recompute invoke_separator from retained parsed_options

### DIFF
--- a/src/specify_cli/integration_runtime.py
+++ b/src/specify_cli/integration_runtime.py
@@ -64,8 +64,15 @@ def with_integration_setting(
     elif raw_options is not None:
         current.pop("parsed_options", None)
 
+    # Recompute the separator from the options actually STORED on ``current``
+    # after the update, not the raw ``parsed_options`` argument. When only
+    # ``script_type`` changes (``parsed_options`` and ``raw_options`` both
+    # None), the previously-stored ``parsed_options`` are retained above, so
+    # deriving the separator from the argument (None) would drop an
+    # options-dependent separator (e.g. Copilot ``--skills`` -> "-") back to
+    # the default ".".
     current["invoke_separator"] = integration.effective_invoke_separator(
-        parsed_options, project_root
+        current.get("parsed_options"), project_root
     )
     settings[key] = current
     return settings

--- a/tests/integrations/test_integration_state.py
+++ b/tests/integrations/test_integration_state.py
@@ -84,3 +84,31 @@ def test_write_integration_json_strips_integration_key(tmp_path):
     assert state["integration"] == "claude"
     assert state["default_integration"] == "claude"
     assert state["installed_integrations"] == ["claude"]
+
+
+def test_with_integration_setting_recomputes_separator_from_retained_options():
+    """Updating only script_type must not drop an options-dependent separator.
+
+    Copilot resolves the command-ref separator to '-' when '--skills' options
+    are stored and '.' otherwise. A second call that changes only script_type
+    (parsed_options=None, raw_options=None) retains the stored parsed_options,
+    so invoke_separator must stay '-', not be recomputed from the None argument.
+    """
+    from specify_cli.integrations import get_integration
+    from specify_cli.integration_runtime import with_integration_setting
+
+    copilot = get_integration("copilot")
+
+    settings = with_integration_setting(
+        {}, "copilot", copilot, parsed_options={"skills": True}
+    )
+    assert settings["copilot"]["invoke_separator"] == "-"
+
+    settings2 = with_integration_setting(
+        {"integration_settings": settings}, "copilot", copilot, script_type="ps"
+    )
+    # parsed_options are retained (only script_type changed) ...
+    assert settings2["copilot"]["parsed_options"] == {"skills": True}
+    assert settings2["copilot"]["script"] == "ps"
+    # ... so the separator must reflect them, not the (None) argument.
+    assert settings2["copilot"]["invoke_separator"] == "-"


### PR DESCRIPTION
## What

`with_integration_setting` (`integration_runtime.py`) recomputed `invoke_separator` from the **raw `parsed_options` argument**:

```python
current["invoke_separator"] = integration.effective_invoke_separator(parsed_options, project_root)
```

When a caller updates **only** `script_type` (`parsed_options=None`, `raw_options=None`), the previously-stored `parsed_options` are **retained** on the setting (the code only pops them when `raw_options is not None`). But the separator was still derived from the `None` argument — so an options-dependent separator (e.g. Copilot in `--skills` mode → `"-"`) silently reverted to the default `"."`, desynchronizing `invoke_separator` from the `parsed_options` actually stored.

## Fix

Derive the separator from `current.get("parsed_options")` — the options actually stored on the setting after the update — so it stays consistent across all branches (new options provided, options cleared via `raw_options`, or only `script_type` changed).

## Tests

`tests/integrations/test_integration_state.py::test_with_integration_setting_recomputes_separator_from_retained_options` — stores Copilot `{"skills": True}` (separator `"-"`), then updates only `script_type`; asserts `parsed_options` is retained and `invoke_separator` stays `"-"`. Fails before the fix (recomputed to `"."`); passes after. `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified via Copilot's options-dependent `effective_invoke_separator` and confirmed fail-before/pass-after.*