### PR TITLE
fix(templates): resolve dependent templates through the preset stack in constitution sync (#3737)

### DIFF
--- a/templates/commands/constitution.md
+++ b/templates/commands/constitution.md
@@ -97,9 +97,10 @@ Follow this execution flow:
    - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
 
 4. Consistency propagation checklist (convert prior checklist into active validations):
-   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
-   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
-   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Resolve each dependent template through the Spec Kit preset/template resolution stack before reading it (equivalent to `specify preset resolve <template-name>`). A project override, an enabled preset, or an extension can supply the active `plan-template`, `spec-template`, or `tasks-template`; when one does, `.specify/templates/<template-name>.md` is NOT the file the other Spec Kit commands read. Propagate the updated guidance to every layer the stack reports — the active provider plus the built-in `.specify/templates/<template-name>.md` fallback — preserving each provider's specialized content and structure rather than overwriting it.
+   - Read the resolved `plan-template` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read the resolved `spec-template` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read the resolved `tasks-template` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
    - Read each installed Spec Kit command file for your agent (including this one) — named `speckit.*` or `speckit-*` (dot or hyphen depending on the agent), or laid out as `speckit-<name>/SKILL.md` for skills-based integrations, e.g. in `.github/agents/`, `.github/skills/`, `.claude/skills/`, or your agent's equivalent commands directory — to verify no outdated references (CLAUDE-only or other agent-specific names) remain when generic guidance is required.
    - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
 
@@ -108,7 +109,7 @@ Follow this execution flow:
    - List of modified principles (old title → new title if renamed)
    - Added sections
    - Removed sections
-   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths — list every layer the resolution stack reported for each template (project override, preset, extension, built-in), and mark a file ✅ updated only if it was actually read and changed
    - Follow-up TODOs if any placeholders intentionally deferred.
 
 6. Validation before final output:

--- a/tests/integrations/test_integration_copilot.py
+++ b/tests/integrations/test_integration_copilot.py
@@ -188,6 +188,29 @@ class TestCopilotIntegration:
         assert "Copy `.specify/templates/spec-template.md`" not in content
         assert "Load `.specify/templates/spec-template.md`" not in content
 
+    def test_constitution_agent_resolves_dependent_templates(self, tmp_path):
+        """Generated constitution agent must resolve each dependent template
+        through the preset stack instead of hardcoding the core paths.
+
+        A replace-strategy preset supplies the active `tasks-template`, so the
+        hardcoded `.specify/templates/tasks-template.md` is not the file the
+        other Spec Kit commands read — the preset copy was left stale (#3737).
+        """
+        from specify_cli.integrations.copilot import CopilotIntegration
+        copilot = CopilotIntegration()
+        m = IntegrationManifest("copilot", tmp_path)
+        copilot.setup(tmp_path, m)
+
+        content = (
+            tmp_path / ".github" / "agents" / "speckit.constitution.agent.md"
+        ).read_text(encoding="utf-8")
+
+        assert "specify preset resolve <template-name>" in content
+        for name in ("plan-template", "spec-template", "tasks-template"):
+            assert f"Read the resolved `{name}`" in content
+            assert f"Read `.specify/templates/{name}.md` and ensure" not in content
+            assert f"Read `.specify/templates/{name}.md` for" not in content
+
     def test_plan_command_has_no_context_placeholder(self, tmp_path):
         """The core plan command must not carry a context-file placeholder —
         agent context files are owned by the opt-in agent-context extension."""


### PR DESCRIPTION
Addresses #3737 (the reporter's items 1–3 and 5 — see *Scope* for what is deliberately left out).

## Problem

Step 4 of the constitution command hardcodes the three dependent template paths:

```
- Read `.specify/templates/plan-template.md`  ...
- Read `.specify/templates/spec-template.md`  ...
- Read `.specify/templates/tasks-template.md` ...
```

But a project override, an **enabled preset**, or an extension can supply the *active* template. When one does, the hardcoded path is **not** the file the other Spec Kit commands read, so the provider's copy is silently left stale — and the Sync Impact Report can list it as updated without it ever having been read.

Reproduced against `main` with the real resolver (throwaway tempdir; an enabled `replace`-strategy preset supplying `tasks-template`, exactly the pattern `presets/self-test/preset.yml` uses):

```
collect_all_layers('tasks-template'):
    explicit-task-dependencies v1.0.0 | replace | .specify/presets/.../tasks-template.md
    core                              | replace | .specify/templates/tasks-template.md

constitution.md step 4 reads : .specify/templates/tasks-template.md   -> "# CORE tasks template"
/speckit.tasks actually uses : .specify/presets/.../tasks-template.md -> "# PRESET tasks template (replace)"
MISMATCH: True
```

The same hardcoding applies to `plan-template` (`scripts/bash/setup-plan.sh` uses `resolve_template "plan-template"`) and `spec-template`, so all three bullets are affected — not just tasks.

## Fix

Prompt-level only. Instruct the agent to resolve each dependent template through the preset/template resolution stack before reading it, and to propagate the updated guidance to **every layer the stack reports** (active provider + built-in fallback), preserving each provider's specialized content.

This mirrors the **already-merged precedent** 14da893 — *"fix(copilot): resolve active spec template (#2765)"* — which fixed the identical class of hardcoding in `specify.md`, using the same wording and the same existing command:

```diff
-   - Copy `templates/spec-template.md` to ... as the starting point
+   - Resolve the active `spec-template` through the Spec Kit preset/template resolution stack (equivalent to `specify preset resolve spec-template`)
```

`specify preset resolve` already exists (`presets/_commands.py`) and already calls `collect_all_layers()`, so there is **no new API, no new `{SCRIPT}`, and no sh/ps/py parity work**. This is also what the issue's own bug assessment labels the *"Preferred"* remediation: `TemplateResolver.collect_all_layers()` already implements the precedence correctly — the prompt simply never used it.

Step 5's Sync Impact Report line is updated to require listing every reported layer and to mark a file ✅ updated only when it was actually read and changed.

## Verification

- New `test_constitution_agent_resolves_dependent_templates` asserts the generated agent file resolves all three templates and no longer carries the hardcoded reads. **Fails before this change**, passes after. Placed beside its precedent test, as 14da893 did.
- `tests/integrations/test_integration_copilot.py`: **53 passed**.
- `markdownlint-cli2` error count on this file is **identical before and after** (14 pre-existing, unchanged by this diff).

## Scope

Reporter items 4 and 6 — a provider-agnostic sync contract enforced in code, and a hard validation that *fails* when a `replace`-strategy preset omits mandated guidance — are intentionally **not** included: both need new CLI/validation surface and a product decision. Happy to follow up if you want that direction.

---
*AI-assisted: authored with Claude Code. I reproduced the MISMATCH on `main` with the real `TemplateResolver` before writing the fix, and mirrored the merged 14da893 precedent for both wording and test placement.*