### PR TITLE
fix: narrow exception in Content-Length header lookup from Exception to AttributeError

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -429,7 +429,7 @@ def _read_response_within_limit(response, max_bytes: int | None = None) -> bytes
     if callable(getheader):
         try:
             raw_length = getheader("Content-Length")
-        except Exception:
+        except AttributeError:
             raw_length = None
         if raw_length is not None:
             try:


### PR DESCRIPTION
## Problem

Bare `except Exception` would swallow `MemoryError`, `RecursionError`, etc.

## Fix

Narrow to `AttributeError` which is the only realistic failure from `getheader()`.

## Testing

- Verified Content-Length header is read correctly

- Verified missing header is handled gracefully