### PR TITLE
fix(events): skip non-UTF-8 extension manifests

### DIFF
--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -895,7 +895,7 @@ def collect_extension_events(project_root: Path) -> ResolvedEvents:
                 continue
             try:
                 data = yaml.safe_load(ext_yml.read_text(encoding="utf-8")) or {}
-            except yaml.YAMLError:
+            except (UnicodeDecodeError, yaml.YAMLError):
                 continue
             if not isinstance(data, dict):
                 continue

--- a/tests/integrations/test_events.py
+++ b/tests/integrations/test_events.py
@@ -164,6 +164,13 @@ class TestCollectExtensionEvents:
         (ext_dir / "extension.yml").write_text("invalid: - - -", encoding="utf-8")
         assert collect_extension_events(tmp_path) == {}
 
+    def test_non_utf8_manifest_skipped(self, tmp_path):
+        ext_dir = tmp_path / ".specify" / "extensions" / "my-ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "extension.yml").write_bytes(b"\xff\xfe")
+
+        assert collect_extension_events(tmp_path) == {}
+
     def test_event_command_ref_canonicalized_via_manifest(self, tmp_path):
         """R1: events are read from a validated ExtensionManifest, so an
         obsolete command ref (e.g. my-ext.boot) is canonicalized


### PR DESCRIPTION
## Summary

- skip non-UTF-8 fallback `extension.yml` files during event collection
- preserve the documented fail-soft behavior for malformed on-disk extensions
- add regression coverage for invalid manifest bytes

## Testing

- `uvx ruff@0.15.0 check src tests`
- `.venv/bin/pytest tests/integrations/test_events.py -q` (105 passed)
- `.venv/bin/pytest -q` (6106 passed, 176 skipped)

## AI disclosure

GitHub Copilot helped identify the missing fallback boundary and review the implementation. I reproduced the failure and validated the final change with targeted and full test suites.