### PR TITLE
fix(workflows): escape the literal bracket in `workflow resolve` layer output

### DIFF
--- a/src/specify_cli/workflows/overlays/_commands.py
+++ b/src/specify_cli/workflows/overlays/_commands.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import typer
 import yaml
+from rich.markup import escape as _escape_markup
 
 from ..._console import console, err_console
 from ...extensions import normalize_priority
@@ -412,14 +413,23 @@ def workflow_resolve(project_root: Path, workflow_id: str) -> dict[str, Any] | N
         priority = (
             "n/a" if layer.tier == "base" else str(normalize_priority(layer.priority))
         )
+        # Escape the literal bracket (\[) so Rich renders `[<tier>]` instead of
+        # parsing it as a style tag: `[base]` and `[project-overlay]` were
+        # silently swallowed, so the tier column vanished from the output
+        # entirely. Layer sources and step ids are user-controlled paths/ids,
+        # so escape those values too.
         console.print(
-            f"  \u2022 [{layer.tier}] {layer.source} "
+            f"  \u2022 \\[{_escape_markup(str(layer.tier))}] "
+            f"{_escape_markup(str(layer.source))} "
             f"(priority={priority})"
         )
 
     console.print("Step attribution:")
     for composed in attribution:
-        console.print(f"  \u2022 {composed.step_id}: {composed.source}")
+        console.print(
+            f"  \u2022 {_escape_markup(str(composed.step_id))}: "
+            f"{_escape_markup(str(composed.source))}"
+        )
 
     return {
         "workflow_id": workflow_id,

--- a/tests/workflows/test_overlay_commands.py
+++ b/tests/workflows/test_overlay_commands.py
@@ -509,6 +509,51 @@ class TestOverlayCli:
         assert payload["layers"][-1]["tier"] == "base"
         assert payload["layers"][-1]["priority"] is None
 
+    def test_workflow_resolve_prints_the_tier_column(self, project_dir, monkeypatch):
+        """The `[<tier>]` column must survive Rich rendering.
+
+        The layer line interpolated a literal `[{layer.tier}]`, so Rich parsed
+        `[base]` / `[project-overlay]` as style tags and swallowed them — the
+        tier column disappeared from every `workflow resolve` run. A bare
+        `"base" in result.output` does not catch this, because the
+        step-attribution section prints the same word as a source; the tier has
+        to be asserted in bracket form on the layers line itself.
+        """
+        monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)
+        _write_workflow(
+            project_dir,
+            "wf",
+            {
+                "schema_version": "1.0",
+                "workflow": {"id": "wf", "name": "WF", "version": "1.0.0"},
+                "steps": [{"id": "a", "type": "command", "command": "echo"}],
+            },
+        )
+        _write_overlay(
+            project_dir,
+            "wf",
+            "ov1",
+            {
+                "id": "ov1",
+                "extends": "wf",
+                "priority": 10,
+                "edits": [{"remove": "a"}],
+            },
+        )
+
+        result = runner.invoke(app, ["workflow", "resolve", "wf"])
+        assert result.exit_code == 0, result.output
+
+        layer_lines = [
+            line
+            for line in result.output.splitlines()
+            if "priority=" in line
+        ]
+        assert layer_lines, result.output
+        joined = "\n".join(layer_lines)
+        assert "[base]" in joined, joined
+        assert "[project-overlay]" in joined, joined
+
     def test_workflow_resolve_equal_priority_layers_sort_by_source(self, project_dir, monkeypatch):
         """Equal-priority overlays are listed alphabetically by source."""
         monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)


### PR DESCRIPTION
## Problem

`workflow_resolve` in `src/specify_cli/workflows/overlays/_commands.py` prints each layer like this:

```python
f"  • [{layer.tier}] {layer.source} (priority={priority})"
```

Rich parses `[base]` and `[project-overlay]` as **style tags**, so the tier column is silently swallowed — on every single run, not just for odd input.

## Reproduction on current `main` (81bf741)

```
BEFORE: '*  .specify/workflows/wf/workflow.yml (priority=n/a)'
AFTER : '* [base] .specify/workflows/wf/workflow.yml (priority=n/a)'

BEFORE: '*  ov1.yml (priority=10)'
AFTER : '* [project-overlay] ov1.yml (priority=10)'
```

Note the double space in the BEFORE lines — that is where the tier used to be. The layer's tier is one of the two things `workflow resolve` exists to tell you (which layer, at what precedence), so the human-readable output is missing half its answer. The `--json` payload carries `tier` correctly; only the printed form loses it.

## Why the existing test didn't catch it

`test_workflow_resolve` asserts:

```python
assert "base" in result.output
```

That passes *with the bug*, because the **step-attribution** section prints the same word as a step source. The tier has to be asserted in bracket form, on the layers line itself — which is what the new test does.

## Fix

Escape the literal bracket with `\[`, exactly as `presets/_commands.py:378` already does:

```python
# presets/_commands.py:374-378
# Escape the literal bracket (\[) so Rich renders `[<strategy>]`
f"    {i + 1}. \[{_escape_markup(str(strategy_label))}] "
```

I also escaped the interpolated values in the same output block — `layer.source` is a filesystem path and `composed.step_id` / `composed.source` are user-authored ids, all of which can contain brackets and would break the same lines. That keeps the whole of this one command's output correct rather than fixing half of it.

**No breaking change.** `rich.markup.escape` is a no-op on bracket-free values, and the `--json` payload is untouched. The only difference is that output which previously lost characters now shows them.

## Verification

- **Fail-before / pass-after:** the new test fails on unpatched `src` and passes with the fix. File: **1 failed → 21 passed**.
- Scoped regression over `tests/workflows`: failure set identical to the clean-`main` baseline captured on `81bf741` (10 pre-existing in scope, all Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*