### PR TITLE
fix: handle TimeoutExpired and OSError in dispatch_command()

### DIFF
--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -407,18 +407,31 @@ class IntegrationBase(ABC):
                 "stderr": "",
             }
 
-        result = subprocess.run(
-            exec_args,
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            timeout=timeout,
-        )
-        return {
-            "exit_code": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-        }
+        try:
+            result = subprocess.run(
+                exec_args,
+                capture_output=True,
+                text=True,
+                cwd=cwd,
+                timeout=timeout,
+            )
+            return {
+                "exit_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "exit_code": 124,
+                "stdout": "",
+                "stderr": f"Command timed out after {timeout}s",
+            }
+        except OSError as exc:
+            return {
+                "exit_code": 1,
+                "stdout": "",
+                "stderr": f"Failed to execute command: {exc}",
+            }
 
     # -- Primitives — building blocks for setup() -------------------------
 

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -401,6 +401,12 @@ class IntegrationBase(ABC):
                     "stdout": "",
                     "stderr": "Interrupted by user",
                 }
+            except OSError as exc:
+                return {
+                    "exit_code": 1,
+                    "stdout": "",
+                    "stderr": f"Failed to execute command: {exc}",
+                }
             return {
                 "exit_code": result.returncode,
                 "stdout": "",

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -320,18 +320,31 @@ class CopilotIntegration(IntegrationBase):
                 "stderr": "",
             }
 
-        result = subprocess.run(
-            cli_args,
-            capture_output=True,
-            text=True,
-            cwd=cwd,
-            timeout=timeout,
-        )
-        return {
-            "exit_code": result.returncode,
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-        }
+        try:
+            result = subprocess.run(
+                cli_args,
+                capture_output=True,
+                text=True,
+                cwd=cwd,
+                timeout=timeout,
+            )
+            return {
+                "exit_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "exit_code": 124,
+                "stdout": "",
+                "stderr": f"Command timed out after {timeout}s",
+            }
+        except OSError as exc:
+            return {
+                "exit_code": 1,
+                "stdout": "",
+                "stderr": f"Failed to execute command: {exc}",
+            }
 
     def command_filename(self, template_name: str) -> str:
         """Copilot commands use ``.agent.md`` extension."""

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -314,6 +314,12 @@ class CopilotIntegration(IntegrationBase):
                     "stdout": "",
                     "stderr": "Interrupted by user",
                 }
+            except OSError as exc:
+                return {
+                    "exit_code": 1,
+                    "stdout": "",
+                    "stderr": f"Failed to execute command: {exc}",
+                }
             return {
                 "exit_code": result.returncode,
                 "stdout": "",


### PR DESCRIPTION
## Problem

`subprocess.run()` with timeout parameter can raise `TimeoutExpired` if the timeout elapses. Also catch `OSError` for cases where the binary is not found or not executable.

## Fix

Added try/except blocks to handle both exception types in both base and copilot dispatch_command().