### PR TITLE
fix: escape Rich markup in workflow error output

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -1383,7 +1383,7 @@ def workflow_run(
         err.print(f"[red]Error:[/red] Workflow not found: {source}")
         raise typer.Exit(1)
     except ValueError as exc:
-        err.print(f"[red]Error:[/red] Invalid workflow: {exc}")
+        err.print(f"[red]Error:[/red] Invalid workflow: {_escape_markup(str(exc))}")
         raise typer.Exit(1)
 
     # Validate

--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -1424,10 +1424,10 @@ def workflow_run(
                 ),
             )
     except ValueError as exc:
-        err.print(f"[red]Error:[/red] {exc}")
+        err.print(f"[red]Error:[/red] {_escape_markup(str(exc))}")
         raise typer.Exit(1)
     except Exception as exc:
-        err.print(f"[red]Workflow failed:[/red] {exc}")
+        err.print(f"[red]Workflow failed:[/red] {_escape_markup(str(exc))}")
         raise typer.Exit(1)
 
     if json_output:


### PR DESCRIPTION
## Summary

Escape exception text with `_escape_markup()` to prevent Rich from interpreting square brackets as markup tags.

## Changes

- `_commands.py`: Added `_escape_markup(str(exc))` in ValueError and Exception handlers