### PR TITLE
fix(agent-context): discover nested plans in Python port mtime fallback

### DIFF
--- a/extensions/agent-context/scripts/python/update_agent_context.py
+++ b/extensions/agent-context/scripts/python/update_agent_context.py
@@ -11,8 +11,9 @@ Usage: update_agent_context.py [plan_path]
 
 When ``plan_path`` is omitted, the script derives it from
 ``.specify/feature.json`` (written by /speckit-specify). Falls back to the most
-recently modified ``specs/*/plan.md`` only when feature.json is absent or its
-plan does not exist yet.
+recently modified ``plan.md`` anywhere under ``specs/`` (including nested scoped
+layouts such as ``specs/<scope>/<feature>/plan.md``) only when feature.json is
+absent or its plan does not exist yet.
 """
 
 from __future__ import annotations
@@ -173,7 +174,7 @@ def _resolve_plan_path(project_root: str) -> str:
     if not plan_path:
         root = Path(project_root).resolve()
         plans = sorted(
-            (root / "specs").glob("*/plan.md"),
+            (root / "specs").rglob("plan.md"),
             key=lambda p: p.stat().st_mtime,
             reverse=True,
         )

--- a/tests/extensions/test_update_agent_context_python_parity.py
+++ b/tests/extensions/test_update_agent_context_python_parity.py
@@ -318,6 +318,27 @@ def test_python_mtime_fallback_matching_bash(tmp_path: Path) -> None:
 
 
 @requires_posix_bash
+def test_python_mtime_fallback_finds_nested_plan_matching_bash(tmp_path: Path) -> None:
+    # Regression: the mtime fallback must discover plan.md in nested scoped
+    # layouts (specs/<scope>/<feature>/plan.md), matching the Bash/PowerShell
+    # ports and the documented recursive-discovery contract (see #3024). A
+    # one-level scan (specs/*/plan.md) would miss this and omit the plan link.
+    repo_a, repo_b = twin_projects(tmp_path, context_file="AGENTS.md")
+    for repo in (repo_a, repo_b):
+        plan = repo / "specs" / "scope-a" / "002-nested" / "plan.md"
+        plan.parent.mkdir(parents=True, exist_ok=True)
+        plan.write_text("# plan\n", encoding="utf-8")
+
+    bash = run_bash(repo_a)
+    py = run_python(repo_b)
+
+    assert_parity(bash, py, repo_a, repo_b)
+    content = (repo_b / "AGENTS.md").read_bytes()
+    assert content == (repo_a / "AGENTS.md").read_bytes()
+    assert b"at specs/scope-a/002-nested/plan.md" in content
+
+
+@requires_posix_bash
 def test_python_prefers_feature_json_over_mtime_matching_bash(tmp_path: Path) -> None:
     repo_a, repo_b = twin_projects(tmp_path, context_file="AGENTS.md")
     now = time.time()


### PR DESCRIPTION
## Description

Closes #3733.

The `agent-context` Python port reintroduced a one-level plan scan (`specs/*/plan.md`) in its mtime fallback, while the Bash (`specs.rglob("plan.md")`) and PowerShell (`-Recurse`) ports search recursively per the fix for #3024. The three ports were therefore out of parity: for nested scoped layouts such as `specs/<scope>/<feature>/plan.md`, the Python port found no plan and omitted the plan link from the managed context section.

This changes the fallback to `(root / "specs").rglob("plan.md")` and updates the module docstring to match the documented recursive-discovery contract.

## Testing

- [x] Ran existing tests with `pytest tests/extensions/` — **213 passed, 63 skipped** (PowerShell parity skipped: no `pwsh` locally).
- [x] Added `test_python_mtime_fallback_finds_nested_plan_matching_bash` to the parity suite. Verified it **fails** on the old one-level glob (Bash finds the nested plan, Python omits it → context files diverge) and **passes** with the recursive scan.
- [ ] Tested with a sample project (if applicable)

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

The one-line fix, the docstring update, and the regression test were written by Claude (Anthropic) under my direction, and I reviewed them. The bug was discovered while enabling this extension in a downstream project; an automated code review flagged the port divergence, which I then traced to the #3024 fix not being carried into the later Python port (#3387).