### PR TITLE
fix(workflows): fail a fan-in step whose `output` is not a mapping

### DIFF
--- a/src/specify_cli/workflows/steps/fan_in/__init__.py
+++ b/src/specify_cli/workflows/steps/fan_in/__init__.py
@@ -20,9 +20,31 @@ class FanInStep(StepBase):
 
     def execute(self, config: dict[str, Any], context: StepContext) -> StepResult:
         wait_for = config.get("wait_for", [])
-        output_config = config.get("output") or {}
-        if not isinstance(output_config, dict):
+        output_config = config.get("output")
+        if output_config is None:
             output_config = {}
+        elif not isinstance(output_config, dict):
+            # ``validate`` rejects a non-mapping ``output`` and its comment says
+            # why: "execute() silently coerces a non-mapping output to {}, so the
+            # author's declared aggregation keys would vanish with no error."
+            # The engine does not auto-validate before ``execute``, so on an
+            # unvalidated run that is exactly what happened -- and ``x or {}``
+            # masked the falsy shapes ([], false, 0, '') before the isinstance
+            # check even ran. Every declared key vanished while the step still
+            # reported COMPLETED, so downstream ``steps.<id>.output.<key>``
+            # resolved to None and interpolated as "": the same "silent empty
+            # result + COMPLETED" wiring bug the ``wait_for`` guard below
+            # rejects. Fail loudly with validate()'s own message instead. An
+            # explicit ``output:`` (YAML null) stays valid, matching validate.
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"Fan-in step {config.get('id', '?')!r}: 'output' must be a "
+                    f"mapping of key -> expression, got "
+                    f"{type(output_config).__name__}."
+                ),
+                output={"results": []},
+            )
 
         # The engine does not auto-validate step config, so an unvalidated run
         # with a non-list ``wait_for`` reaches here raw. Iterating it then

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3626,6 +3626,44 @@ class TestFanInStep:
         assert "'wait_for' must be a list" in (result.error or "")
         assert result.output["results"] == []
 
+    @pytest.mark.parametrize(
+        "bad_output", [[], False, 0, "", ["a"], "oops", 5]
+    )
+    def test_execute_non_mapping_output_fails_loudly(self, bad_output):
+        """A non-mapping ``output`` must fail the step, not drop every key.
+
+        ``validate`` rejects it and says why: "execute() silently coerces a
+        non-mapping output to {}, so the author's declared aggregation keys would
+        vanish with no error." The engine does not auto-validate before
+        ``execute``, so that is exactly what happened — and ``x or {}`` masked
+        the falsy shapes (``[]``, ``false``, ``0``, ``''``) before the isinstance
+        check even ran. The step still returned COMPLETED, so downstream
+        ``steps.<id>.output.<key>`` resolved to None and interpolated as "".
+        """
+        from specify_cli.workflows.steps.fan_in import FanInStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = FanInStep()
+        ctx = StepContext(steps={"a": {"output": {"x": 1}}})
+        result = step.execute(
+            {"id": "collect", "wait_for": ["a"], "output": bad_output}, ctx
+        )
+        assert result.status == StepStatus.FAILED
+        assert "'output' must be a mapping" in (result.error or "")
+        assert result.output["results"] == []
+
+    def test_execute_explicit_null_output_stays_valid(self):
+        """An explicit ``output:`` (YAML null) is valid, matching ``validate``."""
+        from specify_cli.workflows.steps.fan_in import FanInStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = FanInStep()
+        ctx = StepContext(steps={"a": {"output": {"x": 1}}})
+        result = step.execute(
+            {"id": "collect", "wait_for": ["a"], "output": None}, ctx
+        )
+        assert result.status == StepStatus.COMPLETED
+
     @pytest.mark.parametrize("bad_entry", [["a", "b"], {"a": 1}, 123, None])
     def test_execute_non_string_wait_for_entry_fails_loudly(self, bad_entry):
         """A ``wait_for`` list with a non-string entry must fail the step, not


### PR DESCRIPTION
## Problem

`FanInStep.execute` began with:

```python
output_config = config.get("output") or {}
if not isinstance(output_config, dict):
    output_config = {}
```

Any non-mapping `output` was silently replaced with `{}` and the step still returned **COMPLETED**. Every aggregation key the author declared vanished, and downstream `{{ steps.<id>.output.<key> }}` resolved to `None` and interpolated as an empty string.

Note also that `x or {}` masked the **falsy** shapes (`[]`, `false`, `0`, `''`) before the `isinstance` check even ran.

## Reproduction on current `main` (81bf741)

```
output=[]       -> status=completed  error=None
output=False    -> status=completed  error=None
output=0        -> status=completed  error=None
output=''       -> status=completed  error=None
output=['a']    -> status=completed  error=None
output='oops'   -> status=completed  error=None
output=5        -> status=completed  error=None
```

## This is already a known flaw — in this file

`validate` rejects a non-mapping `output`, and its comment names the execute-side bug outright:

```python
output = config.get("output")
if output is not None and not isinstance(output, dict):
    # execute() silently coerces a non-mapping output to {}, so the
    # author's declared aggregation keys would vanish with no error.
    # Reject at validation, mirroring the command-step (#3262) fix.
```

The engine does not auto-validate before `execute` (see `WorkflowEngine.load_workflow`), so on an unvalidated run that comment describes exactly what happens. This PR closes the execute-side half.

## Fix

Fail the step with **validate()'s own message**, mirroring the `wait_for` guard a few lines below in the same method:

```python
output_config = config.get("output")
if output_config is None:
    output_config = {}
elif not isinstance(output_config, dict):
    return StepResult(status=StepStatus.FAILED, error=..., output={"results": []})
```

This is the same "silent empty result + COMPLETED" class the `wait_for` guards in this method already reject, and the same shape as the fan-out non-list `items` guard.

**No breaking change.** An explicit `output:` (YAML null) stays valid, matching `validate` — pinned by a second new test. A mapping behaves exactly as before. The only inputs whose behaviour changes are ones that silently produced an empty aggregation.

## Verification

- **Fail-before / pass-after:** the seven parametrized cases fail on unpatched `src` and pass with the fix.
- `tests/test_workflows.py` scoped regression: failure set identical to the clean-`main` baseline captured on `81bf741` (20 pre-existing in this file, all Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

Tests go into the existing `TestFanInStep`, beside `test_execute_non_list_wait_for_fails_loudly` — the sibling guard whose docstring describes the same wiring bug.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*