### PR TITLE
fix: correct Optional type annotation for _resolved_dir parameter

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -598,7 +598,7 @@ class CommandRegistrar:
         source_dir: Path,
         project_root: Path,
         context_note: Optional[str] = None,
-        _resolved_dir: Path = None,
+        _resolved_dir: Optional[Path] = None,
         link_outputs: bool = False,
         extension_id: Optional[str] = None,
     ) -> List[str]:


### PR DESCRIPTION
Fix _resolved_dir: Path = None to _resolved_dir: Optional[Path] = None in gents.py:601. Every other nullable parameter in this file correctly uses Optional[...].