### PR TITLE
fix(workflows): guard non-mapping 'inputs:' block in engine._resolve_inputs

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -1400,6 +1400,14 @@ class WorkflowEngine:
     ) -> dict[str, Any]:
         """Resolve workflow inputs against definitions and provided values."""
         resolved: dict[str, Any] = {}
+        # execute()/resume() accept UNVALIDATED definitions (load_workflow does
+        # not validate). A non-mapping ``inputs:`` block (bare ``inputs:`` ->
+        # None, or ``inputs: []``) is stored raw, so iterating ``.items()`` here
+        # would crash the run with AttributeError. Treat a non-mapping inputs
+        # block as "no inputs"; validate_workflow reports the malformed shape
+        # via its own isinstance check.
+        if not isinstance(definition.inputs, dict):
+            return {}
         for name, input_def in definition.inputs.items():
             if not isinstance(input_def, dict):
                 continue

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3612,6 +3612,23 @@ class TestWorkflowDefinition:
         assert definition.id == "test-workflow"
         assert len(definition.inputs) == 2
 
+    @pytest.mark.parametrize(
+        "block",
+        [
+            "workflow:\n  id: w\n  name: W\nsteps: []\ninputs: []\n",   # list
+            "workflow:\n  id: w\n  name: W\nsteps: []\ninputs:\n",       # null
+        ],
+    )
+    def test_resolve_inputs_tolerates_non_mapping_inputs(self, block):
+        # execute()/resume() run UNVALIDATED definitions; a non-mapping `inputs:`
+        # block (list/null) is stored raw and would crash _resolve_inputs at
+        # `.items()`. It must be treated as "no inputs" instead.
+        from specify_cli.workflows.engine import WorkflowDefinition, WorkflowEngine
+
+        definition = WorkflowDefinition.from_string(block)
+        resolved = WorkflowEngine()._resolve_inputs(definition, {})  # must not raise
+        assert resolved == {}
+
     def test_from_string_invalid(self):
         from specify_cli.workflows.engine import WorkflowDefinition
 


### PR DESCRIPTION
## What

`WorkflowEngine.execute()` / `resume()` run **unvalidated** definitions (`load_workflow`'s docstring: *"not yet validated; call validate_workflow() separately"*), and `WorkflowDefinition` stores `inputs` raw. So a non-mapping `inputs:` block — bare `inputs:` → `None`, or `inputs: []` → `list` — reached:

```python
for name, input_def in definition.inputs.items():
```

…and crashed the whole run with `AttributeError: 'NoneType'/'list' object has no attribute 'items'`. The steps layer is explicitly hardened for exactly this "engine does not auto-validate" case; the `inputs` container was the gap (the existing per-input `isinstance` skip is only reached *after* the crashing iteration).

## Fix

Return `{}` when `definition.inputs` is not a mapping, mirroring `validate_workflow`'s own `isinstance(definition.inputs, dict)` check. Protects both call sites (`execute` and `resume`); normal dict resolution (defaults + provided overrides) is unchanged, and `validate_workflow` still reports the malformed shape.

## Tests

`tests/test_workflows.py::TestWorkflowDefinition::test_resolve_inputs_tolerates_non_mapping_inputs` (parametrized `inputs: []` and bare `inputs:`) — `_resolve_inputs` returns `{}` instead of raising. Fails before the fix (`AttributeError`). `ruff check` reports no new issues (the pre-existing engine.py `I001` is unrelated and present on main).

---
*AI-assisted: authored with Claude Code. Verified against the `validate_workflow` sibling check and confirmed fail-before/pass-after.*