### PR TITLE
fix(packaging): bundle scripts/python into the wheel core_pack (#3665)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ packages = ["src/specify_cli"]
 "templates/commands" = "specify_cli/core_pack/commands"
 "scripts/bash" = "specify_cli/core_pack/scripts/bash"
 "scripts/powershell" = "specify_cli/core_pack/scripts/powershell"
+"scripts/python" = "specify_cli/core_pack/scripts/python"
 # Bundled extensions (installable via `specify extension add <name>`)
 "extensions/git" = "specify_cli/core_pack/extensions/git"
 "extensions/agent-context" = "specify_cli/core_pack/extensions/agent-context"

--- a/tests/contract/test_wheel_core_pack_scripts.py
+++ b/tests/contract/test_wheel_core_pack_scripts.py
@@ -1,0 +1,40 @@
+"""Contract tests for the script variants bundled into the wheel's core_pack.
+
+``specify init --script <type>`` installs from ``specify_cli/core_pack/scripts/``
+when the CLI runs from a wheel. Any script variant that lives in the repository
+must therefore be force-included at build time, otherwise the generated
+commands reference scripts the released package never ships (#3665).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def _force_include() -> dict[str, str]:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+    return pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+
+
+def test_every_script_variant_is_bundled_into_core_pack():
+    force_include = _force_include()
+    variants = sorted(
+        path.name for path in (REPO_ROOT / "scripts").iterdir() if path.is_dir()
+    )
+
+    assert variants, "expected at least one script variant under scripts/"
+    for variant in variants:
+        assert force_include.get(f"scripts/{variant}") == (
+            f"specify_cli/core_pack/scripts/{variant}"
+        ), f"scripts/{variant} is missing from the wheel force-include list"
+
+
+def test_python_script_variant_is_bundled():
+    # Explicit regression guard for #3665: `--script py` shipped skills that
+    # invoked python3 .specify/scripts/python/*.py while the wheel bundled
+    # only the bash and PowerShell variants.
+    assert _force_include()["scripts/python"] == "specify_cli/core_pack/scripts/python"


### PR DESCRIPTION
Fixes #3665.

## Problem

`specify init --script py` generates command/skill files that invoke `python3 .specify/scripts/python/<name>.py`, but the released wheel never contained those scripts, so `--script py` is non-functional on every install channel (PyPI, Homebrew). `--script sh` and `--script ps` are unaffected.

## Root cause

The wheel's `force-include` list in `pyproject.toml` carried only `scripts/bash` and `scripts/powershell` into `specify_cli/core_pack/`. The installer resolves `--script py` to the variant dirs `("python", <platform shell>)` and copies whatever variant directories exist in the bundle (`shared_infra.py`), so from a wheel the `python/` variant was silently absent.

Neither Python-scripts PR (#3302 PoC, #3386 port) touched `pyproject.toml` — the port wired up `shared_infra.py`, the skill placeholder resolver, the command templates and ~1,800 lines of parity tests, but the packaging manifest was missed. Python scripts under `extensions/*` ship correctly only because those extensions are force-included as whole directories.

## Why CI didn't catch it

Every test runs from a source checkout, where `_locate_core_pack()` returns `None` and the repo-root `scripts/` fallback resolves `scripts/python/` normally. The parity and integration suites therefore pass against files the wheel does not contain, and nothing in CI built a wheel and inspected its contents.

## Fix

- `pyproject.toml`: force-include `scripts/python` alongside the other two variants.
- `tests/contract/test_wheel_core_pack_scripts.py`: new contract test that enumerates `scripts/*` in the repo and asserts each variant is force-included, plus an explicit #3665 regression guard. It asserts against `pyproject.toml` rather than the filesystem, so it holds regardless of checkout vs. wheel — and a future fourth variant cannot be dropped the same way.

## Verification

- Built the wheel: all five `core_pack/scripts/python/*.py` present, no `__pycache__` leakage.
- Installed that wheel into a clean venv and ran `specify init proj --script py --integration claude`. `.specify/scripts/python/` now lands with all five files, and every script path referenced by the generated skills exists on disk.
- Executed the installed scripts in that project: `create_new_feature.py --json` and `check_prerequisites.py --json --paths-only` both return the expected JSON contract.
- Confirmed both new tests fail with the `pyproject.toml` line reverted.
- Full suite: 4992 passed, 155 skipped.

## Note for reviewers

`--script py` also installs the platform shell variant alongside `python/` (`shared_infra.py`), which is deliberate — the bundled `agent-context` and `git` extension command templates still hard-code shell invocations, as documented in the "Script Types and Migration" section of `AGENTS.md`. This PR does not change that behavior; a `py` project still receives `bash/` (or `powershell/`) in addition to `python/`.
