### PR TITLE
fix(github-http): return None on malformed host in resolve_github_release_asset_api_url

### DIFF
--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -102,8 +102,17 @@ def resolve_github_release_asset_api_url(
 
     from specify_cli._download_security import read_response_limited
 
-    parsed = urlparse(download_url)
-    hostname = (parsed.hostname or "").lower()
+    # Accessing ``.hostname`` (like ``.port`` below) raises ValueError on a
+    # malformed authority, e.g. an invalid bracketed IPv6 host
+    # ``https://[not-an-ip]/...``. The function's contract is to return None for
+    # anything it can't resolve, not to raise, so guard the read. ``download_url``
+    # is server-controlled here (a catalog ``download_url`` payload), so a
+    # malformed value must not leak a raw traceback past the caller.
+    try:
+        parsed = urlparse(download_url)
+        hostname = (parsed.hostname or "").lower()
+    except ValueError:
+        return None
     parts = [unquote(part) for part in parsed.path.strip("/").split("/")]
 
     is_ghes = (

--- a/tests/test_github_http.py
+++ b/tests/test_github_http.py
@@ -292,6 +292,23 @@ class TestResolveGitHubReleaseAssetApiUrl:
         assert result is None
         assert called == []
 
+    def test_returns_none_on_malformed_host(self):
+        """A malformed authority (e.g. an invalid bracketed IPv6 host) returns
+        None, not a ValueError (contract: resolve or return None, never raise)."""
+        called = []
+
+        def open_never(url, timeout=None, extra_headers=None):
+            called.append(url)
+            raise AssertionError("open_url_fn must not be called")
+
+        result = resolve_github_release_asset_api_url(
+            "https://[not-an-ip]/o/r/releases/download/v1/ext.zip",
+            open_never,
+            github_hosts=("ghes.example",),
+        )
+        assert result is None
+        assert called == []
+
     def test_passthrough_for_unlisted_ghes_api_asset_url(self):
         """A direct GHES /api/v3 asset URL passes through even when the host is
         not allowlisted: passthrough issues no API request, and the download


### PR DESCRIPTION
## Summary

`resolve_github_release_asset_api_url()` documents a resolve-or-return-`None` contract ("Returns ... `None` when the URL is not a resolvable GitHub release download or the lookup fails"), but reading the parsed authority could raise `ValueError` for a malformed host and leak a raw traceback past the caller.

The function already guards the twin case for `parsed.port` (malformed port -> return `None`). This applies the same guard to the host read: on Python 3.14 `urlparse()` itself raises `ValueError` for an invalid bracketed IPv6 host such as `https://[not-an-ip]/...`; on older versions the raise happens on `.hostname`. Wrapping both `urlparse` and `.hostname` in the `try` covers every version.

This matters because `download_url` is server-controlled — it comes from a catalog `download_url` payload — so a malformed value must not crash resolution.

## Test plan

- Added `test_returns_none_on_malformed_host`, mirroring the existing `test_returns_none_on_malformed_ghes_port`. It fails without the fix (raw `ValueError`) and passes with it.
- `pytest tests/test_github_http.py` -> 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
