### PR TITLE
fix(presets): restore core skills instead of deleting them on preset remove

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -3281,6 +3281,8 @@ class PresetManager:
                 if current_source not in owned_sources:
                     continue
 
+            extension_restore = extension_restore_index.get(skill_name)
+
             # Try to find the core command template. Project-local overrides
             # in core_templates_dir take precedence, but that directory is
             # rarely populated — the real core commands ship in the bundled
@@ -3288,9 +3290,17 @@ class PresetManager:
             # (source checkout). Callers that want a genuine restore (a
             # preset was removed outright, not superseded by another
             # renderer) opt into that fallback via restore_from_bundled_core
-            # so the skill is restored instead of deleted (#3928).
+            # so the skill is restored instead of deleted (#3928). An
+            # installed extension providing a core-named command resolves
+            # ahead of bundled core elsewhere, so skip the bundled fallback
+            # when an extension restore exists — otherwise it would win
+            # over the higher-priority extension layer below.
             core_file = core_templates_dir / f"{short_name}.md"
-            if not core_file.exists() and restore_from_bundled_core:
+            if (
+                not core_file.exists()
+                and restore_from_bundled_core
+                and extension_restore is None
+            ):
                 from .. import _locate_core_pack, _repo_root
 
                 _core_pack = _locate_core_pack()
@@ -3343,7 +3353,6 @@ class PresetManager:
                 mutated_names.append(skill_name)
                 continue
 
-            extension_restore = extension_restore_index.get(skill_name)
             if extension_restore:
                 content = extension_restore["source_file"].read_text(encoding="utf-8")
                 frontmatter, body = registrar.parse_frontmatter(content)

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -2157,7 +2157,10 @@ class PresetManager:
             ]
             if dir_core_ext_names:
                 self._unregister_skills_in_dir(
-                    dir_core_ext_names, skills_dir, dir_agent
+                    dir_core_ext_names,
+                    skills_dir,
+                    dir_agent,
+                    restore_from_bundled_core=True,
                 )
 
             for _skill_name, cmd_name, top_layer in override_skills:
@@ -2992,12 +2995,24 @@ class PresetManager:
         preset_dir: Union[Path, str],
         *,
         additional_owned_sources: Optional[Dict[str, str]] = None,
+        restore_from_bundled_core: bool = False,
     ) -> Dict[Path, tuple[Optional[str], List[str]]]:
         """Restore original SKILL.md files after a preset is removed.
 
         For each skill that was overridden by the preset, attempts to
         regenerate the skill from the core command template.  If no core
         template exists, the skill directory is removed.
+
+        Args:
+            restore_from_bundled_core: When True, a missing project-local
+                core template (the common case — ``specify init`` never
+                populates ``.specify/templates/commands``) falls back to
+                the bundled core_pack/repo-root templates so the skill is
+                restored instead of deleted (#3928). Callers that are
+                retiring a skill because its command now renders elsewhere
+                (a command file superseding it) must leave this False so
+                the skill is removed rather than resurrected with core
+                content that would duplicate the winning command.
 
         ``registered_skills`` records exactly which agent directories this
         preset actually wrote to (see :meth:`_register_skills`), so removal
@@ -3072,6 +3087,7 @@ class PresetManager:
                     renderer_agent,
                     pack_id=pack_id,
                     additional_owned_sources=additional_owned_sources,
+                    restore_from_bundled_core=restore_from_bundled_core,
                 )
                 if mutated_names:
                     restored[skills_dir] = (
@@ -3104,6 +3120,7 @@ class PresetManager:
             selected_ai,
             pack_id=pack_id,
             additional_owned_sources=additional_owned_sources,
+            restore_from_bundled_core=restore_from_bundled_core,
         )
         return (
             {skills_dir: (selected_ai, mutated_names)}
@@ -3177,6 +3194,7 @@ class PresetManager:
         *,
         pack_id: Optional[str] = None,
         additional_owned_sources: Optional[Dict[str, str]] = None,
+        restore_from_bundled_core: bool = False,
     ) -> List[str]:
         """Restore original SKILL.md files within a single skills directory.
 
@@ -3187,6 +3205,7 @@ class PresetManager:
                 placeholder resolution and argument-hint formatting.
             additional_owned_sources: Generated non-preset source markers
                 accepted as owned for specific skill names.
+            restore_from_bundled_core: See ``_unregister_skills``.
 
         Returns:
             Skill names whose files were restored or removed.
@@ -3262,9 +3281,24 @@ class PresetManager:
                 if current_source not in owned_sources:
                     continue
 
