### PR TITLE
clarify: require real interrogatives, ban topic-label questions

### DIFF
--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -140,9 +140,9 @@ Execution steps:
 5. Sequential questioning loop (interactive):
     - Present EXACTLY ONE question at a time.
     - **Question writing quality (applies to every question, MC or short-answer):**
-       - Lead with `**Question:**` followed by a full interrogative sentence that ends with `?`. The question must make sense on its own.
+       - Lead with `**Question:**` followed by a full interrogative that ends with `?`. The question text before the `?` must make sense on its own.
        - NEVER use a topic label, section heading, or requirement id as the question itself. For example, `Acceptance device/runtime matrix (FR-023)` is INVALID — it is a label, not a question.
-       - Put requirement / question ids only in trailing parentheses at the end of the question, never as the whole heading or the whole prompt.
+       - After the `?`, the only permitted suffix is an optional parenthesized requirement/question id. Exact format: `**Question:** <interrogative>?` or `**Question:** <interrogative>? (FR-023)`. Never put the id before the `?`, and never use the id (alone or with a topic label) as the whole prompt.
        - Immediately after the question line, add one plain-language "Why it matters" sentence (the stake for acceptance or shipping) before the recommendation/options.
        - Use everyday wording; introduce jargon only if defined in the same sentence. Self-check: a reader who does not know Spec Kit must be able to answer from the Question line alone. Terse is fine; cryptic labels are not.
     - For multiple‑choice questions:

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -139,6 +139,12 @@ Execution steps:
 
 5. Sequential questioning loop (interactive):
     - Present EXACTLY ONE question at a time.
+    - **Question writing quality (applies to every question, MC or short-answer):**
+       - Lead with `**Question:**` followed by a full interrogative sentence that ends with `?`. The question must stand on its own.
+       - NEVER use a topic label, section heading, or requirement id as the question itself. For example, `Acceptance device/runtime matrix (FR-023)` is INVALID — it is a label, not a question.
+       - Put requirement / question ids only in trailing parentheses at the end of the question, never as the heading or the whole prompt.
+       - Immediately after the question line, add one plain-language "Why it matters" sentence (the stake for acceptance or shipping) before the recommendation/options.
+       - Use everyday wording; introduce jargon only if defined in the same sentence. Self-check: a reader who does not know Spec Kit must be able to answer from the Question line alone. Terse is fine; cryptic labels are not.
     - For multiple‑choice questions:
        - **Analyze all options** and determine the **most suitable option** based on:
           - Best practices for the project type

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -140,9 +140,9 @@ Execution steps:
 5. Sequential questioning loop (interactive):
     - Present EXACTLY ONE question at a time.
     - **Question writing quality (applies to every question, MC or short-answer):**
-       - Lead with `**Question:**` followed by a full interrogative sentence that ends with `?`. The question must stand on its own.
+       - Lead with `**Question:**` followed by a full interrogative sentence that ends with `?`. The question must make sense on its own.
        - NEVER use a topic label, section heading, or requirement id as the question itself. For example, `Acceptance device/runtime matrix (FR-023)` is INVALID — it is a label, not a question.
-       - Put requirement / question ids only in trailing parentheses at the end of the question, never as the heading or the whole prompt.
+       - Put requirement / question ids only in trailing parentheses at the end of the question, never as the whole heading or the whole prompt.
        - Immediately after the question line, add one plain-language "Why it matters" sentence (the stake for acceptance or shipping) before the recommendation/options.
        - Use everyday wording; introduce jargon only if defined in the same sentence. Self-check: a reader who does not know Spec Kit must be able to answer from the Question line alone. Terse is fine; cryptic labels are not.
     - For multiple‑choice questions:


### PR DESCRIPTION
## Summary
Clarify agents often present topic labels or bare requirement ids as "questions" (e.g. `Acceptance device/runtime matrix (FR-023)`), which are not answerable on their own. This extends the question-first UX direction from #1777: every turn must lead with a full interrogative under `**Question:**`, add one plain-language stake sentence, then Recommended/options. Requirement ids belong only in trailing parentheses.

## Test plan
- [ ] Run `/speckit.clarify` on a spec with open NEEDS CLARIFICATION items
- [ ] Confirm each question starts with `**Question:** …?` (not a topic heading)
- [ ] Confirm a "Why it matters" sentence appears before Recommended/options
- [ ] Confirm FR/requirement ids appear only in trailing parentheses


Made with [Cursor](https://cursor.com)