### PR TITLE
fix(powershell): stop `Out-Null` swallowing the AVAILABLE_DOCS status lines

### DIFF
--- a/scripts/powershell/check-prerequisites.ps1
+++ b/scripts/powershell/check-prerequisites.ps1
@@ -141,13 +141,18 @@ if ($Json) {
     Write-Output "FEATURE_DIR:$($paths.FEATURE_DIR)"
     Write-Output "AVAILABLE_DOCS:"
 
-    # Show status of each potential document
-    Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Out-Null
-    Test-FileExists -Path $paths.DATA_MODEL -Description 'data-model.md' | Out-Null
-    Test-DirHasFiles -Path $paths.CONTRACTS_DIR -Description 'contracts/' | Out-Null
-    Test-FileExists -Path $paths.QUICKSTART -Description 'quickstart.md' | Out-Null
+    # Show status of each potential document.
+    # These helpers report their line with Write-Output and ALSO return a
+    # bool, both on the Success stream, so 'Out-Null' discarded the report
+    # line along with the return value and left AVAILABLE_DOCS empty. Drop
+    # only the boolean so the per-document lines reach stdout like the
+    # bash and Python twins.
+    Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Where-Object { $_ -isnot [bool] }
+    Test-FileExists -Path $paths.DATA_MODEL -Description 'data-model.md' | Where-Object { $_ -isnot [bool] }
+    Test-DirHasFiles -Path $paths.CONTRACTS_DIR -Description 'contracts/' | Where-Object { $_ -isnot [bool] }
+    Test-FileExists -Path $paths.QUICKSTART -Description 'quickstart.md' | Where-Object { $_ -isnot [bool] }
 
     if ($IncludeTasks) {
-        Test-FileExists -Path $paths.TASKS -Description 'tasks.md' | Out-Null
+        Test-FileExists -Path $paths.TASKS -Description 'tasks.md' | Where-Object { $_ -isnot [bool] }
     }
 }

--- a/tests/test_check_prerequisites_python_parity.py
+++ b/tests/test_check_prerequisites_python_parity.py
@@ -436,3 +436,38 @@ class TestGetInvokeSeparatorTolerance:
             "integration_settings": {"droid": {"invoke_separator": "-"}},
         })
         assert common.get_invoke_separator(self._repo(tmp_path, body)) == "-"
+
+
+@pytest.mark.skipif(
+    not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available"
+)
+def test_powershell_text_output_lists_available_docs(prereq_repo: Path) -> None:
+    """Text mode must print a status line per document, like the twins.
+
+    `Test-FileExists` / `Test-DirHasFiles` report their line with `Write-Output`
+    and ALSO `return $true/$false`, both on the Success stream. The callers piped
+    the whole call to `| Out-Null` to discard the boolean, which discarded the
+    report line too — so `AVAILABLE_DOCS:` was emitted with nothing under it
+    while the bash and Python twins list every document.
+    """
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True)
+    (feat / "plan.md").write_text("# plan\n", encoding="utf-8")
+    (feat / "research.md").write_text("# research\n", encoding="utf-8")
+    _write_feature_json(prereq_repo)
+
+    ps = _run(_ps_cmd(prereq_repo, "-IncludeTasks"), prereq_repo)
+
+    assert ps.returncode == 0, ps.stderr
+    assert "AVAILABLE_DOCS:" in ps.stdout
+    for doc in (
+        "research.md",
+        "data-model.md",
+        "contracts/",
+        "quickstart.md",
+        "tasks.md",
+    ):
+        assert doc in ps.stdout, (doc, ps.stdout)
+    # The existing file reports [OK], the missing ones [FAIL].
+    assert "[OK] research.md" in _normalize_status_text(ps.stdout), ps.stdout
+    assert "[FAIL] quickstart.md" in _normalize_status_text(ps.stdout), ps.stdout


### PR DESCRIPTION
## Problem

`Test-FileExists` and `Test-DirHasFiles` in `scripts/powershell/common.ps1` do **two** things on the Success stream — they write the report line *and* return a bool:

```powershell
function Test-FileExists {
    param([string]$Path, [string]$Description)
    if (Test-Path -Path $Path -PathType Leaf) {
        Write-Output "  [OK] $Description"
        return $true
    } else {
        Write-Output "  [FAIL] $Description"
        return $false
    }
}
```

`check-prerequisites.ps1` piped the whole call to `| Out-Null` to throw away the boolean — which threw away the report line too.

## Reproduction on current `main` (81bf741)

`powershell.exe -NoProfile -File .specify/scripts/powershell/check-prerequisites.ps1 -IncludeTasks`, in a project with `specs/001-f/plan.md` and `specs/001-f/contracts/`:

```
FEATURE_DIR:...\specs\001-f
AVAILABLE_DOCS:
=== line count: 2 ===
```

`AVAILABLE_DOCS:` is emitted with **nothing under it**. The bash and Python twins list all five documents for the same inputs, so the PowerShell variant silently returns less information — and any agent parsing the doc list sees none.

## Fix

Drop only the boolean:

```powershell
Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Where-Object { $_ -isnot [bool] }
```

Measured after the fix, same project plus `research.md`:

```
FEATURE_DIR:...\specs\001-f
AVAILABLE_DOCS:
  [OK] research.md
  [FAIL] data-model.md
  [FAIL] contracts/
  [FAIL] quickstart.md
  [FAIL] tasks.md
=== line count: 7 ===
```

**No breaking change.** JSON mode does not go through this path and is untouched. The booleans were already being discarded and are still discarded; the only difference is that the lines the helpers were writing now actually reach stdout. Exit codes unchanged.

The file stays **ASCII-only** — verified 0 non-ASCII bytes after the edit.

## Verification

- **Fail-before / pass-after:** the new test fails on unpatched source and passes with the fix. File: **1 failed → 12 passed, 8 skipped**.
- This is the **first PowerShell text-mode test** in this file — every existing PS test uses `-Json`, which is why the gap was never caught. It is gated on the file's existing `HAS_PWSH or _WINDOWS_POWERSHELL` guard.
- Scoped regression: failure set identical to the clean-`main` baseline captured on `81bf741` (0 pre-existing in scope).
- `uvx ruff@0.15.0 check src tests` → clean

Note this test file is also touched by my open #3785 and #3890, so expect a trivial append conflict depending on merge order — happy to rebase.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main` with real `powershell.exe`.*