### PR TITLE
Add yolo to community workflow catalog

### DIFF
--- a/workflows/catalog.community.json
+++ b/workflows/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-07-22T00:00:00Z",
+  "updated_at": "2026-07-29T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/workflows/catalog.community.json",
   "workflows": {
     "pipeline": {
@@ -22,6 +22,29 @@
       ],
       "created_at": "2026-07-10T00:00:00Z",
       "updated_at": "2026-07-21T00:00:00Z"
+    },
+    "yolo": {
+      "id": "yolo",
+      "name": "Full SDD Cycle - no gates",
+      "description": "Runs specify → plan → tasks → implement without review gates",
+      "author": "clintcparker",
+      "version": "0.1.0",
+      "url": "https://raw.githubusercontent.com/clintcparker/speckit-addons/yolo-v0.1.0/workflows/yolo/workflow.yml",
+      "repository": "https://github.com/clintcparker/speckit-addons",
+      "documentation": "https://github.com/clintcparker/speckit-addons/blob/yolo-v0.1.0/workflows/yolo/README.md",
+      "changelog": "https://github.com/clintcparker/speckit-addons/blob/yolo-v0.1.0/workflows/yolo/CHANGELOG.md",
+      "license": "MIT",
+      "requires": {
+        "speckit_version": ">=0.8.5"
+      },
+      "tags": [
+        "sdd",
+        "full-cycle",
+        "no-gates",
+        "automation"
+      ],
+      "created_at": "2026-07-29T00:00:00Z",
+      "updated_at": "2026-07-29T00:00:00Z"
     }
   }
 }

--- a/workflows/catalog.community.json
+++ b/workflows/catalog.community.json
@@ -35,7 +35,7 @@
       "changelog": "https://github.com/clintcparker/speckit-addons/blob/yolo-v0.1.0/workflows/yolo/CHANGELOG.md",
       "license": "MIT",
       "requires": {
-        "speckit_version": ">=0.8.5"
+        "speckit_version": ">=0.8.12"
       },
       "tags": [
         "sdd",


### PR DESCRIPTION
## Workflow Submission

**Workflow Name**: Full SDD Cycle - no gates
**Workflow ID**: `yolo`
**Version**: 0.1.0
**Repository**: https://github.com/clintcparker/speckit-addons
**Raw YAML**: https://raw.githubusercontent.com/clintcparker/speckit-addons/yolo-v0.1.0/workflows/yolo/workflow.yml
**Release**: https://github.com/clintcparker/speckit-addons/releases/tag/yolo-v0.1.0

`yolo` is the built-in `speckit` workflow with the two review gates removed: `specify` → `plan` → `tasks` → `implement`, straight through. It exists for the case where you already trust the shape of the change and would rather review the finished branch than approve two intermediate artifacts — the safety net being source control rather than a gate.

### On the missing gates

The publishing guide recommends gates at decision points, so to be explicit: their absence here is the feature, not an oversight. The README says so plainly and tells users to run it on a branch. The built-in gated `speckit` workflow remains the right default for most people; this is the deliberate opposite trade, and it's marked as such in the name, the description, and the `no-gates` tag.

### Security surface

**No `shell` steps.** All four steps are `command` steps invoking core Spec Kit commands, so there is no arbitrary-command execution to audit and nothing that needs the `run`-field scrutiny the guide calls for.

### Checklist

- [x] Valid `workflow.yml` (passes `specify workflow info`)
- [x] README.md with description, inputs, and step graph
- [x] LICENSE file included (MIT, at the repository root)
- [x] GitHub release created with raw YAML URL
- [x] Workflow tested end-to-end with `specify workflow run`
- [x] All gate steps have clear review messages — *n/a, this workflow has no gate steps by design*
- [x] Input prompts are descriptive
- [x] Added to `workflows/catalog.community.json` (alphabetical order — inserted after `pipeline`)

### Notes

- `requires.speckit_version` is `>=0.8.5`, the first release that resolves `integration: "auto"` engine-side rather than treating it as a literal integration key.
- `requires.integrations.any: ["claude"]` is an advisory compatibility hint. All four commands are core commands provided by every integration, so the workflow runs against whatever the project was initialized with.
- Verified end to end against the published catalog before submitting: `specify workflow catalog add` → `specify workflow add yolo` → `specify workflow info yolo` reports v0.1.0 with four command steps and no gates. Prior real-project usage is described in [this write-up](https://blog.clintcparker.com/2026/07/28/speckit-workflows/).
- The repository is a monorepo intended to host further add-ons, so the workflow lives at `workflows/yolo/` rather than at the repository root. The catalog `url` is pinned to the per-add-on tag `yolo-v0.1.0`.
