### PR TITLE
fix(powershell): resolve SPECIFY_INIT_DIR without .NET Core-only API

### DIFF
--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -60,8 +60,12 @@ function Resolve-SpecifyInitDir {
     # matching note further below). TrimEnd is a no-op on a path with no trailing
     # separator; the one difference is a bare drive root (`C:\` -> `C:`), so keep
     # that separator to preserve a valid rooted path.
+    # A filesystem root is all separator: trimming it would leave an empty (or
+    # drive-only) string and break the Join-Path below. Covers the Windows
+    # drive root (`C:\` -> `C:`) and the POSIX root (`/` -> ``), which
+    # PowerShell on Linux/macOS can return.
     $initRoot = $resolved.Path.TrimEnd('/', '\')
-    if ($initRoot -match '^[A-Za-z]:$') {
+    if (-not $initRoot -or $initRoot -match '^[A-Za-z]:$') {
         $initRoot = $resolved.Path
     }
     if (-not (Test-Path -LiteralPath (Join-Path $initRoot '.specify') -PathType Container)) {

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -55,9 +55,15 @@ function Resolve-SpecifyInitDir {
     }
     # Resolve-Path echoes back any trailing separator from the input; trim it so
     # the returned root matches the bash resolver, whose `cd && pwd` never yields
-    # one. TrimEndingDirectorySeparator is a no-op on a bare root and on a path
-    # that already has no trailing separator.
-    $initRoot = [System.IO.Path]::TrimEndingDirectorySeparator($resolved.Path)
+    # one. Use TrimEnd (not [Path]::TrimEndingDirectorySeparator, which is .NET
+    # Core only and throws on Windows PowerShell 5.1 / .NET Framework — see the
+    # matching note further below). TrimEnd is a no-op on a path with no trailing
+    # separator; the one difference is a bare drive root (`C:\` -> `C:`), so keep
+    # that separator to preserve a valid rooted path.
+    $initRoot = $resolved.Path.TrimEnd('/', '\')
+    if ($initRoot -match '^[A-Za-z]:$') {
+        $initRoot = $resolved.Path
+    }
     if (-not (Test-Path -LiteralPath (Join-Path $initRoot '.specify') -PathType Container)) {
         [Console]::Error.WriteLine("ERROR: SPECIFY_INIT_DIR is not a Spec Kit project (no .specify/ directory): $initRoot")
         if ($ReturnNullOnError) { return $null }


### PR DESCRIPTION
Fixes #3749

### Problem

`scripts/powershell/common.ps1` resolves the `SPECIFY_INIT_DIR` root with `[System.IO.Path]::TrimEndingDirectorySeparator(...)`, which only exists on .NET Core. On **Windows PowerShell 5.1** (.NET Framework) the call throws:

```
Method invocation failed because [System.IO.Path] does not contain a method named 'TrimEndingDirectorySeparator'.
```

so project-root resolution fails before any Spec Kit command can run whenever `SPECIFY_INIT_DIR` is set. PowerShell 7+ users are unaffected (the API exists there), which is why it went unnoticed. The same file already documents this incompatibility ~150 lines later and correctly uses `.TrimEnd('/','')`.

### Fix

Use the `.TrimEnd('/','')` approach the file already endorses, guarding the single case where the two differ — a bare drive root (`C:\`), where `TrimEnd` would strip the separator and yield an invalid `C:` — by preserving the original path there.

### Verification

Reproduced and verified on **Windows PowerShell 5.1** (5.1.26100, Desktop edition):

- Old line: `THROWS: Method invocation failed ... TrimEndingDirectorySeparator`
- New line: resolves correctly, `.specify/` detected.

The existing `@requires_pwsh` tests in `tests/test_init_dir.py` already exercise this path (trailing-slash, relative, precedence, compose). On PS 5.1 **6 of them fail on the current code and all pass with this fix**; they continue to pass on pwsh 7+. Edge cases confirmed: `C:ooar\ -> C:ooar`, `C:oo/ -> C:oo`, `C:\ -> C:\` (preserved), no-op when already clean.
