### PR TITLE
fix(bundler): treat an explicit-null manifest field as missing, not the text "None"

### DIFF
--- a/src/specify_cli/bundler/models/manifest.py
+++ b/src/specify_cli/bundler/models/manifest.py
@@ -96,19 +96,19 @@ class BundleManifest:
         if not isinstance(data, dict):
             raise BundlerError("Manifest must be a YAML mapping at the top level.")
 
-        schema_version = str(data.get("schema_version", "")).strip()
+        schema_version = _text(data.get("schema_version"))
 
         bundle_raw = data.get("bundle")
         if not isinstance(bundle_raw, dict):
             raise BundlerError("Manifest is missing the required 'bundle' mapping.")
         meta = BundleMeta(
-            id=str(bundle_raw.get("id", "")).strip(),
-            name=str(bundle_raw.get("name", "")).strip(),
-            version=str(bundle_raw.get("version", "")).strip(),
-            role=str(bundle_raw.get("role", "")).strip(),
-            description=str(bundle_raw.get("description", "")).strip(),
-            author=str(bundle_raw.get("author", "")).strip(),
-            license=str(bundle_raw.get("license", "")).strip(),
+            id=_text(bundle_raw.get("id")),
+            name=_text(bundle_raw.get("name")),
+            version=_text(bundle_raw.get("version")),
+            role=_text(bundle_raw.get("role")),
+            description=_text(bundle_raw.get("description")),
+            author=_text(bundle_raw.get("author")),
+            license=_text(bundle_raw.get("license")),
         )
 
         requires_raw = data.get("requires")
@@ -117,7 +117,7 @@ class BundleManifest:
         elif not isinstance(requires_raw, dict):
             raise BundlerError("'requires' must be a mapping when present.")
         requires = Requires(
-            speckit_version=str(requires_raw.get("speckit_version", "")).strip(),
+            speckit_version=_text(requires_raw.get("speckit_version")),
             tools=_parse_str_list(requires_raw.get("tools"), "requires.tools"),
             mcp=_parse_str_list(requires_raw.get("mcp"), "requires.mcp"),
         )
@@ -220,6 +220,22 @@ class BundleManifest:
         return self.integration is None
 
 
