### PR TITLE
fix(scripts): stop setup-tasks text mode crashing on a legacy stdout code page

### DIFF
--- a/scripts/python/setup_tasks.py
+++ b/scripts/python/setup_tasks.py
@@ -55,14 +55,31 @@ def _available_docs(paths: FeaturePaths) -> list[str]:
     return docs
 
 
+def _status_marker(ok: bool) -> str:
+    """Return the status glyph, downgraded to ASCII when stdout cannot encode it.
+
+    On Windows sys.stdout falls back to the ANSI code page whenever it is not a
+    console - a pipe or a file redirect, which is how agents and workflow steps
+    invoke these scripts - and U+2713 is unencodable in cp1252, so printing it
+    raised UnicodeEncodeError and aborted the report mid-listing.
+    "[OK]"/"[FAIL]" is the ASCII rendering these markers already have in-tree:
+    see Test-FileExists in scripts/powershell/common.ps1 and
+    normalize_status_text in tests/parity_helpers.py.
+    """
+    glyph = "✓" if ok else "✗"
+    try:
+        glyph.encode(getattr(sys.stdout, "encoding", None) or "utf-8")
+    except (LookupError, UnicodeEncodeError):
+        return "[OK]" if ok else "[FAIL]"
+    return glyph
+
+
 def _check_file(path: Path, description: str) -> None:
-    marker = "✓" if path.is_file() else "✗"
-    print(f"  {marker} {description}")
+    print(f"  {_status_marker(path.is_file())} {description}")
 
 
 def _check_dir(path: Path, description: str) -> None:
-    marker = "✓" if _dir_has_entries(path) else "✗"
-    print(f"  {marker} {description}")
+    print(f"  {_status_marker(_dir_has_entries(path))} {description}")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_setup_tasks_python_parity.py
+++ b/tests/test_setup_tasks_python_parity.py
@@ -205,3 +205,28 @@ def test_missing_template_error_matches_all_variants(repo: Path) -> None:
     assert bash.returncode == ps.returncode == py.returncode == 1
     assert bash.stdout == ps.stdout == py.stdout == ""
     assert bash.stderr == ps.stderr == py.stderr
+
+
+def test_python_text_output_survives_a_legacy_stdout_code_page(repo: Path) -> None:
+    """Text mode must not crash when stdout cannot encode the status glyphs.
+
+    On Windows sys.stdout falls back to the ANSI code page whenever it is not a
+    console — which is every time an agent or a workflow step captures the
+    output. U+2713 is unencodable in cp1252, so printing it raised
+    UnicodeEncodeError and truncated the document listing. The ASCII fallback is
+    the rendering these markers already have in-tree (Test-FileExists in
+    scripts/powershell/common.ps1, and normalize_status_text).
+    """
+    feature = repo / "specs" / "001-my-feature"
+    (feature / "research.md").write_text("# research\n", encoding="utf-8")
+    (feature / "contracts").mkdir()
+
+    env = clean_env()
+    env["PYTHONIOENCODING"] = "cp1252"
+    result = run(py_cmd(repo, SCRIPT), repo, env=env)
+
+    assert result.returncode == 0, result.stderr
+    assert "UnicodeEncodeError" not in result.stderr
+    for doc in ("research.md", "data-model.md", "contracts/", "quickstart.md"):
+        assert doc in result.stdout, (doc, result.stdout)
+    assert "[OK] research.md" in normalize_status_text(result.stdout), result.stdout


### PR DESCRIPTION
## Problem

`_check_file` / `_check_dir` in `scripts/python/setup_tasks.py` hard-code the U+2713 / U+2717 glyphs and `print()` them to `sys.stdout`:

```python
marker = "✓" if path.is_file() else "✗"
print(f"  {marker} {description}")
```

On Windows `sys.stdout` falls back to the ANSI code page whenever stdout is **not a console** — a pipe or a file redirect, which is exactly how an agent or a workflow step invokes these scripts. U+2713 is unencodable in cp1252, so the document listing aborts mid-report with `UnicodeEncodeError`.

## Relationship to #3890

This is the **byte-identical twin** of the block in `scripts/python/check_prerequisites.py`. I flagged it explicitly in that PR's body rather than widening that PR's scope:

> `scripts/python/setup_tasks.py:58-65` carries a byte-identical block and crashes the same way. I kept this PR to one script — happy to extend it to the twin here or as a follow-up, whichever you prefer.

This is that follow-up. The two PRs touch different source files and different test files, so they are independent and can merge in either order.

## Fix

Downgrade to ASCII only when stdout cannot encode the glyph, so a UTF-8 console is unaffected:

```python
glyph = "✓" if ok else "✗"
try:
    glyph.encode(getattr(sys.stdout, "encoding", None) or "utf-8")
except (LookupError, UnicodeEncodeError):
    return "[OK]" if ok else "[FAIL]"
return glyph
```

`[OK]` / `[FAIL]` is the ASCII rendering these markers **already have in this repo**:

| Site | Code |
|---|---|
| `scripts/powershell/common.ps1:243` | `Write-Output "  [OK] $Description"` |
| `scripts/powershell/common.ps1:246` | `Write-Output "  [FAIL] $Description"` |
| `tests/parity_helpers.py:130-131` | `text.replace("  ✓ ", "  [OK] ").replace("  ✗ ", "  [FAIL] ")` |

The PowerShell twin emits the ASCII form natively and the shared parity helper maps the glyphs onto it, so the suite already treats the two as equivalent output.

**Breaking risk:** a UTF-8-capable stdout still gets the glyphs, byte-identical to today. The only case that changes is one that previously raised and truncated the report.

## Verification

- **Fail-before / pass-after:** the new test (running the real script with `PYTHONIOENCODING=cp1252`) fails on unpatched source and passes with the fix. File: **1 failed → 3 passed, 14 skipped** (the skips are the bash-requiring parity cases on Windows).
- Scoped regression: failure set identical to the clean-`main` baseline captured on `81bf741` (0 pre-existing in scope).
- `uvx ruff@0.15.0 check src tests` → clean

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*