### PR TITLE
fix(workflows): strip a resolved condition before the true/false check

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -671,8 +671,20 @@ def evaluate_condition(condition: str, context: Any) -> bool:
     result = evaluate_expression(condition, context)
     # Treat plain "false"/"true" strings as booleans so that
     # condition: "false" (without {{ }}) behaves as expected.
+    #
+    # Strip before matching: the string a condition resolves to is most often
+    # captured command output, and a ``shell`` step stores ``proc.stdout``
+    # verbatim, so ``run: echo false`` resolves to ``"false\n"``. Without the
+    # strip that trailing newline matches neither branch and falls through to
+    # ``bool("false\n")`` -> True, silently taking an ``if`` step's ``then``
+    # branch (and keeping a ``while``/``do-while`` looping) on a step that
+    # printed "false". A workflow cannot strip it itself -- the registered
+    # filters are default/join/map/contains/from_json, there is no ``trim``.
+    # ``InitStep._resolve_bool`` and the catalog readers already strip before
+    # matching boolean text. ``bool(result)`` below still sees the raw string,
+    # so no non-boolean text changes truthiness.
     if isinstance(result, str):
-        lower = result.lower()
+        lower = result.strip().lower()
         if lower == "false":
             return False
         if lower == "true":

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -783,6 +783,39 @@ class TestExpressions:
         assert evaluate_condition("{{ inputs.ready }}", ctx) is True
         assert evaluate_condition("{{ inputs.missing }}", ctx) is False
 
+    def test_condition_strips_captured_command_output(self):
+        """A condition resolving to captured stdout must honour "false".
+
+        A ``shell`` step stores ``proc.stdout`` verbatim, so ``run: echo false``
+        resolves to ``"false\\n"``. Without stripping, the trailing newline
+        matched neither the "false" nor the "true" branch and fell through to
+        ``bool("false\\n")`` -> True, so an ``if`` step took its ``then`` branch
+        on a step that printed "false". There is no ``trim`` filter, so a
+        workflow author cannot strip it themselves.
+        """
+        from specify_cli.workflows.expressions import evaluate_condition
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(steps={"check": {"output": {"stdout": "false\n"}}})
+        assert evaluate_condition("{{ steps.check.output.stdout }}", ctx) is False
+
+        for raw in ("false\n", "false\r\n", " false", "false ", "FALSE\n"):
+            assert evaluate_condition(raw, StepContext()) is False, raw
+        for raw in ("true\n", " true ", "TRUE\r\n"):
+            assert evaluate_condition(raw, StepContext()) is True, raw
+
+    def test_condition_whitespace_only_string_stays_truthy(self):
+        """Stripping must not turn a whitespace-only string into False.
+
+        Only the "false"/"true" special case is stripped; everything else still
+        falls through to ``bool(result)`` on the raw string.
+        """
+        from specify_cli.workflows.expressions import evaluate_condition
+        from specify_cli.workflows.base import StepContext
+
+        assert evaluate_condition("   ", StepContext()) is True
+        assert evaluate_condition("falsey", StepContext()) is True
+
     def test_non_string_passthrough(self):
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext


### PR DESCRIPTION
## Problem

`evaluate_condition()` special-cases the strings `"false"`/`"true"` so that a condition resolving to text behaves as a boolean — its own comment says so:

```python
# Treat plain "false"/"true" strings as booleans so that
# condition: "false" (without {{ }}) behaves as expected.
if isinstance(result, str):
    lower = result.lower()
```

It matches with `result.lower()` and **never strips**. But the most common way a *string* reaches a condition is captured command output, and the shell step stores stdout verbatim (`steps/shell/__init__.py:67`):

```python
"stdout": proc.stdout,
```

So `run: echo false` resolves to `"false\n"` — which matches neither branch and falls through to `bool("false\n")` → `True`.

## Reproduction on current `main` (81bf741)

```
shell stored stdout      : 'false\n'
evaluate_condition       : True     <-- expected False

  'false'      -> False
  'false\n'    -> True     <-- bug
  'false\r\n'  -> True     <-- bug
  ' false'     -> True     <-- bug
  'FALSE\n'    -> True     <-- bug
```

An `if` step takes its `then` branch on a step that printed `false`, and `while`/`do-while` keep dispatching their body — `engine.py` uses this same function as the loop-continuation predicate.

## There is no workaround

`_REGISTERED_FILTERS` is `("default", "join", "map", "contains", "from_json")` — **there is no `trim` filter**, and `docs/reference/workflows.md:510` lists the same five. A workflow author has no way to strip stdout before a condition, so this cannot be worked around in YAML.

## Fix

One line — `result.strip().lower()`.

Existing precedent for stripping before matching boolean text:

| Site | Code |
|---|---|
| `steps/init/__init__.py:241` | `resolved.strip().lower() in ("true", "1", "yes")` |
| `workflows/catalog.py:410` | `raw_install.strip().lower() in (...)` |
| `workflows/catalog.py:1099` | same |

To be precise about the precedent: those return `False` for anything unmatched, whereas `evaluate_condition` falls through to `bool(result)`. They justify the **strip**, not the surrounding semantics.

## Breaking risk

Only strings whose *stripped* form is exactly `false`/`true` but whose raw form is not. Whitespace-padded `false`/`FALSE` now evaluate to `False` instead of `True` — that is the bug being fixed. Padded `true` was already `True` via `bool()` and stays `True`.

`bool(result)` below still sees the **raw** string, so nothing else changes: a whitespace-only string is still truthy, and `"falsey"` is still truthy. Both are pinned by a new test.

## Verification

- **Fail-before / pass-after:** reverting only the changed line makes `test_condition_strips_captured_command_output` fail (`True = evaluate_condition('{{ steps.check.output.stdout }}', ...)`); restoring it gives 2 passed.
- `tests/test_workflows.py` → 839 passed, 20 failed; the failure set is **byte-identical to the clean-`main` baseline** I captured on `81bf741` (20 in this file, all Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

Tests go into the existing `TestExpressions`, beside `test_condition_evaluation`.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*