### PR TITLE
fix(workflows,extensions): tolerate non-list catalog tags in search/info display

### DIFF
--- a/src/specify_cli/extensions/_commands.py
+++ b/src/specify_cli/extensions/_commands.py
@@ -783,8 +783,9 @@ def extension_search(
 
             # Metadata
             console.print(f"\n  [dim]Author:[/dim] {_escape_markup(str(ext.get('author', 'Unknown')))}")
-            if ext.get('tags'):
-                tags_str = ", ".join(str(t) for t in ext['tags'])
+            ext_tags = ext.get('tags', [])
+            if isinstance(ext_tags, list) and ext_tags:
+                tags_str = ", ".join(str(t) for t in ext_tags)
                 console.print(f"  [dim]Tags:[/dim] {_escape_markup(tags_str)}")
 
             # Source catalog
@@ -1007,8 +1008,9 @@ def _print_extension_info(ext_info: dict, manager):
         console.print()
 
     # Tags
-    if ext_info.get('tags'):
-        tags_str = ", ".join(str(t) for t in ext_info['tags'])
+    info_tags = ext_info.get('tags', [])
+    if isinstance(info_tags, list) and info_tags:
+        tags_str = ", ".join(str(t) for t in info_tags)
         console.print(f"[bold]Tags:[/bold] {_escape_markup(tags_str)}")
         console.print()
 

--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -2320,7 +2320,7 @@ def workflow_search(
         if desc:
             console.print(f"    {_escape_markup(str(desc))}")
         tags = wf.get("tags", [])
-        if tags:
+        if isinstance(tags, list) and tags:
             safe_tags = _escape_markup(", ".join(str(t) for t in tags))
             console.print(f"    [dim]Tags: {safe_tags}[/dim]")
         console.print()
@@ -2418,8 +2418,9 @@ def workflow_info(
         console.print(f"  Version:     {_escape_markup(str(info.get('version', '?')))}")
         if info.get("description"):
             console.print(f"  Description: {_escape_markup(str(info['description']))}")
-        if info.get("tags"):
-            safe_tags = _escape_markup(", ".join(str(t) for t in info["tags"]))
+        info_tags = info.get("tags", [])
+        if isinstance(info_tags, list) and info_tags:
+            safe_tags = _escape_markup(", ".join(str(t) for t in info_tags))
             console.print(f"  Tags:        {safe_tags}")
         console.print("  [yellow]Not installed[/yellow]")
     else:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -4366,6 +4366,44 @@ class TestExtensionCatalog:
         results = catalog.search(query="jira")
         assert {r["id"] for r in results} == {"jira"}
 
+    def test_search_and_info_tolerate_non_list_tags(self, temp_dir):
+        """A scalar ``tags:`` value must not crash the search/info display.
+
+        ``ExtensionCatalog.search`` guards its tag *filter* with
+        ``isinstance(raw_tags, list)``, but the ``extension search`` and
+        ``extension info`` display paths only tested truthiness before
+        iterating. ``tags: 5`` is truthy and not iterable, so both raised
+        ``TypeError: 'int' object is not iterable``.
+        """
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        project_dir = temp_dir / "project"
+        project_dir.mkdir()
+        (project_dir / ".specify").mkdir()
+
+        merged = [{
+            "id": "jira",
+            "name": "Jira",
+            "version": "1.0.0",
+            "description": "Jira",
+            "tags": 5,
+        }]
+
+        with patch.object(ExtensionCatalog, "_get_merged_extensions", return_value=merged), \
+                patch("specify_cli.extensions._commands._require_specify_project",
+                      return_value=project_dir):
+            searched = CliRunner().invoke(app, ["extension", "search", "Jira"])
+            info = CliRunner().invoke(app, ["extension", "info", "jira"])
+
+        assert searched.exit_code == 0, searched.output
+        assert "Jira" in searched.output
+        assert "Tags:" not in searched.output
+
+        assert info.exit_code == 0, info.output
+        assert "Tags:" not in info.output
+
     def test_search_tolerates_non_string_author_and_name(self, temp_dir):
         """Non-string catalog author/name must not crash author/query search.
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -10183,6 +10183,44 @@ steps:
         assert "desc [with] brackets" in result.output
         assert "tag[1]" in result.output
 
+    def test_search_and_info_tolerate_non_list_tags(self, project_dir, monkeypatch):
+        """A scalar ``tags:`` value must not crash the search/info display.
+
+        ``WorkflowCatalog.search`` guards its tag *filter* with
+        ``isinstance(raw_tags, list)``, but the ``workflow search`` and
+        ``workflow info`` display paths only tested truthiness before
+        iterating. ``tags: 5`` is truthy and not iterable, so both raised
+        ``TypeError: 'int' object is not iterable``.
+        """
+        from typer.testing import CliRunner
+        from specify_cli import app
+        from specify_cli.workflows.catalog import WorkflowCatalog
+
+        monkeypatch.chdir(project_dir)
+        workflows = {
+            "wf-a": {
+                "name": "Workflow A",
+                "version": "1.0.0",
+                "description": "desc",
+                "tags": 5,
+            },
+        }
+        monkeypatch.setattr(
+            WorkflowCatalog,
+            "_get_merged_workflows",
+            lambda self, force_refresh=False: {k: dict(v) for k, v in workflows.items()},
+        )
+        runner = CliRunner()
+        searched = runner.invoke(app, ["workflow", "search"])
+        info = runner.invoke(app, ["workflow", "info", "wf-a"])
+
+        assert searched.exit_code == 0, searched.output
+        assert "Workflow A" in searched.output
+        assert "Tags:" not in searched.output
+
+        assert info.exit_code == 0, info.output
+        assert "Tags:" not in info.output
+
     def test_catalog_list_escapes_rich_markup(self, project_dir, monkeypatch):
         """User-editable catalog name/url/description must not be parsed as Rich markup."""
         from typer.testing import CliRunner


### PR DESCRIPTION
## Problem

`workflow search`, `workflow info`, `extension search` and `extension info` crash with a raw traceback when a catalog entry carries a **scalar** `tags:` value:

```yaml
wf-a:
  name: Workflow A
  tags: 5        # valid YAML, not a list
```

```
workflow search -> TypeError: 'int' object is not iterable
workflow info   -> TypeError: 'int' object is not iterable
extension search -> TypeError: 'int' object is not iterable
extension info   -> TypeError: 'int' object is not iterable
```

Catalog payloads are user-editable YAML/JSON, so this shape reaches the display unvalidated.

Interestingly, **both backends already handle this correctly.** `WorkflowCatalog.search` and `ExtensionCatalog.search` gate their tag filter on `isinstance(raw_tags, list)`, so `--tag ci` skips the malformed entry cleanly. Only the display paths were unguarded — they tested truthiness and then iterated:

```python
if info.get("tags"):                                   # truthy for 5
    safe_tags = ", ".join(str(t) for t in info["tags"]) # boom
```

So filtering worked while plain rendering crashed.

## Why the existing `str(t)` coercion doesn't cover this

This is a distinct failure mode from the non-string *element* handling added in #3746 / #3747. Coercing elements with `str(t) for t in ...` does nothing when `tags` isn't a sequence at all — the iteration itself is what fails.

## Fix

Use the guard the sibling integration commands already use. `integrations/_query_commands.py:332,402` gate on `isinstance(tags, list) and tags`; this applies the same pattern to workflows and extensions rather than introducing a new idiom.

A repo-wide audit of every `", ".join(str(t) for t in ...)` tag-display site confirms the four sites in these two modules were the only unguarded ones outside presets (which are covered separately in #3769):

| Site | Before | After |
| --- | --- | --- |
| `extensions/_commands.py` search | unguarded | guarded |
| `extensions/_commands.py` `_print_extension_info` | unguarded | guarded |
| `workflows/_commands.py` `workflow_search` | unguarded | guarded |
| `workflows/_commands.py` `workflow_info` | unguarded | guarded |
| `integrations/_query_commands.py` ×2 | already guarded | unchanged |

## Tests

One regression test per module, each covering `search` **and** `info`, driving the full CLI via `CliRunner`:

- `TestWorkflowCliAlignment::test_search_and_info_tolerate_non_list_tags`
- `TestExtensionCatalog::test_search_and_info_tolerate_non_list_tags`

Both fail before the fix with the exact target exception, verified by stashing the source changes:

```
FAILED tests/test_workflows.py::TestWorkflowCliAlignment::test_search_and_info_tolerate_non_list_tags
FAILED tests/test_extensions.py::TestExtensionCatalog::test_search_and_info_tolerate_non_list_tags
  → where 1 = <Result TypeError("'int' object is not iterable")>.exit_code
2 failed
```

`tests/test_workflows.py tests/test_extensions.py` after the fix: **982 passed, 17 failed, 113 errors**. Clean `main` gives **980 passed** with an identical 17 failed / 113 errors — those are pre-existing Windows-local issues (symlink cases needing elevation, and a locked pytest temp root). Net effect is +2 passing, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
