### PR TITLE
fix(agent-context): apply default markers when config markers are blank (bash)

### DIFF
--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -176,13 +176,18 @@ _opts_lines=()
 while IFS= read -r _line || [[ -n "$_line" ]]; do
   _opts_lines+=("$_line")
 done < <(printf '%s\n' "$_raw_opts")
-if (( ${#_opts_lines[@]} < 3 )); then
-  echo "agent-context: malformed config parser output; expected 3 lines (context_files, marker_start, marker_end), got ${#_opts_lines[@]}; skipping update." >&2
+if (( ${#_opts_lines[@]} < 1 )); then
+  echo "agent-context: malformed config parser output; expected at least the context_files line, got ${#_opts_lines[@]}; skipping update." >&2
   exit 0
 fi
+# The marker lines may be absent: the $(...) capture above strips trailing
+# newlines, so blank markers (the config omitting context_markers and relying on
+# defaults) collapse the 3-line output to fewer lines. Default them to empty here
+# and let the DEFAULT_START/END substitution below fill them in, matching the
+# Python and PowerShell ports.
 CONTEXT_FILES_JSON="${_opts_lines[0]}"
-MARKER_START="${_opts_lines[1]}"
-MARKER_END="${_opts_lines[2]}"
+MARKER_START="${_opts_lines[1]:-}"
+MARKER_END="${_opts_lines[2]:-}"
 
 if ! _context_files_raw="$("$_python" - "$CONTEXT_FILES_JSON" <<'PY'
 import json

--- a/tests/extensions/test_update_agent_context_python_parity.py
+++ b/tests/extensions/test_update_agent_context_python_parity.py
@@ -223,6 +223,32 @@ def test_python_custom_markers_matching_bash(tmp_path: Path) -> None:
 
 
 @requires_posix_bash
+def test_python_blank_markers_use_defaults_matching_bash(tmp_path: Path) -> None:
+    # Regression: with blank markers (config relying on the built-in defaults),
+    # the Bash port must fall back to DEFAULT_START/END, matching the Python and
+    # PowerShell ports. Previously the Bash config-parser transport dropped the
+    # trailing empty marker lines under $(...) command substitution, tripping the
+    # "malformed config parser output" guard so the default-marker substitution
+    # became unreachable and the context file was never updated.
+    markers = {"start": "", "end": ""}
+    repo_a, repo_b = twin_projects(
+        tmp_path, context_file="AGENTS.md", context_markers=markers
+    )
+    add_plan(repo_a)
+    add_plan(repo_b)
+
+    bash = run_bash(repo_a)
+    py = run_python(repo_b)
+
+    assert_parity(bash, py, repo_a, repo_b)
+    content = (repo_b / "AGENTS.md").read_bytes()
+    assert content == (repo_a / "AGENTS.md").read_bytes()
+    assert b"<!-- SPECKIT START -->" in content
+    assert b"<!-- SPECKIT END -->" in content
+    assert b"at specs/001-demo/plan.md" in content
+
+
+@requires_posix_bash
 def test_python_multiple_context_files_dedup_matching_bash(tmp_path: Path) -> None:
     files = ["AGENTS.md", "docs/CONTEXT.md", "AGENTS.md"]
     repo_a, repo_b = twin_projects(tmp_path, context_files=files)


### PR DESCRIPTION
## Description

Closes #3735.

When the extension config omits `context_markers` (or sets them blank) to rely on the built-in defaults, the Bash port aborted with `malformed config parser output` and never updated the context file, while the Python (`... or DEFAULT_*`) and PowerShell (default-initialized) ports handled it correctly.

The config parser prints three lines (context_files JSON, `marker_start`, `marker_end`), captured via `_raw_opts="$(...)"`. Command substitution strips trailing newlines, so blank marker lines collapse the output to fewer than three, tripping the `(( ${#_opts_lines[@]} < 3 ))` guard and making the `DEFAULT_START`/`DEFAULT_END` substitution below unreachable — the exact case it was written for.

Fix: require only the mandatory context_files line, and default the marker lines to empty (`${_opts_lines[1]:-}` / `${_opts_lines[2]:-}`) so the existing default-marker substitution fills them in. Single source of truth for the defaults stays in the Bash script.

## Testing

- [x] Ran existing tests with `pytest tests/extensions/` — **213 passed, 63 skipped** (PowerShell parity skipped: no `pwsh` locally).
- [x] Added `test_python_blank_markers_use_defaults_matching_bash` to the parity suite. Verified it **fails** on the old guard (Bash exits without updating while Python writes the section → parity mismatch) and **passes** with the fix.
- [ ] Tested with a sample project (if applicable)

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

The fix and the regression test were written by Claude (Anthropic) under my direction, and I reviewed them. The bug surfaced while enabling this extension in a downstream project; an automated code review flagged the cross-platform divergence, which I traced to the command-substitution newline-stripping interacting with the 3-line guard.