### PR TITLE
docs(assess): clarify the pipeline works on an empty project

### DIFF
--- a/extensions/assess/README.md
+++ b/extensions/assess/README.md
@@ -6,6 +6,8 @@ Discovery answers *"is this worth building?"* Delivery answers *"how do we build
 
 ## Overview
 
+`assess` works equally well for a **freshly initialized, empty project** or for an **existing codebase** — you do not need any source code to assess an idea. The input is just an idea: pasted text, a URL, or a ticket work with no repo at all, and a codebase pointer lets you assess an idea for existing code. Neither is more "correct" than the other.
+
 Each idea lives in its own directory under `.specify/assessments/<slug>/`, with one Markdown artifact per stage:
 
 ```

--- a/extensions/assess/README.md
+++ b/extensions/assess/README.md
@@ -6,7 +6,7 @@ Discovery answers *"is this worth building?"* Delivery answers *"how do we build
 
 ## Overview
 
-`assess` works equally well for a **freshly initialized, empty project** or for an **existing codebase** — you do not need any source code to assess an idea. The input is just an idea: pasted text, a URL, or a ticket work with no repo at all, and a codebase pointer lets you assess an idea for existing code. Neither is more "correct" than the other.
+`assess` runs inside an initialized Spec Kit project (it writes assessments under `.specify/assessments/`), but that project can be **completely empty of source code** — a freshly initialized project with no code works just as well as an established codebase. The input is just an idea: pasted text, a URL, or a ticket need no existing code, while a codebase pointer lets you assess an idea for code that already exists. Neither starting point is more "correct" than the other.
 
 Each idea lives in its own directory under `.specify/assessments/<slug>/`, with one Markdown artifact per stage:
 

--- a/extensions/assess/commands/speckit.assess.intake.md
+++ b/extensions/assess/commands/speckit.assess.intake.md
@@ -21,6 +21,8 @@ The user input is the idea and (optionally) a slug. Treat it as one of:
 3. **A codebase pointer** — phrasing like "an idea for this repo" or a path. Read enough of the repository to record what the idea relates to.
 4. **A mix** of the above.
 
+There is **no requirement for existing source code**: intake works just as well for an empty, freshly initialized project as for an existing codebase. Pasted text or a URL (options 1–2) need no repo; a codebase pointer (option 3) targets existing code. Both are equally valid.
+
 If the input is empty, ask the user for the idea (interactive), or stop with a note that there is nothing to intake (automated).
 
 ## Slug Resolution

--- a/extensions/assess/commands/speckit.assess.intake.md
+++ b/extensions/assess/commands/speckit.assess.intake.md
@@ -21,7 +21,7 @@ The user input is the idea and (optionally) a slug. Treat it as one of:
 3. **A codebase pointer** — phrasing like "an idea for this repo" or a path. Read enough of the repository to record what the idea relates to.
 4. **A mix** of the above.
 
-There is **no requirement for existing source code**: intake works just as well for an empty, freshly initialized project as for an existing codebase. Pasted text or a URL (options 1–2) need no repo; a codebase pointer (option 3) targets existing code. Both are equally valid.
+There is **no requirement for existing source code**: within an initialized Spec Kit project, intake works just as well when the project is empty of code as when it already has a codebase. Pasted text or a URL (options 1–2) need no existing codebase; a codebase pointer (option 3) targets existing code. Both are equally valid.
 
 If the input is empty, ask the user for the idea (interactive), or stop with a note that there is nothing to intake (automated).
 


### PR DESCRIPTION
## Summary

Makes it explicit that the `assess` extension can be used on an **empty, freshly initialized project** — no existing source code is required. An empty project and an existing codebase are equally valid starting points.

Previously the docs only *implied* this, and the "codebase pointer" / "assess this repo" wording in intake could give the impression that existing code was expected. This adds two short, explicit statements.

## Changes

- **`extensions/assess/README.md`** — Overview now states that `assess` works equally well on an empty project or an existing codebase; the input is just an idea (pasted text, a URL, a ticket, or a codebase pointer).
- **`extensions/assess/commands/speckit.assess.intake.md`** — adds a line after the input-types list clarifying there is no requirement for existing source code, and that both starting points are equally valid.

Docs-only change; no behavior or code affected.

---

🤖 This PR was authored autonomously by GitHub Copilot (model: Claude Opus 4.8) on behalf of @mnriem.