-            # Try to find the core command template
-            core_file = core_templates_dir / f"{short_name}.md" if core_templates_dir.exists() else None
-            if core_file and not core_file.exists():
+            # Try to find the core command template. Project-local overrides
+            # in core_templates_dir take precedence, but that directory is
+            # rarely populated — the real core commands ship in the bundled
+            # core_pack (wheel install) or the repo-root templates/ tree
+            # (source checkout). Callers that want a genuine restore (a
+            # preset was removed outright, not superseded by another
+            # renderer) opt into that fallback via restore_from_bundled_core
+            # so the skill is restored instead of deleted (#3928).
+            core_file = core_templates_dir / f"{short_name}.md"
+            if not core_file.exists() and restore_from_bundled_core:
+                from .. import _locate_core_pack, _repo_root
+
+                _core_pack = _locate_core_pack()
+                if _core_pack is not None:
+                    core_file = _core_pack / "commands" / f"{short_name}.md"
+                else:
+                    core_file = _repo_root() / "templates" / "commands" / f"{short_name}.md"
+            if not core_file.exists():
                 core_file = None
 
             if core_file:
@@ -3448,7 +3482,9 @@ class PresetManager:
                 "registered_skills", registered_skills
             )
             if persisted_skills:
-                self._unregister_skills(persisted_skills, dest_dir)
+                self._unregister_skills(
+                    persisted_skills, dest_dir, restore_from_bundled_core=True
+                )
             try:
                 if dest_dir.exists():
                     shutil.rmtree(dest_dir)
@@ -3786,6 +3822,7 @@ class PresetManager:
                 restorable_skills,
                 pack_dir,
                 additional_owned_sources=override_sources,
+                restore_from_bundled_core=True,
             )
             try:
                 from ..agents import CommandRegistrar

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -4957,6 +4957,71 @@ class TestPresetSkills:
         assert "templates/commands/specify.md" in content
         assert "Create or update the feature specification" in content
 
+    def test_extension_wins_over_bundled_core_on_preset_remove(
+        self, project_dir, monkeypatch
+    ):
+        """When an installed extension owns the same skill name as a core
+        command, removing a preset that overrode that skill must restore it
+        from the extension, not silently from the bundled core template.
+        Extensions are resolved ahead of bundled core elsewhere, and the
+        bundled-core fallback added for #3928 must not replace that
+        higher-priority layer.
+
+        The extension-command namespace rules (``speckit.<ext>.<command>``)
+        make a genuine end-to-end name collision with a core command
+        cumbersome to construct through real manifests, so this stubs
+        ``_build_extension_skill_restore_index`` to exercise the priority
+        ordering in ``_unregister_skills_in_dir`` directly -- the code path
+        under test doesn't care how the index entry was produced, only that
+        it wins over the bundled-core fallback when present.
+        """
+        self._write_init_options(project_dir, ai="claude")
+        skills_dir = project_dir / ".claude" / "skills"
+        self._create_skill(skills_dir, "speckit-specify")
+
+        # No project-local core template override — the normal case, and
+        # the one that makes the bundled-core fallback kick in at all.
+        core_cmds = project_dir / ".specify" / "templates" / "commands"
+        assert core_cmds.exists() and not any(core_cmds.iterdir())
+
+        extension_dir = project_dir / ".specify" / "extensions" / "fakeext"
+        (extension_dir / "commands").mkdir(parents=True, exist_ok=True)
+        ext_specify_file = extension_dir / "commands" / "specify.md"
+        ext_specify_file.write_text(
+            "---\ndescription: Extension specify command\n---\n\n"
+            "extension:fakeext specify body\n"
+        )
+
+        manager = PresetManager(project_dir)
+        install_self_test_preset(manager)
+
+        skill_file = skills_dir / "speckit-specify" / "SKILL.md"
+        assert "preset:self-test" in skill_file.read_text(encoding="utf-8")
+
+        fake_restore_index = {
+            "speckit-specify": {
+                "command_name": "speckit.fakeext.specify",
+                "source_file": ext_specify_file,
+                "source": "extension:fakeext",
+                "extension_id": "fakeext",
+                "extension_dir": extension_dir,
+            }
+        }
+        monkeypatch.setattr(
+            manager,
+            "_build_extension_skill_restore_index",
+            lambda: fake_restore_index,
+        )
+
+        manager.remove("self-test")
+
+        assert skill_file.exists()
+        content = skill_file.read_text(encoding="utf-8")
+        assert "preset:self-test" not in content
+        assert "source: extension:fakeext" in content
+        assert "extension:fakeext specify body" in content
+        assert "templates/commands/specify.md" not in content
+
     def test_skill_restored_on_remove_resolves_script_placeholders(self, project_dir):
         """Core restore should resolve {SCRIPT}/{ARGS} placeholders like other skill paths."""
         self._write_init_options(project_dir, ai="claude", ai_skills=True, script="sh")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -4947,12 +4947,12 @@ class TestPresetSkills:
         install_self_test_preset(manager)
 
         skill_file = skills_dir / "speckit-specify" / "SKILL.md"
