### PR TITLE
fix(workflows): reject non-string/non-boolean 'condition' in if/while/do-while steps

### DIFF
--- a/src/specify_cli/workflows/steps/do_while/__init__.py
+++ b/src/specify_cli/workflows/steps/do_while/__init__.py
@@ -72,12 +72,14 @@ class DoWhileStep(StepBase):
             )
         elif not isinstance(config["condition"], str):
             # The engine re-evaluates 'condition' via evaluate_condition() after
-            # each iteration; it returns a non-string as-is and takes bool() of
-            # it -- so a list/dict/number condition silently resolves to a
-            # truthiness (e.g. condition: [1, 2] is always truthy, looping to
-            # max_iterations) with no error. Reject non-strings at validation,
-            # mirroring the prompt/shell/command 'must be a string' checks.
-            # "true"/"false" and an expression like "{{ ... }}" stay valid.
+            # each iteration. That call first delegates to
+            # evaluate_expression() -- which returns a non-string unchanged --
+            # and then coerces the result with bool(). So a list/dict/number
+            # condition silently resolves to its truthiness (e.g.
+            # condition: [1, 2] is always truthy, looping to max_iterations)
+            # with no error. Reject non-strings at validation, mirroring the
+            # prompt/shell/command 'must be a string' checks. "true"/"false"
+            # and an expression like "{{ ... }}" stay valid.
             errors.append(
                 f"Do-while step {config.get('id', '?')!r}: 'condition' must be a "
                 f"string, got {type(config['condition']).__name__}."

--- a/src/specify_cli/workflows/steps/do_while/__init__.py
+++ b/src/specify_cli/workflows/steps/do_while/__init__.py
@@ -70,6 +70,18 @@ class DoWhileStep(StepBase):
                 f"Do-while step {config.get('id', '?')!r} is missing "
                 f"'condition' field."
             )
+        elif not isinstance(config["condition"], str):
+            # The engine re-evaluates 'condition' via evaluate_condition() after
+            # each iteration; it returns a non-string as-is and takes bool() of
+            # it -- so a list/dict/number condition silently resolves to a
+            # truthiness (e.g. condition: [1, 2] is always truthy, looping to
+            # max_iterations) with no error. Reject non-strings at validation,
+            # mirroring the prompt/shell/command 'must be a string' checks.
+            # "true"/"false" and an expression like "{{ ... }}" stay valid.
+            errors.append(
+                f"Do-while step {config.get('id', '?')!r}: 'condition' must be a "
+                f"string, got {type(config['condition']).__name__}."
+            )
         max_iter = config.get("max_iterations")
         if max_iter is not None:
             # bool is a subclass of int, so isinstance(True, int) is True and

--- a/src/specify_cli/workflows/steps/do_while/__init__.py
+++ b/src/specify_cli/workflows/steps/do_while/__init__.py
@@ -70,19 +70,23 @@ class DoWhileStep(StepBase):
                 f"Do-while step {config.get('id', '?')!r} is missing "
                 f"'condition' field."
             )
-        elif not isinstance(config["condition"], str):
+        elif not isinstance(config["condition"], (str, bool)):
             # The engine re-evaluates 'condition' via evaluate_condition() after
             # each iteration. That call first delegates to
             # evaluate_expression() -- which returns a non-string unchanged --
             # and then coerces the result with bool(). So a list/dict/number
             # condition silently resolves to its truthiness (e.g.
             # condition: [1, 2] is always truthy, looping to max_iterations)
-            # with no error. Reject non-strings at validation, mirroring the
-            # prompt/shell/command 'must be a string' checks. "true"/"false"
-            # and an expression like "{{ ... }}" stay valid.
+            # with no error. Reject those at validation, mirroring the
+            # prompt/shell/command 'must be a string' checks.
+            #
+            # A literal ``bool`` stays valid: an unquoted ``condition: false``
+            # is idiomatic YAML and evaluate_condition() already resolves it
+            # exactly (bool passthrough, then a no-op bool()). "true"/"false"
+            # and an expression like "{{ ... }}" stay valid too.
             errors.append(
                 f"Do-while step {config.get('id', '?')!r}: 'condition' must be a "
-                f"string, got {type(config['condition']).__name__}."
+                f"string or boolean, got {type(config['condition']).__name__}."
             )
         max_iter = config.get("max_iterations")
         if max_iter is not None:

