### PR TITLE
fix: catch OSError in streaming dispatch_command()

### DIFF
--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -401,6 +401,12 @@ class IntegrationBase(ABC):
                     "stdout": "",
                     "stderr": "Interrupted by user",
                 }
+            except OSError as exc:
+                return {
+                    "exit_code": 1,
+                    "stdout": "",
+                    "stderr": f"Failed to execute command: {exc}",
+                }
             return {
                 "exit_code": result.returncode,
                 "stdout": "",

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -314,6 +314,12 @@ class CopilotIntegration(IntegrationBase):
                     "stdout": "",
                     "stderr": "Interrupted by user",
                 }
+            except OSError as exc:
+                return {
+                    "exit_code": 1,
+                    "stdout": "",
+                    "stderr": f"Failed to execute command: {exc}",
+                }
             return {
                 "exit_code": result.returncode,
                 "stdout": "",


### PR DESCRIPTION
## Problem

The streaming branch only caught `KeyboardInterrupt` but not `OSError`. If the binary is removed between `shutil.which()` and `subprocess.run()` (TOCTOU race), an `OSError` propagates unhandled.

## Fix

Added `except OSError` handler in both base and copilot streaming dispatch.