### PR TITLE
fix(integrations): render hyphenated /speckit-<name> for Droid (always-slash agent)

### DIFF
--- a/src/specify_cli/_invocation_style.py
+++ b/src/specify_cli/_invocation_style.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 DOLLAR_SKILLS_AGENTS: frozenset[str] = frozenset({"codex", "zcode"})
 
 # Agents that always render /speckit-<name>, regardless of ai_skills.
-ALWAYS_SLASH_AGENTS: frozenset[str] = frozenset({"devin", "grok", "trae", "zed"})
+ALWAYS_SLASH_AGENTS: frozenset[str] = frozenset({"devin", "droid", "grok", "trae", "zed"})
 
 # Agents that render /speckit-<name> only when ai_skills is enabled.
 CONDITIONAL_SLASH_AGENTS: frozenset[str] = frozenset(

--- a/tests/integrations/test_integration_droid.py
+++ b/tests/integrations/test_integration_droid.py
@@ -43,6 +43,15 @@ class TestDroidIntegration(SkillsIntegrationTests):
         i = get_integration(self.KEY)
         assert i.multi_install_safe is True
 
+    def test_is_slash_skills_agent(self):
+        """Droid is an always-skills agent whose commands install as
+        /speckit-<name>, so is_slash_skills_agent must report True — otherwise
+        hook invocations and the init next-steps panel render the dotted
+        /speckit.<name> form Droid never registers (mirrors grok/trae/zed/devin)."""
+        from specify_cli._invocation_style import is_slash_skills_agent
+
+        assert is_slash_skills_agent("droid", True) is True
+
     def test_install_url_points_to_factory(self):
         i = get_integration(self.KEY)
         url = i.config.get("install_url")

--- a/tests/integrations/test_integration_droid.py
+++ b/tests/integrations/test_integration_droid.py
@@ -50,7 +50,12 @@ class TestDroidIntegration(SkillsIntegrationTests):
         /speckit.<name> form Droid never registers (mirrors grok/trae/zed/devin)."""
         from specify_cli._invocation_style import is_slash_skills_agent
 
+        # True in BOTH the enabled and disabled cases: Droid is *always* slash,
+        # not conditional. The disabled case is what distinguishes an
+        # ALWAYS_SLASH agent from a CONDITIONAL_SLASH one (which would be False
+        # when ai_skills is disabled).
         assert is_slash_skills_agent("droid", True) is True
+        assert is_slash_skills_agent("droid", False) is True
 
     def test_install_url_points_to_factory(self):
         i = get_integration(self.KEY)


### PR DESCRIPTION
## What

`DroidIntegration` is an always-skills agent — it installs commands as `.factory/skills/speckit-<name>/SKILL.md` and its `build_command_invocation` returns the hyphenated `/speckit-<name>`. But `"droid"` was missing from every set in `_invocation_style.py` (`DOLLAR_SKILLS_AGENTS`, `ALWAYS_SLASH_AGENTS`, `CONDITIONAL_SLASH_AGENTS`), so `is_slash_skills_agent("droid", True)` returned `False`.

As a result, both `HookExecutor._render_hook_invocation` and `specify init`'s next-steps `_display_cmd` fell through to the **dotted** `/speckit.<name>` form — a command Droid never registers. Hook dispatch and the printed getting-started commands pointed at nonexistent commands for Droid users.

## Fix

Add `"droid"` to `ALWAYS_SLASH_AGENTS`, matching its always-skills siblings `grok`/`trae`/`zed`/`devin` (each added to that set by its own integration PR — e.g. grok in #3535, zed in #2780; Droid's #3587 omitted it).

## Tests

`tests/integrations/test_integration_droid.py::TestDroidIntegration::test_is_slash_skills_agent` — asserts `is_slash_skills_agent("droid", True) is True` (fails before the fix). Full droid suite (46 tests) passes; `ruff` clean.

---
*AI-assisted: authored with Claude Code. I confirmed Droid is an always-skills `SkillsIntegration` (hyphenated `build_command_invocation`, no `is_skills_mode` override) and that grok/trae/zed/devin establish the `ALWAYS_SLASH_AGENTS` precedent.*