### PR TITLE
fix: add JSON error handling to auth config loader

### DIFF
--- a/src/specify_cli/authentication/config.py
+++ b/src/specify_cli/authentication/config.py
@@ -102,7 +102,10 @@ def load_auth_config(
         except OSError:
             pass  # stat failed — skip permission check
 
-    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{config_path} contains invalid JSON: {exc}") from exc
 
     if not isinstance(raw, dict):
         raise ValueError(f"auth.json must be a JSON object, got {type(raw).__name__}")

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -205,7 +205,7 @@ class TestLoadAuthConfig:
     def test_invalid_json_raises(self, tmp_path):
         cfg = tmp_path / "auth.json"
         cfg.write_text("not json")
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(ValueError, match="invalid JSON"):
             load_auth_config(cfg)
 
     def test_not_object_raises(self, tmp_path):


### PR DESCRIPTION
## Summary

Wrap `json.loads()` in `load_auth_config()` with try/except to catch malformed JSON.

## Changes

- `authentication/config.py`: Catch `JSONDecodeError` and raise clean `ValueError`