### PR TITLE
fix(scripts): tolerate an unusable integration.json in the Python helper

### DIFF
--- a/scripts/python/common.py
+++ b/scripts/python/common.py
@@ -258,16 +258,27 @@ def get_invoke_separator(repo_root: Path) -> str:
     integration_json = repo_root / ".specify" / "integration.json"
     if not integration_json.is_file():
         return "."
+    # Split the parse out of the lookup and guard the top-level shape, matching
+    # read_feature_json_feature_directory below and the bash/PowerShell twins,
+    # which both fall back to "." for any unusable integration.json:
+    #   * a non-mapping top level ([], "forge", 42, null) is valid JSON, so
+    #     json.JSONDecodeError never fires and state.get(...) raised
+    #     AttributeError;
+    #   * a non-UTF-8 file raises UnicodeDecodeError, which is a ValueError --
+    #     not an OSError -- so it escaped the except tuple. Realistic on
+    #     Windows, where PowerShell 5.1's Out-File/`>` default to UTF-16.
     try:
         state = json.loads(integration_json.read_text(encoding="utf-8"))
-        key = state.get("default_integration") or state.get("integration") or ""
-        settings = state.get("integration_settings")
-        if isinstance(key, str) and isinstance(settings, dict):
-            entry = settings.get(key)
-            if isinstance(entry, dict) and entry.get("invoke_separator") in {".", "-"}:
-                return entry["invoke_separator"]
-    except (OSError, json.JSONDecodeError):
-        pass
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return "."
+    if not isinstance(state, dict):
+        return "."
+    key = state.get("default_integration") or state.get("integration") or ""
+    settings = state.get("integration_settings")
+    if isinstance(key, str) and isinstance(settings, dict):
+        entry = settings.get(key)
+        if isinstance(entry, dict) and entry.get("invoke_separator") in {".", "-"}:
+            return entry["invoke_separator"]
     return "."
 
 

--- a/scripts/python/common.py
+++ b/scripts/python/common.py
@@ -259,7 +259,7 @@ def get_invoke_separator(repo_root: Path) -> str:
     if not integration_json.is_file():
         return "."
     # Split the parse out of the lookup and guard the top-level shape, matching
-    # read_feature_json_feature_directory below and the bash/PowerShell twins,
+    # read_feature_json_feature_directory above and the bash/PowerShell twins,
     # which both fall back to "." for any unusable integration.json:
     #   * a non-mapping top level ([], "forge", 42, null) is valid JSON, so
     #     json.JSONDecodeError never fires and state.get(...) raised

--- a/tests/test_check_prerequisites_python_parity.py
+++ b/tests/test_check_prerequisites_python_parity.py
@@ -370,3 +370,69 @@ def test_python_branch_falls_back_to_feature_dir_basename(prereq_repo: Path) -> 
 
     assert py.returncode == 0, py.stderr
     assert _json_stdout(py)["BRANCH"] == "001-my-feature"
