### PR TITLE
fix(extensions): guard non-numeric catalog downloads in search/info rendering

### DIFF
--- a/src/specify_cli/extensions/_commands.py
+++ b/src/specify_cli/extensions/_commands.py
@@ -790,8 +790,16 @@ def extension_search(
 
             # Stats
             stats = []
-            if ext.get('downloads') is not None:
-                stats.append(f"Downloads: {ext['downloads']:,}")
+            downloads = ext.get('downloads')
+            if downloads is not None:
+                # Catalog fields are untrusted; a non-numeric ``downloads``
+                # (e.g. the JSON string "1500") would crash the ``:,`` format
+                # with "Cannot specify ',' with 's'". Only group-format numbers.
+                stats.append(
+                    f"Downloads: {downloads:,}"
+                    if isinstance(downloads, (int, float))
+                    else f"Downloads: {downloads}"
+                )
             if ext.get('stars') is not None:
                 stats.append(f"Stars: {ext['stars']}")
             if stats:
@@ -971,8 +979,16 @@ def _print_extension_info(ext_info: dict, manager):
 
     # Statistics
     stats = []
-    if ext_info.get('downloads') is not None:
-        stats.append(f"Downloads: {ext_info['downloads']:,}")
+    downloads = ext_info.get('downloads')
+    if downloads is not None:
+        # Catalog fields are untrusted; a non-numeric ``downloads`` (e.g. the
+        # JSON string "1500") would crash the ``:,`` format with "Cannot
+        # specify ',' with 's'". Only group-format numbers.
+        stats.append(
+            f"Downloads: {downloads:,}"
+            if isinstance(downloads, (int, float))
+            else f"Downloads: {downloads}"
+        )
     if ext_info.get('stars') is not None:
         stats.append(f"Stars: {ext_info['stars']}")
     if stats:

--- a/src/specify_cli/extensions/_commands.py
+++ b/src/specify_cli/extensions/_commands.py
@@ -803,8 +803,11 @@ def extension_search(
                     if isinstance(downloads, (int, float))
                     else f"Downloads: {_escape_markup(str(downloads))}"
                 )
-            if ext.get('stars') is not None:
-                stats.append(f"Stars: {ext['stars']}")
+            stars = ext.get('stars')
+            if stars is not None:
+                # Same untrusted-value/Rich-markup hazard as `downloads` above,
+                # in the same joined string.
+                stats.append(f"Stars: {_escape_markup(str(stars))}")
             if stats:
                 console.print(f"  [dim]{' | '.join(stats)}[/dim]")
 
@@ -995,8 +998,11 @@ def _print_extension_info(ext_info: dict, manager):
             if isinstance(downloads, (int, float))
             else f"Downloads: {_escape_markup(str(downloads))}"
         )
-    if ext_info.get('stars') is not None:
-        stats.append(f"Stars: {ext_info['stars']}")
+    stars = ext_info.get('stars')
+    if stars is not None:
+        # Same untrusted-value/Rich-markup hazard as `downloads` above, in the
+        # same joined string.
+        stats.append(f"Stars: {_escape_markup(str(stars))}")
     if stats:
         console.print(f"[bold]Statistics:[/bold] {' | '.join(stats)}")
         console.print()

