### PR TITLE
fix(presets): escape user-supplied catalog name/URL in `preset catalog add`/`remove` output

### DIFF
--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -662,10 +662,15 @@ def preset_catalog_add(
         console.print("[red]Error:[/red] Invalid catalog config: 'catalogs' must be a list.")
         raise typer.Exit(1)
 
+    # Only rendering is escaped — the raw values are what get persisted and
+    # compared below, so a name containing markup still round-trips exactly.
+    safe_name = _escape_markup(str(name))
+    safe_url = _escape_markup(str(url))
+
     # Check for duplicate name
     for existing in catalogs:
         if isinstance(existing, dict) and existing.get("name") == name:
-            console.print(f"[yellow]Warning:[/yellow] A catalog named '{name}' already exists.")
+            console.print(f"[yellow]Warning:[/yellow] A catalog named '{safe_name}' already exists.")
             console.print("Use 'specify preset catalog remove' first, or choose a different name.")
             raise typer.Exit(1)
 
@@ -681,10 +686,11 @@ def preset_catalog_add(
     config_path.write_text(yaml.safe_dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True), encoding="utf-8")
 
     install_label = "install allowed" if install_allowed else "discovery only"
-    console.print(f"\n[green]✓[/green] Added catalog '[bold]{name}[/bold]' ({install_label})")
-    console.print(f"  URL: {url}")
+    console.print(f"\n[green]✓[/green] Added catalog '[bold]{safe_name}[/bold]' ({install_label})")
+    console.print(f"  URL: {safe_url}")
     console.print(f"  Priority: {priority}")
-    console.print(f"\nConfig saved to {_display_project_path(project_root, config_path)}")
+    config_label = _escape_markup(str(_display_project_path(project_root, config_path)))
+    console.print(f"\nConfig saved to {config_label}")
 
 
 @preset_catalog_app.command("remove")
@@ -712,17 +718,20 @@ def preset_catalog_remove(
     if not isinstance(catalogs, list):
         console.print("[red]Error:[/red] Invalid catalog config: 'catalogs' must be a list.")
         raise typer.Exit(1)
+    # Rendering only — the raw name drives the comparison below.
+    safe_name = _escape_markup(str(name))
+
     original_count = len(catalogs)
     catalogs = [c for c in catalogs if isinstance(c, dict) and c.get("name") != name]
 
     if len(catalogs) == original_count:
-        console.print(f"[red]Error:[/red] Catalog '{name}' not found.")
+        console.print(f"[red]Error:[/red] Catalog '{safe_name}' not found.")
         raise typer.Exit(1)
 
     config["catalogs"] = catalogs
     config_path.write_text(yaml.safe_dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True), encoding="utf-8")
 
-    console.print(f"[green]✓[/green] Removed catalog '{name}'")
+    console.print(f"[green]✓[/green] Removed catalog '{safe_name}'")
     if not catalogs:
         console.print("\n[dim]No catalogs remain in config. Built-in defaults will be used.[/dim]")
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -2787,6 +2787,80 @@ class TestPresetCatalogMultiCatalog:
         assert "https://example.com/[cat].json" in result.output
         assert "desc [with] brackets" in result.output
 
+    def test_catalog_add_escapes_rich_markup(self, project_dir):
+        """`preset catalog add` must not parse the name/url as Rich markup.
+
+        An unbalanced closing tag raised MarkupError *after* the entry was
+        already written to preset-catalogs.yml, so the user saw a traceback
+        and no confirmation for a catalog that had in fact been added.
+        """
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        name = "[/red]my-catalog"
+        url = "https://example.com/[bold]c.json"
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir):
+            result = runner.invoke(
+                app, ["preset", "catalog", "add", url, "--name", name]
+            )
+        assert result.exit_code == 0, result.output
+        # Rendered verbatim, not swallowed as markup.
+        assert name in result.output
+        assert url in result.output
+        # Only rendering is escaped: the raw values still round-trip to disk.
+        config = yaml.safe_load(
+            (project_dir / ".specify" / "preset-catalogs.yml").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert config["catalogs"][0]["name"] == name
+        assert config["catalogs"][0]["url"] == url
+
+    def test_catalog_remove_escapes_rich_markup(self, project_dir):
+        """`preset catalog remove` must not parse the name as Rich markup."""
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        name = "[/red]my-catalog"
+        (project_dir / ".specify" / "preset-catalogs.yml").write_text(
+            yaml.dump({
+                "catalogs": [
+                    {
+                        "name": name,
+                        "url": "https://example.com/c.json",
+                        "priority": 1,
+                        "install_allowed": False,
+                    }
+                ]
+            }),
+            encoding="utf-8",
+        )
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir):
+            result = runner.invoke(app, ["preset", "catalog", "remove", name])
+        assert result.exit_code == 0, result.output
+        assert name in result.output
+
+    def test_catalog_remove_escapes_markup_in_not_found_error(self, project_dir):
+        """The not-found error path renders the name too."""
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        (project_dir / ".specify" / "preset-catalogs.yml").write_text(
+            yaml.dump({"catalogs": []}), encoding="utf-8"
+        )
+        runner = CliRunner()
+        with patch.object(Path, "cwd", return_value=project_dir):
+            result = runner.invoke(
+                app, ["preset", "catalog", "remove", "[/red]absent"]
+            )
+        assert result.exit_code == 1
+        assert "[/red]absent" in result.output
+
     def test_env_var_overrides_catalogs(self, project_dir, monkeypatch):
         """Test that SPECKIT_PRESET_CATALOG_URL env var overrides defaults."""
         monkeypatch.setenv(


### PR DESCRIPTION
## Problem

`preset_catalog_add` and `preset_catalog_remove` interpolate the raw `--name` and URL straight into `console.print()`, so Rich parses user input as markup. Two distinct failure modes, both reproduced on current `main` (2e44ed6):

**1. Silent misreporting** — the markup is consumed, so the reported name isn't the persisted name:

```
name='[bold red]pwned[/]'
  add -> exit 0
    "Added catalog 'pwned' (discovery only)"      <-- reports 'pwned'
```

The YAML records `[bold red]pwned[/]`. A user who then runs `preset catalog remove pwned` — the only name they were shown — gets "not found".

**2. Unhandled `MarkupError`**, and it fires *after* the config is written:

```
name='safe'  url='https://example.com/[/bold]c.json'
  add -> exit 1
    UNHANDLED MarkupError: closing tag '[/bold]' at position 27 doesn't match any open tag
  rm  -> exit 0
    "Removed catalog 'safe'"                      <-- so it HAD been added
```

The traceback tells the user the command failed. The subsequent successful `remove` proves it succeeded. `remove` crashes the same way on a bracketed name, including on its not-found error path.

## Why this is a gap rather than a design choice

`presets/_commands.py` already imports `_escape_markup` (L16) and already escapes exactly these fields in `preset catalog list` (L589-592), an invariant pinned by the existing `test_catalog_list_escapes_rich_markup` in the same test class. `add`/`remove` were simply missed. This also mirrors the escaping just merged for the integrations twin in #3772.

## Fix

~10 changed lines in one file: `safe_name`/`safe_url` locals used at every render site (duplicate-name warning, the added/removed confirmations, the URL line, the not-found error, and the `Config saved to` label).

**Only rendering changes.** The raw `name` still drives `existing.get("name") == name` and still goes into `preset-catalogs.yml`. One of the new tests asserts that round-trip explicitly:

```python
assert config["catalogs"][0]["name"] == name   # raw, with brackets
assert config["catalogs"][0]["url"] == url
```

After the fix, all three repro cases exit 0 and print the name **verbatim** (`[bold red]pwned[/]`, not `pwned`).

## Test placement

The three new tests go **inside the existing `TestPresetCatalogMultiCatalog` class, directly after `test_catalog_list_escapes_rich_markup`** — the precedent test for this exact invariant.

I chose that deliberately over adding a class at EOF: my own open #3773 appends `class TestPresetCatalogRichMarkup` to this file and #3769 appends there too. A duplicate class name in one module silently shadows the earlier definition — it would have dropped #3773's tests from the run with no error. Placing these mid-file also keeps this PR from colliding with either append.

## Verification

- **Fail-before / pass-after:** all 3 new tests fail on unpatched `src` (`assert '[/red]absent' in ''` where output is empty because of the `MarkupError`) and pass with the fix.
- `tests/test_presets.py` + `tests/integrations/test_cli.py` → failure set is **byte-identical to clean `main`** (7+7, all Windows symlink-privilege tests); passed count 464 → 467, exactly my 3 new tests.
- Two existing tests do assert on this output and both still pass — `test_catalog_config_output_uses_posix_paths` (asserts `Config saved to .specify/preset-catalogs.yml`) and `test_project_scoped_commands_require_specify_directory`, which invokes `preset catalog add`/`remove`. `rich.markup.escape` is a no-op on bracket-free paths.
- `uvx ruff@0.15.0 check` → clean

## Note

`PresetCatalog._validate_catalog_url` is a standalone class rather than a `CatalogStackBase` subclass, so nothing here changes validation behaviour — this PR is display-only.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`; every output above is from runs I did.*