### PR TITLE
fix: make StepRegistry atomic and raise on corruption

### DIFF
--- a/src/specify_cli/workflows/catalog.py
+++ b/src/specify_cli/workflows/catalog.py
@@ -885,28 +885,43 @@ class StepRegistry:
         # Defense-in-depth: refuse to read the registry if any parent directory
         # under .specify/workflows/steps is a symlink, which could redirect the
         # read outside the project root.
-        if self._has_symlinked_parent():
-            return default_registry
-        # Defense-in-depth: also refuse to read a symlinked registry file,
-        # which could redirect the read outside the project root.
-        if self.registry_path.is_symlink():
-            return default_registry
+        if self._has_symlinked_parent() or self.registry_path.is_symlink():
+            raise OSError(
+                f"Refusing to read step registry at {self.registry_path}: "
+                "a parent directory or the registry file itself is a symlink"
+            )
         if self.registry_path.exists():
             try:
                 with open(self.registry_path, encoding="utf-8") as f:
                     data = json.load(f)
-                # Validate shape: must be a dict with a dict "steps" field
-                if not isinstance(data, dict):
-                    return default_registry
-                if not isinstance(data.get("steps"), dict):
-                    data["steps"] = {}
-                return data
-            except (json.JSONDecodeError, ValueError, OSError, UnicodeError):
-                return default_registry
+            except OSError as exc:
+                raise OSError(
+                    f"Failed to read step registry at {self.registry_path}: {exc}"
+                ) from exc
+            except (
+                json.JSONDecodeError,
+                ValueError,
+                UnicodeError,
+            ) as exc:
+                raise OSError(
+                    f"Step registry at {self.registry_path} is corrupted: {exc}"
+                ) from exc
+            # Validate shape: must be a dict with a dict "steps" field
+            if not isinstance(data, dict):
+                raise OSError(
+                    f"Step registry at {self.registry_path} is corrupted: "
+                    "top-level value must be an object"
+                )
+            if not isinstance(data.get("steps"), dict):
+                raise OSError(
+                    f"Step registry at {self.registry_path} is corrupted: "
+                    "'steps' must be an object"
+                )
+            return data
         return default_registry
 
     def save(self) -> None:
-        """Persist registry to disk.
+        """Persist registry to disk atomically.
 
         Raises ``StepValidationError`` with a clear message on filesystem
         errors (read-only fs, permission denied, ...) so callers can surface
@@ -918,8 +933,21 @@ class StepRegistry:
             )
         try:
             self.steps_dir.mkdir(parents=True, exist_ok=True)
-            with open(self.registry_path, "w", encoding="utf-8") as f:
-                json.dump(self.data, f, indent=2)
+            fd, tmp = tempfile.mkstemp(
+                dir=str(self.registry_path.parent),
+                prefix=f".{self.registry_path.name}.",
+                suffix=".tmp",
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(self.data, f, indent=2)
+                os.replace(tmp, self.registry_path)
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
         except OSError as exc:
             raise StepValidationError(
                 f"Failed to write step registry at {self.registry_path}: {exc}"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -16447,3 +16447,48 @@ steps:
         result = runner.invoke(app, ["workflow", "disable", "align-wf"])
         assert result.exit_code == 0
         assert "already disabled" in result.output
+
+
+class TestStepRegistryAtomicSaveRegression:
+    """Regression: StepRegistry must use atomic save and raise on corruption."""
+
+    def test_load_raises_on_symlinked_file(self, tmp_path):
+        """StepRegistry must raise OSError on symlinked registry file."""
+        import json
+        from specify_cli.workflows.catalog import StepRegistry
+
+        steps_dir = tmp_path / ".specify" / "workflows" / "steps"
+        steps_dir.mkdir(parents=True)
+        registry_path = steps_dir / StepRegistry.REGISTRY_FILE
+        real_file = tmp_path / "real_registry.json"
+        real_file.write_text(json.dumps({"schema_version": "1.0", "steps": {}}), encoding="utf-8")
+        registry_path.symlink_to(real_file)
+
+        with pytest.raises(OSError, match="symlink"):
+            StepRegistry(tmp_path)
+
+    def test_load_raises_on_corrupted_json(self, tmp_path):
+        """StepRegistry must raise OSError on corrupted JSON."""
+        from specify_cli.workflows.catalog import StepRegistry
+
+        steps_dir = tmp_path / ".specify" / "workflows" / "steps"
+        steps_dir.mkdir(parents=True)
+        registry_path = steps_dir / StepRegistry.REGISTRY_FILE
+        registry_path.write_text("not valid json {{{", encoding="utf-8")
+
+        with pytest.raises(OSError, match="corrupted"):
+            StepRegistry(tmp_path)
+
+    def test_save_uses_atomic_write(self, tmp_path):
+        """StepRegistry.save() must use atomic write via mkstemp + os.replace."""
+        from specify_cli.workflows.catalog import StepRegistry
+
+        registry = StepRegistry(tmp_path)
+        registry.add("test-step", {"type": "command", "config": {}})
+        registry.save()
+
+        registry_path = tmp_path / ".specify" / "workflows" / "steps" / StepRegistry.REGISTRY_FILE
+        assert registry_path.exists()
+        import json
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert "test-step" in data.get("steps", {})


### PR DESCRIPTION
## Problem

`StepRegistry._load()` silently returned empty defaults on corruption, causing installed steps to appear to vanish. `save()` wrote directly to the target file risking data loss.

## Fix

`_load()` now raises `OSError` on symlinked paths and corrupted files. `save()` now uses atomic writes via mkstemp + os.replace.