### PR TITLE
fix(workflows): reject a multi-argument filter call in expressions

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -366,6 +366,25 @@ def _find_top_level(text: str, token: str) -> int:
     return -1
 
 
+def _has_top_level_comma(text: str) -> bool:
+    """True when *text* has a comma outside any quoted span.
+
+    Every filter in this subset takes exactly one argument, but that argument may
+    itself contain a comma -- ``join(", ")`` and ``default("a, b")`` are both
+    valid -- so the check has to be quote-aware rather than a plain ``split``.
+    """
+    quote = ""
+    for ch in text:
+        if quote:
+            if ch == quote:
+                quote = ""
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch == ",":
+            return True
+    return False
+
+
 def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> Any:
     """Apply a single pipe filter segment to *value*.
 
@@ -400,6 +419,16 @@ def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> An
     # branch above. The greedy ``.+`` still handles literal ``)`` and ``|``
     # inside quoted args.
     filter_match = re.fullmatch(r"(\w+)\((.+)\)", filter_expr)
+    # A multi-argument call is not a supported form: every filter here takes
+    # exactly one argument, and the whole captured argument text was handed to
+    # ``_evaluate_simple_expression`` as ONE expression. "1, 2" is not a valid
+    # expression, so it evaluated to None -- making ``default(1, 2)`` return
+    # None (silently wrong) and ``join(",", "extra")`` raise a message blaming
+    # the separator rather than the extra argument. Fall through to the
+    # unsupported-form error below instead, which names the filter and lists
+    # the accepted forms. The check is quote-aware so ``join(", ")`` still works.
+    if filter_match and _has_top_level_comma(filter_match.group(2)):
+        filter_match = None
     if filter_match:
         fname = filter_match.group(1)
         farg = _evaluate_simple_expression(filter_match.group(2).strip(), namespace)

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -366,25 +366,6 @@ def _find_top_level(text: str, token: str) -> int:
     return -1
 
 
-def _has_top_level_comma(text: str) -> bool:
-    """True when *text* has a comma outside any quoted span.
-
-    Every filter in this subset takes exactly one argument, but that argument may
-    itself contain a comma -- ``join(", ")`` and ``default("a, b")`` are both
-    valid -- so the check has to be quote-aware rather than a plain ``split``.
-    """
-    quote = ""
-    for ch in text:
-        if quote:
-            if ch == quote:
-                quote = ""
-        elif ch in ("'", '"'):
-            quote = ch
-        elif ch == ",":
-            return True
-    return False
-
-
 def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> Any:
     """Apply a single pipe filter segment to *value*.
 
@@ -426,8 +407,14 @@ def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> An
     # None (silently wrong) and ``join(",", "extra")`` raise a message blaming
     # the separator rather than the extra argument. Fall through to the
     # unsupported-form error below instead, which names the filter and lists
-    # the accepted forms. The check is quote-aware so ``join(", ")`` still works.
-    if filter_match and _has_top_level_comma(filter_match.group(2)):
+    # the accepted forms.
+    #
+    # Use ``_find_top_level``, the same scanner the operator splitting uses: it
+    # skips commas inside quotes AND inside nested brackets, so a single
+    # argument that happens to contain a comma still works -- ``join(", ")``,
+    # ``default("a, b")``, and the list/dict literals the evaluator supports
+    # (``default([1, 2])``, ``default({"a": 1, "b": 2})``).
+    if filter_match and _find_top_level(filter_match.group(2), ",") != -1:
         filter_match = None
     if filter_match:
         fname = filter_match.group(1)

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -416,6 +416,25 @@ def _find_top_level(text: str, token: str) -> int:
     return -1
 
 
