### PR TITLE
fix(workflows): escape step-graph brackets in `workflow info` so the step type shows

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -2376,7 +2376,15 @@ def workflow_info(
             console.print(f"\n  [bold]Steps ({len(definition.steps)}):[/bold]")
             for step in definition.steps:
                 stype = step.get("type", "command")
-                console.print(f"    → {step.get('id', '?')} [{stype}]")
+                # Escape the literal bracket (\[) so Rich renders `[<type>]`
+                # instead of parsing it as a style tag named after the step
+                # type (which it silently swallows); escape id/type too, as
+                # the sibling workflow_list does. Mirrors the `\[disabled]`
+                # precedent above.
+                console.print(
+                    f"    → {_escape_markup(str(step.get('id', '?')))} "
+                    f"\\[{_escape_markup(str(stype))}]"
+                )
         return
 
     # Try catalog

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -7860,6 +7860,37 @@ class TestWorkflowAddCaseInsensitiveSuffix:
         assert "installed" in result.output
 
 
+class TestWorkflowInfoStepGraph:
+    """`workflow info` must render each step as `→ <id> [<type>]` with LITERAL
+    brackets. Rich parses an unescaped `[<type>]` as a style tag and silently
+    swallows it, so the step type would vanish from the output."""
+
+    def test_step_type_rendered_in_literal_brackets(self, temp_dir, monkeypatch):
+        import types
+
+        from typer.testing import CliRunner
+        from specify_cli import app
+        from specify_cli.workflows.engine import WorkflowEngine
+
+        (temp_dir / ".specify" / "workflows").mkdir(parents=True)
+
+        fake = types.SimpleNamespace(
+            name="My WF", id="my-wf", version="1.0.0", author="", description="",
+            default_integration=None, inputs={},
+            steps=[{"id": "step-one", "type": "gate"}],
+        )
+        monkeypatch.setattr(WorkflowEngine, "load_workflow", lambda self, wid: fake)
+        monkeypatch.chdir(temp_dir)
+
+        result = CliRunner().invoke(app, ["workflow", "info", "my-wf"])
+
+        assert result.exit_code == 0, result.output
+        assert "step-one" in result.output
+        # The step type must survive as a literal bracketed token, not be eaten
+        # by Rich as an unknown style tag.
+        assert "[gate]" in result.output
+
+
 class TestWorkflowAddSymlinkGuard:
     def test_add_malformed_ipv6_url_exits_cleanly(self, temp_dir, monkeypatch):
         """A malformed IPv6 URL must produce a clean error, not a ValueError traceback."""


### PR DESCRIPTION
## What

`specify workflow info <id>` renders each step's line as `→ <id> [<type>]` — with the step type meant to appear inside **literal** square brackets. But `console.print` has Rich markup enabled, so `[<type>]` is parsed as an opening style tag named after the step type (`command`, `gate`, `prompt`, …). Those aren't valid Rich styles and there's no closing tag, so Rich **silently swallows the whole `[<type>]` token** — every step prints as `→ <id> ` with the type gone.

## Fix

Escape the literal bracket with `\[` so Rich renders `[<type>]` verbatim, and escape the id/type through `_escape_markup` (as the sibling `workflow_list` already does for displayed fields). Mirrors the in-file `\[disabled]` precedent in `workflow_list`.

## Tests

`tests/test_workflows.py::TestWorkflowInfoStepGraph::test_step_type_rendered_in_literal_brackets` — monkeypatches `WorkflowEngine.load_workflow` to return a definition with a `gate` step and asserts `[gate]` appears in `workflow info` output. Fails before the fix (output is `→ step-one ` — the `[gate]` swallowed). `ruff` clean.

---
*AI-assisted: authored with Claude Code. Reproduced the Rich markup-swallowing behavior and verified fail-before/pass-after.*