### PR TITLE
fix: narrow bare except Exception in preset command reconciliation

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -1727,7 +1727,7 @@ class PresetManager:
                                     )
                                     record_written(written)
                                     registered = True
-                            except (ImportError, FileNotFoundError, OSError, ValueError, TypeError):
+                            except (ImportError, FileNotFoundError, OSError):
                                 # Extension registration failed; fall back to
                                 # generic path-based registration below.
                                 pass

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -1727,7 +1727,7 @@ class PresetManager:
                                     )
                                     record_written(written)
                                     registered = True
-                            except Exception:
+                            except (ImportError, FileNotFoundError, OSError, ValueError, TypeError):
                                 # Extension registration failed; fall back to
                                 # generic path-based registration below.
                                 pass


### PR DESCRIPTION
## Summary

Narrow bare `except Exception` to specific exception types to let programming errors propagate.

## Changes

- `presets/__init__.py`: Replace `except Exception` with `(ImportError, FileNotFoundError, OSError, ValueError, TypeError)`