### PR TITLE
fix(workflows): validate prompt step 'timeout' like the shell step

### DIFF
--- a/src/specify_cli/workflows/steps/prompt/__init__.py
+++ b/src/specify_cli/workflows/steps/prompt/__init__.py
@@ -157,12 +157,16 @@ class PromptStep(StepBase):
         if "timeout" not in config:
             return None
         timeout = config["timeout"]
-        if (
-            isinstance(timeout, bool)
-            or not isinstance(timeout, (int, float))
-            or not math.isfinite(timeout)
-            or timeout <= 0
-        ):
+        try:
+            valid_timeout = (
+                not isinstance(timeout, bool)
+                and isinstance(timeout, (int, float))
+                and timeout > 0
+                and math.isfinite(timeout)
+            )
+        except OverflowError:
+            valid_timeout = False
+        if not valid_timeout:
             return (
                 f"Prompt step {config.get('id', '?')!r}: 'timeout' must be a "
                 f"positive number of seconds, got {timeout!r}."

--- a/src/specify_cli/workflows/steps/prompt/__init__.py
+++ b/src/specify_cli/workflows/steps/prompt/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import shutil
 from pathlib import Path
 from typing import Any
@@ -88,6 +89,15 @@ class PromptStep(StepBase):
                 ),
             )
 
+        # An invalid timeout reaches subprocess.run() and raises a raw
+        # TypeError ("unsupported operand type(s) for +: 'float' and 'str'")
+        # or ValueError, which the engine re-raises — taking down the whole
+        # run with a message that names neither the step nor 'timeout'. Fail
+        # this step cleanly instead, mirroring the shell step.
+        timeout_error = self._timeout_error(config)
+        if timeout_error is not None:
+            return StepResult(status=StepStatus.FAILED, error=timeout_error)
+
         # Attempt CLI dispatch
         timeout = config.get("timeout", 300)
         dispatch_result = self._try_dispatch(
@@ -130,6 +140,34 @@ class PromptStep(StepBase):
                     f"CLI not found or not installed."
                 ),
             )
+
+    @staticmethod
+    def _timeout_error(config: dict[str, Any]) -> str | None:
+        """Return an error message if ``config['timeout']`` is invalid, else None.
+
+        Shared by execute() and validate() so both paths reject the same
+        values with the same message, mirroring the shell step. An absent
+        ``timeout`` is valid (the default is used). bool is a subclass of int,
+        but ``timeout: true`` is a config error rather than a duration, so it
+        is rejected explicitly. Non-finite floats (YAML ``.inf``/``.nan``) pass
+        a plain ``> 0`` check but would raise in subprocess.run(), and a
+        non-positive timeout makes subprocess.run() report an immediate
+        TimeoutExpired, so both are rejected too.
+        """
+        if "timeout" not in config:
+            return None
+        timeout = config["timeout"]
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout <= 0
+        ):
+            return (
+                f"Prompt step {config.get('id', '?')!r}: 'timeout' must be a "
+                f"positive number of seconds, got {timeout!r}."
+            )
+        return None
 
     @staticmethod
     def _try_dispatch(
@@ -250,4 +288,7 @@ class PromptStep(StepBase):
                 f"Prompt step {config.get('id', '?')!r}: 'model' must be a "
                 f"string, got {type(model).__name__}."
             )
+        timeout_error = self._timeout_error(config)
+        if timeout_error is not None:
+            errors.append(timeout_error)
         return errors

--- a/src/specify_cli/workflows/steps/prompt/__init__.py
+++ b/src/specify_cli/workflows/steps/prompt/__init__.py
@@ -165,6 +165,9 @@ class PromptStep(StepBase):
                 and math.isfinite(timeout)
             )
         except OverflowError:
