### PR TITLE
fix: bound response read in integration catalog fetch

### DIFF
--- a/src/specify_cli/integrations/catalog.py
+++ b/src/specify_cli/integrations/catalog.py
@@ -207,7 +207,7 @@ class IntegrationCatalog(CatalogStackBase):
                         max_bytes=MAX_JSON_METADATA_BYTES,
                         error_type=IntegrationCatalogError,
                         label=f"catalog from {entry.url}",
-                    )
+                    ).decode("utf-8")
                 )
 
             shape_error = _catalog_shape_error(catalog_data)


### PR DESCRIPTION
Replace unbounded esp.read() with ead_response_limited() in integrations/catalog.py to prevent DoS via oversized catalog responses.