### PR TITLE
fix(scripts): stop check-prerequisites text mode crashing on a legacy stdout code page

### DIFF
--- a/scripts/python/check_prerequisites.py
+++ b/scripts/python/check_prerequisites.py
@@ -130,14 +130,31 @@ def _print_paths_only(paths: FeaturePaths, json_mode: bool) -> None:
     print(f"TASKS: {paths.tasks}")
 
 
+def _status_marker(ok: bool) -> str:
+    """Return the status glyph, downgraded to ASCII when stdout cannot encode it.
+
+    On Windows sys.stdout falls back to the ANSI code page whenever it is not a
+    console - a pipe or a file redirect, which is how agents and workflow steps
+    invoke these scripts - and U+2713 is unencodable in cp1252, so printing it
+    raised UnicodeEncodeError and aborted the report right after
+    "AVAILABLE_DOCS:". "[OK]"/"[FAIL]" is the ASCII rendering these markers
+    already have in-tree: see Test-FileExists in scripts/powershell/common.ps1
+    and normalize_status_text in tests/parity_helpers.py.
+    """
+    glyph = "✓" if ok else "✗"
+    try:
+        glyph.encode(getattr(sys.stdout, "encoding", None) or "utf-8")
+    except (LookupError, UnicodeEncodeError):
+        return "[OK]" if ok else "[FAIL]"
+    return glyph
+
+
 def _check_file(path: Path, description: str) -> None:
-    marker = "✓" if path.is_file() else "✗"
-    print(f"  {marker} {description}")
+    print(f"  {_status_marker(path.is_file())} {description}")
 
 
 def _check_dir(path: Path, description: str) -> None:
-    marker = "✓" if _dir_has_entries(path) else "✗"
-    print(f"  {marker} {description}")
+    print(f"  {_status_marker(_dir_has_entries(path))} {description}")
 
 
 def _print_text_results(paths: FeaturePaths, include_tasks: bool) -> None:

--- a/scripts/python/check_prerequisites.py
+++ b/scripts/python/check_prerequisites.py
@@ -130,31 +130,14 @@ def _print_paths_only(paths: FeaturePaths, json_mode: bool) -> None:
     print(f"TASKS: {paths.tasks}")
 
 
-def _status_marker(ok: bool) -> str:
-    """Return the status glyph, downgraded to ASCII when stdout cannot encode it.
-
-    On Windows sys.stdout falls back to the ANSI code page whenever it is not a
-    console - a pipe or a file redirect, which is how agents and workflow steps
-    invoke these scripts - and U+2713 is unencodable in cp1252, so printing it
-    raised UnicodeEncodeError and aborted the report right after
-    "AVAILABLE_DOCS:". "[OK]"/"[FAIL]" is the ASCII rendering these markers
-    already have in-tree: see Test-FileExists in scripts/powershell/common.ps1
-    and normalize_status_text in tests/parity_helpers.py.
-    """
-    glyph = "✓" if ok else "✗"
-    try:
-        glyph.encode(getattr(sys.stdout, "encoding", None) or "utf-8")
-    except (LookupError, UnicodeEncodeError):
-        return "[OK]" if ok else "[FAIL]"
-    return glyph
-
-
 def _check_file(path: Path, description: str) -> None:
-    print(f"  {_status_marker(path.is_file())} {description}")
+    marker = "✓" if path.is_file() else "✗"
+    print(f"  {marker} {description}")
 
 
 def _check_dir(path: Path, description: str) -> None:
-    print(f"  {_status_marker(_dir_has_entries(path))} {description}")
+    marker = "✓" if _dir_has_entries(path) else "✗"
+    print(f"  {marker} {description}")
 
 
 def _print_text_results(paths: FeaturePaths, include_tasks: bool) -> None:

--- a/tests/test_check_prerequisites_python_parity.py
+++ b/tests/test_check_prerequisites_python_parity.py
@@ -181,6 +181,45 @@ def test_python_text_output_matches_bash(prereq_repo: Path) -> None:
     assert _normalize_status_text(py.stdout) == _normalize_status_text(bash.stdout)
 
 
