### PR TITLE
fix(presets): guard non-list/non-mapping provides.templates in PresetManifest

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -322,7 +322,7 @@ class PresetManifest:
 
         # Validate provides section
         provides = self.data["provides"]
-        if "templates" not in provides or not provides["templates"]:
+        if "templates" not in provides:
             raise PresetValidationError(
                 "Preset must provide at least one template"
             )
@@ -333,10 +333,20 @@ class PresetManifest:
         # install handler already catches, instead of a raw TypeError
         # ('int'/'NoneType' object is not iterable) that escapes to an
         # unhandled traceback. Mirrors the sibling ExtensionManifest guards.
+        #
+        # Order matters: the container's TYPE is checked before its emptiness,
+        # so a FALSY non-list (``templates: 0``/``false``/``null``/``''``/``{}``)
+        # reports the accurate type error rather than the misleading "must
+        # provide at least one template". An empty list still reports the
+        # latter, since that genuinely is a list with no templates.
         templates = provides["templates"]
         if not isinstance(templates, list):
             raise PresetValidationError(
                 "Invalid provides.templates: expected a list"
+            )
+        if not templates:
+            raise PresetValidationError(
+                "Preset must provide at least one template"
             )
         for tmpl in templates:
             if not isinstance(tmpl, dict):

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -327,8 +327,22 @@ class PresetManifest:
                 "Preset must provide at least one template"
             )
 
-        # Validate templates
-        for tmpl in provides["templates"]:
+        # Validate templates. Guard the container and each entry's shape so a
+        # malformed third-party preset.yml (e.g. ``templates: 5`` or
+        # ``templates: [null]``) raises a clean PresetValidationError the
+        # install handler already catches, instead of a raw TypeError
+        # ('int'/'NoneType' object is not iterable) that escapes to an
+        # unhandled traceback. Mirrors the sibling ExtensionManifest guards.
+        templates = provides["templates"]
+        if not isinstance(templates, list):
+            raise PresetValidationError(
+                "Invalid provides.templates: expected a list"
+            )
+        for tmpl in templates:
+            if not isinstance(tmpl, dict):
+                raise PresetValidationError(
+                    "Each template entry in 'provides.templates' must be a mapping"
+                )
             if "type" not in tmpl or "name" not in tmpl or "file" not in tmpl:
                 raise PresetValidationError(
                     "Template missing 'type', 'name', or 'file'"

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -197,6 +197,28 @@ class TestPresetManifest:
             with pytest.raises(PresetValidationError, match="YAML mapping"):
                 PresetManifest(manifest_path)
 
+    def test_non_list_templates_raises_validation_error(self, temp_dir, valid_pack_data):
+        """A non-list provides.templates (e.g. a scalar) raises PresetValidationError,
+        not a raw 'int object is not iterable' TypeError — mirrors ExtensionManifest."""
+        valid_pack_data["provides"]["templates"] = 5
+        manifest_path = temp_dir / "preset.yml"
+        manifest_path.write_text(yaml.dump(valid_pack_data), encoding="utf-8")
+        with pytest.raises(PresetValidationError, match="templates.*expected a list"):
+            PresetManifest(manifest_path)
+
+    @pytest.mark.parametrize("bad_entry", [None, 5, "oops", ["nested"]])
+    def test_non_mapping_template_entry_raises_validation_error(
+        self, temp_dir, valid_pack_data, bad_entry
+    ):
+        """A non-mapping template entry (null/scalar/list) raises PresetValidationError,
+        not a raw 'argument of type ... is not iterable' TypeError from the
+        `"type" not in tmpl` membership test — mirrors ExtensionManifest."""
+        valid_pack_data["provides"]["templates"] = [bad_entry]
+        manifest_path = temp_dir / "preset.yml"
+        manifest_path.write_text(yaml.dump(valid_pack_data), encoding="utf-8")
+        with pytest.raises(PresetValidationError, match="must be a mapping"):
+            PresetManifest(manifest_path)
+
     def test_missing_schema_version(self, temp_dir, valid_pack_data):
         """Test missing schema_version field."""
         del valid_pack_data["schema_version"]

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -197,13 +197,37 @@ class TestPresetManifest:
             with pytest.raises(PresetValidationError, match="YAML mapping"):
                 PresetManifest(manifest_path)
 
-    def test_non_list_templates_raises_validation_error(self, temp_dir, valid_pack_data):
-        """A non-list provides.templates (e.g. a scalar) raises PresetValidationError,
-        not a raw 'int object is not iterable' TypeError — mirrors ExtensionManifest."""
-        valid_pack_data["provides"]["templates"] = 5
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            5, "oops", {"a": 1},   # truthy non-lists
+            0, False, None, "", {},  # FALSY non-lists: must not fall through to
+                                     # the misleading "at least one template"
+        ],
+    )
+    def test_non_list_templates_raises_validation_error(
+        self, temp_dir, valid_pack_data, bad
+    ):
+        """A non-list provides.templates raises the accurate type error, not a raw
+        'int object is not iterable' TypeError and not the misleading "must provide
+        at least one template" (which a falsy non-list hit while the type check
+        sat behind the emptiness check) — mirrors ExtensionManifest."""
+        valid_pack_data["provides"]["templates"] = bad
         manifest_path = temp_dir / "preset.yml"
         manifest_path.write_text(yaml.dump(valid_pack_data), encoding="utf-8")
         with pytest.raises(PresetValidationError, match="templates.*expected a list"):
