### PR TITLE
docs: use absolute image URLs in README for PyPI rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img src="./media/logo_large.webp" alt="Spec Kit Logo" width="200" height="200"/>
+    <img src="https://raw.githubusercontent.com/github/spec-kit/main/media/logo_large.webp" alt="Spec Kit Logo" width="200" height="200"/>
     <h1>🌱 Spec Kit</h1>
     <h3><em>Define what to build before building it — with any AI coding agent.</em></h3>
 </div>
@@ -136,7 +136,7 @@ For detailed step-by-step instructions, see our [comprehensive guide](./spec-dri
 
 Want to see Spec Kit in action? Watch our [video overview](https://www.youtube.com/watch?v=a9eR1xsfvHg&pp=0gcJCckJAYcqIYzv)!
 
-[![Spec Kit video header](/media/spec-kit-video-header.jpg)](https://www.youtube.com/watch?v=a9eR1xsfvHg&pp=0gcJCckJAYcqIYzv)
+[![Spec Kit video header](https://raw.githubusercontent.com/github/spec-kit/main/media/spec-kit-video-header.jpg)](https://www.youtube.com/watch?v=a9eR1xsfvHg&pp=0gcJCckJAYcqIYzv)
 
 ## 🌍 Community
 


### PR DESCRIPTION
## Summary

Relative image paths in `README.md` do not render on the PyPI project page. This converts the remaining relative image references to absolute `raw.githubusercontent.com` URLs so they display correctly on https://pypi.org/project/specify-cli/ while continuing to render on GitHub.

### Changes
- Logo image: `./media/logo_large.webp` → absolute raw URL
- Video header image: `/media/spec-kit-video-header.jpg` → absolute raw URL

`pyproject.toml` already sets `readme = "README.md"`, so the README is what PyPI displays.

Addresses the rendering gap noted in #2908.

---

_This PR was authored by GitHub Copilot (model: Claude Opus 4.8), acting autonomously on behalf of @mnriem._