### PR TITLE
fix(workflows): keep the init step's documented `ignore_agent_tools` default on an explicit null

### DIFF
--- a/src/specify_cli/workflows/steps/init/__init__.py
+++ b/src/specify_cli/workflows/steps/init/__init__.py
@@ -91,9 +91,17 @@ class InitStep(StepBase):
 
         force = self._resolve_bool(config.get("force"), context)
         # Workflows run unattended; skip the agent CLI presence check by default.
-        ignore_agent_tools = self._resolve_bool(
-            config.get("ignore_agent_tools", True), context
-        )
+        # ``config.get(key, True)`` applies that default only when the key is
+        # ABSENT: a bare ``ignore_agent_tools:`` in YAML parses to None, which
+        # ``_resolve_bool`` then turns into False -- flipping the documented
+        # default and re-enabling the agent-CLI presence check this step promises
+        # to skip, so an unattended run fails with "Agent Detection Error" for
+        # any integration whose CLI is not installed. Normalize an explicit null
+        # to the default, mirroring the while/do-while ``max_iterations`` handling.
+        raw_ignore_agent_tools = config.get("ignore_agent_tools")
+        if raw_ignore_agent_tools is None:
+            raw_ignore_agent_tools = True
+        ignore_agent_tools = self._resolve_bool(raw_ignore_agent_tools, context)
 
         argv: list[str] = ["init"]
         if here:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2173,6 +2173,59 @@ class TestInitStep:
         assert "--ignore-agent-tools" in argv
         assert (tmp_path / ".specify").is_dir()
 
+    def test_explicit_null_ignore_agent_tools_keeps_documented_default(
+        self, tmp_path
+    ):
+        """A bare ``ignore_agent_tools:`` must keep the documented default.
+
+        The class docstring says "Because workflows run unattended, the step
+        defaults to ``--ignore-agent-tools``" and the field docs say "defaults to
+        ``true``". But ``config.get(key, True)`` applies the default only when the
+        key is ABSENT — a bare ``ignore_agent_tools:`` in YAML parses to None,
+        which ``_resolve_bool`` turned into False, dropping the flag and
+        re-enabling the agent-CLI presence check for an unattended run.
+        """
+        from specify_cli.workflows.steps.init import InitStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        step = InitStep()
+        ctx = StepContext(
+            project_root=str(tmp_path), default_integration="copilot"
+        )
+        result = step.execute(
+            {
+                "id": "bootstrap",
+                "here": True,
+                "script": "sh",
+                "ignore_agent_tools": None,
+            },
+            ctx,
+        )
+
+        assert result.status == StepStatus.COMPLETED
+        assert "--ignore-agent-tools" in result.output["argv"]
+
+    def test_explicit_false_ignore_agent_tools_is_honoured(self, tmp_path):
+        """An explicit ``false`` must still opt in to the agent-CLI check."""
+        from specify_cli.workflows.steps.init import InitStep
+        from specify_cli.workflows.base import StepContext
+
+        step = InitStep()
+        ctx = StepContext(
+            project_root=str(tmp_path), default_integration="copilot"
+        )
+        result = step.execute(
+            {
+                "id": "bootstrap",
+                "here": True,
+                "script": "sh",
+                "ignore_agent_tools": False,
+            },
+            ctx,
+        )
+
+        assert "--ignore-agent-tools" not in result.output["argv"]
+
     def test_default_integration_falls_back_to_workflow_default(self, tmp_path):
         from specify_cli.workflows.steps.init import InitStep
         from specify_cli.workflows.base import StepContext, StepStatus


### PR DESCRIPTION
## Problem

`InitStep` documents this default in two places:

> **class docstring** — "Because workflows run unattended, the step defaults to `--ignore-agent-tools` (skip checks for an installed agent CLI)"

> **field docs** — "`ignore_agent_tools` — Skip checks for the coding agent CLI (defaults to `true`)."

It implements it as:

```python
ignore_agent_tools = self._resolve_bool(
    config.get("ignore_agent_tools", True), context
)
```

`config.get(key, default)` substitutes the default only when the key is **absent**. A bare `ignore_agent_tools:` in YAML parses to `None`, and `_resolve_bool(None)` → `bool(None)` → `False`.

## Reproduction on current `main` (81bf741)

```
key ABSENT                   -> ignore_agent_tools=True    flag emitted: YES
bare  ignore_agent_tools:    -> ignore_agent_tools=False   flag emitted: NO   <-- bug
explicit true                -> ignore_agent_tools=True    flag emitted: YES
explicit false               -> ignore_agent_tools=False   flag emitted: NO
```

So `--ignore-agent-tools` is dropped, `specify init` re-runs the agent-CLI presence check, and an **unattended** workflow run fails with "Agent Detection Error" for any integration whose CLI is not installed on the runner — the precise failure the documented default exists to avoid.

A bare key is a normal YAML authoring shape, and it reads as "leave this at its default", which is the opposite of what happened.

## Fix

Normalise an explicit null to the documented default before resolving:

```python
raw_ignore_agent_tools = config.get("ignore_agent_tools")
if raw_ignore_agent_tools is None:
    raw_ignore_agent_tools = True
ignore_agent_tools = self._resolve_bool(raw_ignore_agent_tools, context)
```

This mirrors how the while/do-while steps handle `max_iterations` — `config.get("max_iterations")` followed by an explicit `if ... is None` default, rather than relying on `.get`'s default.

**No breaking change.** An absent key, an explicit `true`, and an explicit `false` all behave exactly as before — a second new test pins that `false` still opts in to the agent check. The only input whose behaviour changes is the explicit null, which moves from silently inverting the documented default to honouring it.

## Verification

- **Fail-before / pass-after:** `test_explicit_null_ignore_agent_tools_keeps_documented_default` fails on unpatched `src` and passes with the fix. `tests/test_workflows.py`: **21 failed → 20 failed**, 838 → 839 passed.
- The remaining 20 are identical to the clean-`main` baseline I captured on `81bf741` (all Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

Tests go into the existing `TestInitStep`, beside `test_builds_here_argv_and_bootstraps`, which already asserts `--ignore-agent-tools` is in the argv.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*