--- a/src/specify_cli/extensions/_commands.py
+++ b/src/specify_cli/extensions/_commands.py
@@ -794,11 +794,14 @@ def extension_search(
             if downloads is not None:
                 # Catalog fields are untrusted; a non-numeric ``downloads``
                 # (e.g. the JSON string "1500") would crash the ``:,`` format
-                # with "Cannot specify ',' with 's'". Only group-format numbers.
+                # with "Cannot specify ',' with 's'". Only group-format numbers,
+                # and escape the fallback: the joined stats are rendered as Rich
+                # markup, so a value like "[/red]foo" would raise MarkupError
+                # (matching how every other catalog field here is escaped).
                 stats.append(
                     f"Downloads: {downloads:,}"
                     if isinstance(downloads, (int, float))
-                    else f"Downloads: {downloads}"
+                    else f"Downloads: {_escape_markup(str(downloads))}"
                 )
             if ext.get('stars') is not None:
                 stats.append(f"Stars: {ext['stars']}")
@@ -983,11 +986,14 @@ def _print_extension_info(ext_info: dict, manager):
     if downloads is not None:
         # Catalog fields are untrusted; a non-numeric ``downloads`` (e.g. the
         # JSON string "1500") would crash the ``:,`` format with "Cannot
-        # specify ',' with 's'". Only group-format numbers.
+        # specify ',' with 's'". Only group-format numbers, and escape the
+        # fallback: the joined stats are rendered as Rich markup, so a value
+        # like "[/red]foo" would raise MarkupError (matching how every other
+        # catalog field here is escaped).
         stats.append(
             f"Downloads: {downloads:,}"
             if isinstance(downloads, (int, float))
-            else f"Downloads: {downloads}"
+            else f"Downloads: {_escape_markup(str(downloads))}"
         )
     if ext_info.get('stars') is not None:
         stats.append(f"Stars: {ext_info['stars']}")

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -4034,6 +4034,65 @@ class TestExtensionCatalog:
         results = catalog.search()
         assert len(results) == 2
 
+    def test_info_renders_non_numeric_downloads(self):
+        """A non-numeric ``downloads`` from an untrusted catalog must not crash
+        the info renderer with 'Cannot specify ',' with 's''; it renders as-is."""
+        from unittest.mock import MagicMock
+        from specify_cli.extensions._commands import _print_extension_info
+
+        manager = MagicMock()
+        manager.registry.is_installed.return_value = False
+        ext_info = {
+            "name": "Jira", "id": "jira", "version": "1.0.0",
+            "description": "desc", "downloads": "1500",  # string from catalog JSON
+        }
+        # Must not raise ValueError.
+        _print_extension_info(ext_info, manager)
+
+    def test_search_survives_non_numeric_downloads(self, temp_dir):
+        """`specify extension search` must not abort with a raw ValueError when a
+        catalog entry's ``downloads`` is a non-numeric string."""
+        import yaml as yaml_module
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        project_dir = temp_dir / "project"
+        project_dir.mkdir()
+        (project_dir / ".specify").mkdir()
+        config_path = project_dir / ".specify" / "extension-catalogs.yml"
+        with open(config_path, "w") as f:
+            yaml_module.dump(
+                {"catalogs": [{
+                    "name": "test-catalog",
+                    "url": ExtensionCatalog.DEFAULT_CATALOG_URL,
+                    "priority": 1, "install_allowed": True,
+                }]}, f,
+            )
+
+        catalog = ExtensionCatalog(project_dir)
+        catalog_data = {
+            "schema_version": "1.0",
+            "extensions": {"jira": {
+                "name": "Jira", "id": "jira", "version": "1.0.0",
+                "description": "Jira integration", "author": "x",
+                "tags": ["jira"], "verified": True,
+                "downloads": "1500",  # non-numeric, straight from catalog JSON
+            }},
+        }
+        catalog.cache_dir.mkdir(parents=True, exist_ok=True)
+        catalog.cache_file.write_text(json.dumps(catalog_data))
+        catalog.cache_metadata_file.write_text(json.dumps({
+            "cached_at": datetime.now(timezone.utc).isoformat(),
+            "catalog_url": "http://test.com",
+        }))
+
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir):
+            result = runner.invoke(app, ["extension", "search"], catch_exceptions=True)
+        assert result.exit_code == 0, result.output
+        assert "Downloads: 1500" in result.output
+
     def test_search_by_query(self, temp_dir):
         """Test searching by query text."""
         import yaml as yaml_module

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -4034,9 +4034,18 @@ class TestExtensionCatalog:
         results = catalog.search()
         assert len(results) == 2
 
-    def test_info_renders_non_numeric_downloads(self):
-        """A non-numeric ``downloads`` from an untrusted catalog must not crash
-        the info renderer with 'Cannot specify ',' with 's''; it renders as-is."""
+    @pytest.mark.parametrize(
+        "downloads",
+        [
+            "1500",          # plain string: crashed the ``:,`` format
+            "[/red]foo",      # unbalanced closing tag: raises MarkupError unescaped
+            "[bold]x[/bold]",  # balanced tags: would silently restyle the output
+        ],
+    )
+    def test_info_renders_non_numeric_downloads(self, downloads):
+        """A non-numeric ``downloads`` from an untrusted catalog must not crash the
+        info renderer — neither with 'Cannot specify ',' with 's'' (the ``:,``
+        format) nor with a Rich MarkupError (the joined stats are markup)."""
         from unittest.mock import MagicMock
         from specify_cli.extensions._commands import _print_extension_info
 
@@ -4044,14 +4053,16 @@ class TestExtensionCatalog:
         manager.registry.is_installed.return_value = False
         ext_info = {
             "name": "Jira", "id": "jira", "version": "1.0.0",
-            "description": "desc", "downloads": "1500",  # string from catalog JSON
+            "description": "desc", "downloads": downloads,  # from catalog JSON
         }
-        # Must not raise ValueError.
+        # Must not raise ValueError or rich.errors.MarkupError.
         _print_extension_info(ext_info, manager)
 
