### PR TITLE
fix(integrations): don't abort uninstall when the manifest file can't be deleted

### DIFF
--- a/src/specify_cli/integrations/manifest.py
+++ b/src/specify_cli/integrations/manifest.py
@@ -400,7 +400,19 @@ class IntegrationManifest:
         # Remove the manifest file itself
         manifest = root / ".specify" / "integrations" / f"{self.key}.manifest.json"
         if remove_manifest and manifest.exists():
-            manifest.unlink()
+            try:
+                manifest.unlink()
+            except OSError:
+                # An undeletable manifest (read-only file, a directory left at
+                # the path, a Windows lock) must not abort the uninstall after
+                # the tracked files were already removed: the caller would lose
+                # the (removed, skipped) result and never run its post-uninstall
+                # bookkeeping. Report it like any other file we could not
+                # remove, mirroring the path.unlink() guard above. The
+                # empty-parent cleanup below is left unconditional: with the
+                # manifest still on disk its parent is non-empty, so the first
+                # rmdir() raises and breaks immediately.
+                skipped.append(manifest)
             parent = manifest.parent
             while parent != root:
                 try:

--- a/tests/integrations/test_manifest.py
+++ b/tests/integrations/test_manifest.py
@@ -242,6 +242,34 @@ class TestManifestUninstall:
             "remove_manifest=False must keep the manifest file on disk"
         )
 
+    def test_undeletable_manifest_is_skipped_not_raised(self, tmp_path):
+        """An undeletable manifest must not abort the whole uninstall.
+
+        The tracked files are removed *before* the manifest, so raising here
+        loses the ``(removed, skipped)`` result the caller needs: the CLI's
+        post-uninstall bookkeeping (reassigning the default integration,
+        rewriting/removing ``integration.json``, clearing init options) never
+        runs, leaving a removed integration still recorded as installed.
+
+        Leaving a directory at the manifest path is a portable way to make
+        ``unlink()`` fail with no chmod and no monkeypatch: it raises
+        ``IsADirectoryError`` on Linux and ``PermissionError`` on
+        Windows/macOS, both ``OSError`` subclasses.
+        """
+        m = IntegrationManifest("test", tmp_path, version="1.0")
+        m.record_file("f.txt", "content")
+        m.save()
+        m.manifest_path.unlink()
+        m.manifest_path.mkdir()
+
+        removed, skipped = m.uninstall()
+
+        assert removed == [tmp_path / "f.txt"]
+        assert not (tmp_path / "f.txt").exists()
+        assert m.manifest_path in skipped, (
+            "an undeletable manifest must be reported in skipped"
+        )
+
     def test_cleans_empty_parent_dirs(self, tmp_path):
         m = IntegrationManifest("test", tmp_path)
         m.record_file("a/b/c/f.txt", "content")


### PR DESCRIPTION
## Problem

`IntegrationManifest.uninstall()` (`src/specify_cli/integrations/manifest.py`) guards every tracked-file delete:

```python
try:
    path.unlink()
except OSError:
    skipped.append(path)
    continue
```

…but the manifest's own delete is bare:

```python
if remove_manifest and manifest.exists():
    manifest.unlink()          # <-- unguarded
```

The manifest is deleted **last**, after every tracked file is already gone. So an undeletable manifest — a read-only file, a directory left at the path, a Windows lock, an ACL — raises out of `uninstall()` when the destructive work has already happened.

## Why this matters more than a lost return value

The caller doesn't just lose `(removed, skipped)`. Everything after the call is skipped (`integrations/_install_commands.py:282`):

- reassigning the default integration when the removed one was default
- `_write_integration_json(...)` / `_remove_integration_json(...)`
- `_clear_init_options_for_integration(...)`

So the files are gone but `integration.json` still records the integration as installed — and possibly still as the default. The project is left in a state the CLI can't reach again through `uninstall`.

## Reproduction on current `main` (2e44ed6)

Leaving a directory at the manifest path (portable, no chmod, no monkeypatch):

```
manifest saved: True | tracked file: True
manifest path is now a directory: True
uninstall() RAISED PermissionError: [WinError 5] Access is denied: ...test.manifest.json
  tracked file deleted anyway? True   <-- work done, but caller lost (removed, skipped)
```

After the fix, same harness:

```
uninstall() -> removed=1 skipped=1  (no crash)
```

## Fix

+13/-1 in one source file — guard it like its sibling:

```python
try:
    manifest.unlink()
except OSError:
    skipped.append(manifest)
```

The empty-parent cleanup below is deliberately left **unconditional** rather than moved into an `else:`. With the manifest still on disk its parent is non-empty, so the first `rmdir()` raises and breaks immediately — an `else:` would be behaviourally identical while re-indenting 8 lines for no reason. I mention it so the omission reads as a decision, not an oversight.

## Precedent

- The tracked-file `path.unlink()` guard in this same function is the pattern being mirrored — the `_sha256` guard added by merged **#3376** points at it explicitly: *"(mirrors the path.unlink() OSError guard below)"*. #3376 hardened this function against `OSError` from managed files but left the manifest unlink bare.
- `integrations/kimi/__init__.py:151` already does `except OSError: skipped.append(legacy_dir)` for an undeletable legacy **directory**.

## Anticipating one review question

The CLI renders `skipped` under a header along the lines of *"N modified file(s) were preserved"*, and an undeletable manifest isn't "modified". I still think `skipped` is right: the docstring commits only to `` `(removed, skipped)` — absolute paths``, and kimi already puts undeletable directories there. The alternative — a third return value — would be a signature change to a public method for a rare I/O error. Happy to adjust the CLI wording in a follow-up if you'd rather the header were broader.

## Verification

- **Fail-before / pass-after:** the new test raises `PermissionError: [WinError 5]` on unpatched `src` and passes with the fix.
- `tests/integrations/test_manifest.py` → **48 passed, 6 failed**; the *same 6* fail on clean `main` (`2e44ed6`) with **47 passed** — all six are Windows symlink-privilege tests (`test_rejects_symlink_target`, `test_symlink_removed_with_force`, …), unrelated to this change. Delta is exactly my one new passing test.
- `tests/integrations/` → 2253 passed, 19 skipped; failures identical to baseline.
- `uvx ruff@0.15.0 check` → clean

The new test needs no chmod and no monkeypatch: `Path.unlink()` on a directory raises `IsADirectoryError` on Linux and `PermissionError` on Windows/macOS — both `OSError` subclasses, so it exercises the guard on every CI platform.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`; every number above is from output I ran.*