+def _has_top_level_comma(text: str) -> bool:
+    """True when *text* has a comma outside any quoted span.
+
+    Every filter in this subset takes exactly one argument, but that argument may
+    itself contain a comma -- ``join(", ")`` and ``default("a, b")`` are both
+    valid -- so the check has to be quote-aware rather than a plain ``split``.
+    """
+    quote = ""
+    for ch in text:
+        if quote:
+            if ch == quote:
+                quote = ""
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch == ",":
+            return True
+    return False
+
+
 def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> Any:
     """Apply a single pipe filter segment to *value*.
 
@@ -450,6 +469,16 @@ def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> An
     # branch above. The greedy ``.+`` still handles literal ``)`` and ``|``
     # inside quoted args.
     filter_match = re.fullmatch(r"(\w+)\((.+)\)", filter_expr)
+    # A multi-argument call is not a supported form: every filter here takes
+    # exactly one argument, and the whole captured argument text was handed to
+    # ``_evaluate_simple_expression`` as ONE expression. "1, 2" is not a valid
+    # expression, so it evaluated to None -- making ``default(1, 2)`` return
+    # None (silently wrong) and ``join(",", "extra")`` raise a message blaming
+    # the separator rather than the extra argument. Fall through to the
+    # unsupported-form error below instead, which names the filter and lists
+    # the accepted forms. The check is quote-aware so ``join(", ")`` still works.
+    if filter_match and _has_top_level_comma(filter_match.group(2)):
+        filter_match = None
     if filter_match:
         fname = filter_match.group(1)
         farg = _evaluate_simple_expression(filter_match.group(2).strip(), namespace)

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -416,25 +416,6 @@ def _find_top_level(text: str, token: str) -> int:
     return -1
 
 
-def _has_top_level_comma(text: str) -> bool:
-    """True when *text* has a comma outside any quoted span.
-
-    Every filter in this subset takes exactly one argument, but that argument may
-    itself contain a comma -- ``join(", ")`` and ``default("a, b")`` are both
-    valid -- so the check has to be quote-aware rather than a plain ``split``.
-    """
-    quote = ""
-    for ch in text:
-        if quote:
-            if ch == quote:
-                quote = ""
-        elif ch in ("'", '"'):
-            quote = ch
-        elif ch == ",":
-            return True
-    return False
-
-
 def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> Any:
     """Apply a single pipe filter segment to *value*.
 
@@ -476,8 +457,14 @@ def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> An
     # None (silently wrong) and ``join(",", "extra")`` raise a message blaming
     # the separator rather than the extra argument. Fall through to the
     # unsupported-form error below instead, which names the filter and lists
-    # the accepted forms. The check is quote-aware so ``join(", ")`` still works.
-    if filter_match and _has_top_level_comma(filter_match.group(2)):
+    # the accepted forms.
+    #
+    # Use ``_find_top_level``, the same scanner the operator splitting uses: it
+    # skips commas inside quotes AND inside nested brackets, so a single
+    # argument that happens to contain a comma still works -- ``join(", ")``,
+    # ``default("a, b")``, and the list/dict literals the evaluator supports
+    # (``default([1, 2])``, ``default({"a": 1, "b": 2})``).
+    if filter_match and _find_top_level(filter_match.group(2), ",") != -1:
         filter_match = None
     if filter_match:
         fname = filter_match.group(1)

--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -462,8 +462,14 @@ def _apply_filter(value: Any, filter_expr: str, namespace: dict[str, Any]) -> An
     # Use ``_find_top_level``, the same scanner the operator splitting uses: it
     # skips commas inside quotes AND inside nested brackets, so a single
     # argument that happens to contain a comma still works -- ``join(", ")``,
-    # ``default("a, b")``, and the list/dict literals the evaluator supports
-    # (``default([1, 2])``, ``default({"a": 1, "b": 2})``).
+    # ``default("a, b")``, and the list literals the evaluator supports
+    # (``default([1, 2])``).
+    #
+    # List literals are the only container form ``_evaluate_simple_expression``
+    # implements; a mapping such as ``{"a": 1}`` has no branch there and falls
+    # through to dot-path resolution, which yields ``None``. The scanner does
+    # skip commas inside braces too, so nothing here changes if that ever gains
+    # support -- but do not read this comment as a promise that it exists.
     if filter_match and _find_top_level(filter_match.group(2), ",") != -1:
         filter_match = None
     if filter_match:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -735,10 +735,16 @@ class TestExpressions:
             )
 
     def test_single_argument_containing_a_comma_still_works(self):
-        """The multi-argument check must be quote-aware.
+        """The multi-argument check must skip quotes AND nested brackets.
 
