### PR TITLE
fix: use chunked read for integration and preset manifest hash

### DIFF
--- a/src/specify_cli/integrations/catalog.py
+++ b/src/specify_cli/integrations/catalog.py
@@ -841,5 +841,8 @@ class IntegrationDescriptor:
 
     def get_hash(self) -> str:
         """SHA-256 hash of the descriptor file."""
+        h = hashlib.sha256()
         with open(self.path, "rb") as fh:
-            return f"sha256:{hashlib.sha256(fh.read()).hexdigest()}"
+            for chunk in iter(lambda: fh.read(8192), b""):
+                h.update(chunk)
+        return f"sha256:{h.hexdigest()}"

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -452,8 +452,11 @@ class PresetManifest:
 
     def get_hash(self) -> str:
         """Calculate SHA256 hash of manifest file."""
+        h = hashlib.sha256()
         with open(self.path, 'rb') as f:
-            return f"sha256:{hashlib.sha256(f.read()).hexdigest()}"
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+        return f"sha256:{h.hexdigest()}"
 
 
 class PresetRegistry:

--- a/tests/integrations/test_integration_catalog.py
+++ b/tests/integrations/test_integration_catalog.py
@@ -642,6 +642,10 @@ class TestIntegrationDescriptor:
         desc = IntegrationDescriptor(p)
         h = desc.get_hash()
         assert h.startswith("sha256:")
+        import hashlib
+        content = p.read_bytes()
+        expected = f"sha256:{hashlib.sha256(content).hexdigest()}"
+        assert h == expected
 
     def test_tools_accessor(self, tmp_path):
         data = {**VALID_DESCRIPTOR, "requires": {

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -337,7 +337,10 @@ class TestPresetManifest:
         manifest = PresetManifest(pack_dir / "preset.yml")
         hash_val = manifest.get_hash()
         assert hash_val.startswith("sha256:")
-        assert len(hash_val) > 10
+        import hashlib
+        content = (pack_dir / "preset.yml").read_bytes()
+        expected = f"sha256:{hashlib.sha256(content).hexdigest()}"
+        assert hash_val == expected
 
     def test_multiple_templates(self, temp_dir, valid_pack_data):
         """Test pack with multiple templates of different types."""


### PR DESCRIPTION
## Summary

Replace unbounded `f.read()` with chunked iteration to prevent excessive memory allocation.

## Changes

- `integrations/catalog.py`: Use chunked read in `get_hash()`
- `presets/__init__.py`: Use chunked read in `get_hash()`