### PR TITLE
fix: narrow bare except Exception in version fallback

### DIFF
--- a/src/specify_cli/_assets.py
+++ b/src/specify_cli/_assets.py
@@ -105,7 +105,7 @@ def get_speckit_version() -> str:
     """Get current spec-kit version."""
     try:
         return importlib.metadata.version("specify-cli")
-    except Exception:
+    except importlib.metadata.PackageNotFoundError:
         # Fallback: try reading from pyproject.toml
         try:
             import tomllib
@@ -114,8 +114,6 @@ def get_speckit_version() -> str:
                 with open(pyproject_path, "rb") as f:
                     data = tomllib.load(f)
                     return data.get("project", {}).get("version", "unknown")
-        except Exception:
-            # Intentionally ignore any errors while reading/parsing pyproject.toml.
-            # If this lookup fails for any reason, we fall back to returning "unknown" below.
+        except (OSError, KeyError, ValueError):
             pass
     return "unknown"


### PR DESCRIPTION
## Summary

Replace overly broad `except Exception` with specific exception types in `get_speckit_version()` fallback.

## Changes

- `_assets.py`: Narrow outer exception to `PackageNotFoundError`
- `_assets.py`: Narrow inner exception to `(OSError, KeyError, ValueError)`