### PR TITLE
fix(presets): validate required manifest mappings

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -296,6 +296,12 @@ class PresetManifest:
                 f"(expected {self.SCHEMA_VERSION})"
             )
 
+        for section in ("preset", "requires", "provides"):
+            if not isinstance(self.data[section], dict):
+                raise PresetValidationError(
+                    f"Invalid {section}: expected a mapping"
+                )
+
         # Validate preset metadata
         pack = self.data["preset"]
         for field in ["id", "name", "version", "description"]:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -197,6 +197,25 @@ class TestPresetManifest:
             with pytest.raises(PresetValidationError, match="YAML mapping"):
                 PresetManifest(manifest_path)
 
+    @pytest.mark.parametrize("section", ["preset", "requires", "provides"])
+    @pytest.mark.parametrize("bad_value", [None, [], "text"])
+    def test_required_section_not_mapping_raises_validation_error(
+        self, temp_dir, valid_pack_data, section, bad_value
+    ):
+        """Required manifest sections reject null, list, and scalar values."""
+        valid_pack_data[section] = bad_value
+        manifest_path = temp_dir / "preset.yml"
+        manifest_path.write_text(
+            yaml.safe_dump(valid_pack_data),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(
+            PresetValidationError,
+            match=rf"Invalid {section}: expected a mapping",
+        ):
+            PresetManifest(manifest_path)
+
     @pytest.mark.parametrize(
         "bad",
         [


### PR DESCRIPTION
## Summary

- require the `preset`, `requires`, and `provides` manifest sections to be mappings
- raise `PresetValidationError` instead of leaking raw type errors from nested access
- cover invalid section shapes with regression tests

## Testing

- `uvx ruff@0.15.0 check src tests`
- `.venv/bin/pytest tests/test_presets.py -q` (517 passed)
- `.venv/bin/pytest -q` (6114 passed, 176 skipped)

## AI disclosure

GitHub Copilot helped identify the missing shape guards and review the implementation. I reproduced the failures and validated the final change with targeted and full test suites.