-    def test_search_survives_non_numeric_downloads(self, temp_dir):
-        """`specify extension search` must not abort with a raw ValueError when a
-        catalog entry's ``downloads`` is a non-numeric string."""
+    @pytest.mark.parametrize("downloads", ["1500", "[/red]foo"])
+    def test_search_survives_non_numeric_downloads(self, temp_dir, downloads):
+        """`specify extension search` must not abort when a catalog entry's
+        ``downloads`` is a non-numeric string — not with a raw ValueError from the
+        ``:,`` format, nor with a Rich MarkupError from unescaped markup."""
         import yaml as yaml_module
         from typer.testing import CliRunner
         from unittest.mock import patch
@@ -4077,7 +4088,7 @@ class TestExtensionCatalog:
                 "name": "Jira", "id": "jira", "version": "1.0.0",
                 "description": "Jira integration", "author": "x",
                 "tags": ["jira"], "verified": True,
-                "downloads": "1500",  # non-numeric, straight from catalog JSON
+                "downloads": downloads,  # non-numeric, straight from catalog JSON
             }},
         }
         catalog.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -4091,7 +4102,8 @@ class TestExtensionCatalog:
         with patch.object(Path, "cwd", return_value=project_dir):
             result = runner.invoke(app, ["extension", "search"], catch_exceptions=True)
         assert result.exit_code == 0, result.output
-        assert "Downloads: 1500" in result.output
+        # Rendered literally (escaped), not interpreted as markup or dropped.
+        assert f"Downloads: {downloads}" in result.output
 
     def test_search_by_query(self, temp_dir):
         """Test searching by query text."""

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -4058,6 +4058,20 @@ class TestExtensionCatalog:
         # Must not raise ValueError or rich.errors.MarkupError.
         _print_extension_info(ext_info, manager)
 
+    def test_info_renders_markup_bearing_stars(self):
+        """``stars`` sits in the same joined stats string as ``downloads`` and is
+        equally catalog-controlled, so it must be escaped too."""
+        from unittest.mock import MagicMock
+        from specify_cli.extensions._commands import _print_extension_info
+
+        manager = MagicMock()
+        manager.registry.is_installed.return_value = False
+        ext_info = {
+            "name": "Jira", "id": "jira", "version": "1.0.0",
+            "description": "desc", "stars": "[/red]x",
+        }
+        _print_extension_info(ext_info, manager)  # must not raise MarkupError
+
     @pytest.mark.parametrize("downloads", ["1500", "[/red]foo"])
     def test_search_survives_non_numeric_downloads(self, temp_dir, downloads):
         """`specify extension search` must not abort when a catalog entry's


### PR DESCRIPTION
## Problem

`specify extension search` and `specify extension info <id>` render a catalog entry's `downloads` field with the `:,` thousands separator:

```python
stats.append(f"Downloads: {ext['downloads']:,}")   # extension_search
...
stats.append(f"Downloads: {ext_info['downloads']:,}")  # _print_extension_info
```

guarded only by `is not None`. But `:,` is only valid for `int`/`float` — on a string it raises `ValueError: Cannot specify ',' with 's'`.

Catalog payloads are only **shape**-validated (`_validate_catalog_payload` checks that `extensions` is a dict); individual entry fields are never type-checked, and `_get_merged_extensions` returns the raw catalog dicts. So a catalog entry with `"downloads": "1500"` (a quoted number — realistic from a community catalog, a `SPECKIT_CATALOG_URL` catalog, a project/user catalog, or a poisoned cache) makes the **whole command** abort with an uncaught traceback. Reproduced end-to-end: with such a cache, both `extension search` and `extension info` exit non-zero with `ValueError("Cannot specify ',' with 's'.")`.

## Fix

Group-format `downloads` only when it is actually numeric; otherwise render it as-is:

```python
downloads = ext.get('downloads')
if downloads is not None:
    stats.append(
        f"Downloads: {downloads:,}"
        if isinstance(downloads, (int, float))
        else f"Downloads: {downloads}"
    )
```

(and the equivalent in `_print_extension_info`). Numeric values (`int`/`float`, including `bool`) take the identical `:,` branch, so **correct catalogs render byte-for-byte the same** — only the previously-crashing case changes to print the value. This mirrors the module's existing defensive treatment: every other field in these two renderers is already `str()`-wrapped.

## Verification

- `test_info_renders_non_numeric_downloads` (direct) and `test_search_survives_non_numeric_downloads` (end-to-end via `CliRunner`): both **fail before** with the exact `ValueError`, **pass after** (`exit_code == 0`, output shows `Downloads: 1500`).
- `TestExtensionCatalog`: **64 passed**. `ruff` clean.

---
*AI-assisted: authored with Claude Code. I reproduced the crash on `main` through the real CLI (catalog cache with a string `downloads`) before writing the guard, and confirmed numeric output is unchanged.*