### PR TITLE
fix: use missing_ok=True in integration JSON removal

### DIFF
--- a/src/specify_cli/integrations/_helpers.py
+++ b/src/specify_cli/integrations/_helpers.py
@@ -121,8 +121,7 @@ def _clear_init_options_for_integration(project_root: Path, integration_key: str
 def _remove_integration_json(project_root: Path) -> None:
     """Remove ``.specify/integration.json`` if it exists."""
     path = project_root / INTEGRATION_JSON
-    if path.exists():
-        path.unlink()
+    path.unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace check-then-act pattern with `unlink(missing_ok=True)` to eliminate TOCTOU race.

## Changes

- `integrations/_helpers.py`: Use `missing_ok=True` in `_remove_integration_json()`