### PR TITLE
fix(extensions): hyphenate command names in the Forge post-install listing

### DIFF
--- a/src/specify_cli/extensions/_commands.py
+++ b/src/specify_cli/extensions/_commands.py
@@ -623,16 +623,22 @@ def extension_add(
         for warning in manifest.warnings:
             console.print(f"\n[yellow]⚠  Compatibility warning:[/yellow] {_escape_markup(str(warning))}")
 
-        is_cline = load_init_options(project_root).get("ai") == "cline"
+        selected_ai = load_init_options(project_root).get("ai")
+        is_cline = selected_ai == "cline"
+        is_forge = selected_ai == "forge"
 
         if is_cline:
             from specify_cli.integrations.cline import format_cline_command_name
+        if is_forge:
+            from specify_cli.integrations.forge import format_forge_command_name
 
         console.print("\n[bold cyan]Provided commands:[/bold cyan]")
         for cmd in manifest.commands:
             cmd_name = cmd['name']
             if is_cline:
                 cmd_name = format_cline_command_name(cmd_name)
+            elif is_forge:
+                cmd_name = format_forge_command_name(cmd_name)
             console.print(f"  • {_escape_markup(str(cmd_name))} - {_escape_markup(str(cmd.get('description', '')))}")
 
         # Report agent skills registration

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -9010,3 +9010,34 @@ class TestConfigManagerCrossExtensionEnvLeak:
         # Must not raise; must fall back to the "no siblings" path.
         cfg = ConfigManager(tmp_path, "testext")._get_env_config()
         assert cfg == {"url": "v"}
+
+
+def test_forge_extension_install_listing_hyphenates_command_names(
+    extension_dir, project_dir
+):
+    """The post-install 'Provided commands' listing must show hyphenated
+    /speckit-<name> command names for a Forge project (Forge registers
+    hyphenated names), mirroring the existing Cline handling."""
+    import json
+    import os
+
+    from typer.testing import CliRunner
+
+    from specify_cli import app
+
+    init_options = project_dir / ".specify" / "init-options.json"
+    init_options.write_text(json.dumps({"ai": "forge", "script": "sh"}))
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(project_dir)
+        result = CliRunner().invoke(
+            app, ["extension", "add", str(extension_dir), "--dev"]
+        )
+    finally:
+        os.chdir(old_cwd)
+
+    assert result.exit_code == 0, result.output
+    # Forge registers hyphenated command names, so the summary must match.
+    assert "speckit-test-ext-hello" in result.output
+    assert "speckit.test-ext.hello" not in result.output


### PR DESCRIPTION
## What

After `specify extension add`, the **"Provided commands"** summary hyphenated command names only for Cline:

```python
is_cline = load_init_options(project_root).get("ai") == "cline"
...
if is_cline:
    cmd_name = format_cline_command_name(cmd_name)
```

For a **Forge** project the names were printed in dotted form (e.g. `speckit.test-ext.hello`), but Forge registers its commands hyphenated (`speckit-test-ext-hello`, via `format_forge_command_name`). So the post-install summary told Forge users to run commands that don't exist under the dotted name.

## Fix

Extend the existing Cline handling to Forge via `format_forge_command_name`. This completes the Forge command-name parity already fixed for hook invocations (#3641) and the init next-steps panel (#3642) — the extension-install listing was the third and last site.

## Tests

`tests/test_extensions.py::test_forge_extension_install_listing_hyphenates_command_names` — installs an extension (`extension add --dev`) in a Forge project and asserts the listing shows `speckit-test-ext-hello`, not the dotted form. Fails before the fix; passes after. `ruff` clean.

---
*AI-assisted: authored with Claude Code. Completes the Forge parity series (#3641/#3642) and verified fail-before/pass-after.*