### PR TITLE
fix(scripts): use a .NET Framework-safe trim in the PowerShell init-dir resolver

### DIFF
--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -55,9 +55,17 @@ function Resolve-SpecifyInitDir {
     }
     # Resolve-Path echoes back any trailing separator from the input; trim it so
     # the returned root matches the bash resolver, whose `cd && pwd` never yields
-    # one. TrimEndingDirectorySeparator is a no-op on a bare root and on a path
-    # that already has no trailing separator.
-    $initRoot = [System.IO.Path]::TrimEndingDirectorySeparator($resolved.Path)
+    # one. TrimEnd (not [Path]::TrimEndingDirectorySeparator, which is .NET Core
+    # only) keeps this working on Windows PowerShell 5.1 / .NET Framework, as
+    # Get-FeaturePathsEnv already does below. Unlike a bare TrimEnd, the
+    # GetPathRoot check preserves a path that *is* its own root ('C:\' must not
+    # become 'C:', which every later API re-resolves against the current
+    # directory instead of the drive root). No-op on a path with no trailing
+    # separator.
+    $initRoot = $resolved.Path.TrimEnd('/', '\')
+    if ($initRoot.Length -lt [System.IO.Path]::GetPathRoot($resolved.Path).Length) {
+        $initRoot = $resolved.Path
+    }
     if (-not (Test-Path -LiteralPath (Join-Path $initRoot '.specify') -PathType Container)) {
         [Console]::Error.WriteLine("ERROR: SPECIFY_INIT_DIR is not a Spec Kit project (no .specify/ directory): $initRoot")
         if ($ReturnNullOnError) { return $null }

--- a/tests/test_init_dir.py
+++ b/tests/test_init_dir.py
@@ -11,6 +11,7 @@ See proposals/monorepo-support and github/spec-kit discussion #2834.
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -29,6 +30,11 @@ GIT_CREATE_FEATURE_SH = (
 HAS_PWSH = shutil.which("pwsh") is not None
 _POWERSHELL = shutil.which("powershell.exe") or shutil.which("powershell")
 _PS_EXE = "pwsh" if HAS_PWSH else _POWERSHELL
+
+# Windows PowerShell 5.1 (.NET Framework) specifically, never pwsh: the only
+# host that lacks the .NET Core-only [System.IO.Path] members, so it is the only
+# one that can pin a 5.1 compatibility regression (issue #3749).
+_WINDOWS_POWERSHELL = _POWERSHELL if os.name == "nt" else None
 
 
 def _clean_env() -> dict[str, str]:
@@ -99,6 +105,10 @@ def _bash_path(path: Path) -> str:
 
 requires_pwsh = pytest.mark.skipif(
     not (HAS_PWSH or _POWERSHELL), reason="no PowerShell available"
+)
+
+requires_windows_powershell = pytest.mark.skipif(
+    _WINDOWS_POWERSHELL is None, reason="Windows PowerShell 5.1 not available"
 )
 
 
@@ -465,3 +475,131 @@ def test_ps_file_path_errors_no_fallback(tmp_path: Path) -> None:
     result = _ps("Get-RepoRoot", cwd=web, env=env)
     assert result.returncode != 0
     assert "does not point to an existing directory" in result.stderr
+
+
+# ── Windows PowerShell 5.1 compatibility (issue #3749) ──────────────────────
+#
+# The CI matrix runs these PowerShell tests under `pwsh` on every OS, and pwsh
+# is .NET Core, so a .NET Framework-only regression is invisible to it. The
+# static test below therefore runs everywhere and is the one that actually
+# guards CI; the runtime tests pin the real behavior where a 5.1 host exists.
+
+# .NET Core-only [System.IO.Path] members. Absent on .NET Framework, so calling
+# one throws "does not contain a method named ..." on Windows PowerShell 5.1.
+_DOTNET_CORE_ONLY_PATH_MEMBERS = (
+    "TrimEndingDirectorySeparator",
+    "EndsInDirectorySeparator",
+    "GetRelativePath",
+    "Join",
+)
+
+
+@pytest.mark.parametrize("member", _DOTNET_CORE_ONLY_PATH_MEMBERS)
+def test_shipped_ps1_avoids_dotnet_core_only_path_members(member: str) -> None:
+    """No shipped .ps1 may call a .NET Core-only [System.IO.Path] member.
+
+    Windows PowerShell 5.1 ships on every Windows box and runs on .NET
+    Framework, where these members do not exist. A call is not a graceful
+    degradation but a hard "Method invocation failed" at the call site, which
+    for a root resolver aborts the command before it starts.
+
+    Runs on all platforms because the CI matrix only has pwsh (.NET Core),
+    where such a call works fine -- so this static check is what keeps CI able
+    to catch the regression at all.
+    """
+    # Anchored to the Path type: [string]::Join and other same-named members on
+    # .NET Framework types are unaffected and must not be flagged.
+    pattern = re.compile(
+        r"\[(?:System\.IO\.)?Path\]::" + re.escape(member) + r"\s*\(",
+        re.IGNORECASE,
+    )
+    offenders = []
+    for ps1 in sorted(PROJECT_ROOT.glob("scripts/powershell/*.ps1")) + sorted(
+        PROJECT_ROOT.glob("extensions/*/scripts/powershell/*.ps1")
+    ):
+        for lineno, line in enumerate(
+            ps1.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            code = line.split("#", 1)[0]
+            if pattern.search(code):
+                offenders.append(f"{ps1.relative_to(PROJECT_ROOT)}:{lineno}")
+    assert not offenders, (
+        f"[System.IO.Path]::{member}() is .NET Core only and throws on Windows "
+        f"PowerShell 5.1; found at {offenders}. Use a .NET Framework-safe "
+        f"equivalent (e.g. TrimEnd('/', '\\') for a trailing separator)."
+    )
+
+
+@requires_windows_powershell
+def test_ps51_init_dir_resolves(tmp_path: Path) -> None:
+    """SPECIFY_INIT_DIR must resolve under Windows PowerShell 5.1 (issue #3749).
+
+    Before the fix, Resolve-SpecifyInitDir called the .NET Core-only
+    [System.IO.Path]::TrimEndingDirectorySeparator, so every 5.1 invocation
+    threw at that line -- root resolution failed before the requested command
+    ran, and $initRoot stayed $null so the very next Join-Path threw too.
+    """
+    web = _make_project(tmp_path, "web")
+    env = {**_clean_env(), "SPECIFY_INIT_DIR": str(web)}
+    result = subprocess.run(
+        [_WINDOWS_POWERSHELL, "-NoProfile", "-Command", f'. "{COMMON_PS}"; Get-RepoRoot'],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert "does not contain a method named" not in result.stderr, result.stderr
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(web)
+
+
+@requires_windows_powershell
+def test_ps51_init_dir_trailing_separator_trimmed(tmp_path: Path) -> None:
+    """The 5.1-safe trim must still strip a trailing separator, for bash parity.
+
+    Resolve-Path echoes back the input's trailing separator; the bash resolver's
+    `cd && pwd` never yields one, so the two must agree.
+    """
+    web = _make_project(tmp_path, "web")
+    for suffix in ("/", "\\"):
+        env = {**_clean_env(), "SPECIFY_INIT_DIR": f"{web}{suffix}"}
+        result = subprocess.run(
+            [
+                _WINDOWS_POWERSHELL,
+                "-NoProfile",
+                "-Command",
+                f'. "{COMMON_PS}"; Get-RepoRoot',
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == str(web)
+
+
+@requires_pwsh
+def test_ps_drive_root_reports_root_not_bare_drive(tmp_path: Path) -> None:
+    """A path that IS its own root must survive the trim intact.
+
+    A bare TrimEnd('/', '\\') -- the obvious 5.1-safe swap -- turns 'C:\\' into
+    'C:', which is not the drive root but a drive-relative reference that every
+    later path API re-resolves against the *current directory*. Validation would
+    then probe the wrong tree entirely and, on a cwd that happens to contain
+    .specify/, silently accept 'C:' as the project root. The drive root
+    normally has no .specify/, so assert on the error naming the intact root.
+    """
+    root = Path(tmp_path.anchor or "/")
+    if (root / ".specify").exists():
+        pytest.skip("filesystem root is itself a Spec Kit project")
+    env = {**_clean_env(), "SPECIFY_INIT_DIR": str(root)}
+    result = _ps("Get-RepoRoot", cwd=tmp_path, env=env)
+    assert result.returncode != 0
+    assert "not a Spec Kit project" in result.stderr
+    # The error echoes the resolved root, so it pins what the trim produced:
+    # 'C:\' (or '/') intact, never the bare 'C:' (or '') a naive TrimEnd leaves.
+    reported = result.stderr.replace("\r", "").rstrip("\n").split("directory): ", 1)[-1]
+    assert reported == str(root)


### PR DESCRIPTION
Fixes #3749

## The bug

`Resolve-SpecifyInitDir` in `scripts/powershell/common.ps1` normalized the resolved path with `[System.IO.Path]::TrimEndingDirectorySeparator`, which is **.NET Core only**. Windows PowerShell 5.1 runs on .NET Framework, so on every 5.1 host the call throws and root resolution fails before the requested command can run:

```
$ $env:SPECIFY_INIT_DIR = "C:\repo\web"
$ .specify\scripts\powershell\check-prerequisites.ps1 -Json
check-prerequisites.ps1 : Method invocation failed because [System.IO.Path]
does not contain a method named 'TrimEndingDirectorySeparator'.
```

As the issue notes, the same file already documents this exact incompatibility and avoids it correctly in `Get-FeaturePathsEnv` about 150 lines below — `TrimEnd`, with a comment naming `TrimEndingDirectorySeparator` as .NET Core only.

**One thing worse than the issue describes:** the throw is non-terminating, so when the resolver is dot-sourced `$initRoot` stays `$null`, the very next `Join-Path` throws too, `Get-RepoRoot` returns `$null` — and the shell **exits 0**. A caller that checks the exit code sees success with an empty root:

```
ROOT=[]   TYPE=null   exit=0
```

## The fix

Switched to the `TrimEnd('/', '\')` the file already endorses.

The obvious swap isn't quite enough on its own, which is the one wrinkle worth reviewing. A bare `TrimEnd` turns `C:\` into `C:` — not the drive root but a *drive-relative* reference that later path APIs re-resolve against the **current directory**:

```powershell
[System.IO.Path]::GetFullPath('C:\')  # -> C:\
[System.IO.Path]::GetFullPath('C:')   # -> C:\Users\E\Desktop\...   (cwd!)
```

So validation would probe the wrong tree entirely and, from a cwd that happens to contain `.specify/`, could silently accept `C:` as the project root — a silent wrong-project write, which is exactly what this resolver's strictness exists to prevent. A `GetPathRoot` length check keeps a path that *is* its own root intact. Both `GetPathRoot` and `TrimEnd` exist on .NET Framework (verified).

Trailing-separator trimming — the reason the call was there, since bash's `cd && pwd` never yields one and the two resolvers must agree — is unchanged, as are all error paths and messages.

I checked the rest of the shipped `.ps1` surface for the same class: `TrimEndingDirectorySeparator` was the only .NET Core-only `[System.IO.Path]` member in use. Every other static call (`IsPathRooted`, `GetFullPath`, `GetTempFileName`, `GetDirectoryName`, …) exists on .NET Framework.

## Tests

- **`test_shipped_ps1_avoids_dotnet_core_only_path_members`** — static check that no shipped `.ps1` calls a .NET Core-only `[System.IO.Path]` member (`TrimEndingDirectorySeparator`, `EndsInDirectorySeparator`, `GetRelativePath`, `Join`). This runs on **all** platforms and is what actually guards CI: the matrix runs the PowerShell tests under `pwsh`, which is .NET Core, so a .NET Framework-only regression is otherwise invisible to it. Anchored to the `Path` type so the legitimate `[string]::Join` in `create-new-feature.ps1` is not flagged.
- **`test_ps51_init_dir_resolves`** / **`test_ps51_init_dir_trailing_separator_trimmed`** — runtime tests against `powershell.exe` specifically (never `pwsh`), covering resolution and bash parity. Skipped where no 5.1 host exists.
- **`test_ps_drive_root_reports_root_not_bare_drive`** — asserts the reported root survives the trim intact, pinning the `C:\` → `C:` regression the naive fix would introduce.

**Test-the-test:** reverting the source change fails all four — the runtime pair with the `does not contain a method named` throw, the static check by locating the call. Applying *only* the naive `TrimEnd` fails the drive-root test, which reports `C:` instead of `C:\`.

Verified on Windows PowerShell 5.1.19041.6456, including the previously-crashing `check-prerequisites.ps1 -Json` end to end (now returns `{"FEATURE_DIR":"...","AVAILABLE_DOCS":[]}`, exit 0). No regressions across `test_init_dir.py`, `test_init_dir_cli.py`, `test_ps1_encoding.py`, `test_check_prerequisites_paths_only.py`, `test_setup_plan_feature_json.py`, `test_setup_tasks.py`, `test_setup_plan_no_overwrite.py`, `test_branch_numbering.py`.

Side effect worth noting: this also fixes **six pre-existing `test_ps_*` failures** on 5.1-only hosts (`test_ps_valid_path_resolves_from_outside`, `test_ps_relative_path_normalized_against_cwd`, `test_ps_trailing_slash_tolerated`, `test_ps_precedence_over_cwd_project`, `test_ps_composes_with_feature_directory_override`, `test_ps_path_without_specify_errors_no_fallback`). Those were this bug, not test-harness issues — they pass on CI only because the runners ship `pwsh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
