### PR TITLE
fix: bundle scripts/python in wheel so `--script py` works (#3665)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ packages = ["src/specify_cli"]
 "templates/commands" = "specify_cli/core_pack/commands"
 "scripts/bash" = "specify_cli/core_pack/scripts/bash"
 "scripts/powershell" = "specify_cli/core_pack/scripts/powershell"
+"scripts/python" = "specify_cli/core_pack/scripts/python"
 # Bundled extensions (installable via `specify extension add <name>`)
 "extensions/git" = "specify_cli/core_pack/extensions/git"
 "extensions/agent-context" = "specify_cli/core_pack/extensions/agent-context"


### PR DESCRIPTION
## Summary

Fixes #3665. `specify init --script py` produced commands/skills referencing `.specify/scripts/python/*.py`, but those files were never installed — `init` laid down the bash scripts instead, so every command failed at its first setup step.

## Root cause

The wheel `[tool.hatch.build.targets.wheel.force-include]` block in `pyproject.toml` mapped `scripts/bash` and `scripts/powershell` into `core_pack`, but omitted `scripts/python`. The top-level core Python scripts (`check_prerequisites.py`, `common.py`, `create_new_feature.py`, `setup_plan.py`, `setup_tasks.py`) were therefore missing from the packaged wheel, even though the extension python scripts were bundled.

## Fix

Add the missing `scripts/python` → `specify_cli/core_pack/scripts/python` force-include mapping, mirroring the other script variants. No runtime code change was needed — `install_shared_infra` in `shared_infra.py` already resolves the `python` variant dir for `--script py`.

## Verification

Built the wheel locally and confirmed the scripts now ship:

```console
$ unzip -Z1 dist/specify_cli-*.whl | grep 'core_pack/scripts/python/'
specify_cli/core_pack/scripts/python/check_prerequisites.py
specify_cli/core_pack/scripts/python/common.py
specify_cli/core_pack/scripts/python/create_new_feature.py
specify_cli/core_pack/scripts/python/setup_plan.py
specify_cli/core_pack/scripts/python/setup_tasks.py
```

---

This PR was authored autonomously by GitHub Copilot (model: Claude Opus 4.8) on behalf of @mnriem.