### PR TITLE
fix(workflows): guard non-mapping 'workflow:' block in WorkflowDefinition

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -42,6 +42,17 @@ class WorkflowDefinition:
         self.source_path = source_path
 
         workflow = data.get("workflow", {})
+        # A present-but-non-mapping ``workflow:`` block (bare ``workflow:`` ->
+        # None, or ``workflow: <str/list>``) would crash the following
+        # ``workflow.get(...)`` calls with AttributeError, so construction fails
+        # before any validation can run. Normalize the local to {} instead: the
+        # header fields fall back to their defaults and ``validate_workflow``
+        # (which reads those parsed attributes) reports the missing
+        # ``workflow.id``/``workflow.name``. ``self.data`` is deliberately left
+        # holding the raw value, since it is what gets written back out when a
+        # definition is serialized. Mirrors the default_options guard below.
+        if not isinstance(workflow, dict):
+            workflow = {}
         self.id: str = workflow.get("id", "")
         self.name: str = workflow.get("name", "")
         self.version: str = workflow.get("version", "0.0.0")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3643,9 +3643,16 @@ class TestWorkflowDefinition:
         assert definition.id == ""
         errors = validate_workflow(definition)
         assert any("workflow.id" in e for e in errors)
-        # The raw value is left untouched on .data (used when the definition is
-        # written back out), so the guard normalizes only the local.
-        assert "workflow" in definition.data
+        # The RAW malformed value is preserved on .data (the guard only
+        # normalizes the local var, not self.data) — .data is what gets written
+        # back out when a definition is serialized. Assert it was NOT replaced
+        # with {} by comparing against the original parse and confirming it is
+        # still a non-mapping.
+        import yaml
+
+        raw_workflow = yaml.safe_load(block).get("workflow")
+        assert definition.data["workflow"] == raw_workflow
+        assert not isinstance(definition.data["workflow"], dict)
 
     def test_from_string_invalid(self):
         from specify_cli.workflows.engine import WorkflowDefinition

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3629,6 +3629,24 @@ class TestWorkflowDefinition:
         resolved = WorkflowEngine()._resolve_inputs(definition, {})  # must not raise
         assert resolved == {}
 
+    @pytest.mark.parametrize(
+        "block", ["workflow:\nsteps: []\n", "workflow: hi\nsteps: []\n", "workflow: [a]\nsteps: []\n"]
+    )
+    def test_non_mapping_workflow_block_parses_then_validates(self, block):
+        # A present-but-non-mapping `workflow:` block must not crash construction
+        # with AttributeError; it should parse to an empty header so
+        # validate_workflow reports the missing id/name (it reads the parsed
+        # attributes, not the raw block).
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition.from_string(block)  # must not raise
+        assert definition.id == ""
+        errors = validate_workflow(definition)
+        assert any("workflow.id" in e for e in errors)
+        # The raw value is left untouched on .data (used when the definition is
+        # written back out), so the guard normalizes only the local.
+        assert "workflow" in definition.data
+
     def test_from_string_invalid(self):
         from specify_cli.workflows.engine import WorkflowDefinition
 


### PR DESCRIPTION
## What

A present-but-non-mapping top-level `workflow:` block crashed `WorkflowDefinition.__init__` with `AttributeError`:

- bare `workflow:` → YAML `null`
- `workflow: some-string` → `str`
- `workflow: [a, b]` → `list`

`workflow = data.get("workflow", {})` only substitutes `{}` when the key is **absent**, so a present non-dict value reached `workflow.get("id", "")` → `AttributeError: 'NoneType'/'str'/'list' object has no attribute 'get'`.

This fires inside `from_yaml`/`from_string` — **before** `validate_workflow` can report the malformed shape — and in the CLI (`workflow run`/`resume`, whose `load_workflow` is wrapped to catch only `FileNotFoundError`/`ValueError`) it escapes as a raw traceback instead of a clean "Invalid workflow" message.

## Fix

Normalize the local `workflow` to `{}` when it isn't a mapping (`self.data` keeps the raw value so `validate_workflow` still reports it), mirroring the adjacent `default_options` guard (`if not isinstance(...): = {}`).

## Tests

`tests/test_workflows.py::TestWorkflowDefinition::test_non_mapping_workflow_block_parses_then_validates` (parametrized null/str/list) — construction no longer raises, and `validate_workflow` reports the missing `workflow.id`. Fails before the fix (all three crash). `ruff` clean.

---
*AI-assisted: authored with Claude Code. Verified against the `default_options` sibling guard and confirmed fail-before/pass-after, incl. `self.data` round-trip.*