### PR TITLE
fix(integrations): preserve non-UTF-8 VS Code settings

### DIFF
--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -497,7 +497,7 @@ class CopilotIntegration(IntegrationBase):
         """
         try:
             existing = json.loads(dst.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
             # Cannot parse existing file (likely JSONC with comments).
             # Skip merge to preserve the user's settings, but show
             # what they should add manually.

--- a/tests/integrations/test_integration_copilot.py
+++ b/tests/integrations/test_integration_copilot.py
@@ -109,6 +109,21 @@ class TestCopilotIntegration:
         assert settings not in created
         assert not any("settings.json" in k for k in m.files)
 
+    def test_setup_preserves_non_utf8_vscode_settings(self, tmp_path, caplog):
+        from specify_cli.integrations.copilot import CopilotIntegration
+        copilot = CopilotIntegration()
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir(parents=True)
+        settings = vscode_dir / "settings.json"
+        original = b'{"editor.fontSize": 14}\xff'
+        settings.write_bytes(original)
+        m = IntegrationManifest("copilot", tmp_path)
+
+        copilot.setup(tmp_path, m)
+
+        assert settings.read_bytes() == original
+        assert "Could not parse" in caplog.text
+
     def test_all_created_files_tracked_in_manifest(self, tmp_path):
         from specify_cli.integrations.copilot import CopilotIntegration
         copilot = CopilotIntegration()


### PR DESCRIPTION
Fixes #3831

A non-UTF-8 `.vscode/settings.json` escapes the existing parse-failure fallback and aborts setup. This handles decode errors through the same preservation path used for malformed JSON, leaving the file unchanged and showing the manual settings guidance.

The regression test covers setup with non-UTF-8 settings.