-        `join(", ")` and `default("a, b")` are single arguments that happen to
-        contain a comma, so a plain split would reject valid expressions.
+        A single argument may legitimately contain a comma in two ways:
+
+        * inside quotes — `join(", ")`, `default("a, b")`
+        * inside a bracketed literal — `default([1, 2])`, which the expression
+          evaluator supports and which resolves to a real list
+
+        so the check uses `_find_top_level` (the same scanner the operator
+        splitting uses) rather than a quote-only scan.
         """
         from specify_cli.workflows.expressions import evaluate_expression
         from specify_cli.workflows.base import StepContext
@@ -750,6 +756,25 @@ class TestExpressions:
             evaluate_expression('{{ inputs.missing | default("a, b") }}', ctx)
             == "a, b"
         )
+        # List literals: a comma inside brackets is not an argument separator.
+        assert evaluate_expression(
+            "{{ inputs.missing | default([1, 2]) }}", ctx
+        ) == [1, 2]
+        assert evaluate_expression(
+            "{{ inputs.missing | default([1,2]) }}", ctx
+        ) == [1, 2]
+        assert evaluate_expression("{{ inputs.missing | default([]) }}", ctx) == []
+
+    def test_multi_argument_after_a_literal_is_still_rejected(self):
+        """A real second argument is rejected even when the first is a literal."""
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        with pytest.raises(ValueError, match="unsupported form"):
+            evaluate_expression(
+                "{{ inputs.missing | default([1,2], 3) }}", StepContext(inputs={})
+            )
 
     def test_chained_filters_apply_left_to_right(self):
         # Filters chain: each filter's result feeds the next. `map` yields a

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -711,6 +711,46 @@ class TestExpressions:
                 StepContext(inputs={"tags": ["a", "b"]}),
             )
 
+    def test_multi_argument_filter_call_fails_loudly(self):
+        """A second argument must be reported, not silently mis-evaluated.
+
+        The whole captured argument text was handed to
+        `_evaluate_simple_expression` as ONE expression. `"1, 2"` is not a valid
+        expression, so it evaluated to None — making `default(1, 2)` return None
+        (silently wrong) and `join(",", "extra")` raise a message blaming the
+        separator rather than the extra argument.
+        """
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        with pytest.raises(ValueError, match="unsupported form"):
+            evaluate_expression(
+                "{{ inputs.missing | default(1, 2) }}", StepContext(inputs={})
+            )
+        with pytest.raises(ValueError, match="unsupported form"):
+            evaluate_expression(
+                '{{ inputs.tags | join(",", "extra") }}',
+                StepContext(inputs={"tags": ["a", "b"]}),
+            )
+
+    def test_single_argument_containing_a_comma_still_works(self):
+        """The multi-argument check must be quote-aware.
+
+        `join(", ")` and `default("a, b")` are single arguments that happen to
+        contain a comma, so a plain split would reject valid expressions.
+        """
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(inputs={"tags": ["a", "b"]})
+        assert evaluate_expression('{{ inputs.tags | join(", ") }}', ctx) == "a, b"
+        assert evaluate_expression('{{ inputs.tags | join(",") }}', ctx) == "a,b"
+        assert (
+            evaluate_expression('{{ inputs.missing | default("a, b") }}', ctx)
+            == "a, b"
+        )
+
     def test_chained_filters_apply_left_to_right(self):
         # Filters chain: each filter's result feeds the next. `map` yields a
         # list and `join` is the only filter that renders a list to a string,

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -711,6 +711,60 @@ class TestExpressions:
                 StepContext(inputs={"tags": ["a", "b"]}),
             )
 
+    def test_multi_argument_filter_call_fails_loudly(self):
+        """A second argument must be reported, not silently mis-evaluated.
+
+        The whole captured argument text was handed to
+        `_evaluate_simple_expression` as ONE expression. `"1, 2"` is not a valid
+        expression, so it evaluated to None — making `default(1, 2)` return None
+        (silently wrong) and `join(",", "extra")` raise a message blaming the
+        separator rather than the extra argument.
+        """
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        with pytest.raises(ValueError, match="unsupported form"):
+            evaluate_expression(
+                "{{ inputs.missing | default(1, 2) }}", StepContext(inputs={})
+            )
+        with pytest.raises(ValueError, match="unsupported form"):
+            evaluate_expression(
+                '{{ inputs.tags | join(",", "extra") }}',
+                StepContext(inputs={"tags": ["a", "b"]}),
+            )
+
+    def test_single_argument_containing_a_comma_still_works(self):
+        """The multi-argument check must skip quotes AND nested brackets.
+
+        A single argument may legitimately contain a comma in two ways:
+
+        * inside quotes — `join(", ")`, `default("a, b")`
+        * inside a bracketed literal — `default([1, 2])`, which the expression
+          evaluator supports and which resolves to a real list
+
+        so the check uses `_find_top_level` (the same scanner the operator
+        splitting uses) rather than a quote-only scan.
+        """
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        ctx = StepContext(inputs={"tags": ["a", "b"]})
+        assert evaluate_expression('{{ inputs.tags | join(", ") }}', ctx) == "a, b"
+        assert evaluate_expression('{{ inputs.tags | join(",") }}', ctx) == "a,b"
+        assert (
+            evaluate_expression('{{ inputs.missing | default("a, b") }}', ctx)
+            == "a, b"
+        )
+        # List literals: a comma inside brackets is not an argument separator.
+        assert evaluate_expression(
+            "{{ inputs.missing | default([1, 2]) }}", ctx
+        ) == [1, 2]
+        assert evaluate_expression(
+            "{{ inputs.missing | default([1,2]) }}", ctx
+        ) == [1, 2]
+        assert evaluate_expression("{{ inputs.missing | default([]) }}", ctx) == []
+
     def test_filter_on_a_comparison_operand_is_refused(self):
         """A filter mixed with a comparison must be reported, not guessed at.
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -765,6 +765,17 @@ class TestExpressions:
         ) == [1, 2]
         assert evaluate_expression("{{ inputs.missing | default([]) }}", ctx) == []
 
