### PR TITLE
fix: cap stdin read at 1 MiB to prevent DoS

### DIFF
--- a/src/specify_cli/commands/event.py
+++ b/src/specify_cli/commands/event.py
@@ -24,12 +24,16 @@ def event_run(
     """Resolve and run an event-driven command script with stdin payload."""
     from ..events import resolve_and_run_event_command
 
-    # Read payload from stdin if available (capped at 1 MiB to prevent DoS)
-    _MAX_PAYLOAD = 1 * 1024 * 1024
+    # Read payload from stdin if available (capped at 1 MiB to prevent DoS).
+    MAX_STDIN_BYTES = 1 * 1024 * 1024
     if not sys.stdin.isatty():
-        raw = sys.stdin.read(_MAX_PAYLOAD)
+        raw = sys.stdin.read(MAX_STDIN_BYTES)
         if not sys.stdin.eof:
-            raise typer.Exit(code=1, message="stdin payload exceeds 1 MiB limit")
+            raise typer.Exit(
+                code=1,
+                message="stdin payload exceeds 1 MiB limit; "
+                "truncate or pipe a smaller payload",
+            )
         payload = raw
     else:
         payload = "{}"

--- a/src/specify_cli/commands/event.py
+++ b/src/specify_cli/commands/event.py
@@ -24,8 +24,15 @@ def event_run(
     """Resolve and run an event-driven command script with stdin payload."""
     from ..events import resolve_and_run_event_command
 
-    # Read payload from stdin if available
-    payload = sys.stdin.read() if not sys.stdin.isatty() else "{}"
+    # Read payload from stdin if available (capped at 1 MiB to prevent DoS)
+    _MAX_PAYLOAD = 1 * 1024 * 1024
+    if not sys.stdin.isatty():
+        raw = sys.stdin.read(_MAX_PAYLOAD)
+        if not sys.stdin.eof:
+            raise typer.Exit(code=1, message="stdin payload exceeds 1 MiB limit")
+        payload = raw
+    else:
+        payload = "{}"
 
     # Run the event command
     project_root = Path.cwd()  # The agent runs events from project root


### PR DESCRIPTION
Unbounded sys.stdin.read() allowed a malicious caller to exhaust memory by sending a multi-gigabyte payload. Cap at 1 MiB and raise typer.Exit if truncated.

