### PR TITLE
fix(kimi): preserve non-UTF-8 user skills

### DIFF
--- a/src/specify_cli/integrations/kimi/__init__.py
+++ b/src/specify_cli/integrations/kimi/__init__.py
@@ -317,7 +317,7 @@ def _is_speckit_generated_skill(skill_dir: Path) -> bool:
 
     try:
         content = skill_file.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeError):
         return False
 
     if not content.startswith("---"):

--- a/tests/integrations/test_integration_kimi.py
+++ b/tests/integrations/test_integration_kimi.py
@@ -199,6 +199,24 @@ class TestKimiTeardownLegacyCleanup:
 
         assert user_skill.exists()
 
+    def test_teardown_preserves_non_utf8_user_skill(self, tmp_path):
+        i = get_integration("kimi")
+
+        user_skill = (
+            tmp_path
+            / ".kimi"
+            / "skills"
+            / "speckit-user-owned"
+            / "SKILL.md"
+        )
+        user_skill.parent.mkdir(parents=True)
+        user_skill.write_bytes(b"\xff\xfe")
+
+        m = IntegrationManifest("kimi", tmp_path)
+        i.teardown(tmp_path, m)
+
+        assert user_skill.read_bytes() == b"\xff\xfe"
+
 
 class TestKimiCommandInvocation:
     """Kimi dispatch must use the native ``/skill:`` slash command."""


### PR DESCRIPTION
## Summary

- treat a non-UTF-8 `SKILL.md` as user-owned during Kimi legacy cleanup
- preserve unreadable user skill content instead of aborting teardown
- add regression coverage for invalid UTF-8 skill bytes

## Testing

- `uvx ruff@0.15.0 check src tests`
- `.venv/bin/pytest tests/integrations/test_integration_kimi.py -q` (49 passed)
- `.venv/bin/pytest -q` (6106 passed, 176 skipped)

## AI disclosure

GitHub Copilot helped identify the cleanup edge case and review the implementation. I reproduced the failure and validated the final change with targeted and full test suites.