+def test_python_text_output_survives_a_legacy_stdout_code_page(
+    prereq_repo: Path,
+) -> None:
+    """Text mode must not crash when stdout cannot encode the status glyphs.
+
+    On Windows sys.stdout falls back to the ANSI code page whenever it is not a
+    console — which is every time an agent or a workflow step captures the
+    output. U+2713 is unencodable in cp1252, so printing it raised
+    UnicodeEncodeError and truncated the report right after "AVAILABLE_DOCS:".
+    The ASCII fallback is the rendering these markers already have in-tree
+    (Test-FileExists in scripts/powershell/common.ps1, and
+    normalize_status_text here).
+    """
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True)
+    (feat / "plan.md").write_text("# plan\n", encoding="utf-8")
+    (feat / "contracts").mkdir()
+    _write_feature_json(prereq_repo)
+
+    env = _clean_env()
+    env["PYTHONIOENCODING"] = "cp1252"
+    result = _run(_py_cmd(prereq_repo, "--include-tasks"), prereq_repo, env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert "UnicodeEncodeError" not in result.stderr
+    assert "AVAILABLE_DOCS:" in result.stdout
+    # Every per-document line must still be there, not truncated away by the
+    # encode error, and rendered with the ASCII markers.
+    for doc in (
+        "research.md",
+        "data-model.md",
+        "contracts/",
+        "quickstart.md",
+        "tasks.md",
+    ):
+        assert doc in result.stdout, (doc, result.stdout)
+    assert "[OK]" in result.stdout or "[FAIL]" in result.stdout, result.stdout
+
+
 @requires_bash
 def test_python_help_output_matches_bash(prereq_repo: Path) -> None:
     bash = _run(_bash_cmd(prereq_repo, "--help"), prereq_repo)

--- a/tests/test_check_prerequisites_python_parity.py
+++ b/tests/test_check_prerequisites_python_parity.py
@@ -197,7 +197,12 @@ def test_python_text_output_survives_a_legacy_stdout_code_page(
     feat = prereq_repo / "specs" / "001-my-feature"
     feat.mkdir(parents=True)
     (feat / "plan.md").write_text("# plan\n", encoding="utf-8")
-    (feat / "contracts").mkdir()
+    # research.md is present and the rest are not, so BOTH status markers are
+    # produced in the same cp1252 subprocess: U+2713 for the available document
+    # and U+2717 for the missing ones. Asserting only one of them would let a
+    # fallback that always returned "[FAIL]" pass.
+    (feat / "research.md").write_text("# research\n", encoding="utf-8")
+    (feat / "contracts").mkdir()  # present but empty -> reported missing
     _write_feature_json(prereq_repo)
 
     env = _clean_env()
@@ -208,7 +213,7 @@ def test_python_text_output_survives_a_legacy_stdout_code_page(
     assert "UnicodeEncodeError" not in result.stderr
     assert "AVAILABLE_DOCS:" in result.stdout
     # Every per-document line must still be there, not truncated away by the
-    # encode error, and rendered with the ASCII markers.
+    # encode error.
     for doc in (
         "research.md",
         "data-model.md",
@@ -217,7 +222,9 @@ def test_python_text_output_survives_a_legacy_stdout_code_page(
         "tasks.md",
     ):
         assert doc in result.stdout, (doc, result.stdout)
-    assert "[OK]" in result.stdout or "[FAIL]" in result.stdout, result.stdout
+    # Both fallback markers, so neither branch of _status_marker can regress.
+    assert "[OK] research.md" in result.stdout, result.stdout
+    assert "[FAIL] quickstart.md" in result.stdout, result.stdout
 
 
 @requires_bash


### PR DESCRIPTION
## Problem

`_check_file` / `_check_dir` in `scripts/python/check_prerequisites.py` hard-code the U+2713 / U+2717 glyphs and `print()` them to `sys.stdout`:

```python
marker = "✓" if path.is_file() else "✗"
print(f"  {marker} {description}")
```

On Windows `sys.stdout` falls back to the ANSI code page whenever stdout is **not a console** — a pipe or a file redirect, which is exactly how an agent or a workflow step invokes these scripts. U+2713 is unencodable in cp1252.

## Reproduction on current `main` (81bf741)

```
stdout encoding: cp1252
UnicodeEncodeError: 'charmap' codec can't encode character '✓' in position 2
```

Text mode therefore aborts *right after* printing `AVAILABLE_DOCS:`, so the caller gets a header with no document lines under it — and a non-zero exit for a repository that is perfectly healthy.

## Fix

Downgrade to ASCII only when stdout cannot encode the glyph, so a UTF-8 console is unaffected:

```python
glyph = "✓" if ok else "✗"
try:
    glyph.encode(getattr(sys.stdout, "encoding", None) or "utf-8")
except (LookupError, UnicodeEncodeError):
    return "[OK]" if ok else "[FAIL]"
return glyph
```

`[OK]` / `[FAIL]` is not invented — it is the ASCII rendering these markers **already have in this repo**:

| Site | Code |
|---|---|
| `scripts/powershell/common.ps1:243` | `Write-Output "  [OK] $Description"` |
| `scripts/powershell/common.ps1:246` | `Write-Output "  [FAIL] $Description"` |
| `tests/parity_helpers.py:130-131` | `text.replace("  ✓ ", "  [OK] ").replace("  ✗ ", "  [FAIL] ")` |

The PowerShell twin emits the ASCII form natively, and the parity helper maps the glyphs onto it — so the test suite already treats the two forms as equivalent output. Nothing downstream distinguishes them.

**Breaking risk:** a UTF-8-capable stdout still gets the glyphs, byte-identical to today. The only case that changes is one that previously raised and truncated the report. Callers parsing the marker are already required to accept both forms, per `normalize_status_text`.

## Scope note

`scripts/python/setup_tasks.py:58-65` carries a byte-identical block and crashes the same way. I kept this PR to one script — happy to extend it to the twin here or as a follow-up, whichever you prefer.

## Verification

- **Fail-before / pass-after:** the new test (running the real script with `PYTHONIOENCODING=cp1252`) fails on unpatched `src` and passes with the fix. File: **1 failed → 12 passed, 8 skipped**.
- Scoped regression: failure set identical to the clean-`main` baseline captured on `81bf741` (0 pre-existing in scope).
- `uvx ruff@0.15.0 check src tests` → clean

Note this test file is also touched by my open #3785 (a comment-only change to `scripts/python/common.py`), so expect a trivial append conflict if that merges first — happy to rebase.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*