### PR TITLE
fix(workflows): filter parser rejects trailing tokens (fullmatch, not match)

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -392,8 +392,14 @@ def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> An
             )
         return _filter_from_json(value)
 
-    # Parse filter name and argument
-    filter_match = re.match(r"(\w+)\((.+)\)", filter_expr)
+    # Parse filter name and argument. Use fullmatch (not match) so trailing
+    # tokens after the closing paren — e.g. a comparison/boolean operator that
+    # binds looser than the pipe, as in ``count | default(0) > 5`` — are not
+    # silently discarded but fall through to the "unsupported form" ValueError
+    # below, mirroring the strict trailing-token handling of the from_json
+    # branch above. The greedy ``.+`` still handles literal ``)`` and ``|``
+    # inside quoted args.
+    filter_match = re.fullmatch(r"(\w+)\((.+)\)", filter_expr)
     if filter_match:
         fname = filter_match.group(1)
         farg = _evaluate_simple_expression(filter_match.group(2).strip(), namespace)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -686,6 +686,28 @@ class TestExpressions:
         ):
             evaluate_expression("{{ inputs.tags | map }}", ctx)
 
+    def test_filter_call_with_trailing_tokens_fails_loudly(self):
+        # A trailing operator/token after a filter's closing paren must not be
+        # silently discarded (the parser used an unanchored regex). It must
+        # fall through to the "unsupported form" ValueError, like the from_json
+        # branch's strict trailing-token handling.
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        # A comparison after a filter (binds looser than the pipe) was dropped,
+        # so `default('7') > '5'` silently returned '7'.
+        with pytest.raises(ValueError, match="unsupported form"):
+            evaluate_expression(
+                "{{ inputs.missing | default('7') > '5' }}", StepContext(inputs={})
+            )
+        # Trailing garbage after a valid filter call.
+        with pytest.raises(ValueError, match="unsupported form"):
+            evaluate_expression(
+                "{{ inputs.tags | join(',') extra }}",
+                StepContext(inputs={"tags": ["a", "b"]}),
+            )
+
     def test_chained_filters_apply_left_to_right(self):
         # Filters chain: each filter's result feeds the next. `map` yields a
         # list and `join` is the only filter that renders a list to a string,


### PR DESCRIPTION
## What

`_apply_filter` parsed a `name(arg)` filter with an **unanchored** regex — `re.match(r"(\w+)\((.+)\)", filter_expr)` — so any tokens **after** the closing paren were silently discarded.

`_evaluate_simple_expression` splits the top-level `|` **before** comparison/boolean operators, so an expression like `count | default(0) > 5` was split into value `count` and filter segment `default(0) > 5`. That segment matched the unanchored regex as `default(0)`, and `> 5` **vanished** — the filter's value was returned as if it were the whole expression, producing a silently wrong result (e.g. a condition that's always true).

This contradicts both the function's own docstring ("Raises ValueError on any mis-wired or unknown filter rather than silently returning value unchanged") and the sibling `from_json` branch, which explicitly rejects trailing tokens.

## Fix

Use `re.fullmatch` so a mis-wired segment falls through to the existing `"filter '<name>' used in an unsupported form"` `ValueError`. The greedy `.+` still matches every legitimate form (literal `)` and `|` inside quoted args), so registered/chained/quoted-pipe filters are unaffected.

## Tests

`tests/test_workflows.py::TestExpressions::test_filter_call_with_trailing_tokens_fails_loudly` — a comparison after a filter and trailing garbage both now raise (fail before the fix — `DID NOT RAISE`). The full filter/expression/condition/pipe suite (67 tests, incl. `test_pipe_in_quoted_arg_is_not_a_filter_separator`, `test_chained_filters_apply_left_to_right`) passes. `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified fail-before/pass-after and that all legitimate filter forms still match under `fullmatch`.*