### PR TITLE
fix(agents): coerce a non-string description in TOML command rendering

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -302,8 +302,20 @@ class CommandRegistrar:
         toml_lines = []
 
         if "description" in frontmatter:
+            # Frontmatter comes from ``yaml.safe_load``, so ``description`` can
+            # be any YAML type: ``description:`` with no value yields None,
+            # ``description: 2`` an int, an unquoted ``true`` a bool.
+            # ``_render_basic_toml_string`` iterates the value and calls ord()
+            # on each character, so a non-string raises a raw TypeError -- and a
+            # list of single-character items is silently concatenated into a
+            # wrong value (``["a", "b"]`` -> ``"ab"``). Coerce first, matching
+            # ``render_yaml_command`` below and ``TomlIntegration
+            # ._extract_description``, which both normalise it already.
+            description = frontmatter["description"]
+            if not isinstance(description, str):
+                description = str(description) if description is not None else ""
             toml_lines.append(
-                f"description = {self._render_basic_toml_string(frontmatter['description'])}"
+                f"description = {self._render_basic_toml_string(description)}"
             )
             toml_lines.append("")
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -2662,6 +2662,36 @@ Real body starts here.
 
         assert parsed["description"] == "first line\nsecond line\n"
 
+    @pytest.mark.parametrize(
+        ("description", "expected"),
+        [
+            (None, ""),                    # "description:" with no value
+            (42, "42"),                    # unquoted number
+            (True, "True"),                # unquoted boolean
+            (["a", "b"], "['a', 'b']"),    # was silently concatenated to "ab"
+        ],
+    )
+    def test_render_toml_command_coerces_non_string_description(
+        self, description, expected
+    ):
+        """Frontmatter comes from yaml.safe_load, so description can be any type.
+
+        _render_basic_toml_string iterates the value and calls ord() per
+        character, so a non-string raised a raw TypeError and a list of
+        single-character items was silently concatenated into a wrong value.
+        render_yaml_command (same class) already coerces; this brings the TOML
+        branch to parity.
+        """
+        from specify_cli.agents import CommandRegistrar as AgentCommandRegistrar
+
+        registrar = AgentCommandRegistrar()
+        output = registrar.render_toml_command(
+            {"description": description}, "body", "extension:test-ext"
+        )
+
+        parsed = tomllib.loads(output)
+        assert parsed["description"] == expected
+
     def test_render_toml_command_escapes_control_characters(self):
         """Control characters and a lone CR must be escaped so the TOML parses.
 


### PR DESCRIPTION
## Problem

`CommandRegistrar.render_toml_command` passes the raw frontmatter `description` straight into `_render_basic_toml_string`, which iterates the value and calls `ord()` on each character. Frontmatter comes from `yaml.safe_load`, so `description` can be any YAML type:

```
description='ok string'  ->  description = "ok string"
description=None         ->  TypeError: 'NoneType' object is not iterable
description=42           ->  TypeError: 'int' object is not iterable
description=True         ->  TypeError: 'bool' object is not iterable
description=['a','b']    ->  description = "ab"        <- silently WRONG value
```

`description:` with no value is the easy one to hit — plain YAML for an empty field.

## Format-branch asymmetry

This is the **only** renderer reached from `register_commands`' format branches that does not normalise `description`:

| branch | handling |
| --- | --- |
| `render_yaml_command` (same class, ~70 lines below) | already coerces: `if not isinstance(description, str): description = str(description) if description is not None else ""` |
| `render_markdown_command` | goes through `yaml.dump`, which handles any type |
| built-in gemini/tabnine template path (`TomlIntegration._extract_description`) | returns `""` for a non-str |
| **`render_toml_command`** | **no guard** |

So extension/preset commands rendered for the two TOML agents were the only ones affected.

## Fix

Apply the same coercion the sibling already uses. After:

```
None       -> description = ""
42         -> description = "42"
True       -> description = "True"
['a','b']  -> description = "['a', 'b']"
1.5        -> description = "1.5"
```

Each still parses as valid TOML (asserted via `tomllib.loads`). String descriptions are untouched, so existing output is byte-identical.

## Verification

- `test_render_toml_command_coerces_non_string_description` — 4 parametrized types, asserted through `tomllib.loads`: **all 4 fail before** this change, pass after.
- The 7 pre-existing `test_render_toml_command_*` tests (embedded triple quotes, multiline, control characters, backslashes, trailing backslash) all still pass — **11 passed** together.
- `uvx ruff@0.15.0 check src tests` clean.

---
*AI-assisted: authored with Claude Code. I reproduced each failure mode through the real renderer on `main`, including the silent `['a','b'] -> "ab"` mangling, and confirmed the sibling YAML branch already handled all three before mirroring it.*