### PR TITLE
fix: normalize non-UTF-8 integration manifests

### DIFF
--- a/src/specify_cli/integrations/manifest.py
+++ b/src/specify_cli/integrations/manifest.py
@@ -471,6 +471,10 @@ class IntegrationManifest:
         path = inst.manifest_path
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
+        except UnicodeDecodeError as exc:
+            raise ValueError(
+                f"Integration manifest at {path} is not valid UTF-8"
+            ) from exc
         except json.JSONDecodeError as exc:
             raise ValueError(
                 f"Integration manifest at {path} contains invalid JSON"

--- a/tests/integrations/test_manifest.py
+++ b/tests/integrations/test_manifest.py
@@ -375,6 +375,14 @@ class TestManifestLoadValidation:
         with pytest.raises(ValueError, match="invalid JSON"):
             IntegrationManifest.load("bad", tmp_path)
 
+    def test_load_non_utf8_json_raises_value_error(self, tmp_path):
+        path = tmp_path / ".specify" / "integrations" / "bad.manifest.json"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"\xff\xfe")
+
+        with pytest.raises(ValueError, match="valid UTF-8"):
+            IntegrationManifest.load("bad", tmp_path)
+
     def test_load_filters_recovered_files_not_in_files(self, tmp_path):
         # Finding B (Round-9): a recovered_files entry referencing a path
         # not present in files indicates an internally-inconsistent manifest


### PR DESCRIPTION
## Summary

- convert manifest decoding failures into the same public `ValueError` boundary used for malformed JSON
- report a clear invalid UTF-8 message while preserving exception chaining
- add regression coverage for non-UTF-8 manifest bytes

## Testing

- `uvx ruff@0.15.0 check src tests`
- `.venv/bin/python -m pytest -q tests/integrations/test_manifest.py` (55 passed)
- `.venv/bin/python -m pytest -q` (6009 passed, 173 skipped)

## AI disclosure

GitHub Copilot helped identify the inconsistent error boundary and review the implementation. I reproduced the failure and validated the final change with targeted and full test suites.
