### PR TITLE
fix: remove TOCTOU race in RunState.load

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -714,12 +714,13 @@ class RunState:
         cls._validate_run_id(run_id)
         runs_dir = project_root / ".specify" / "workflows" / "runs" / run_id
         state_path = runs_dir / "state.json"
-        if not state_path.exists():
+
+        try:
+            with open(state_path, encoding="utf-8") as f:
+                state_data = json.load(f)
+        except FileNotFoundError:
             msg = f"Run state not found: {state_path}"
             raise FileNotFoundError(msg)
-
-        with open(state_path, encoding="utf-8") as f:
-            state_data = json.load(f)
         if not isinstance(state_data, dict):
             raise ValueError("Invalid run state: expected a JSON object")
         missing_fields = [


### PR DESCRIPTION

## Summary

Remove `exists()` check before `open()` and catch `FileNotFoundError` directly to prevent TOCTOU race.

## Changes

- `engine.py`: Replaced exists()+open() with open() wrapped in try/except FileNotFoundError