+            # An int too large to convert to float (e.g. a 400-digit YAML
+            # scalar) clears every clause above and raises here — and would
+            # raise the same from subprocess.run(timeout=...).
             valid_timeout = False
         if not valid_timeout:
             return (

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1706,7 +1706,7 @@ class TestPromptStep:
         assert "'model' must be a string" in (res.error or ""), falsey
 
     @pytest.mark.parametrize(
-        "bad", ["30", True, float("inf"), float("nan"), 0, -5, ["30"], None]
+        "bad", ["30", True, float("inf"), float("nan"), 0, -5, ["30"], None, 10**400]
     )
     def test_validate_rejects_invalid_timeout(self, bad):
         """'timeout' reaches subprocess.run(), so validate() must reject junk.
@@ -1714,6 +1714,11 @@ class TestPromptStep:
         The sibling shell step already rejects exactly these values; the
         prompt step gained a ``timeout`` without the matching guard, so a
         workflow that fails validation as a shell step passed as a prompt one.
+
+        ``10**400`` is an int too large to convert to float: it passes
+        ``isinstance``/``> 0`` but makes ``math.isfinite()`` — and later
+        ``subprocess.run()`` — raise ``OverflowError``, so the guard has to
+        catch that rather than let it escape as the crash it exists to stop.
         """
         from specify_cli.workflows.steps.prompt import PromptStep
 
@@ -1764,8 +1769,9 @@ class TestPromptStep:
         # A string/list raises TypeError and NaN raises ValueError inside
         # subprocess.run(); ``True`` would silently become a 1s timeout (bool
         # is an int subclass); a non-positive value reports an immediate
-        # TimeoutExpired for a command that never got the time to run.
-        for bad in ("30", True, float("nan"), 0, -5, ["30"]):
+        # TimeoutExpired for a command that never got the time to run; an int
+        # too large to convert to float raises OverflowError.
+        for bad in ("30", True, float("nan"), 0, -5, ["30"], 10**400):
             with patch(
                 "specify_cli.workflows.steps.prompt.shutil.which",
                 return_value="/opt/claude",

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1705,6 +1705,84 @@ class TestPromptStep:
         assert res.status is StepStatus.FAILED, falsey
         assert "'model' must be a string" in (res.error or ""), falsey
 
+    @pytest.mark.parametrize(
+        "bad", ["30", True, float("inf"), float("nan"), 0, -5, ["30"], None]
+    )
+    def test_validate_rejects_invalid_timeout(self, bad):
+        """'timeout' reaches subprocess.run(), so validate() must reject junk.
+
+        The sibling shell step already rejects exactly these values; the
+        prompt step gained a ``timeout`` without the matching guard, so a
+        workflow that fails validation as a shell step passed as a prompt one.
+        """
+        from specify_cli.workflows.steps.prompt import PromptStep
+
+        step = PromptStep()
+        errors = step.validate(
+            {"id": "p", "type": "prompt", "prompt": "hi", "timeout": bad}
+        )
+        assert any("'timeout' must be a positive number" in e for e in errors), (
+            bad,
+            errors,
+        )
+
+    @pytest.mark.parametrize("good", [300, 5, 0.5])
+    def test_validate_accepts_valid_timeout(self, good):
+        """A positive int/float timeout — and an absent one — stay valid."""
+        from specify_cli.workflows.steps.prompt import PromptStep
+
+        step = PromptStep()
+        for config in (
+            {"id": "p", "type": "prompt", "prompt": "hi", "timeout": good},
+            {"id": "p", "type": "prompt", "prompt": "hi"},
+        ):
+            errors = step.validate(config)
+            assert not any("'timeout'" in e for e in errors), (config, errors)
+
+    def test_execute_fails_cleanly_on_invalid_timeout(self, monkeypatch):
+        """execute() must fail the step, not raise, on an invalid timeout.
+
+        The engine does not auto-validate step config and re-raises anything a
+        step throws, so an unvalidated ``timeout`` reaching subprocess.run()
+        raised a raw ``TypeError: unsupported operand type(s) for +: 'float'
+        and 'str'`` (or ``ValueError`` for NaN) that aborted the entire run —
+        naming neither the step nor the field — after earlier steps had
+        already run their side effects.
+        """
+        import subprocess
+        from unittest.mock import patch
+
+        from specify_cli.workflows.steps.prompt import PromptStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("subprocess.run should not run on invalid timeout")
+
+        monkeypatch.setattr(subprocess, "run", fail_if_called)
+        step = PromptStep()
+        ctx = StepContext(inputs={}, default_integration="claude")
+        # A string/list raises TypeError and NaN raises ValueError inside
+        # subprocess.run(); ``True`` would silently become a 1s timeout (bool
+        # is an int subclass); a non-positive value reports an immediate
+        # TimeoutExpired for a command that never got the time to run.
+        for bad in ("30", True, float("nan"), 0, -5, ["30"]):
+            with patch(
+                "specify_cli.workflows.steps.prompt.shutil.which",
+                return_value="/opt/claude",
+            ):
+                result = step.execute(
+                    {
+                        "id": "p",
+                        "type": "prompt",
+                        "prompt": "hi",
+                        "integration": "claude",
+                        "timeout": bad,
+                    },
+                    ctx,
+                )
+            assert result.status is StepStatus.FAILED, bad
+            assert "'timeout' must be a positive number" in (result.error or ""), bad
+
 
 class TestShellStep:
     """Test the shell step type."""


### PR DESCRIPTION
## Problem

#3768 added a `timeout` to the prompt step and passed it straight into `subprocess.run(timeout=...)`. Neither `validate()` nor `execute()` checks it, so a bad value from a user-authored `workflow.yml` escapes as a raw exception.

```yaml
steps:
  - id: first
    type: shell
    run: echo side-effect
  - id: ask
    type: prompt
    prompt: do it
    timeout: abc
```

```
$ specify workflow run wf.yml
  ▸ [first] shell …
Workflow failed: unsupported operand type(s) for +: 'float' and 'str'
```

The engine re-raises anything a step throws, so this takes down the **whole run** — after `first` has already run its side effect — with a message naming neither the step nor the field.

| `timeout:` | Result today |
| --- | --- |
| `abc`, `[30]` | `TypeError: unsupported operand type(s) for +: 'float' and 'str'` — run aborts |
| `.nan` | `ValueError: cannot convert float NaN to integer` — run aborts |
| `0`, `-5` | immediate `TimeoutExpired` for a command that never got the time to run |
| `true` | silently becomes a **1-second** limit (bool is an int subclass) |

The sibling **shell** step already rejects exactly these values via a `_timeout_error()` helper shared by `execute()` and `validate()` — so the same workflow fails validation cleanly as a shell step and crashes as a prompt one.

## Fix

Mirror that helper onto `PromptStep`: `validate()` reports the contract error, and `execute()` re-checks it so an unvalidated run (the engine does not auto-validate step config) fails just that step instead of aborting.

```
Workflow validation failed:
  • Prompt step 'ask': 'timeout' must be a positive number of seconds, got 'abc'.
```

Caught before the first step runs. Positive int/float timeouts and an absent `timeout` are unaffected.

## Tests

12 tests in `TestPromptStep`, mirroring the shell step's:

- `test_validate_rejects_invalid_timeout` — `"30"`, `True`, `inf`, `nan`, `0`, `-5`, `["30"]`, `None`
- `test_validate_accepts_valid_timeout` — `300`, `5`, `0.5`, and an absent field
- `test_execute_fails_cleanly_on_invalid_timeout` — with `subprocess.run` patched to assert it is never reached

Test-the-test: with the source fix reverted, all 9 rejection tests fail; the 3 accepts-valid tests correctly still pass.

`pytest tests/test_workflows.py` → **725 passed, 17 failed, 67 errors**, identical to the pre-existing baseline on this Windows box (symlink tests requiring elevation + `pytest-of-E` tmpdir permission errors). None are in the touched paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
