### PR TITLE
test(extensions): fix stale manifest validation message assertion

### DIFF
--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -658,18 +658,21 @@ class TestExtensionManifest:
     def test_empty_provides_and_no_hooks_keeps_its_own_message(
         self, temp_dir, valid_manifest_data
     ):
-        """...and with no hooks either, it keeps the pre-existing message rather
-        than the new shape error."""
+        """...and with no hooks (or events) either, it reports the "nothing
+        provided" message rather than the new shape error."""
         import yaml
 
         valid_manifest_data["provides"] = {}
         valid_manifest_data.pop("hooks", None)
+        valid_manifest_data.pop("events", None)
 
         manifest_path = temp_dir / "extension.yml"
         with open(manifest_path, 'w') as f:
             yaml.dump(valid_manifest_data, f)
 
-        with pytest.raises(ValidationError, match="at least one command or hook"):
+        with pytest.raises(
+            ValidationError, match="at least one command, hook, or event"
+        ):
             ExtensionManifest(manifest_path)
 
     def test_hooks_not_dict_rejected(self, temp_dir, valid_manifest_data):


### PR DESCRIPTION
## Summary

The `Test & Lint Python` workflow is failing on `main` ([run 30458202746](https://github.com/github/spec-kit/actions/runs/30458202746)) on a single test:

```
tests/test_extensions.py::TestExtensionManifest::test_empty_provides_and_no_hooks_keeps_its_own_message
E   AssertionError: Regex pattern did not match.
E     Expected regex: 'at least one command or hook'
E     Actual message: 'Extension must provide at least one command, hook, or event'
```

This is a stale test, not a product bug. When the extension `events` feature landed, `ExtensionManifest` validation (`src/specify_cli/extensions/__init__.py`) was updated to raise:

> Extension must provide at least one command, hook, or event

but this test still asserted the old wording. On the `fail-fast` matrix this one failure cancels the other `pytest` jobs, so the whole workflow goes red.

## Changes

- Update the assertion regex to `"at least one command, hook, or event"`.
- Also `pop("events", …)` from the fixture so the test genuinely exercises the empty-provides / no-hooks / no-events path.
- Reword the docstring, since the message legitimately changed.

## Testing

`pytest tests/test_extensions.py::TestExtensionManifest` → **55 passed**.

---

🤖 Opened by GitHub Copilot (model: Claude Opus 4.8) on behalf of @mnriem.