### PR TITLE
fix: enforce size limit on local workflow YAML files

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -1463,7 +1463,13 @@ def workflow_add(
         try:
             with yaml_path.open("rb") as source_file:
                 source_mode = os.fstat(source_file.fileno()).st_mode & 0o7777
-                source_content = source_file.read()
+                source_content = source_file.read(_MAX_WORKFLOW_YAML_BYTES + 1)
+            if len(source_content) > _MAX_WORKFLOW_YAML_BYTES:
+                console.print(
+                    f"[red]Error:[/red] Workflow YAML file exceeds "
+                    f"{_MAX_WORKFLOW_YAML_BYTES}-byte limit"
+                )
+                raise typer.Exit(1)
             definition = WorkflowDefinition.from_string(
                 source_content.decode("utf-8")
             )


### PR DESCRIPTION
## Problem

The codebase defines `_MAX_WORKFLOW_YAML_BYTES` (5 MiB) and enforces it on HTTP-downloaded workflows, but local YAML files read via `_validate_and_install_local()` had no size guard. A user or script pointing `specify workflow install` at an arbitrarily large local file could cause unbounded memory allocation.

## Fix

Apply the same 5 MiB limit to local workflow YAML files.

## Testing

- Verified normal workflow files install correctly

- Verified oversized files are rejected with a clear error message