### PR TITLE
fix(auth): resolve az via shutil.which so azure-cli token works on Windows

### DIFF
--- a/src/specify_cli/authentication/azure_devops.py
+++ b/src/specify_cli/authentication/azure_devops.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json as _json
 import os
+import shutil
 import subprocess
 from typing import TYPE_CHECKING
 
@@ -71,9 +72,17 @@ class AzureDevOpsAuth(AuthProvider):
     def _acquire_via_az_cli() -> str | None:
         """Run ``az account get-access-token`` and return the access token."""
         try:
+            # Windows: ``subprocess.run`` calls ``CreateProcess``, which does
+            # not consult ``PATHEXT``, so a bare ``"az"`` (installed as
+            # ``az.cmd``) fails with ``WinError 2`` even after ``az login``.
+            # Resolve via ``shutil.which`` (which honors ``PATHEXT``) so the
+            # ``.cmd`` shim works. On POSIX this is a harmless lookup that
+            # returns the same executable; ``or "az"`` preserves the prior
+            # behavior (and the existing OSError path) when ``az`` is absent.
+            az = shutil.which("az") or "az"
             result = subprocess.run(  # noqa: S603, S607
                 [
-                    "az",
+                    az,
                     "account",
                     "get-access-token",
                     "--resource",

--- a/src/specify_cli/authentication/azure_devops.py
+++ b/src/specify_cli/authentication/azure_devops.py
@@ -77,9 +77,19 @@ class AzureDevOpsAuth(AuthProvider):
             # ``az.cmd``) fails with ``WinError 2`` even after ``az login``.
             # Resolve via ``shutil.which`` (which honors ``PATHEXT``) so the
             # ``.cmd`` shim works. On POSIX this is a harmless lookup that
-            # returns the same executable; ``or "az"`` preserves the prior
-            # behavior (and the existing OSError path) when ``az`` is absent.
-            az = shutil.which("az") or "az"
+            # returns the same executable.
+            #
+            # Require an ABSOLUTE result: on Windows ``shutil.which`` prepends
+            # the current directory to the search path (unless
+            # ``NoDefaultCurrentDirectoryInExePath`` is set), so a stray
+            # ``.\az.cmd`` in the working directory would otherwise be resolved
+            # ahead of the real Azure CLI and run for a credential operation. A
+            # legitimate install always resolves to an absolute path, so this
+            # costs nothing; falling back to the bare ``"az"`` preserves the
+            # prior behavior (and the existing OSError path) when ``az`` is
+            # absent.
+            resolved = shutil.which("az")
+            az = resolved if resolved and os.path.isabs(resolved) else "az"
             result = subprocess.run(  # noqa: S603, S607
                 [
                     az,

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -542,19 +542,25 @@ class TestAzureDevOpsAuth:
         entry = AuthConfigEntry(
             hosts=("dev.azure.com",), provider="azure-devops", auth="azure-cli",
         )
+        # Build the absolute path with the HOST's rules: the production code
+        # calls os.path.isabs(), so a hardcoded Windows path would read as
+        # RELATIVE on POSIX runners and silently exercise the fallback branch
+        # instead of the one under test.
+        resolved_path = os.path.join(os.path.abspath(os.sep), "opt", "az", "az.CMD")
+        assert os.path.isabs(resolved_path)
         result = MagicMock()
         result.returncode = 0
         result.stdout = '{"accessToken": "tok"}'
         with patch(
             "specify_cli.authentication.azure_devops.shutil.which",
-            return_value=r"C:\Program Files\az\wbin\az.CMD",
+            return_value=resolved_path,
         ), patch(
             "specify_cli.authentication.azure_devops.subprocess.run",
             return_value=result,
         ) as run:
             assert AzureDevOpsAuth().resolve_token(entry) == "tok"
         argv = run.call_args.args[0]
-        assert argv[0] == r"C:\Program Files\az\wbin\az.CMD"
+        assert argv[0] == resolved_path
         assert argv[1:4] == ["account", "get-access-token", "--resource"]
 
     @pytest.mark.parametrize("which_result", [None, r".\az.CMD", "az.cmd", "./az"])

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -557,9 +557,12 @@ class TestAzureDevOpsAuth:
         assert argv[0] == r"C:\Program Files\az\wbin\az.CMD"
         assert argv[1:4] == ["account", "get-access-token", "--resource"]
 
-    def test_resolve_token_azure_cli_falls_back_to_bare_az(self):
-        """When shutil.which finds nothing, fall back to the bare "az" so the
-        existing OSError-not-installed path is preserved."""
+    @pytest.mark.parametrize("which_result", [None, r".\az.CMD", "az.cmd", "./az"])
+    def test_resolve_token_azure_cli_falls_back_to_bare_az(self, which_result):
+        """Fall back to the bare "az" when shutil.which finds nothing OR returns a
+        NON-ABSOLUTE path. On Windows shutil.which searches the current directory
+        first, so a stray .\\az.cmd must never be executed for a credential
+        operation; the bare name also preserves the not-installed OSError path."""
         from unittest.mock import patch, MagicMock
         entry = AuthConfigEntry(
             hosts=("dev.azure.com",), provider="azure-devops", auth="azure-cli",
@@ -569,13 +572,13 @@ class TestAzureDevOpsAuth:
         result.stdout = '{"accessToken": "tok"}'
         with patch(
             "specify_cli.authentication.azure_devops.shutil.which",
-            return_value=None,
+            return_value=which_result,
         ), patch(
             "specify_cli.authentication.azure_devops.subprocess.run",
             return_value=result,
         ) as run:
             assert AzureDevOpsAuth().resolve_token(entry) == "tok"
-        assert run.call_args.args[0][0] == "az"
+        assert run.call_args.args[0][0] == "az", which_result
 
     def test_resolve_token_azure_cli_not_installed_returns_none(self):
         """azure-cli returns None when az is not installed."""

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -535,6 +535,48 @@ class TestAzureDevOpsAuth:
         with patch("specify_cli.authentication.azure_devops.subprocess.run", return_value=result):
             assert AzureDevOpsAuth().resolve_token(entry) is None
 
+    def test_resolve_token_azure_cli_resolves_executable(self):
+        """The az executable is resolved via shutil.which before invocation, so
+        the .cmd/.bat shim on Windows (CreateProcess ignores PATHEXT) is used."""
+        from unittest.mock import patch, MagicMock
+        entry = AuthConfigEntry(
+            hosts=("dev.azure.com",), provider="azure-devops", auth="azure-cli",
+        )
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = '{"accessToken": "tok"}'
+        with patch(
+            "specify_cli.authentication.azure_devops.shutil.which",
+            return_value=r"C:\Program Files\az\wbin\az.CMD",
+        ), patch(
+            "specify_cli.authentication.azure_devops.subprocess.run",
+            return_value=result,
+        ) as run:
+            assert AzureDevOpsAuth().resolve_token(entry) == "tok"
+        argv = run.call_args.args[0]
+        assert argv[0] == r"C:\Program Files\az\wbin\az.CMD"
+        assert argv[1:4] == ["account", "get-access-token", "--resource"]
+
+    def test_resolve_token_azure_cli_falls_back_to_bare_az(self):
+        """When shutil.which finds nothing, fall back to the bare "az" so the
+        existing OSError-not-installed path is preserved."""
+        from unittest.mock import patch, MagicMock
+        entry = AuthConfigEntry(
+            hosts=("dev.azure.com",), provider="azure-devops", auth="azure-cli",
+        )
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = '{"accessToken": "tok"}'
+        with patch(
+            "specify_cli.authentication.azure_devops.shutil.which",
+            return_value=None,
+        ), patch(
+            "specify_cli.authentication.azure_devops.subprocess.run",
+            return_value=result,
+        ) as run:
+            assert AzureDevOpsAuth().resolve_token(entry) == "tok"
+        assert run.call_args.args[0][0] == "az"
+
     def test_resolve_token_azure_cli_not_installed_returns_none(self):
         """azure-cli returns None when az is not installed."""
         from unittest.mock import patch


### PR DESCRIPTION
## Problem

`AzureDevOpsAuth._acquire_via_az_cli()` runs:

```python
result = subprocess.run(["az", "account", "get-access-token", ...], ...)
```

with a bare `"az"`. On **Windows** the Azure CLI is installed as `az.cmd`, and `subprocess.run` calls `CreateProcess`, which — unlike a shell — does **not** consult `PATHEXT`. So a bare `"az"` fails with `WinError 2 (FileNotFoundError)` even when `az` works fine in the user's terminal after `az login`. The `except OSError` swallows it, so `auth: azure-cli` silently returns **no token** on Windows.

(Verified on a Windows box: `shutil.which("az")` → `...\wbin\az.CMD`, i.e. the runnable target is the `.CMD` shim, which the bare name never reaches.)

## Fix

Resolve the executable with `shutil.which("az")` (which honors `PATHEXT`) before invoking it — exactly the fix the maintainer already applied in `integrations/base.py` for the same CreateProcess/`.cmd` problem:

```python
az = shutil.which("az") or "az"
result = subprocess.run([az, "account", "get-access-token", ...], ...)
```

`or "az"` preserves the previous behaviour (and the existing not-installed `OSError` path) when `az` is absent. On POSIX `shutil.which` returns the same executable, so behaviour is unchanged there.

## Verification

- New `test_resolve_token_azure_cli_resolves_executable`: patches `shutil.which` → a fake `az.CMD` path and asserts the resolved path is `argv[0]`. **Fails before** (no `shutil` import to resolve with), **passes after**.
- New `test_resolve_token_azure_cli_falls_back_to_bare_az`: `shutil.which` → `None` still yields `argv[0] == "az"` (fallback preserved).
- Existing azure-cli success/failure/not-installed tests unchanged: **11 passed**. `ruff` clean.

---
*AI-assisted: authored with Claude Code. I confirmed on Windows that `shutil.which("az")` resolves to `az.CMD` and mirrored the maintainer's existing `integrations/base.py` resolution.*