### PR TITLE
fix(workflows): reject mismatched run state IDs

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -732,6 +732,11 @@ class RunState:
                 "Invalid run state: missing required field(s): "
                 + ", ".join(missing_fields)
             )
+        if state_data["run_id"] != run_id:
+            raise ValueError(
+                f"Invalid run state: stored run_id {state_data['run_id']!r} "
+                f"does not match requested run_id {run_id!r}"
+            )
 
         workflow_id = state_data["workflow_id"]
         if not isinstance(workflow_id, str) or not _ID_PATTERN.fullmatch(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -6768,6 +6768,35 @@ class TestRunState:
         with pytest.raises(FileNotFoundError):
             RunState.load("nonexistent", project_dir)
 
+    def test_load_rejects_stored_run_id_mismatch(self, project_dir):
+        """The state payload cannot redirect later writes to another run."""
+        from specify_cli.workflows.engine import RunState
+
+        run_dir = (
+            project_dir
+            / ".specify"
+            / "workflows"
+            / "runs"
+            / "requested-run"
+        )
+        run_dir.mkdir(parents=True)
+        (run_dir / "state.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "other-run",
+                    "workflow_id": "test-workflow",
+                    "status": "created",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="stored run_id 'other-run' does not match requested run_id 'requested-run'",
+        ):
+            RunState.load("requested-run", project_dir)
+
     @pytest.mark.parametrize(
         ("installed_workflow_id", "installed_registry_root"),
         [


### PR DESCRIPTION
## Summary

- reject persisted run state whose `run_id` differs from the requested run directory
- prevent a corrupt state file from redirecting later saves into another run
- add regression coverage for mismatched stored identities

## Testing

- `uvx ruff@0.15.0 check src tests`
- `.venv/bin/pytest tests/test_workflows.py -q` (873 passed)
- `.venv/bin/pytest -q` (6106 passed, 176 skipped)

## AI disclosure

GitHub Copilot helped identify the inconsistent identity boundary and review the implementation. I reproduced the failure and validated the final change with targeted and full test suites.