### PR TITLE
fix(auth): normalize whitespace in auth-config env-var/id references at store time

### DIFF
--- a/src/specify_cli/authentication/config.py
+++ b/src/specify_cli/authentication/config.py
@@ -13,6 +13,7 @@ import stat
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 
@@ -51,6 +52,19 @@ def _is_valid_host_pattern(pattern: str) -> bool:
         return True  # exact hostname — already validated as non-empty
     # Only *.suffix is allowed; no other wildcard positions
     return pattern.startswith("*.") and "*" not in pattern[2:]
+
+
+def _norm(value: Any) -> Any:
+    """Strip surrounding whitespace from a whitespace-insignificant string
+    config reference (env-var names, tenant/client ids) before it is stored.
+
+    These fields are validated on their ``.strip()``ed form, so an accidentally
+    padded value passes validation but then silently breaks the verbatim
+    ``os.environ.get(...)`` / URL lookups downstream. Normalizing at store time
+    mirrors how ``hosts`` is already handled (``h.strip().lower()``). Non-string
+    values (e.g. ``None``) pass through unchanged.
+    """
+    return value.strip() if isinstance(value, str) else value
 
 
 def load_auth_config(
@@ -182,10 +196,10 @@ def load_auth_config(
                 provider=provider,
                 auth=auth,
                 token=token,
-                token_env=token_env,
-                tenant_id=entry_raw.get("tenant_id"),
-                client_id=entry_raw.get("client_id"),
-                client_secret_env=entry_raw.get("client_secret_env"),
+                token_env=_norm(token_env),
+                tenant_id=_norm(entry_raw.get("tenant_id")),
+                client_id=_norm(entry_raw.get("client_id")),
+                client_secret_env=_norm(entry_raw.get("client_secret_env")),
             )
         )
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -157,6 +157,26 @@ class TestLoadAuthConfig:
         assert entries[0].auth == "azure-ad"
         assert entries[0].tenant_id == "tid"
 
+    def test_padded_azure_ad_refs_are_normalized(self, tmp_path):
+        # The normalization also covers tenant_id / client_id / client_secret_env
+        # (used verbatim in the OAuth token URL/body and os.environ.get). Padded
+        # values were validated on their stripped form but stored raw.
+        cfg = tmp_path / "auth.json"
+        cfg.write_text(json.dumps({
+            "providers": [{
+                "hosts": ["dev.azure.com"],
+                "provider": "azure-devops",
+                "auth": "azure-ad",
+                "tenant_id": "  tid  ",
+                "client_id": "  cid  ",
+                "client_secret_env": "  SECRET  ",
+            }]
+        }))
+        entries = load_auth_config(cfg)
+        assert entries[0].tenant_id == "tid"
+        assert entries[0].client_id == "cid"
+        assert entries[0].client_secret_env == "SECRET"
+
     def test_azure_cli_config(self, tmp_path):
         cfg = tmp_path / "auth.json"
         cfg.write_text(json.dumps({

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -92,6 +92,27 @@ class TestLoadAuthConfig:
         assert entries[0].auth == "bearer"
         assert entries[0].token_env == "GH_TOKEN"
 
+    def test_padded_token_env_is_normalized_and_resolves(self, tmp_path, monkeypatch):
+        # token_env is validated on its stripped form but was stored raw, so a
+        # padded env-var name passed validation yet broke the verbatim
+        # os.environ.get() lookup — resolve_token silently returned None.
+        monkeypatch.setenv("GH_TOKEN", "secret-tok")
+        cfg = tmp_path / "auth.json"
+        cfg.write_text(json.dumps({
+            "providers": [{
+                "hosts": ["github.com"],
+                "provider": "github",
+                "auth": "bearer",
+                "token_env": "  GH_TOKEN  ",
+            }]
+        }))
+        entries = load_auth_config(cfg)
+        assert len(entries) == 1
+        # Stored normalized (matching how hosts are normalized), ...
+        assert entries[0].token_env == "GH_TOKEN"
+        # ... so the env lookup finds the token instead of returning None.
+        assert GitHubAuth().resolve_token(entries[0]) == "secret-tok"
+
     def test_valid_ado_config(self, tmp_path):
         cfg = tmp_path / "auth.json"
         cfg.write_text(json.dumps({


### PR DESCRIPTION
## What

In `load_auth_config`, the fields `token_env`, `client_secret_env`, `tenant_id`, and `client_id` are **validated** on their `.strip()`ed form (proving they're non-empty ignoring surrounding whitespace) but then **stored raw** on the `AuthConfigEntry`.

So an accidentally padded value (e.g. `"token_env": " GH_TOKEN "`) passes validation, yet downstream:
- `base.py` → `os.environ.get(entry.token_env)`
- `azure_devops.py` → `os.environ.get(entry.client_secret_env, "")`, and `tenant_id`/`client_id` used verbatim in the OAuth URL/body

…all use the padded name literally, so the env var is never found. `load_auth_config` succeeds with **no error**, but `resolve_token` returns `None` and the request silently downgrades to unauthenticated (401/403 on private resources) with no diagnostic — the classic validate-normalized-but-store-original bug.

The `hosts` field in the same function already does it right (`hosts = [h.strip().lower() for h in hosts]`); these references were just never given the same normalization.

## Fix

A module-level `_norm` helper strips whitespace-insignificant string references at store time (non-strings like `None` pass through). Applied to `token_env`, `tenant_id`, `client_id`, `client_secret_env`. `token` is left unchanged (already stripped at resolve time in `base.py`).

## Tests

`tests/test_authentication.py::TestLoadAuthConfig::test_padded_token_env_is_normalized_and_resolves` — a `" GH_TOKEN "` config now stores `"GH_TOKEN"` and `GitHubAuth().resolve_token(...)` finds the token. Fails before the fix (`resolve_token` returns `None`). Full auth suite (140 tests) passes; `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified the validate-vs-store asymmetry against the `hosts` sibling and confirmed fail-before/pass-after end-to-end through `resolve_token`.*