### PR TITLE
fix(workflows): fail a gate whose `on_reject` is not abort/skip/retry instead of silently completing a rejection

### DIFF
--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -75,6 +75,31 @@ class GateStep(StepBase):
                 },
             )
 
+        # ``validate`` rejects an ``on_reject`` outside abort/skip/retry, but the
+        # engine does not auto-validate before ``execute``. The reject branch
+        # below handles only "abort" and "retry" and then falls through to its
+        # ``on_reject == "skip"`` case, so on an unvalidated run any other value
+        # makes a REJECTED gate report COMPLETED and the run walks straight past
+        # the review the gate exists to enforce. Reachable by a capitalisation
+        # slip ("Abort"), a guessed verb ("fail", "stop"), a non-string, or the
+        # ``None`` that a bare ``on_reject:`` yields -- note ``config.get(k,
+        # default)`` does NOT substitute the default for an explicit null. Fail
+        # loudly instead, mirroring the ``options``/``verdict_input`` guards here.
+        if on_reject not in ("abort", "skip", "retry"):
+            return StepResult(
+                status=StepStatus.FAILED,
+                error=(
+                    f"Gate step {config.get('id', '?')!r}: 'on_reject' must be "
+                    f"'abort', 'skip', or 'retry', got {on_reject!r}."
+                ),
+                output={
+                    "message": message,
+                    "options": options,
+                    "on_reject": on_reject,
+                    "choice": None,
+                },
+            )
+
         if has_verdict_input and (
             not isinstance(verdict_input, str) or not verdict_input
         ):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2549,6 +2549,36 @@ steps:
         })
         assert any("on_reject" in e for e in errors)
 
+    @pytest.mark.parametrize(
+        "bad_on_reject", ["Abort", "fail", "stop", "SKIP", None, 5, ["abort"]]
+    )
+    def test_execute_invalid_on_reject_fails_loudly(self, bad_on_reject):
+        """An unrecognised ``on_reject`` must not silently complete a rejection.
+
+        ``validate`` rejects anything outside abort/skip/retry, but the engine
+        does not auto-validate before ``execute``. The reject branch handles only
+        "abort" and "retry", then falls through to its ``"skip"`` case — so a
+        REJECTED gate reported COMPLETED and the run continued past the review
+        the gate exists to enforce. Reachable by a capitalisation slip, a guessed
+        verb, a non-string, or a bare ``on_reject:`` (which yields None, since
+        ``config.get(k, default)`` does not replace an explicit null).
+        """
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        result = GateStep().execute(
+            {
+                "id": "review",
+                "message": "Review the spec.",
+                "options": ["approve", "reject"],
+                "on_reject": bad_on_reject,
+                "verdict_input": "spec_verdict",
+            },
+            StepContext(inputs={"spec_verdict": "reject"}),
+        )
+        assert result.status == StepStatus.FAILED
+        assert "'on_reject' must be" in (result.error or "")
+
     def test_validate_non_string_options_does_not_raise(self):
         """Non-string options with on_reject=abort/retry must be REPORTED as an
         error, not crash: the reject-choice check calls o.lower() on each option,


### PR DESCRIPTION
## Problem

`GateStep.execute` reads `on_reject = config.get("on_reject", "abort")`. In the reject branch it handles only two literals before falling through:

```python
if on_reject == "abort":  ...
if on_reject == "retry":  ...
# on_reject == "skip" → completed, downstream steps decide
```

So **any** other value lands in the `"skip"` case. A gate that was *rejected* reports COMPLETED, and the run continues past the review the gate exists to enforce.

## Reproduction on current `main` (81bf741)

Same config, REJECT verdict, varying only `on_reject`:

```
on_reject='abort'  -> failed     error="Gate rejected by user at step 'g'"
on_reject='retry'  -> paused
on_reject='skip'   -> completed  (by design)
on_reject='Abort'  -> completed  <-- rejection silently discarded
on_reject='fail'   -> completed  <-- same
on_reject='stop'   -> completed  <-- same
on_reject=None     -> completed  <-- same
on_reject=5        -> completed  <-- same
```

This is a *fail-open* failure mode on a safety control, and every trigger is an ordinary authoring mistake:

- a capitalisation slip — `Abort`, `SKIP`
- a guessed verb — `fail`, `stop`
- a bare `on_reject:` in YAML, which parses to `None`. Note `config.get(key, default)` does **not** substitute the default for an explicit null.

## Fix

`validate` already rejects anything outside the three literals:

```python
on_reject = config.get("on_reject", "abort")
if on_reject not in ("abort", "skip", "retry"):
    errors.append(...)
```

…but the engine does not auto-validate before `execute` (see `WorkflowEngine.load_workflow`), so this PR adds the matching execute-side guard. It mirrors the `options` and `verdict_input` guards already in this method, and is placed **before** the non-TTY short-circuit so the error surfaces in CI rather than pausing and failing later on interactive resume.

**No breaking change.** All three documented values behave exactly as before — the existing `test_reject_verdict_input_preserves_reject_behavior` parametrizes over them and still passes untouched. The only inputs whose behaviour changes are ones that previously discarded a rejection.

## Verification

- **Fail-before / pass-after:** the seven parametrized invalid values fail on unpatched `src` and pass with the fix. `tests/test_workflows.py`: **27 failed → 20 failed**, 837 → 844 passed.
- The remaining 20 are identical to the clean-`main` baseline I captured on `81bf741` (all Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

Test goes into the existing `TestGateStep`, beside `test_validate_invalid_on_reject` — the validate-side half of the same contract.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*