### PR TITLE
ci: pin the Ruff rule set explicitly so a Ruff default-expansion can't red CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,21 @@ show_missing = true
 skip_covered = false
 
 [tool.ruff.lint]
-# Lock in subprocess security posture: any reintroduction of shell=True
-# (or os.system / popen2) must be acknowledged with an explicit `# noqa`
-# pointing at the rule, making the deviation visible in review.
-extend-select = [
+# Pin the rule set explicitly instead of relying on Ruff's *default* select
+# (which `extend-select` builds on). A Ruff release that expands the default
+# rule set would otherwise start failing CI on long-standing code across the
+# whole repo — `uvx ruff` is unpinned in CI, so it always resolves the latest
+# Ruff. `select` below is Ruff's historical default (E4/E7/E9/F) plus the
+# subprocess-security rules the project has always enforced.
+#
+# Subprocess security posture: any reintroduction of shell=True (or os.system
+# / popen2) must be acknowledged with an explicit `# noqa` pointing at the
+# rule, making the deviation visible in review.
+select = [
+    "E4",
+    "E7",
+    "E9",
+    "F",
     "S602",  # subprocess-popen-with-shell-equals-true
     "S604",  # call-with-shell-equals-true
     "S605",  # start-process-with-a-shell


### PR DESCRIPTION
## Problem

The `ruff` CI job runs `uvx ruff check src tests`, and `uvx ruff` (unpinned) always resolves the **latest** Ruff. The lint config builds on Ruff's **default** select via `extend-select`, so a Ruff release that expands the default rule set starts failing long-standing code across the whole repo.

Right now, `uvx ruff check src tests` on a clean `main` reports **~1476 findings** — dominated by rules the project doesn't select:

```
733  I001    161  UP006   105  RUF012   92  PLW1510
 49  BLE001   45  UP017    26  RUF059   ...
```

This affects **every open PR** (older PRs show a cached green from before the Ruff release).

## Fix

Replace `extend-select` with an explicit `select` that reproduces Ruff's historical default (`E4`/`E7`/`E9`/`F`) **plus** the subprocess-security rules the project has always enforced (`S602`/`S604`/`S605`). This pins the *rule set* (independent of Ruff's version), which is more robust than pinning a Ruff version.

## Verification

- `uvx ruff check src tests` → **All checks passed!** (was ~1476 errors)
- The subprocess-security guards still fire — a `subprocess.run("ls", shell=True)` probe is still flagged `S602`.
- No source changes; `pyproject.toml` only.

*(If you'd instead prefer to adopt the new default rules or pin a specific Ruff version, happy to adjust — this is the minimal change to restore green CI without a repo-wide auto-fix.)*

---
*AI-assisted: authored with Claude Code. I confirmed the 1476 findings are all from rules outside the project's intended set and that the explicit `select` restores green while preserving the S6xx security posture.*