### PR TITLE
fix: add missing utf-8 encoding to registry file open calls

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -523,7 +523,7 @@ class ExtensionRegistry:
             return {"schema_version": self.SCHEMA_VERSION, "extensions": {}}
 
         try:
-            with open(self.registry_path, "r") as f:
+            with open(self.registry_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
             # Validate loaded data is a dict (handles corrupted registry files)
             if not isinstance(data, dict):
@@ -539,7 +539,7 @@ class ExtensionRegistry:
     def _save(self):
         """Save registry to disk."""
         self.extensions_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.registry_path, "w") as f:
+        with open(self.registry_path, "w", encoding="utf-8") as f:
             json.dump(self.data, f, indent=2)
 
     def add(self, extension_id: str, metadata: dict):

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -450,7 +450,7 @@ class PresetRegistry:
             }
 
         try:
-            with open(self.registry_path, 'r') as f:
+            with open(self.registry_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
             # Validate loaded data is a dict (handles corrupted registry files)
             if not isinstance(data, dict):
@@ -471,7 +471,7 @@ class PresetRegistry:
     def _save(self):
         """Save registry to disk."""
         self.packs_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.registry_path, 'w') as f:
+        with open(self.registry_path, 'w', encoding='utf-8') as f:
             json.dump(self.data, f, indent=2)
 
     def add(self, pack_id: str, metadata: dict):


### PR DESCRIPTION
Add encoding='utf-8' to 4 open() calls in extensions/__init__.py (lines 538, 554) and presets/__init__.py (lines 460, 481) that read/write registry JSON files. On Windows with non-UTF-8 locales, these would produce UnicodeDecodeError or corrupted data. The parallel code in workflows/catalog.py already specifies encoding='utf-8' correctly.