### PR TITLE
fix(workflows): escape the step-progress line so step ids render (and `/` stops failing the run)

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -1054,7 +1054,18 @@ def workflow_run(
     load_custom_steps(project_root)
     engine = WorkflowEngine(project_root)
     if not json_output:
-        engine.on_step_start = lambda sid, label: console.print(f"  \u25b8 [{sid}] {label} \u2026")
+        # Escape the literal bracket (\[) so Rich renders `[<step id>]` instead
+        # of parsing it as a style tag named after the step id -- which it
+        # silently swallows (losing the only identifying content on the line),
+        # applies as formatting when the id happens to be a real style such as
+        # `bold`, or raises MarkupError when the id forms a closing tag (`/`),
+        # failing the whole run. Escape the interpolated values too, since both
+        # come from workflow YAML. Mirrors the `\[<type>]` step-graph precedent
+        # in workflow_info below.
+        engine.on_step_start = lambda sid, label: console.print(
+            f"  \u25b8 \\[{_escape_markup(str(sid))}] "
+            f"{_escape_markup(str(label))} \u2026"
+        )
 
     err = _error_console(json_output)
 
@@ -1176,7 +1187,18 @@ def workflow_resume(
     load_custom_steps(project_root)
     engine = WorkflowEngine(project_root)
     if not json_output:
-        engine.on_step_start = lambda sid, label: console.print(f"  \u25b8 [{sid}] {label} \u2026")
+        # Escape the literal bracket (\[) so Rich renders `[<step id>]` instead
+        # of parsing it as a style tag named after the step id -- which it
+        # silently swallows (losing the only identifying content on the line),
+        # applies as formatting when the id happens to be a real style such as
+        # `bold`, or raises MarkupError when the id forms a closing tag (`/`),
+        # failing the whole run. Escape the interpolated values too, since both
+        # come from workflow YAML. Mirrors the `\[<type>]` step-graph precedent
+        # in workflow_info below.
+        engine.on_step_start = lambda sid, label: console.print(
+            f"  \u25b8 \\[{_escape_markup(str(sid))}] "
+            f"{_escape_markup(str(label))} \u2026"
+        )
 
     inputs = _parse_input_values(input_values, json_output=json_output)
     err = _error_console(json_output)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -9584,6 +9584,92 @@ steps:
         assert asset_calls[0][1] == {"Accept": "application/octet-stream"}
 
 
+class TestWorkflowStepStartProgressLine:
+    """The `run`/`resume` step-progress line must render the step id literally.
+
+    The line is built as `  ▸ [<id>] <label> …`, so Rich parsed the bracketed id
+    as a style tag: it silently swallowed the id (the only identifying content
+    on the line), applied it as formatting when the id happened to be a real
+    style like `bold`, and raised MarkupError — failing the whole run — when the
+    id formed a closing tag such as `/`. `validate_workflow` places no charset
+    restriction on step ids, so all of these are accepted workflows.
+    """
+
+    def _write(self, tmp_path, step_id):
+        path = tmp_path / "wf.yml"
+        path.write_text(
+            'schema_version: "1.0"\n'
+            "workflow:\n"
+            '  id: "probe-wf"\n'
+            '  name: "Probe"\n'
+            '  version: "1.0.0"\n'
+            "steps:\n"
+            f'  - id: "{step_id}"\n'
+            "    type: shell\n"
+            '    run: "exit 0"\n',
+            encoding="utf-8",
+        )
+        return path
+
+    @pytest.mark.parametrize("step_id", ["greet", "bold", "a]b"])
+    def test_progress_line_shows_step_id(self, tmp_path, monkeypatch, step_id):
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app, ["workflow", "run", str(self._write(tmp_path, step_id))]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert f"[{step_id}]" in result.stdout
+
+    def test_step_id_forming_a_closing_tag_does_not_fail_the_run(
+        self, tmp_path, monkeypatch
+    ):
+        """`id: "/"` raised MarkupError from inside the progress callback, which
+        surfaced as a failed run with no step results."""
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app, ["workflow", "run", str(self._write(tmp_path, "/"))]
+        )
+        assert result.exit_code == 0, result.stdout
+        assert "Status: completed" in result.stdout
+        assert "[/]" in result.stdout
+
+    def test_resume_progress_line_shows_step_id(self, tmp_path, monkeypatch):
+        """`workflow resume` installs its own copy of the same callback, so it
+        needs independent coverage — a one-line fix would miss the twin."""
+        import json as _json
+
+        from typer.testing import CliRunner
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        path = tmp_path / "wf.yml"
+        path.write_text(
+            'schema_version: "1.0"\n'
+            "workflow:\n"
+            '  id: "probe-resume"\n'
+            '  name: "Probe"\n'
+            '  version: "1.0.0"\n'
+            "steps:\n"
+            "  - id: boom\n"
+            "    type: shell\n"
+            '    run: "exit 1"\n',
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        first = runner.invoke(app, ["workflow", "run", str(path), "--json"])
+        run_id = _json.loads(first.stdout).get("run_id")
+        assert run_id
+
+        resumed = runner.invoke(app, ["workflow", "resume", run_id])
+        assert "[boom]" in resumed.stdout
+
+
 class TestWorkflowRunExitCodes:
     """CLI-level tests for the run/resume process exit codes."""
 


### PR DESCRIPTION
## Problem

`workflow run` and `workflow resume` install the same step-progress callback:

```python
engine.on_step_start = lambda sid, label: console.print(f"  ▸ [{sid}] {label} …")
```

Rich parses the bracketed step id as a **style tag**. Both arguments come from workflow YAML and neither is escaped, which produces three distinct failures on `main`:

**1. The step id is silently swallowed on every run** — the only identifying content on the line.

```
workflow with `id: greet`  ->  "  ▸  shell …"      ("[greet]" absent)
```

**2. An id that forms a closing tag fails the whole run.** `validate_workflow` places no charset restriction on step ids (it rejects only non-strings, `:`, and duplicates), so `id: "/"` is an accepted workflow. The callback then raises `MarkupError`, which propagates into `execute()`'s handler:

```
rich.errors.MarkupError: closing tag '[/]' at position 4 has nothing to close
-> run persisted as `failed`, step_results: {}   (the shell step never ran)
-> exit 1 with a Rich internals error
```

**3. An id that is a real style (`bold`, `red`, `dim`) is applied as formatting** to the rest of the line. The unescaped `label` (from `step_config["command"]`) compounds all of this.

## Fix

Escape the literal bracket with `\[` and escape both interpolated values — at **both** sites (`workflow_run` line 1051 and `workflow_resume` line 1173; the arrow appears exactly twice in `src/`).

This mirrors the `\[<type>]` step-graph precedent already in this file (`workflow_info`), including its comment rationale.

Escaping only the values is **not** sufficient — the f-string's own brackets are what Rich consumes. Verified:

| step id | before | escape values only | this fix |
| --- | --- | --- | --- |
| `greet` | `  ▸  shell …` | `  ▸  shell …` | `  ▸ [greet] shell …` |
| `bold` | `  ▸  shell …` | `  ▸  shell …` | `  ▸ [bold] shell …` |
| `/` | **MarkupError** | **MarkupError** | `  ▸ [/] shell …` |
| `a]b` | `  ▸ b] shell …` | `  ▸ b] shell …` | `  ▸ [a]b] shell …` |

## Verification

Driven through the real CLI (`CliRunner`, `workflow run`):

```
id='greet' exit=0 id_visible=True  line='  > [greet] shell ...'
id='bold'  exit=0 id_visible=True  line='  > [bold] shell ...'
id='/'     exit=0 id_visible=True  line='  > [/] shell ...'      <- was a failed run
id='a]b'   exit=0 id_visible=True  line='  > [a]b] shell ...'
```

- 5 new tests (3 parametrized ids, the `/` crash, plus a **resume-side** case that drives `run --json` → `resume <run_id>` so the twin is covered independently): **all fail before this change**, pass after.
- `TestWorkflowRunExitCodes` (the neighbouring pre-existing class) still green — **9 passed** together.
- `uvx ruff@0.15.0 check src tests` clean.
- Nothing depended on the broken output: no test or doc references the progress line (`docs/reference/workflows.md` documents only the `--json` payload).

---
*AI-assisted: authored with Claude Code. I reproduced all three failure modes on `main` through the real CLI, confirmed that escaping only the interpolated values leaves the bug, and matched the existing `\[` convention in this file.*