-        assert "preset:self-test" in skill_file.read_text()
+        assert "preset:self-test" in skill_file.read_text(encoding="utf-8")
 
         manager.remove("self-test")
 
         assert skill_file.exists(), "Core skill must be restored, not deleted"
-        content = skill_file.read_text()
+        content = skill_file.read_text(encoding="utf-8")
         assert "preset:self-test" not in content
         assert "templates/commands/specify.md" in content
         assert "Create or update the feature specification" in content

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -4925,6 +4925,38 @@ class TestPresetSkills:
         assert "templates/commands/specify.md" in content, "Should reference core template"
         assert "disable-model-invocation: false" in content
 
+    def test_skill_restored_on_preset_remove_without_project_core_templates(self, project_dir):
+        """Removing a preset must restore core skills even when the project
+        has no ``.specify/templates/commands`` directory of its own — which
+        is the normal case, since ``specify init`` never populates it. The
+        real core commands live in the bundled core_pack/repo-root templates
+        tree, and restoration must fall back there instead of deleting the
+        skill outright (#3928).
+        """
+        self._write_init_options(project_dir, ai="claude")
+        skills_dir = project_dir / ".claude" / "skills"
+        self._create_skill(skills_dir, "speckit-specify")
+
+        # The project_dir fixture's commands dir is empty, matching a real
+        # project — specify init never populates project-local overrides
+        # for unmodified core commands.
+        core_cmds = project_dir / ".specify" / "templates" / "commands"
+        assert core_cmds.exists() and not any(core_cmds.iterdir())
+
+        manager = PresetManager(project_dir)
+        install_self_test_preset(manager)
+
+        skill_file = skills_dir / "speckit-specify" / "SKILL.md"
+        assert "preset:self-test" in skill_file.read_text()
+
+        manager.remove("self-test")
+
+        assert skill_file.exists(), "Core skill must be restored, not deleted"
+        content = skill_file.read_text()
+        assert "preset:self-test" not in content
+        assert "templates/commands/specify.md" in content
+        assert "Create or update the feature specification" in content
+
     def test_skill_restored_on_remove_resolves_script_placeholders(self, project_dir):
         """Core restore should resolve {SCRIPT}/{ARGS} placeholders like other skill paths."""
         self._write_init_options(project_dir, ai="claude", ai_skills=True, script="sh")


### PR DESCRIPTION
Fixes #3928

## Bug

When a preset that overrides core commands/skills is removed, the corresponding
core skills are deleted instead of being restored — the only way to get them
back is to re-scaffold with `specify init`.

## Root cause

`PresetManager._unregister_skills_in_dir` looks for the original core command
template at `self.project_root / ".specify" / "templates" / "commands"`. That
directory is never populated by `specify init` in a real project — the actual
core command templates live in the bundled `core_pack/commands/` directory
(wheel install) or the repo-root `templates/commands/` tree (source checkout),
exactly like `PresetResolver.resolve_core()` already falls back to via
`_locate_core_pack()` / `_repo_root()`.

Because the lookup always missed, every preset-removal restoration fell
through to the "no core template found" branch and deleted the skill outright.

## Fix

Restoration now falls back to the bundled core_pack/repo-root templates when
the project-local override directory doesn't have the file. This fallback is
gated behind a new `restore_from_bundled_core` flag so the pre-existing "retire
a stale skill because its command now renders as a command file elsewhere"
path (triggered by `ai_skills` mode toggles) keeps its original delete
behavior — it must not resurrect a duplicate skill that a command file has
already superseded.

## Repro (before the fix)

```
specify init --here --integration claude
specify preset add lean --dev presets/lean
ls .claude/skills          # all 10 core skills present
specify preset remove lean
ls .claude/skills          # only 5 remain — specify/plan/tasks/implement/constitution deleted
```

After the fix, all 10 skills are present again, restored with core content
after `specify preset remove lean`.

## Testing

Added `test_skill_restored_on_preset_remove_without_project_core_templates`,
which (unlike the existing `test_skill_restored_on_preset_remove`) does not
pre-seed `.specify/templates/commands` with a fake core file, matching what a
real `specify init` project looks like. Confirmed it fails without the fix
(`AssertionError: Core skill must be restored, not deleted`) via
`git checkout HEAD~1 -- src/specify_cli/presets/__init__.py`, then passes with
the fix restored.

```
$ .venv/bin/python -m pytest tests/test_presets.py -q
526 passed in 7.40s

$ .venv/bin/python -m pytest tests -q
6380 passed, 9 skipped in 396.25s

$ .venv/bin/python -m pytest tests/test_agent_config_consistency.py -q
28 passed in 0.24s

$ uvx ruff@0.15.0 check src tests
All checks passed!
```

## AI disclosure

This PR was authored primarily by an AI coding agent (Claude Code): it
diagnosed the root cause, implemented the fix, and wrote/verified the
regression test. I reviewed the diff and test output before submitting.
