### PR TITLE
fix: correct Optional type annotation for context_note parameter

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -270,7 +270,7 @@ class CommandRegistrar:
         return text
 
     def render_markdown_command(
-        self, frontmatter: dict, body: str, source_id: str, context_note: str = None
+        self, frontmatter: dict, body: str, source_id: str, context_note: Optional[str] = None
     ) -> str:
         """Render command in Markdown format.
 
@@ -597,7 +597,7 @@ class CommandRegistrar:
         source_id: str,
         source_dir: Path,
         project_root: Path,
-        context_note: str = None,
+        context_note: Optional[str] = None,
         _resolved_dir: Path = None,
         link_outputs: bool = False,
         extension_id: Optional[str] = None,
@@ -1016,7 +1016,7 @@ class CommandRegistrar:
         source_id: str,
         source_dir: Path,
         project_root: Path,
-        context_note: str = None,
+        context_note: Optional[str] = None,
         link_outputs: bool = False,
         create_missing_active_skills_dir: bool = False,
         extension_id: Optional[str] = None,


### PR DESCRIPTION
## Summary

The `context_note` parameter in `CommandRegistrar` methods was annotated as `str = None` - a type lie where the default is `None` but the type hint says `str`. Static type checkers (mypy/pyright) flag this as an error.

## Changes

- **`src/specify_cli/agents.py`** (lines 273, 600, 1019): Changed `context_note: str = None` to `context_note: Optional[str] = None`, consistent with how `extension_id` in the same class is already typed.

## Testing

This is a type-correctness fix - no runtime behavior change. Existing tests continue to pass.