+
+
+class TestGetInvokeSeparatorTolerance:
+    """`get_invoke_separator` must fall back to "." for an unusable
+    `integration.json`, matching its bash and PowerShell twins.
+
+    The bash twin tries jq -> python3 -> awk and keeps its `separator="."`
+    default on any parse failure; the PowerShell twin likewise returns ".".
+    The Python twin instead indexed the parsed value directly, so two shapes
+    escaped its `except (OSError, json.JSONDecodeError)`:
+
+      * a non-mapping top level (`[]`, `"forge"`, `42`, `null`) is valid JSON,
+        so JSONDecodeError never fires and `.get()` raised AttributeError;
+      * a non-UTF-8 file raises UnicodeDecodeError -- a ValueError, not an
+        OSError. Realistic on Windows, where PowerShell 5.1's `Out-File`/`>`
+        default to UTF-16.
+
+    The sibling `read_feature_json_feature_directory` in the same module
+    already guards both.
+    """
+
+    @staticmethod
+    def _load_common():
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("_speckit_common_py", COMMON_PY)
+        module = importlib.util.module_from_spec(spec)
+        # Register before exec: the module defines @dataclass types, and
+        # dataclasses resolves cls.__module__ through sys.modules.
+        sys.modules[spec.name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:  # pragma: no cover - defensive cleanup
+            sys.modules.pop(spec.name, None)
+            raise
+        return module
+
+    def _repo(self, tmp_path: Path, body: str | bytes) -> Path:
+        (tmp_path / ".specify").mkdir(parents=True, exist_ok=True)
+        target = tmp_path / ".specify" / "integration.json"
+        if isinstance(body, bytes):
+            target.write_bytes(body)
+        else:
+            target.write_text(body, encoding="utf-8")
+        return tmp_path
+
+    @pytest.mark.parametrize(
+        "body", ["[]", '[{"a": 1}]', '"forge"', "42", "true", "null"]
+    )
+    def test_non_mapping_integration_json_falls_back(self, tmp_path: Path, body: str):
+        common = self._load_common()
+        assert common.get_invoke_separator(self._repo(tmp_path, body)) == "."
+
+    def test_non_utf8_integration_json_falls_back(self, tmp_path: Path):
+        common = self._load_common()
+        raw = '{"default_integration": "forge"}'.encode("utf-16")
+        assert common.get_invoke_separator(self._repo(tmp_path, raw)) == "."
+
+    def test_hyphen_separator_is_still_honoured(self, tmp_path: Path):
+        """Regression guard: the real feature must keep working."""
+        common = self._load_common()
+        body = json.dumps({
+            "default_integration": "droid",
+            "integration_settings": {"droid": {"invoke_separator": "-"}},
+        })
+        assert common.get_invoke_separator(self._repo(tmp_path, body)) == "-"


### PR DESCRIPTION
## Problem

`get_invoke_separator()` in `scripts/python/common.py` indexes the parsed JSON directly:

```python
state = json.loads(integration_json.read_text(encoding="utf-8"))
key = state.get("default_integration") or state.get("integration") or ""   # AttributeError
...
except (OSError, json.JSONDecodeError):    # covers neither escape below
    pass
```

Two shapes escape that tuple, while **both** of its twins fall back to `"."`:

1. **A non-mapping top level** (`[]`, `"forge"`, `42`, `true`, `null`) is *valid JSON*, so `json.JSONDecodeError` never fires and `.get()` raises `AttributeError`.
2. **A non-UTF-8 file** raises `UnicodeDecodeError` — a `ValueError`, **not** an `OSError`. Realistic on Windows, where PowerShell 5.1's `Out-File` / `>` default to **UTF-16**.

Measured on `main` — the Python helper crashed on 6 of 7 inputs while bash and PowerShell 5.1 (tested natively) returned `"."` for every one:

| `.specify/integration.json` | python | bash | pwsh 5.1 |
| --- | --- | --- | --- |
| `{"default_integration":"forge"}` | `'.'` | `.` | `.` |
| `[]` | **AttributeError** | `.` | `.` |
| `[{"a":1}]` | **AttributeError** | `.` | `.` |
| `"forge"` | **AttributeError** | `.` | `.` |
| `42` | **AttributeError** | `.` | `.` |
| `null` | **AttributeError** | `.` | `.` |
| UTF-16 file | **UnicodeDecodeError** | `.` | `.` |

The bash twin keeps its `separator="."` default when jq → python3 → awk all fail to parse; the PowerShell twin likewise returns `"."`.

## Fix

Split the parse out of the lookup, complete the exception tuple, and guard the top-level shape — matching **`read_feature_json_feature_directory` in this same module**, which already does exactly this:

```python
try:
    state = json.loads(integration_json.read_text(encoding="utf-8"))
except (OSError, UnicodeError, json.JSONDecodeError):
    return "."
if not isinstance(state, dict):
    return "."
```

So this makes `get_invoke_separator` consistent both with its cross-language twins **and** with its neighbour in the same file — it was the odd one out.

## Verification

- New `TestGetInvokeSeparatorTolerance`: 6 parametrized non-mapping shapes + the UTF-16 case → **7 fail before**, pass after.
- `test_hyphen_separator_is_still_honoured` — regression guard that the real feature (`invoke_separator: "-"` for e.g. droid/forge) keeps working; passes before *and* after.
- `tests/test_check_prerequisites_python_parity.py`: **19 passed, 8 skipped** (the skips are the pre-existing bash/pwsh legs gated off on this machine; baseline was 11 passed, 8 skipped).
- Tests are plain unit tests (no bash/pwsh gating), so they run on every CI platform.
- `uvx ruff@0.15.0 check src tests scripts` clean.

No behaviour change for a well-formed `integration.json`: every path that previously returned a value is byte-for-byte identical.

---
*AI-assisted: authored with Claude Code. I measured all three implementations side by side (PowerShell 5.1 natively on Windows) before writing the fix, and matched the guard style already present in the same module.*