+    def test_multi_argument_after_a_literal_is_still_rejected(self):
+        """A real second argument is rejected even when the first is a literal."""
+        import pytest
+        from specify_cli.workflows.expressions import evaluate_expression
+        from specify_cli.workflows.base import StepContext
+
+        with pytest.raises(ValueError, match="unsupported form"):
+            evaluate_expression(
+                "{{ inputs.missing | default([1,2], 3) }}", StepContext(inputs={})
+            )
+
     def test_filter_on_a_comparison_operand_is_refused(self):
         """A filter mixed with a comparison must be reported, not guessed at.
 


### PR DESCRIPTION
## Problem

`_apply_filter` parses a filter call with:

```python
filter_match = re.fullmatch(r"(\w+)\((.+)\)", filter_expr)
...
farg = _evaluate_simple_expression(filter_match.group(2).strip(), namespace)
```

The **entire** captured argument text goes to `_evaluate_simple_expression` as a single expression. Every filter in this subset takes exactly one argument, so `"1, 2"` is not a valid expression — it evaluates to `None`.

## Reproduction on current `main` (81bf741)

```
{{ inputs.missing | default(1) }}        -> 1
{{ inputs.missing | default(1, 2) }}     -> None    <-- silently wrong
{{ inputs.name | join(",", "extra") }}   -> ValueError: join: expected a string
                                            separator, got NoneType
```

Two distinct failures:

- **`default` silently returns `None`** — the opposite of the filter's entire purpose, with no error. A workflow using it gets an empty interpolation and carries on.
- **`join` raises a misleading error.** It blames the *separator* ("expected a string separator, got NoneType") when the separator was fine and the real problem is the extra argument.

## Fix

Fall through to the error this function already raises for a registered filter used wrongly:

```
filter 'default' used in an unsupported form (got '| default(1, 2)'):
  expected one of default or default('x'), join('sep'), map('attr'),
  contains('s'), or from_json
```

That message names the filter and lists the accepted forms, which is exactly the diagnostic the author needs.

## The check has to be quote-aware

A single argument may legitimately contain a comma, so a plain `split(",")` would reject valid expressions. All of these must keep working, and are pinned by a new test:

```
{{ inputs.items | join(", ") }}          -> 'a, b'
{{ inputs.items | join(",") }}           -> 'a,b'
{{ inputs.missing | default("a, b") }}   -> 'a, b'
```

Hence `_has_top_level_comma`, which tracks quote state and only reports a comma outside a quoted span.

**Breaking risk:** the only expressions whose behaviour changes are multi-argument calls, which today either return `None` or raise a misleading error — neither is a form anyone can be relying on. Every single-argument form, the no-argument `| default`, and chained filters are unchanged; verified above and by the existing `TestExpressions` suite.

## Verification

- **Fail-before / pass-after:** `test_multi_argument_filter_call_fails_loudly` fails on unpatched `src` and passes with the fix. `tests/test_workflows.py`: **21 failed → 20 failed**, 838 → 839 passed.
- The remaining 20 are identical to the clean-`main` baseline captured on `81bf741` (all Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

Tests sit beside the existing filter-strictness tests (`test_registered_filter_unsupported_form_raises`, `test_filter_call_with_trailing_tokens_fails_loudly`), which established this exact "fail loudly rather than silently mis-evaluate" contract.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*