### PR TITLE
Update Architecture Guard extension to v1.13.1

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -290,8 +290,8 @@
       "id": "architecture-guard",
       "description": "Framework-agnostic architecture review extension for validating implementation against governance and architecture constitutions, detecting architectural drift, and generating non-blocking refactor tasks.",
       "author": "DyanGalih",
-      "version": "1.8.17",
-      "download_url": "https://github.com/DyanGalih/spec-kit-architecture-guard/archive/refs/tags/v1.8.17.zip",
+      "version": "1.13.1",
+      "download_url": "https://github.com/DyanGalih/spec-kit-architecture-guard/archive/refs/tags/v1.13.1.zip",
       "repository": "https://github.com/DyanGalih/spec-kit-architecture-guard",
       "homepage": "https://github.com/DyanGalih/spec-kit-architecture-guard",
       "documentation": "https://github.com/DyanGalih/spec-kit-architecture-guard/blob/main/docs/architecture-overview.md",
@@ -303,7 +303,7 @@
         "speckit_version": ">=0.1.0"
       },
       "provides": {
-        "commands": 10,
+        "commands": 14,
         "hooks": 3
       },
       "tags": [
@@ -313,13 +313,14 @@
         "refactor",
         "workflow",
         "governance",
-        "guardrails"
+        "guardrails",
+        "hygiene"
       ],
       "verified": false,
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-05-05T07:26:00Z",
-      "updated_at": "2026-06-08T00:00:00Z"
+      "updated_at": "2026-07-24T00:00:00Z"
     },
     "archive": {
       "name": "Archive Extension",


### PR DESCRIPTION
## Summary
Updates the **Architecture Guard** community extension entry from v1.8.17 to v1.13.1, as requested in the submission update issue.

## Validation
- Repository DyanGalih/spec-kit-architecture-guard is public and contains extension.yml, README.md, LICENSE, CONTRIBUTING.md.
- GitHub release 1.13.1 exists (published 2026-07-16); download URL follows the rchive/refs/tags/vX.Y.Z.zip pattern and resolves correctly.
- extension.yml fetched at the 1.13.1 tag confirms 14 commands / 3 hooks, matching the updated provides block.
- Extension ID rchitecture-guard already exists in the catalog (this is an **update**, not a new addition) — entry updated in place, created_at/downloads/stars preserved.
- docs/community/extensions.md row required no changes (description/category/effect unchanged).
- JSON validated after edit.

Closes #3564
cc @DyanGalih