### PR TITLE
fix: narrow bare except Exception in VS Code settings merge

### DIFF
--- a/src/specify_cli/_utils.py
+++ b/src/specify_cli/_utils.py
@@ -213,7 +213,7 @@ def handle_vscode_settings(sub_item, dest_file, rel_path, verbose=False, tracker
             shutil.copy2(sub_item, dest_file)
             log("Copied (no existing settings.json):", "blue")
 
-    except Exception as e:
+    except (OSError, ValueError, KeyError) as e:
         log(f"Warning: Could not merge settings: {e}", "yellow")
         if not dest_file.exists():
             shutil.copy2(sub_item, dest_file)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,5 +1,7 @@
 import stat
 
+import pytest
+
 from specify_cli import merge_json_files
 from specify_cli import handle_vscode_settings
 
@@ -188,3 +190,25 @@ def test_handle_vscode_settings_preserves_mode_on_atomic_write(tmp_path):
 
     after_mode = stat.S_IMODE(dest_file.stat().st_mode)
     assert after_mode == before_mode
+
+
+def test_handle_vscode_settings_propagates_programming_errors(tmp_path):
+    """Unexpected programming errors (TypeError) must propagate, not be silently swallowed."""
+    vscode_dir = tmp_path / ".vscode"
+    vscode_dir.mkdir()
+    dest_file = vscode_dir / "settings.json"
+    dest_file.write_text('{"a": 1}\n', encoding="utf-8")
+    template_file = tmp_path / "template_settings.json"
+    template_file.write_text('{"b": 2}\n', encoding="utf-8")
+
+    import specify_cli._utils as utils_mod
+    original_merge = utils_mod.merge_json_files
+    utils_mod.merge_json_files = lambda *a, **kw: (_ for _ in ()).throw(TypeError("boom"))
+    try:
+        with pytest.raises(TypeError):
+            handle_vscode_settings(
+                template_file, dest_file, "settings.json",
+                verbose=False, tracker=None,
+            )
+    finally:
+        utils_mod.merge_json_files = original_merge


### PR DESCRIPTION
## Summary

Narrow bare `except Exception` to specific exception types to let programming errors propagate.

## Changes

- `_utils.py`: Replace `except Exception` with `(OSError, ValueError, KeyError)`