+def _text(raw: Any) -> str:
+    """Coerce a manifest scalar into stripped text, mapping an explicit null to ``""``.
+
+    A ``.get(key, "")`` default only covers a *missing* key. A key that is
+    present but null -- how YAML spells an empty field (``author:`` with nothing
+    after it) -- yields ``None``, and ``str(None)`` is the literal ``"None"``.
+    That text is non-empty, so it sailed past the ``if not value`` required-field
+    checks in :meth:`BundleManifest.structural_errors`: an empty required field
+    was silently accepted and the bundle shipped ``"None"`` as its
+    author/license/description.
+    """
+    if raw is None:
+        return ""
+    return str(raw).strip()
+
+
 def _parse_str_list(raw: Any, field_name: str) -> tuple[str, ...]:
     """Coerce a manifest list-of-strings field into a tuple of strings.
 
@@ -247,7 +263,7 @@ def _parse_refs(kind: str, raw: Any) -> list[ComponentRef]:
         refs.append(
             ComponentRef(
                 kind=kind,
-                id=str(item.get("id", "")).strip(),
+                id=_text(item.get("id")),
                 version=(str(item["version"]).strip() if item.get("version") else None),
                 source=(str(item["source"]).strip() if item.get("source") else None),
                 priority=priority,

--- a/tests/contract/test_manifest_schema.py
+++ b/tests/contract/test_manifest_schema.py
@@ -26,6 +26,45 @@ def test_missing_required_field_is_reported_by_name():
     assert any("bundle.license" in e for e in errors)
 
 
+@pytest.mark.parametrize(
+    "field", ["name", "role", "description", "author", "license"]
+)
+def test_explicit_null_bundle_field_is_reported_as_missing(field):
+    """A field present but null is how YAML spells an empty value (`author:`).
+
+    `str(None)` is the literal text "None", which is non-empty, so it passed the
+    required-field checks: the bundle validated clean and shipped "None" as its
+    author/license/description.
+    """
+    data = valid_manifest_dict()
+    data["bundle"][field] = None
+    manifest = BundleManifest.from_dict(data)
+    assert getattr(manifest.bundle, field) == ""
+    assert any(f"bundle.{field}" in e for e in manifest.structural_errors())
+
+
+def test_explicit_null_speckit_version_is_reported_as_missing():
+    data = valid_manifest_dict()
+    data["requires"]["speckit_version"] = None
+    manifest = BundleManifest.from_dict(data)
+    assert manifest.requires.speckit_version == ""
+    assert any("speckit_version" in e for e in manifest.structural_errors())
+
+
+def test_explicit_null_component_id_is_not_named_none():
+    """A null component id must not become a component literally named "None"."""
+    data = valid_manifest_dict()
+    for kind, items in (data.get("provides") or {}).items():
+        if isinstance(items, list) and items and isinstance(items[0], dict):
+            items[0]["id"] = None
+            break
+    else:  # pragma: no cover - fixture is expected to provide components
+        pytest.skip("fixture has no component list to null out")
+    manifest = BundleManifest.from_dict(data)
+    assert manifest.components, "fixture is expected to declare components"
+    assert all(ref.id != "None" for ref in manifest.components)
+
+
 def test_unsupported_schema_version_is_rejected():
     data = valid_manifest_dict(schema_version="9.9")
     errors = BundleManifest.from_dict(data).structural_errors()


### PR DESCRIPTION
## Problem

`BundleManifest.from_dict` reads every required scalar as `str(raw.get(key, "")).strip()`. The `""` default only covers a **missing** key. A key that is *present but null* — exactly how YAML spells an empty field — yields `None`, and `str(None)` is the literal string `"None"`. That value is non-empty, so it sails straight past the `if not value` required-field checks in `structural_errors()`.

```yaml
bundle:
  id: demo
  name: Demo
  version: 1.0.0
  role: developer
  description:      # <- empty
  author:           # <- empty
  license:          # <- empty
```

Reproduced on `main`:

```
description='None'   author='None'   license='None'
structural_errors() == []
specify bundle validate -> exit 0: "demo is well-formed and valid."
```

So an empty required field is **silently accepted**, and the bundle ships the literal text `"None"` as its author/license/description — which is what `bundle info` and a catalog entry then display to users. A null `provides.<kind>[].id` likewise became a component literally named `"None"`.

## Fix

Add a `_text()` helper beside the existing `_parse_str_list` — matching this file's established "one coercion helper, applied at every site" shape — that maps an explicit null to `""`, and route the required scalars (`schema_version`, the six `bundle.*` fields, `requires.speckit_version`, component `id`) through it.

After:

```
description=''  author=''
structural_errors():
  - Missing required field: bundle.description.
  - Missing required field: bundle.author.
  - Missing required field: bundle.license.
```

This is the same silent-acceptance class as the already-merged guards in this exact function — #3629 (present-but-non-mapping `integration:` was silently dropped) and #3661 (falsy non-mapping `requires`/`provides`).

## Not a behaviour change for valid input

`_text` is equivalent to the code it replaces for every input except an explicit `None`: an absent key already produced `""`, and non-null scalars are still `str()`-coerced and stripped. Verified — a valid manifest still yields `structural_errors() == []` with `author='Ali'`.

## Verification

- `test_explicit_null_bundle_field_is_reported_as_missing` (5 parametrized fields) + null `speckit_version` + null component id: **7 fail before**, pass after.
- `tests/contract/test_manifest_schema.py`: **35 passed** (28 pre-existing untouched).
- `tests/contract/` + `tests/unit/`: **272 passed** — the 3 remaining failures are pre-existing Windows symlink-privilege tests (need admin; pass on CI's Linux/macOS runners).
- `uvx ruff@0.15.0 check src tests` clean.

---
*AI-assisted: authored with Claude Code. I reproduced the `"None"` values and the clean `bundle validate` on `main` first, then confirmed valid manifests are unaffected after the change.*