### PR TITLE
fix(bundler): treat a blank active integration as indeterminate in the FR-019 guard

### DIFF
--- a/src/specify_cli/bundler/services/resolver.py
+++ b/src/specify_cli/bundler/services/resolver.py
@@ -77,6 +77,16 @@ def resolve_install_plan(
 
     # FR-019: integration-compatibility — a bundle that pins a different
     # integration than the project's active one halts (no silent change).
+    #
+    # A blank integration arrives as ``""``, not ``None`` — which is not a usable
+    # integration id but satisfied NEITHER guard below (the first is a truthiness
+    # test, the second an ``is None`` test), so a pinned bundle was silently
+    # adopted: precisely the outcome this guard exists to prevent. Treat blank as
+    # indeterminate, and strip first like the writer
+    # (``integration_state.clean_integration_key``) so a padded value is not
+    # reported as clashing with itself.
+    if active_integration is not None:
+        active_integration = active_integration.strip() or None
     effective_integration = active_integration
     if manifest.integration is not None:
         required = manifest.integration.id

--- a/tests/unit/test_bundler_resolver.py
+++ b/tests/unit/test_bundler_resolver.py
@@ -62,6 +62,32 @@ def test_pinned_integration_with_indeterminate_active_fails():
         )
 
 
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_pinned_integration_with_blank_active_fails(blank):
+    """A blank active integration is indeterminate, not a match.
+
+    The clash guard is a truthiness test and the indeterminate guard is an
+    `is None` test, so `""` satisfied neither and fell through to
+    `effective_integration = required` — silently adopting the bundle's pinned
+    integration, the exact outcome the docstring says the guard prevents.
+    """
+    manifest = _manifest(integration={"id": "claude"})
+    with pytest.raises(BundlerError, match="could not be determined"):
+        resolve_install_plan(
+            manifest, speckit_version="0.11.2", active_integration=blank
+        )
+
+
+def test_padded_active_integration_is_not_a_clash_with_itself():
+    """A padded value must strip, like the writer's clean_integration_key,
+    rather than be reported as clashing with its own unpadded form."""
+    manifest = _manifest(integration={"id": "claude"})
+    plan = resolve_install_plan(
+        manifest, speckit_version="0.11.2", active_integration="  claude  "
+    )
+    assert plan.effective_integration == "claude"
+
+
 def test_pinned_integration_with_indeterminate_active_allows_explicit_override():
     manifest = _manifest(integration={"id": "claude"})
     plan = resolve_install_plan(


### PR DESCRIPTION
## Problem

`resolve_install_plan` in `src/specify_cli/bundler/services/resolver.py` enforces FR-019 with two guards:

```python
if active_integration and required != active_integration:      # clash        (truthiness)
if active_integration is None and not integration_explicit:    # indeterminate (identity)
```

An empty string satisfies **neither** — it is falsy, so the first is skipped; it is not `None`, so the second is skipped. Execution falls through to `effective_integration = required`, silently adopting the bundle's pinned integration.

That is precisely what the function's own docstring says it prevents:

> …resolution fails instead of silently adopting the bundle's required integration (FR-019 guard).

## Reproduction on current `main` (81bf741)

Same manifest, pinned to `copilot`:

```
active=None         -> BundlerError: ... active integration could not be determined
active='' (blank)   -> effective_integration='copilot'   (NO ERROR)   <-- bug
active='claude'     -> BundlerError: ... targets integration 'copilot'
```

Both a known-different integration and an unknown one halt. Only the blank one silently proceeds — and it proceeds by adopting a *different* integration than the project has, which is the one outcome FR-019 exists to block.

## Fix

Normalise blank to `None` before the guards, stripping first:

```python
if active_integration is not None:
    active_integration = active_integration.strip() or None
```

The strip matches the **writer** side. `integration_state.clean_integration_key` is the canonical normaliser:

```python
def clean_integration_key(key: Any) -> str | None:
    """Return a stripped integration key, or None for empty/non-string values."""
    if not isinstance(key, str) or not key.strip():
        return None
    return key.strip()
```

Without stripping, `"  claude  "` would be reported as clashing with `claude` — i.e. with itself. A new test pins that.

**No breaking change.** `None` and any non-blank value behave exactly as before. The only inputs whose behaviour changes are blank/whitespace ones, which move from "silently adopt a foreign integration" to the existing `could not be determined` error — the same path `None` already takes. `--integration` with an explicit value still overrides, unchanged.

## Verification

- **Fail-before / pass-after:** the four new cases fail on unpatched `src` and pass with the fix. File: **4 failed → 12 passed**.
- Scoped regression over `tests/unit`: failure set identical to the clean-`main` baseline captured on `81bf741` (2 pre-existing in scope).
- `uvx ruff@0.15.0 check src tests` → clean

Tests sit beside `test_pinned_integration_with_indeterminate_active_fails`, the existing FR-019 guard test asserting the same `could not be determined` message.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*