### PR TITLE
fix: add utf-8 encoding to extension and preset registry file I/O

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -535,7 +535,7 @@ class ExtensionRegistry:
             return {"schema_version": self.SCHEMA_VERSION, "extensions": {}}
 
         try:
-            with open(self.registry_path, "r") as f:
+            with open(self.registry_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
             # Validate loaded data is a dict (handles corrupted registry files)
             if not isinstance(data, dict):
@@ -551,7 +551,7 @@ class ExtensionRegistry:
     def _save(self):
         """Save registry to disk."""
         self.extensions_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.registry_path, "w") as f:
+        with open(self.registry_path, "w", encoding="utf-8") as f:
             json.dump(self.data, f, indent=2)
 
     def add(self, extension_id: str, metadata: dict):

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -481,7 +481,7 @@ class PresetRegistry:
             }
 
         try:
-            with open(self.registry_path, 'r') as f:
+            with open(self.registry_path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
             # Validate loaded data is a dict (handles corrupted registry files)
             if not isinstance(data, dict):
@@ -502,7 +502,7 @@ class PresetRegistry:
     def _save(self):
         """Save registry to disk."""
         self.packs_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.registry_path, 'w') as f:
+        with open(self.registry_path, 'w', encoding='utf-8') as f:
             json.dump(self.data, f, indent=2)
 
     def add(self, pack_id: str, metadata: dict):


### PR DESCRIPTION
## Summary

Add explicit `encoding='utf-8'` to extension and preset registry file I/O to prevent corruption on non-UTF-8 Windows locales.

## Changes

- `extensions/__init__.py`: Added `encoding='utf-8'` to registry read/write
- `presets/__init__.py`: Added `encoding='utf-8'` to registry read/write