+            PresetManifest(manifest_path)
+
+    def test_empty_list_templates_still_reports_no_templates(
+        self, temp_dir, valid_pack_data
+    ):
+        """An EMPTY LIST is a well-typed container with no templates, so it keeps
+        the "must provide at least one template" message (regression guard for the
+        type-before-emptiness ordering)."""
+        valid_pack_data["provides"]["templates"] = []
+        manifest_path = temp_dir / "preset.yml"
+        manifest_path.write_text(yaml.dump(valid_pack_data), encoding="utf-8")
+        with pytest.raises(PresetValidationError, match="at least one template"):
             PresetManifest(manifest_path)
 
     @pytest.mark.parametrize("bad_entry", [None, 5, "oops", ["nested"]])

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -218,17 +218,10 @@ class TestPresetManifest:
         with pytest.raises(PresetValidationError, match="templates.*expected a list"):
             PresetManifest(manifest_path)
 
-    def test_empty_list_templates_still_reports_no_templates(
-        self, temp_dir, valid_pack_data
-    ):
-        """An EMPTY LIST is a well-typed container with no templates, so it keeps
-        the "must provide at least one template" message (regression guard for the
-        type-before-emptiness ordering)."""
-        valid_pack_data["provides"]["templates"] = []
-        manifest_path = temp_dir / "preset.yml"
-        manifest_path.write_text(yaml.dump(valid_pack_data), encoding="utf-8")
-        with pytest.raises(PresetValidationError, match="at least one template"):
-            PresetManifest(manifest_path)
+    # NOTE: the empty-list case (a well-typed container with no templates, which
+    # must keep the "must provide at least one template" message after the
+    # type-before-emptiness reordering) is already covered by
+    # test_no_templates_provided below.
 
     @pytest.mark.parametrize("bad_entry", [None, 5, "oops", ["nested"]])
     def test_non_mapping_template_entry_raises_validation_error(


### PR DESCRIPTION
## Problem

`PresetManifest._validate` iterates `provides["templates"]` with **no shape guards**, unlike the direct sibling `ExtensionManifest._validate` (which guards both the container and each entry). A malformed third-party `preset.yml` therefore crashes with a **raw `TypeError`** rather than a clean validation error:

```
templates: 5        →  TypeError: 'int' object is not iterable
templates: [null]   →  TypeError: argument of type 'NoneType' is not iterable
templates: [5]      →  TypeError: argument of type 'int' is not iterable
```

The install handler (`presets/_commands.py`) only catches `PresetCompatibilityError` / `PresetValidationError` / `PresetError`, so the `TypeError` escapes all three and dumps an **unhandled Python traceback** to the user on `specify preset install`. (A string/list entry is arguably worse — it slips past into the misleading `"Template missing 'type', 'name', or 'file'"`.)

Reproduced on `main` (`4d3a428`): the same three malformed shapes fed to the sibling `ExtensionManifest` return clean `ValidationError`s — confirming the parity gap.

## Fix

Add the two guards `ExtensionManifest` already has, raising `PresetValidationError`:

```python
templates = provides["templates"]
if not isinstance(templates, list):
    raise PresetValidationError("Invalid provides.templates: expected a list")
for tmpl in templates:
    if not isinstance(tmpl, dict):
        raise PresetValidationError("Each template entry in 'provides.templates' must be a mapping")
    ...
```

Valid manifests (a list of mappings) pass both guards unchanged — **no behaviour change for correct input**.

## Verification

- New `test_non_list_templates_raises_validation_error` + parametrized `test_non_mapping_template_entry_raises_validation_error` (`None`/`5`/`"oops"`/`["nested"]`): **fail before** (raw `TypeError` or the misleading "Template missing…" message), **pass after** (clean `PresetValidationError`). Mirrors the existing `test_non_mapping_yaml_raises_validation_error` precedent.
- Full `TestPresetManifest`: **24 passed**. `ruff` clean.

---
*AI-assisted: authored with Claude Code. I reproduced the raw `TypeError`s on `main` and confirmed the sibling `ExtensionManifest` already returns clean errors for the identical shapes.*