### PR TITLE
fix(bundler): reject falsy non-mapping requires/provides in CatalogEntry.from_dict

### DIFF
--- a/src/specify_cli/bundler/models/catalog.py
+++ b/src/specify_cli/bundler/models/catalog.py
@@ -152,14 +152,21 @@ class CatalogEntry:
         if not isinstance(data, dict):
             raise BundlerError("Each catalog entry must be a mapping.")
         entry_id = str(data.get("id", "")).strip()
-        requires = data.get("requires") or {}
-        if not isinstance(requires, dict):
+        # `or {}` would coerce a FALSY non-mapping (0, '', False, []) to {} before
+        # the isinstance guard, silently accepting a corrupt catalog entry; only
+        # an absent/None value means "not present".
+        requires = data.get("requires")
+        if requires is None:
+            requires = {}
+        elif not isinstance(requires, dict):
             raise BundlerError(
                 f"Catalog entry '{entry_id or '<unknown>'}': 'requires' must be a "
                 "mapping when present."
             )
-        provides_raw = data.get("provides") or {}
-        if not isinstance(provides_raw, dict):
+        provides_raw = data.get("provides")
+        if provides_raw is None:
+            provides_raw = {}
+        elif not isinstance(provides_raw, dict):
             raise BundlerError(
                 f"Catalog entry '{entry_id or '<unknown>'}': 'provides' must be a "
                 "mapping when present."

--- a/tests/contract/test_catalog_schema.py
+++ b/tests/contract/test_catalog_schema.py
@@ -207,3 +207,17 @@ def test_catalog_entry_rejects_non_mapping_provides():
     data["provides"] = "extensions"
     with pytest.raises(BundlerError, match="'provides' must be a mapping"):
         CatalogEntry.from_dict(data)
+
+
+@pytest.mark.parametrize("field", ["requires", "provides"])
+@pytest.mark.parametrize("bad", [[], "", 0, False])
+def test_catalog_entry_rejects_falsy_non_mapping(field, bad):
+    # `or {}` coerced a FALSY non-mapping ([], '', 0, False) to {} before the
+    # isinstance guard, silently accepting a corrupt entry; only absent/None
+    # means "not present". Mirrors the manifest requires/provides guard.
+    from specify_cli.bundler.models.catalog import CatalogEntry
+
+    data = catalog_entry_dict("demo")
+    data[field] = bad
+    with pytest.raises(BundlerError, match=f"'{field}' must be a mapping"):
+        CatalogEntry.from_dict(data)


### PR DESCRIPTION
## What

`CatalogEntry.from_dict` used `data.get("requires") or {}` and `data.get("provides") or {}`. The `or {}` coerces a **falsy** non-mapping value (`[]`, `''`, `0`, `false`) to `{}` **before** the `isinstance` guard runs — so a corrupt catalog entry with e.g. `requires: []` passed validation silently. Only a *truthy* non-mapping (e.g. `provides: "extensions"`) reached the guard and raised.

This is the same falsy-coercion hole fixed for the bundle manifest in #3629 / #3661 and for records in a sibling PR — this closes it for catalog entries.

## Fix

Handle `None` explicitly (default to `{}`) and reject every other non-mapping.

## Tests

`tests/contract/test_catalog_schema.py::test_catalog_entry_rejects_falsy_non_mapping` — parametrized over `requires`/`provides` × `[]`/`''`/`0`/`False`; all raise after the fix, all passed silently before. `ruff` clean; all 29 contract tests pass.

---
*AI-assisted: authored with Claude Code. Verified against the merged manifest mapping guards and confirmed fail-before/pass-after.*