### PR TITLE
fix: narrow exception in kimi skill detection from Exception to specific types

### DIFF
--- a/src/specify_cli/integrations/kimi/__init__.py
+++ b/src/specify_cli/integrations/kimi/__init__.py
@@ -339,9 +339,13 @@ def _is_speckit_generated_skill(skill_dir: Path) -> bool:
 
     try:
         import yaml
+    except ImportError:
+        return False
 
+    try:
         frontmatter = yaml.safe_load("".join(lines[1:close_idx]))
-    except Exception:
+    except yaml.YAMLError:
+        return False
         return False
 
     if not isinstance(frontmatter, dict):


### PR DESCRIPTION
## Problem

Bare `except Exception` catches everything including `MemoryError`, `RecursionError`, etc.

## Fix

Narrow to `(ImportError, yaml.YAMLError)` which are the realistic failure modes.