### PR TITLE
fix: use missing_ok=True in extension cache clear

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -3829,10 +3829,8 @@ class ExtensionCatalog(CatalogStackBase):
 
     def clear_cache(self):
         """Clear the catalog cache (both legacy and URL-hash-based files)."""
-        if self.cache_file.exists():
-            self.cache_file.unlink()
-        if self.cache_metadata_file.exists():
-            self.cache_metadata_file.unlink()
+        self.cache_file.unlink(missing_ok=True)
+        self.cache_metadata_file.unlink(missing_ok=True)
         # Also clear any per-URL hash-based cache files
         if self.cache_dir.exists():
             for extra_cache in self.cache_dir.glob("catalog-*.json"):


### PR DESCRIPTION
## Summary

Replace check-then-act pattern with `unlink(missing_ok=True)` to eliminate TOCTOU race.

## Changes

- `extensions/__init__.py`: Use `missing_ok=True` in `clear_cache()` matching the pattern used for per-URL cache files