### PR TITLE
test(workflows): name the condition-rejection tests for the real boundary

### DIFF
--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2491,7 +2491,7 @@ class TestIfThenStep:
         assert any("missing 'condition'" in e for e in errors)
 
     @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, 1.5])
-    def test_validate_rejects_non_string_condition(self, bad):
+    def test_validate_rejects_non_string_non_bool_condition(self, bad):
         # A list/dict/number condition is returned unchanged by
         # evaluate_expression, and evaluate_condition then bool()-coerces it, so
         # it silently resolves to its truthiness (e.g. [1, 2] is always True)
@@ -2908,7 +2908,7 @@ class TestWhileStep:
         # max_iterations is optional (defaults to 10)
 
     @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, 1.5])
-    def test_validate_rejects_non_string_condition(self, bad):
+    def test_validate_rejects_non_string_non_bool_condition(self, bad):
         from specify_cli.workflows.steps.while_loop import WhileStep
 
         step = WhileStep()
@@ -3040,7 +3040,7 @@ class TestDoWhileStep:
         # max_iterations is optional (defaults to 10)
 
     @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, 1.5])
-    def test_validate_rejects_non_string_condition(self, bad):
+    def test_validate_rejects_non_string_non_bool_condition(self, bad):
         from specify_cli.workflows.steps.do_while import DoWhileStep
 
         step = DoWhileStep()


### PR DESCRIPTION
Small follow-up to #3706 (merged in a9c9905), addressing the last Copilot note on it. Test names only — no behaviour change.

## Problem

#3706 landed a pair of tests in each of the three conditional step classes, and their names contradict each other:

```python
def test_validate_rejects_non_string_condition(self, bad):        # [["a","b"], {"k":"v"}, 5, 1.5]
def test_validate_accepts_string_or_bool_condition(self, good):   # ["true", "false", "{{ ... }}", True, False]
```

A bool *is* a non-string, so the first name claims something the second one disproves. Copilot flagged exactly this on #3706 (three suppressed low-confidence notes on `tests/test_workflows.py`), but the review landed close to the merge, so it wasn't picked up:

> This name says every non-string value is rejected, but the adjacent contract test verifies that booleans are accepted. Rename it to describe the actual non-string/non-boolean boundary so test reports do not contradict the behavior.

That's my leftover: when I updated the contract to accept booleans I renamed the *acceptance* test and missed its sibling.

## Fix

```
test_validate_rejects_non_string_condition
  -> test_validate_rejects_non_string_non_bool_condition
```

in `TestIfThenStep`, `TestWhileStep` and `TestDoWhileStep` — matching the validator's own message, `'condition' must be a string or boolean, got <type>`.

**3 insertions, 3 deletions, one file.** Parametrized values untouched; no source changes.

## Why it's worth a PR

The names appear in every test report and in `-k` selections, so `rejects_non_string` reads as a contract the code deliberately does not implement — accepting `bool` is intentional (`condition: false` resolves correctly today, and two of the three steps default `condition` to the bool `False` themselves, so rejecting it would be a breaking change).

## Verification

- 38 condition tests pass
- `uvx ruff@0.15.0 check src tests` → clean
- Branched from current `main` (a9c9905)

---
*Written with assistance from Claude Code.*