### PR TITLE
docs(upgrade): Claude Code files live in .claude/skills, not .claude/commands

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -307,7 +307,7 @@ Alternatively, run the `/speckit.specify` command which creates `.specify/featur
 2. **For CLI-based agents**, verify files exist:
 
    ```bash
-   ls -la .claude/commands/      # Claude Code
+   ls -la .claude/skills/        # Claude Code
    ls -la .gemini/commands/      # Gemini
    ls -la .cursor/skills/      # Cursor
    ls -la .pi/prompts/           # Pi Coding Agent
@@ -356,7 +356,7 @@ This warning appears when you run `specify init --here` (or `specify init .`) in
 
 Only Spec Kit infrastructure files:
 
-- Agent command files (`.claude/commands/`, `.github/prompts/`, etc.)
+- Agent command/skill files (`.claude/skills/`, `.github/prompts/`, etc.)
 - Scripts in `.specify/scripts/`
 - Templates in `.specify/templates/`
 - Missing memory files such as `.specify/memory/constitution.md` may be created from templates; an existing constitution is preserved
@@ -445,7 +445,7 @@ Once you've run `specify init`, the slash commands (like `/speckit.specify`, `/s
    ls -la .github/prompts/
 
    # For Claude
-   ls -la .claude/commands/
+   ls -la .claude/skills/
 
    # For Pi
    ls -la .pi/prompts/


### PR DESCRIPTION
## Problem

`docs/upgrade.md` points users at `.claude/commands/` in three places when verifying/locating Claude Code's installed files:

- line 310 — troubleshooting *"verify files exist"* (`ls -la .claude/commands/  # Claude Code`)
- line 359 — *"what gets overwritten"* list
- line 448 — a second *"verify command files exist"* block

But the Claude Code integration installs into **`.claude/skills`** (`src/specify_cli/integrations/claude/__init__.py` → `"dir": ".claude/skills"`), and the *"what gets kept"* list earlier in **this same doc** (line 98) already correctly says `.claude/skills/`. So the doc is internally inconsistent, and the three troubleshooting checks tell users to `ls` a directory that does not exist for a Claude Code install.

## Fix

Correct all three spots to `.claude/skills/` (and reword one label to "command/skill files" to match line 98's phrasing). Documentation-only.

## Verification

- `grep .claude/commands docs/upgrade.md` → no matches remain.
- Cross-checked against `integrations/claude` (`"dir": ".claude/skills"`) and the already-correct line 98.
- `markdownlint-cli2 docs/upgrade.md` → 0 issues.

---
*AI-assisted: authored with Claude Code. I confirmed the install dir in the integration source and that line 98 of the same doc already uses `.claude/skills/`.*