### PR TITLE
fix(workflows): report a falsy non-mapping overlay manifest as a shape error

### DIFF
--- a/src/specify_cli/workflows/overlays/layer_sources.py
+++ b/src/specify_cli/workflows/overlays/layer_sources.py
@@ -152,18 +152,26 @@ class ProjectOverlaySource:
             if path.is_symlink():
                 raise OverlayLoadError(path, ["Symlinked overlay files are not allowed"])
             try:
-                data = yaml.safe_load(path.read_text(encoding="utf-8"))
+                text = path.read_text(encoding="utf-8")
+                # ``safe_load`` returns None for BOTH an empty document and an
+                # explicit null scalar (``null``, ``~``, ``Null``, ``NULL``), so
+                # it cannot tell them apart on its own. ``compose`` yields no
+                # node only for a genuinely empty document.
+                is_empty_document = yaml.compose(text) is None
+                data = yaml.safe_load(text)
             except yaml.YAMLError as exc:
                 raise OverlayLoadError(path, [f"Invalid YAML: {exc}"]) from exc
             except (OSError, UnicodeDecodeError) as exc:
                 raise OverlayLoadError(path, [f"Cannot load overlay: {exc}"]) from exc
-            # Only an empty document (``None``) becomes an empty mapping, so the
-            # missing-field errors are reported. ``or {}`` also masked the FALSY
-            # non-mappings (``[]``, ``false``, ``0``, ``''``), which must be
-            # reported as the wrong manifest shape like their truthy twins
-            # (``- a``, ``hello``) already are. The sibling reader for these same
-            # files, ``_read_overlay`` in overlays/_commands.py, does not coerce.
-            if data is None:
+            # Only a genuinely EMPTY document becomes an empty mapping, so its
+            # missing-field errors are reported. Every non-mapping document --
+            # including an explicit ``null``/``~`` and the falsy shapes ``[]``,
+            # ``false``, ``0``, ``''`` that the previous ``or {}`` masked -- must
+            # reach ``validate_overlay_yaml`` unchanged so it reports the wrong
+            # manifest shape, like the truthy twins (``- a``, ``hello``) already
+            # do. The sibling reader for these same files, ``_read_overlay`` in
+            # overlays/_commands.py, does not coerce either.
+            if is_empty_document:
                 data = {}
             if (
                 not include_disabled

--- a/src/specify_cli/workflows/overlays/layer_sources.py
+++ b/src/specify_cli/workflows/overlays/layer_sources.py
@@ -152,11 +152,19 @@ class ProjectOverlaySource:
             if path.is_symlink():
                 raise OverlayLoadError(path, ["Symlinked overlay files are not allowed"])
             try:
-                data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+                data = yaml.safe_load(path.read_text(encoding="utf-8"))
             except yaml.YAMLError as exc:
                 raise OverlayLoadError(path, [f"Invalid YAML: {exc}"]) from exc
             except (OSError, UnicodeDecodeError) as exc:
                 raise OverlayLoadError(path, [f"Cannot load overlay: {exc}"]) from exc
+            # Only an empty document (``None``) becomes an empty mapping, so the
+            # missing-field errors are reported. ``or {}`` also masked the FALSY
+            # non-mappings (``[]``, ``false``, ``0``, ``''``), which must be
+            # reported as the wrong manifest shape like their truthy twins
+            # (``- a``, ``hello``) already are. The sibling reader for these same
+            # files, ``_read_overlay`` in overlays/_commands.py, does not coerce.
+            if data is None:
+                data = {}
             if (
                 not include_disabled
                 and isinstance(data, dict)

--- a/tests/workflows/test_overlay_layer_sources.py
+++ b/tests/workflows/test_overlay_layer_sources.py
@@ -30,6 +30,53 @@ def _write_overlay_file(project_dir: Path, workflow_id: str, overlay_id: str, da
     return path
 
 
+class TestProjectOverlaySourceManifestShape:
+    """A non-mapping overlay manifest is reported as a shape error."""
+
+    @pytest.mark.parametrize("content", ["[]", "false", "0", "''"])
+    def test_falsy_non_mapping_manifest_reports_shape_error(
+        self, project_dir: Path, content: str
+    ) -> None:
+        """`or {}` masked the falsy non-mappings.
+
+        `validate_overlay_yaml` opens with a `isinstance(data, dict)` check, so a
+        truthy non-mapping (`- a`, `hello`) correctly reports "Overlay manifest
+        must be a mapping." But `yaml.safe_load(...) or {}` replaced `[]`,
+        `false`, `0` and `''` with an empty mapping first, so those files were
+        reported as three bogus missing-field errors instead of the wrong shape.
+        The sibling reader for these same files, `_read_overlay` in
+        `overlays/_commands.py`, does not coerce.
+        """
+        ov_dir = project_dir / ".specify" / "workflows" / "overlays" / "wf"
+        ov_dir.mkdir(parents=True, exist_ok=True)
+        (ov_dir / "ov.yml").write_text(content, encoding="utf-8")
+
+        source = ProjectOverlaySource(project_dir)
+        with pytest.raises(OverlayLoadError) as exc_info:
+            source.collect("wf")
+
+        assert exc_info.value.errors == ["Overlay manifest must be a mapping."], (
+            exc_info.value.errors
+        )
+
+    def test_empty_document_still_reports_missing_fields(
+        self, project_dir: Path
+    ) -> None:
+        """An empty document is not a wrong shape — it is a mapping with no keys,
+        so the missing-field errors must still be what is reported."""
+        ov_dir = project_dir / ".specify" / "workflows" / "overlays" / "wf"
+        ov_dir.mkdir(parents=True, exist_ok=True)
+        (ov_dir / "ov.yml").write_text("", encoding="utf-8")
+
+        source = ProjectOverlaySource(project_dir)
+        with pytest.raises(OverlayLoadError) as exc_info:
+            source.collect("wf")
+
+        assert any("is required" in err for err in exc_info.value.errors), (
+            exc_info.value.errors
+        )
+
+
 class TestProjectOverlaySourceFileReadErrors:
     """File-read errors must be wrapped in OverlayLoadError, not leaked as raw tracebacks."""
 

--- a/tests/workflows/test_overlay_layer_sources.py
+++ b/tests/workflows/test_overlay_layer_sources.py
@@ -33,19 +33,27 @@ def _write_overlay_file(project_dir: Path, workflow_id: str, overlay_id: str, da
 class TestProjectOverlaySourceManifestShape:
     """A non-mapping overlay manifest is reported as a shape error."""
 
-    @pytest.mark.parametrize("content", ["[]", "false", "0", "''"])
+    @pytest.mark.parametrize(
+        "content", ["[]", "false", "0", "''", "null", "~", "NULL"]
+    )
     def test_falsy_non_mapping_manifest_reports_shape_error(
         self, project_dir: Path, content: str
     ) -> None:
-        """`or {}` masked the falsy non-mappings.
+        """Every non-mapping document reports the mapping-shape error.
 
-        `validate_overlay_yaml` opens with a `isinstance(data, dict)` check, so a
+        `validate_overlay_yaml` opens with an `isinstance(data, dict)` check, so a
         truthy non-mapping (`- a`, `hello`) correctly reports "Overlay manifest
-        must be a mapping." But `yaml.safe_load(...) or {}` replaced `[]`,
-        `false`, `0` and `''` with an empty mapping first, so those files were
-        reported as three bogus missing-field errors instead of the wrong shape.
-        The sibling reader for these same files, `_read_overlay` in
-        `overlays/_commands.py`, does not coerce.
+        must be a mapping." Two things masked that for other documents:
+
+        * `yaml.safe_load(...) or {}` replaced the falsy shapes `[]`, `false`,
+          `0` and `''` with an empty mapping.
+        * `safe_load` returns `None` for an explicit null scalar (`null`, `~`,
+          `NULL`) as well as for an empty document, so a `data is None` check
+          swallowed those too.
+
+        Both now reach the validator unchanged; only a genuinely empty document
+        is normalised to `{}` (pinned separately below), using `yaml.compose`,
+        which yields no node only for an empty document.
         """
         ov_dir = project_dir / ".specify" / "workflows" / "overlays" / "wf"
         ov_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem

`ProjectOverlaySource.collect` in `src/specify_cli/workflows/overlays/layer_sources.py` reads an overlay manifest with:

```python
data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
```

`validate_overlay_yaml` opens with `if not isinstance(data, dict): return None, ["Overlay manifest must be a mapping."]` — so a wrong-shaped manifest is meant to be reported as exactly that. But `or {}` replaces every **falsy** non-mapping with an empty mapping *before* that check runs, so those files are misreported.

## Reproduction on current `main` (81bf741)

Whole-document overlay manifests, same code path:

```
'- a'    -> ['Overlay manifest must be a mapping.']          <-- correct
'hello'  -> ['Overlay manifest must be a mapping.']          <-- correct
'[]'     -> ["Overlay 'id' is required and must be a non-empty string.",
             "Overlay 'extends' is required and must be a non-empty string.",
             "Overlay 'edits' is required and must be a list."]
'false'  -> same three
'0'      -> same three
"''"     -> same three
```

So `[]`, `false`, `0` and `''` produce three misleading "required field" errors, sending the author looking for missing keys in a document that has the wrong shape entirely. Their truthy twins get the right answer.

## Precedent

The sibling reader for these *same files*, in the *same package* — `_read_overlay` in `overlays/_commands.py:160` — does not coerce:

```python
data = yaml.safe_load(content)
```

So the two readers of one file format disagree, and the coercing one is the outlier.

## Fix

Drop `or {}`; normalise only an empty document:

```python
data = yaml.safe_load(path.read_text(encoding="utf-8"))
...
if data is None:
    data = {}
```

**No breaking change.** `None` (an empty file) still becomes `{}`, so a genuinely empty overlay still reports its missing fields — pinned by a second new test. Every mapping is unaffected. The only inputs whose behaviour changes are the four falsy non-mappings, which move from three wrong errors to one right one.

## Verification

- **Fail-before / pass-after:** the four parametrized cases fail on unpatched `src` and pass with the fix — **8 failed → 4 failed**, and those remaining 4 are Windows symlink-privilege tests that fail on clean `main`.
- Scoped regression over `tests/workflows`: failure set identical to the clean-`main` baseline captured on `81bf741` (10 pre-existing in scope).
- `uvx ruff@0.15.0 check src tests` → clean

New class sits next to the existing `TestProjectOverlaySourceFileReadErrors`, which covers the other failure modes of this same read.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*