### PR TITLE
fix(cli): render the literal `[suffix]` in `--tag` help and rejection message

### DIFF
--- a/src/specify_cli/_version.py
+++ b/src/specify_cli/_version.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import typer
 from packaging.version import InvalidVersion, Version
+from rich.markup import escape as _escape_markup
 
 from ._download_security import MAX_JSON_METADATA_BYTES, read_response_limited
 from ._console import console
@@ -1230,7 +1231,10 @@ def self_upgrade(
     tag: str | None = typer.Option(
         None,
         "--tag",
-        help="Pin the target version (vX.Y.Z[suffix]). Without --tag, the "
+        # Typer renders help through Rich, so escape the literal bracket (\[)
+        # or `[suffix]` is parsed as a style tag and dropped -- `--help` then
+        # advertises only `(vX.Y.Z)`, contradicting docs/upgrade.md and README.
+        help="Pin the target version (vX.Y.Z\\[suffix]). Without --tag, the "
         "latest stable release is resolved via GitHub Releases.",
     ),
 ) -> None:
@@ -1270,7 +1274,14 @@ def self_upgrade(
         try:
             tag = _validate_tag(tag)
         except typer.BadParameter as exc:
-            console.print(str(exc), soft_wrap=True)
+            # Escape at the print site rather than baking `\[` into
+            # _INVALID_TAG_MESSAGE: the message is also raised through
+            # typer.BadParameter, which Click renders without Rich, so the
+            # constant must stay plain text. Unescaped, Rich parses the literal
+            # `[suffix]` as a style tag and drops it, leaving the user with
+            # "expected vMAJOR.MINOR.PATCH" -- implying a bare vX.Y.Z is the only
+            # accepted form when -rc1 / .dev0 / +build.42 are all valid.
+            console.print(_escape_markup(str(exc)), soft_wrap=True)
             raise typer.Exit(1) from exc
 
     plan, failure_reason = _build_upgrade_plan(target_tag_override=tag)

--- a/tests/test_self_upgrade_verification.py
+++ b/tests/test_self_upgrade_verification.py
@@ -472,6 +472,26 @@ class TestTagValidation:
         output = strip_ansi(result.output)
         assert "Invalid --tag" in output or "expected vMAJOR.MINOR.PATCH" in output
 
+    def test_rejection_message_keeps_the_suffix_token(
+        self, uv_tool_argv0, clean_environ
+    ):
+        """Rich must not swallow the literal `[suffix]`.
+
+        Unescaped it is parsed as a style tag and dropped, so the user is told
+        only "expected vMAJOR.MINOR.PATCH" -- implying a bare vX.Y.Z is the only
+        accepted form, when -rc1 / .dev0 / +build.42 are all valid and are
+        documented as such in docs/upgrade.md and README.md.
+        """
+        result = runner.invoke(app, ["self", "upgrade", "--tag", "latest"])
+        assert result.exit_code == 1
+        assert "expected vMAJOR.MINOR.PATCH[suffix]" in strip_ansi(result.output)
+
+    def test_tag_option_help_keeps_the_suffix_token(self):
+        """Typer renders option help through Rich, so `--help` dropped it too."""
+        result = runner.invoke(app, ["self", "upgrade", "--help"])
+        assert result.exit_code == 0
+        assert "[suffix]" in strip_ansi(result.output)
+
 
 class TestUnknownCurrent:
     """'unknown' current version renders literally in notice and success message."""


### PR DESCRIPTION
## Problem

Both places a user learns the `specify self upgrade --tag` syntax silently drop the `[suffix]` token, because Rich parses the literal square brackets as a markup tag and discards them.

**1. The rejection message** (`_INVALID_TAG_MESSAGE`, printed via `console.print(str(exc))`):

```
$ specify self upgrade --tag latest
Invalid --tag: expected vMAJOR.MINOR.PATCH          <- [suffix] gone
```

The constant itself is intact — `'Invalid --tag: expected vMAJOR.MINOR.PATCH[suffix]'` — so Rich is the culprit.

**2. The `--tag` option help** (Typer renders help through the same Rich pipeline):

```
$ specify self upgrade --help
--tag  TEXT  Pin the target version (vX.Y.Z). Without --tag, ...   <- [suffix] gone
```

So the CLI implies a bare `vX.Y.Z` is the **only** accepted form, when `v1.0.0-rc1`, `v0.8.0.dev0` and `v0.8.0+build.42` are all valid — and the shipped docs advertise the suffix in four places (`docs/upgrade.md` ×3, `README.md` ×2). The CLI contradicts its own documentation.

## Fix

- **Rejection message:** escape at the **print site**, not in the constant. `_INVALID_TAG_MESSAGE` is also raised through `typer.BadParameter` (three call sites), which Click renders *without* Rich — baking `\[` into the constant would leak a stray backslash there. So `_INVALID_TAG_MESSAGE` stays byte-identical and the existing assertion on it keeps passing.
- **Option help:** escape the literal bracket (`vX.Y.Z\[suffix]`), since Typer renders it through Rich.

Same literal-bracket class as the existing precedents in `workflows/_commands.py` (`\[disabled]`, `\[<type>]`).

After:

```
Invalid --tag: expected vMAJOR.MINOR.PATCH[suffix]
--tag  TEXT  Pin the target version (vX.Y.Z[suffix]). Without ...
```

## Verification

- `test_rejection_message_keeps_the_suffix_token` and `test_tag_option_help_keeps_the_suffix_token`: **both fail before**, pass after.
- `tests/test_self_upgrade_verification.py`: **42 passed** (40 pre-existing untouched, including `test_invalid_tags_rejected`).
- `uvx ruff@0.15.0 check src tests` clean.

Static CLI text only — no validation semantics change, `_validate_tag` untouched, valid tags behave identically.

---
*AI-assisted: authored with Claude Code. I confirmed the constant was intact and Rich was eating the token (rather than assuming a typo), and checked why escaping belongs at the print site instead of in the shared constant.*