### PR TITLE
fix: show error details in preset catalog config read failure

### DIFF
--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -765,8 +765,8 @@ def preset_catalog_remove(
 
     try:
         config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        console.print("[red]Error:[/red] Failed to read preset catalog config.")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] Failed to read preset catalog config: {e}")
         raise typer.Exit(1)
 
     catalogs = config.get("catalogs", [])


### PR DESCRIPTION
## Summary

Capture and display exception message when reading preset-catalogs.yml fails.

## Changes

- `_commands.py`: Added `as e` to except clause and display error details