--- a/src/specify_cli/workflows/steps/if_then/__init__.py
+++ b/src/specify_cli/workflows/steps/if_then/__init__.py
@@ -62,13 +62,15 @@ class IfThenStep(StepBase):
                 f"If step {config.get('id', '?')!r} is missing 'condition' field."
             )
         elif not isinstance(config["condition"], str):
-            # execute() feeds 'condition' to evaluate_condition(), which returns
-            # a non-string as-is and takes bool() of it -- so a list/dict/number
-            # condition silently resolves to a truthiness (e.g. condition: [1, 2]
-            # is always True) with no error, branching wrongly on an authoring
-            # mistake. Reject non-strings at validation, mirroring the prompt/
-            # shell/command 'must be a string' checks. "true"/"false" and an
-            # expression like "{{ ... }}" are strings, so they stay valid.
+            # execute() feeds 'condition' to evaluate_condition(), which first
+            # delegates to evaluate_expression() -- that returns a non-string
+            # unchanged -- and then coerces the result with bool(). So a
+            # list/dict/number condition silently resolves to its truthiness
+            # (e.g. condition: [1, 2] is always True) with no error, branching
+            # wrongly on an authoring mistake. Reject non-strings at validation,
+            # mirroring the prompt/shell/command 'must be a string' checks.
+            # "true"/"false" and an expression like "{{ ... }}" are strings, so
+            # they stay valid.
             errors.append(
                 f"If step {config.get('id', '?')!r}: 'condition' must be a "
                 f"string, got {type(config['condition']).__name__}."

--- a/src/specify_cli/workflows/steps/if_then/__init__.py
+++ b/src/specify_cli/workflows/steps/if_then/__init__.py
@@ -61,6 +61,18 @@ class IfThenStep(StepBase):
             errors.append(
                 f"If step {config.get('id', '?')!r} is missing 'condition' field."
             )
+        elif not isinstance(config["condition"], str):
+            # execute() feeds 'condition' to evaluate_condition(), which returns
+            # a non-string as-is and takes bool() of it -- so a list/dict/number
+            # condition silently resolves to a truthiness (e.g. condition: [1, 2]
+            # is always True) with no error, branching wrongly on an authoring
+            # mistake. Reject non-strings at validation, mirroring the prompt/
+            # shell/command 'must be a string' checks. "true"/"false" and an
+            # expression like "{{ ... }}" are strings, so they stay valid.
+            errors.append(
+                f"If step {config.get('id', '?')!r}: 'condition' must be a "
+                f"string, got {type(config['condition']).__name__}."
+            )
         if "then" not in config:
             errors.append(
                 f"If step {config.get('id', '?')!r} is missing 'then' field."

--- a/src/specify_cli/workflows/steps/if_then/__init__.py
+++ b/src/specify_cli/workflows/steps/if_then/__init__.py
@@ -61,19 +61,23 @@ class IfThenStep(StepBase):
             errors.append(
                 f"If step {config.get('id', '?')!r} is missing 'condition' field."
             )
-        elif not isinstance(config["condition"], str):
+        elif not isinstance(config["condition"], (str, bool)):
             # execute() feeds 'condition' to evaluate_condition(), which first
             # delegates to evaluate_expression() -- that returns a non-string
             # unchanged -- and then coerces the result with bool(). So a
             # list/dict/number condition silently resolves to its truthiness
             # (e.g. condition: [1, 2] is always True) with no error, branching
-            # wrongly on an authoring mistake. Reject non-strings at validation,
+            # wrongly on an authoring mistake. Reject those at validation,
             # mirroring the prompt/shell/command 'must be a string' checks.
-            # "true"/"false" and an expression like "{{ ... }}" are strings, so
-            # they stay valid.
+            #
+            # A literal ``bool`` stays valid: an unquoted ``condition: false``
+            # is idiomatic YAML, evaluate_condition() already resolves it
+            # exactly (bool passthrough, then a no-op bool()), and this step
+            # itself defaults ``condition`` to ``False``. "true"/"false" and an
+            # expression like "{{ ... }}" are strings, so they stay valid too.
             errors.append(
                 f"If step {config.get('id', '?')!r}: 'condition' must be a "
-                f"string, got {type(config['condition']).__name__}."
+                f"string or boolean, got {type(config['condition']).__name__}."
             )
         if "then" not in config:
             errors.append(

--- a/src/specify_cli/workflows/steps/while_loop/__init__.py
+++ b/src/specify_cli/workflows/steps/while_loop/__init__.py
@@ -79,6 +79,18 @@ class WhileStep(StepBase):
                 f"While step {config.get('id', '?')!r} is missing "
                 f"'condition' field."
             )
+        elif not isinstance(config["condition"], str):
+            # execute() feeds 'condition' to evaluate_condition(), which returns
+            # a non-string as-is and takes bool() of it -- so a list/dict/number
+            # condition silently resolves to a truthiness (e.g. condition: [1, 2]
+            # is always truthy, spinning the loop to max_iterations) with no
+            # error. Reject non-strings at validation, mirroring the prompt/
+            # shell/command 'must be a string' checks. "true"/"false" and an
+            # expression like "{{ ... }}" are strings, so they stay valid.
+            errors.append(
+                f"While step {config.get('id', '?')!r}: 'condition' must be a "
+                f"string, got {type(config['condition']).__name__}."
+            )
         max_iter = config.get("max_iterations")
         if max_iter is not None:
             # bool is a subclass of int, so isinstance(True, int) is True and

--- a/src/specify_cli/workflows/steps/while_loop/__init__.py
+++ b/src/specify_cli/workflows/steps/while_loop/__init__.py
@@ -80,13 +80,15 @@ class WhileStep(StepBase):
                 f"'condition' field."
             )
         elif not isinstance(config["condition"], str):
-            # execute() feeds 'condition' to evaluate_condition(), which returns
-            # a non-string as-is and takes bool() of it -- so a list/dict/number
-            # condition silently resolves to a truthiness (e.g. condition: [1, 2]
-            # is always truthy, spinning the loop to max_iterations) with no
-            # error. Reject non-strings at validation, mirroring the prompt/
-            # shell/command 'must be a string' checks. "true"/"false" and an
-            # expression like "{{ ... }}" are strings, so they stay valid.
+            # execute() feeds 'condition' to evaluate_condition(), which first
+            # delegates to evaluate_expression() -- that returns a non-string
+            # unchanged -- and then coerces the result with bool(). So a
+            # list/dict/number condition silently resolves to its truthiness
+            # (e.g. condition: [1, 2] is always truthy, spinning the loop to
+            # max_iterations) with no error. Reject non-strings at validation,
+            # mirroring the prompt/shell/command 'must be a string' checks.
+            # "true"/"false" and an expression like "{{ ... }}" are strings, so
+            # they stay valid.
             errors.append(
                 f"While step {config.get('id', '?')!r}: 'condition' must be a "
                 f"string, got {type(config['condition']).__name__}."

--- a/src/specify_cli/workflows/steps/while_loop/__init__.py
+++ b/src/specify_cli/workflows/steps/while_loop/__init__.py
@@ -79,19 +79,23 @@ class WhileStep(StepBase):
                 f"While step {config.get('id', '?')!r} is missing "
                 f"'condition' field."
             )
-        elif not isinstance(config["condition"], str):
+        elif not isinstance(config["condition"], (str, bool)):
             # execute() feeds 'condition' to evaluate_condition(), which first
             # delegates to evaluate_expression() -- that returns a non-string
             # unchanged -- and then coerces the result with bool(). So a
             # list/dict/number condition silently resolves to its truthiness
             # (e.g. condition: [1, 2] is always truthy, spinning the loop to
-            # max_iterations) with no error. Reject non-strings at validation,
+            # max_iterations) with no error. Reject those at validation,
             # mirroring the prompt/shell/command 'must be a string' checks.
-            # "true"/"false" and an expression like "{{ ... }}" are strings, so
-            # they stay valid.
+            #
+            # A literal ``bool`` stays valid: an unquoted ``condition: false``
+            # is idiomatic YAML, evaluate_condition() already resolves it
+            # exactly (bool passthrough, then a no-op bool()), and this step
+            # itself defaults ``condition`` to ``False``. "true"/"false" and an
+            # expression like "{{ ... }}" are strings, so they stay valid too.
             errors.append(
                 f"While step {config.get('id', '?')!r}: 'condition' must be a "
-                f"string, got {type(config['condition']).__name__}."
+                f"string or boolean, got {type(config['condition']).__name__}."
             )
         max_iter = config.get("max_iterations")
         if max_iter is not None:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2492,9 +2492,10 @@ class TestIfThenStep:
 
     @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, True])
     def test_validate_rejects_non_string_condition(self, bad):
