### PR TITLE
fix: escape Rich markup in `workflow resolve` output

### DIFF
--- a/src/specify_cli/workflows/overlays/_commands.py
+++ b/src/specify_cli/workflows/overlays/_commands.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import typer
 import yaml
+from rich.markup import escape as _escape_markup
 
 from ..._console import console, err_console
 from ...extensions import normalize_priority
@@ -412,14 +413,23 @@ def workflow_resolve(project_root: Path, workflow_id: str) -> dict[str, Any] | N
         priority = (
             "n/a" if layer.tier == "base" else str(normalize_priority(layer.priority))
         )
+        # ``\[`` keeps the literal bracket: unescaped, Rich parses ``[base]`` /
+        # ``[project-overlay]`` as a style tag and swallows the tier label whole.
         console.print(
-            f"  \u2022 [{layer.tier}] {layer.source} "
+            f"  \u2022 \\[{_escape_markup(layer.tier)}] "
+            f"{_escape_markup(layer.source)} "
             f"(priority={priority})"
         )
 
     console.print("Step attribution:")
     for composed in attribution:
-        console.print(f"  \u2022 {composed.step_id}: {composed.source}")
+        # Step IDs come from base-workflow / overlay YAML, which only bans ``:``
+        # \u2014 brackets pass validation, so they reach Rich as markup. A balanced
+        # ``[stuff]`` is swallowed; an unbalanced ``[/red]`` raises MarkupError.
+        console.print(
+            f"  \u2022 {_escape_markup(composed.step_id)}: "
+            f"{_escape_markup(composed.source)}"
+        )
 
     return {
         "workflow_id": workflow_id,

--- a/tests/workflows/test_overlay_commands.py
+++ b/tests/workflows/test_overlay_commands.py
@@ -509,6 +509,86 @@ class TestOverlayCli:
         assert payload["layers"][-1]["tier"] == "base"
         assert payload["layers"][-1]["priority"] is None
 
+    def test_workflow_resolve_prints_tier_labels(self, project_dir, monkeypatch):
+        """Layer tiers render literally; an unescaped ``[base]`` is eaten as markup."""
+        monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)
+        _write_workflow(
+            project_dir,
+            "wf",
+            {
+                "schema_version": "1.0",
+                "workflow": {"id": "wf", "name": "WF", "version": "1.0.0"},
+                "steps": [{"id": "a", "type": "command", "command": "echo"}],
+            },
+        )
+        _write_overlay(
+            project_dir,
+            "wf",
+            "ov1",
+            {
+                "id": "ov1",
+                "extends": "wf",
+                "priority": 10,
+                "edits": [
+                    {
+                        "operation": "insert_after",
+                        "anchor": "a",
+                        "step": {"id": "new", "type": "command", "command": "echo"},
+                    }
+                ],
+            },
+        )
+
+        result = runner.invoke(app, ["workflow", "resolve", "wf"])
+        assert result.exit_code == 0, result.output
+        assert "[base]" in result.output
+        assert "[project-overlay]" in result.output
+
+    @pytest.mark.parametrize(
+        "step_id",
+        [
+            # Balanced tag: silently swallowed, so the step vanishes from output.
+            "new[stuff]",
+            # Unbalanced closer: raises MarkupError -> traceback and exit 1.
+            "new[/red]",
+        ],
+    )
+    def test_workflow_resolve_escapes_rich_markup_in_step_id(
+        self, project_dir, monkeypatch, step_id
+    ):
+        """Step IDs are unvalidated for brackets, so they must be escaped."""
+        monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)
+        _write_workflow(
+            project_dir,
+            "wf",
+            {
+                "schema_version": "1.0",
+                "workflow": {"id": "wf", "name": "WF", "version": "1.0.0"},
+                "steps": [{"id": "a", "type": "command", "command": "echo"}],
+            },
+        )
+        _write_overlay(
+            project_dir,
+            "wf",
+            "ov1",
+            {
+                "id": "ov1",
+                "extends": "wf",
+                "priority": 10,
+                "edits": [
+                    {
+                        "operation": "insert_after",
+                        "anchor": "a",
+                        "step": {"id": step_id, "type": "command", "command": "echo"},
+                    }
+                ],
+            },
+        )
+
+        result = runner.invoke(app, ["workflow", "resolve", "wf"])
+        assert result.exit_code == 0, result.output
+        assert step_id in result.output
+
     def test_workflow_resolve_equal_priority_layers_sort_by_source(self, project_dir, monkeypatch):
         """Equal-priority overlays are listed alphabetically by source."""
         monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)


### PR DESCRIPTION
## Problem

`specify workflow resolve <id>` prints its two summary sections through `console.print`, which has Rich markup enabled. Neither line escaped its interpolated fields.

**1. The tier label never rendered — on every invocation.**

```python
f"  • [{layer.tier}] {layer.source} (priority={priority})"
```

Rich parses `[base]` and `[project-overlay]` as style tags, so the bracketed tier is swallowed. This needs no untrusted input; the column has simply never worked:

```
  •  project:ov1 (priority=10)     <- tier label missing
  •  base (priority=n/a)           <- tier label missing
```

**2. Step IDs reach Rich as markup.**

Step IDs come from base-workflow / overlay YAML and are validated only against `:` (`_parse_edit` in `overlays/schema.py`) — brackets pass validation. Two failure modes:

- Balanced `[stuff]` is silently swallowed, so `new[stuff]` prints as `new` and the step appears to vanish.
- Unbalanced `[/red]` raises `rich.errors.MarkupError` → uncaught traceback, **exit 1**. The workflow can't be inspected at all:

```
$ specify workflow resolve wf
...
Step attribution:
  • a: base
MarkupError: closing tag '[/red]' at position 7 doesn't match any open tag
```

## Fix

Route the interpolated fields through `rich.markup.escape` and escape the literal tier bracket as `\[`. This matches the pattern already used by `workflow info`'s step graph and `workflow_list`'s `\[disabled]`.

Display-only: the returned payload was already unescaped and is unchanged, so machine-readable callers see no difference.

## Tests

Three regression tests in `TestOverlayCli`, all verified to fail without the fix:

- `test_workflow_resolve_prints_tier_labels` — asserts `[base]` and `[project-overlay]` appear in output
- `test_workflow_resolve_escapes_rich_markup_in_step_id` — parametrized over `new[stuff]` (swallowed) and `new[/red]` (crashes)

`tests/workflows/test_overlay_commands.py` passes 23/23. The wider `tests/workflows/` suite shows 10 pre-existing failures, all symlink-permission tests that fail identically on a clean tree on Windows without elevation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
