### PR TITLE
fix: correct nullable resolved directory annotation

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -598,7 +598,7 @@ class CommandRegistrar:
         source_dir: Path,
         project_root: Path,
         context_note: Optional[str] = None,
-        _resolved_dir: Path = None,
+        _resolved_dir: Optional[Path] = None,
         link_outputs: bool = False,
         extension_id: Optional[str] = None,
     ) -> List[str]:

--- a/tests/test_agent_config_consistency.py
+++ b/tests/test_agent_config_consistency.py
@@ -2,10 +2,12 @@
 
 import re
 from pathlib import Path
+from typing import get_args, get_type_hints
 
 import yaml
 
 from specify_cli import AGENT_CONFIG
+from specify_cli.agents import CommandRegistrar as AgentCommandRegistrar
 from specify_cli.extensions import CommandRegistrar
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -102,6 +104,14 @@ def _supported_agent_names_from_agent_request_template() -> list[str]:
 
 class TestAgentConfigConsistency:
     """Ensure agent configuration stays synchronized across key surfaces."""
+
+    def test_register_commands_resolved_dir_annotation_accepts_none(self):
+        """The internal resolved-directory override defaults to None."""
+        resolved_dir_type = get_type_hints(
+            AgentCommandRegistrar.register_commands
+        )["_resolved_dir"]
+
+        assert type(None) in get_args(resolved_dir_type)
 
     def test_issue_template_agent_lists_match_runtime_integrations(self):
         """GitHub issue templates should list all concrete built-in agents."""


### PR DESCRIPTION
## Description

`CommandRegistrar.register_commands()` accepts `None` for its internal
`_resolved_dir` override, but annotated the parameter as `Path`. This corrects
the type contract to `Optional[Path]`, matching the existing default and nearby
optional parameters. Runtime behavior is unchanged.

The regression test resolves the runtime type hints and verifies that
`_resolved_dir` accepts `None`.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Full suite: 5422 passed, 172 skipped.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot (GPT-5.6 Sol) autonomously identified, implemented, tested, and
self-reviewed this change on behalf of @marcelsafin.