-        # A non-string condition is returned as-is by evaluate_condition and
-        # bool()-coerced, so it silently resolves to a truthiness (e.g. [1, 2]
-        # is always True) instead of erroring on the authoring mistake.
+        # A non-string condition is returned unchanged by evaluate_expression,
+        # and evaluate_condition then bool()-coerces it, so it silently resolves
+        # to its truthiness (e.g. [1, 2] is always True) instead of erroring on
+        # the authoring mistake.
         from specify_cli.workflows.steps.if_then import IfThenStep
 
         step = IfThenStep()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2490,6 +2490,25 @@ class TestIfThenStep:
         errors = step.validate({"id": "test", "then": []})
         assert any("missing 'condition'" in e for e in errors)
 
+    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, True])
+    def test_validate_rejects_non_string_condition(self, bad):
+        # A non-string condition is returned as-is by evaluate_condition and
+        # bool()-coerced, so it silently resolves to a truthiness (e.g. [1, 2]
+        # is always True) instead of erroring on the authoring mistake.
+        from specify_cli.workflows.steps.if_then import IfThenStep
+
+        step = IfThenStep()
+        errors = step.validate({"id": "test", "condition": bad, "then": []})
+        assert any("'condition' must be a string" in e for e in errors), bad
+
+    @pytest.mark.parametrize("good", ["true", "false", "{{ inputs.flag }}"])
+    def test_validate_accepts_string_condition(self, good):
+        from specify_cli.workflows.steps.if_then import IfThenStep
+
+        step = IfThenStep()
+        errors = step.validate({"id": "test", "condition": good, "then": []})
+        assert not any("'condition' must be a string" in e for e in errors), good
+
     @pytest.mark.parametrize("bad_branch", [{"id": "x"}, "oops", 5])
     def test_execute_non_list_then_fails_loudly(self, bad_branch):
         """A non-list ``then`` must fail the step, not crash the run.
@@ -2880,6 +2899,14 @@ class TestWhileStep:
         assert any("missing 'condition'" in e for e in errors)
         # max_iterations is optional (defaults to 10)
 
+    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, True])
+    def test_validate_rejects_non_string_condition(self, bad):
+        from specify_cli.workflows.steps.while_loop import WhileStep
+
+        step = WhileStep()
+        errors = step.validate({"id": "test", "condition": bad, "steps": []})
+        assert any("'condition' must be a string" in e for e in errors), bad
+
     def test_validate_invalid_max_iterations(self):
         from specify_cli.workflows.steps.while_loop import WhileStep
 
@@ -2993,6 +3020,14 @@ class TestDoWhileStep:
         errors = step.validate({"id": "test", "steps": []})
         assert any("missing 'condition'" in e for e in errors)
         # max_iterations is optional (defaults to 10)
+
+    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, True])
+    def test_validate_rejects_non_string_condition(self, bad):
+        from specify_cli.workflows.steps.do_while import DoWhileStep
+
+        step = DoWhileStep()
+        errors = step.validate({"id": "test", "condition": bad, "steps": []})
+        assert any("'condition' must be a string" in e for e in errors), bad
 
     def test_validate_steps_not_list(self):
         from specify_cli.workflows.steps.do_while import DoWhileStep

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2490,25 +2490,32 @@ class TestIfThenStep:
         errors = step.validate({"id": "test", "then": []})
         assert any("missing 'condition'" in e for e in errors)
 
-    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, True])
+    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, 1.5])
     def test_validate_rejects_non_string_condition(self, bad):
-        # A non-string condition is returned unchanged by evaluate_expression,
-        # and evaluate_condition then bool()-coerces it, so it silently resolves
-        # to its truthiness (e.g. [1, 2] is always True) instead of erroring on
-        # the authoring mistake.
+        # A list/dict/number condition is returned unchanged by
+        # evaluate_expression, and evaluate_condition then bool()-coerces it, so
+        # it silently resolves to its truthiness (e.g. [1, 2] is always True)
+        # instead of erroring on the authoring mistake.
         from specify_cli.workflows.steps.if_then import IfThenStep
 
         step = IfThenStep()
         errors = step.validate({"id": "test", "condition": bad, "then": []})
-        assert any("'condition' must be a string" in e for e in errors), bad
+        assert any("'condition' must be a" in e for e in errors), bad
 
-    @pytest.mark.parametrize("good", ["true", "false", "{{ inputs.flag }}"])
-    def test_validate_accepts_string_condition(self, good):
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "true", "false", "{{ inputs.flag }}",
+            True, False,  # unquoted YAML bool: resolved exactly, and it is the
+                          # default this step itself uses -- must stay valid
+        ],
+    )
+    def test_validate_accepts_string_or_bool_condition(self, good):
         from specify_cli.workflows.steps.if_then import IfThenStep
 
         step = IfThenStep()
         errors = step.validate({"id": "test", "condition": good, "then": []})
-        assert not any("'condition' must be a string" in e for e in errors), good
+        assert not any("'condition' must be a" in e for e in errors), good
 
     @pytest.mark.parametrize("bad_branch", [{"id": "x"}, "oops", 5])
     def test_execute_non_list_then_fails_loudly(self, bad_branch):
@@ -2900,13 +2907,23 @@ class TestWhileStep:
         assert any("missing 'condition'" in e for e in errors)
         # max_iterations is optional (defaults to 10)
 
-    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, True])
+    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, 1.5])
     def test_validate_rejects_non_string_condition(self, bad):
         from specify_cli.workflows.steps.while_loop import WhileStep
 
         step = WhileStep()
         errors = step.validate({"id": "test", "condition": bad, "steps": []})
-        assert any("'condition' must be a string" in e for e in errors), bad
+        assert any("'condition' must be a" in e for e in errors), bad
+
+    @pytest.mark.parametrize("good", [True, False, "true", "{{ inputs.go }}"])
+    def test_validate_accepts_string_or_bool_condition(self, good):
+        # ``condition: false`` unquoted is idiomatic YAML and is this step's own
+        # default, so a literal bool must not be rejected.
+        from specify_cli.workflows.steps.while_loop import WhileStep
+
+        step = WhileStep()
+        errors = step.validate({"id": "test", "condition": good, "steps": []})
+        assert not any("'condition' must be a" in e for e in errors), good
 
     def test_validate_invalid_max_iterations(self):
         from specify_cli.workflows.steps.while_loop import WhileStep
@@ -3022,13 +3039,23 @@ class TestDoWhileStep:
         assert any("missing 'condition'" in e for e in errors)
         # max_iterations is optional (defaults to 10)
 
-    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, True])
+    @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, 1.5])
     def test_validate_rejects_non_string_condition(self, bad):
         from specify_cli.workflows.steps.do_while import DoWhileStep
 
         step = DoWhileStep()
         errors = step.validate({"id": "test", "condition": bad, "steps": []})
-        assert any("'condition' must be a string" in e for e in errors), bad
+        assert any("'condition' must be a" in e for e in errors), bad
+
+    @pytest.mark.parametrize("good", [True, False, "true", "{{ inputs.go }}"])
+    def test_validate_accepts_string_or_bool_condition(self, good):
+        # ``condition: false`` unquoted is idiomatic YAML; evaluate_condition
+        # resolves a literal bool exactly, so it must not be rejected.
+        from specify_cli.workflows.steps.do_while import DoWhileStep
+
+        step = DoWhileStep()
+        errors = step.validate({"id": "test", "condition": good, "steps": []})
+        assert not any("'condition' must be a" in e for e in errors), good
 
     def test_validate_steps_not_list(self):
         from specify_cli.workflows.steps.do_while import DoWhileStep


### PR DESCRIPTION
## Problem

`IfThenStep`, `WhileStep`, and `DoWhileStep` `validate()` confirm that `condition` is **present** but never check its type.

At run time `execute()` feeds `condition` to `evaluate_condition()`, which first delegates to `evaluate_expression()` — that returns a non-string **unchanged** — and then coerces the result with `bool()`:

```python
def evaluate_expression(template, context):
    if not isinstance(template, str):
        return template   # non-string returned as-is
    ...

def evaluate_condition(condition, context):
    result = evaluate_expression(condition, context)
    ...
    return bool(result)
```

So a **list/dict/number** condition silently resolves to its truthiness instead of erroring on the authoring mistake:

- `condition: [1, 2]` → `bool([1, 2])` → **always True** → the if-branch is always taken / the while-loop spins to `max_iterations`
- `condition: {}` → always False, etc.

No error is reported, so the mistake is invisible.

## Fix

Reject a present-but-non-`str`/non-`bool` `condition` in each of the three steps' `validate()`, mirroring the existing `prompt`/`shell`/`command` type checks.

### Why booleans are accepted (contract note)

An earlier revision of this PR rejected **every** non-string, including `bool`. That was wrong — it would have been a **breaking change**, so the validator now accepts `(str, bool)`:

- An unquoted `condition: false` is idiomatic YAML, and it already resolves **correctly** today: `evaluate_expression` passes the bool through and `evaluate_condition`'s `bool()` is a no-op. Verified on `main`: `evaluate_condition(False)` → `False`, `evaluate_condition(True)` → `True`, and end-to-end `condition: false` takes the else-branch while `condition: true` dispatches `then`.
- Two of the three steps **default** `condition` to the bool `False` themselves (`config.get("condition", False)`), so `bool` is the field's own natural type — not an authoring mistake.

A bool is therefore not part of the silent-coercion bug this PR fixes; only `list`/`dict`/`int`/`float` are. `"true"`/`"false"` and expressions like `"{{ inputs.flag }}"` are strings and stay valid, as before.

## Verification

- New parametrized tests (`[list, dict, int, float]`) across all three step classes: **fail before** the guard, **pass after**.
- `test_validate_accepts_string_or_bool_condition` covers `"true"`/`"false"`/`"{{ ... }}"` **and** literal `True`/`False` in each step — the regression guard for the contract above.
- Full `TestIfThenStep`/`TestWhileStep`/`TestDoWhileStep` green; `ruff@0.15.0` clean.

---
*AI-assisted: authored with Claude Code. I traced the runtime path (`evaluate_expression` → `evaluate_condition` → `bool()`), confirmed the silent coercion on `main`, and confirmed that literal booleans already behave correctly there — which is why they are accepted rather than rejected.*