### PR TITLE
feat(workflows): add dry-run previews

### DIFF
--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -12,6 +12,7 @@ specify workflow run <source>
 | ------------------- | -------------------------------------------------------- |
 | `-i` / `--input`    | Pass input values as `key=value` (repeatable)            |
 | `--json`            | Emit the run outcome as a single JSON object             |
+| `--dry-run`         | Preview agent-facing steps without dispatching an agent  |
 
 Runs a workflow from a catalog ID, URL, or local file path. Inputs declared by the workflow can be provided via `--input` or will be prompted interactively.
 
@@ -20,6 +21,14 @@ Example:
 ```bash
 specify workflow run speckit -i spec="Build a kanban board with drag-and-drop task management" -i scope=full
 ```
+
+Use `--dry-run` to resolve and preview each built-in `command`, `prompt`, and `gate` step without invoking an integration CLI or waiting for gate input:
+
+```bash
+specify workflow run speckit --dry-run -i spec="Build a kanban board"
+```
+
+> **Warning:** Workflow dry-run is not a side-effect-free sandbox. Built-in `shell` and `init` steps, plus custom step types, keep their normal behavior and may execute commands or write files. Inspect the workflow before running it. The dry-run setting is stored in the run state, so `workflow resume` continues to preview command, prompt, and gate steps while retaining the same warning and side-effect boundary.
 
 With `--json`, a single machine-readable object is printed instead of formatted text (the default output is unchanged when the flag is omitted):
 
@@ -53,6 +62,37 @@ For `failed` and `aborted` runs, the payload includes an `error` field carrying 
 ```
 
 `completed` and `paused` runs omit the `error` field. The error is persisted in the run's `state.json`, so `specify workflow status <run_id> --json` surfaces the same message after the fact.
+
+Dry-run JSON adds `dry_run: true` and a `previews` array. Each preview contains the step ID and type, the resolved configuration, and the same human-readable message shown in formatted output:
+
+```json
+{
+  "run_id": "662bf791",
+  "workflow_id": "build-and-review",
+  "status": "completed",
+  "current_step_id": "review",
+  "current_step_index": 1,
+  "dry_run": true,
+  "previews": [
+    {
+      "step_id": "specify",
+      "type": "command",
+      "configuration": {
+        "command": "speckit.specify",
+        "integration": "copilot",
+        "model": null,
+        "options": {},
+        "input": {
+          "args": "Build a kanban board"
+        }
+      },
+      "message": "[DRY RUN] command='speckit.specify'; integration='copilot'; model=None; options={}; input={'args': 'Build a kanban board'}"
+    }
+  ]
+}
+```
+
+If execution raises after some previews have been resolved, `--json` still emits one failed object and includes those partial previews. Formatted output prints the same partial previews before the error.
 
 > **Note:** Most workflow commands require a project already initialized with `specify init`. The exception is `specify workflow run <local-file.{yml,yaml}>`, which can run outside a project; in that case, run state is stored under the current directory's `.specify/workflows/runs/<run_id>/`.
 

--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -1169,7 +1169,9 @@ def _failed_step_error(state: Any) -> str | None:
     return getattr(state, "error", None)
 
 
-def _workflow_run_payload(state: Any) -> dict[str, Any]:
+def _workflow_run_payload(
+    state: Any, *, include_previews: bool = True
+) -> dict[str, Any]:
     """Machine-readable summary of a run/resume outcome."""
     payload = {
         "run_id": state.run_id,
@@ -1184,7 +1186,189 @@ def _workflow_run_payload(state: Any) -> dict[str, Any]:
     error = _failed_step_error(state)
     if error is not None:
         payload["error"] = error
+    if getattr(state, "dry_run", False):
+        payload["dry_run"] = True
+        if include_previews:
+            payload["previews"] = _dry_run_previews(state)
     return payload
+
+
+def _dry_run_previews(state: Any) -> list[dict[str, Any]]:
+    """Return stable, structured previews from dry-run-capable steps."""
+    previews: list[dict[str, Any]] = []
+    recorded = getattr(state, "dry_run_previews", None)
+    sources: list[tuple[Any, dict[str, Any]]] = []
+    if isinstance(recorded, list):
+        def order_key(record: Any) -> tuple[int, ...]:
+            if isinstance(record, dict):
+                order = record.get("order")
+                if isinstance(order, list) and all(
+                    isinstance(part, int) and not isinstance(part, bool)
+                    for part in order
+                ):
+                    return (0, *order)
+            return (1,)
+
+        for record in sorted(recorded, key=order_key):
+            if not isinstance(record, dict):
+                continue
+            sources.append(
+                (
+                    record.get("step_id", "?"),
+                    {
+                        "type": record.get("type", "command"),
+                        "output": record.get("output"),
+                    },
+                )
+            )
+    else:
+        # Legacy dry-run states predate the separate ordered preview log.
+        sources.extend((getattr(state, "step_results", None) or {}).items())
+
+    for step_id, step in sources:
+        if not isinstance(step, dict):
+            continue
+        output = step.get("output")
+        if not isinstance(output, dict) or output.get("dry_run") is not True:
+            continue
+        message = output.get("dry_run_message")
+        if not isinstance(message, str):
+            continue
+        structured = output.get("dry_run_preview")
+        if isinstance(structured, dict):
+            step_type = structured.get("type", step.get("type", "command"))
+            configuration = {
+                key: value for key, value in structured.items() if key != "type"
+            }
+        else:
+            # Persisted runs produced by an earlier dry-run implementation may
+            # only carry the human-readable message. Keep those resumable while
+            # exposing the strongest structure that remains available.
+            step_type = step.get("type", "command")
+            configuration = {}
+        previews.append(
+            {
+                "step_id": str(step_id),
+                "type": str(step_type),
+                "configuration": configuration,
+                "message": message,
+            }
+        )
+    return previews
+
+
+def _print_dry_run_previews(state: Any) -> None:
+    """Render dry-run previews for human output, if any were produced."""
+    previews = _dry_run_previews(state)
+    if not previews:
+        return
+    console.print("\n[bold cyan]Dry-run previews:[/bold cyan]")
+    for preview in previews:
+        console.print(
+            f"  \u25b8 \\[{_escape_markup(preview['step_id'])}] "
+            f"{_escape_markup(preview['message'])}"
+        )
+        configuration = preview.get("configuration")
+        if isinstance(configuration, dict) and configuration:
+            rendered = json.dumps(
+                configuration,
+                ensure_ascii=False,
+                separators=(",", ": "),
+            )
+            console.print(f"      configuration: {_escape_markup(rendered)}")
+
+
+def _print_dry_run_warning() -> None:
+    """Explain the deliberately limited side-effect boundary before execution."""
+    console.print(
+        "[yellow]DRY RUN:[/yellow] command, prompt, and gate steps "
+        "will not dispatch an agent; shell, init, and custom steps still execute.\n"
+    )
+
+
+def _exception_run_state(exc: Exception) -> Any:
+    """Return only the engine-owned state attached to a workflow exception."""
+    from .engine import RunState
+
+    try:
+        candidate = getattr(exc, "_speckit_workflow_state", None)
+    except Exception:
+        return None
+    return candidate if isinstance(candidate, RunState) else None
+
+
+def _workflow_exception_payload(
+    exc: Exception,
+    *,
+    workflow_id: str | None = None,
+    dry_run: bool = False,
+    fallback_state: Any = None,
+) -> dict[str, Any]:
+    """Build the one-object JSON failure contract for an engine exception."""
+    partial_state = _exception_run_state(exc) or fallback_state
+    if partial_state is not None:
+        payload = _workflow_run_payload(partial_state)
+        payload["status"] = "failed"
+        payload["error"] = str(exc)
+        return payload
+    payload: dict[str, Any] = {
+        "run_id": None,
+        "workflow_id": workflow_id,
+        "status": "failed",
+        "current_step_id": None,
+        "current_step_index": 0,
+        "error": str(exc),
+    }
+    if dry_run:
+        payload["dry_run"] = True
+        payload["previews"] = []
+    return payload
+
+
+@contextlib.contextmanager
+def _workflow_preflight_guard(
+    json_output: bool,
+    *,
+    error_message: str,
+    workflow_id: str | None = None,
+    run_id: str | None = None,
+    dry_run: bool = False,
+    fallback_state: Any = None,
+):
+    """Keep pre-execution output off JSON stdout and emit one failure object."""
+    try:
+        with _stdout_to_stderr_when(json_output):
+            yield
+    except typer.Exit:
+        if json_output:
+            exc = RuntimeError(error_message)
+            payload = _workflow_exception_payload(
+                exc,
+                workflow_id=workflow_id,
+                dry_run=dry_run,
+                fallback_state=fallback_state,
+            )
+            if run_id is not None and payload.get("run_id") is None:
+                payload["run_id"] = run_id
+            _emit_workflow_json(payload)
+        raise
+    except Exception as exc:
+        if json_output:
+            payload = _workflow_exception_payload(
+                exc,
+                workflow_id=workflow_id,
+                dry_run=dry_run,
+                fallback_state=fallback_state,
+            )
+            if run_id is not None and payload.get("run_id") is None:
+                payload["run_id"] = run_id
+            _emit_workflow_json(payload)
+        else:
+            console.print(
+                f"[red]Workflow preparation failed:[/red] "
+                f"{_escape_markup(str(exc))}"
+            )
+        raise typer.Exit(1)
 
 
 def _is_gate_step(step: dict[str, Any]) -> bool:
@@ -1316,6 +1500,14 @@ def workflow_run(
         "--json",
         help="Emit the run outcome as a single JSON object instead of formatted text.",
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Preview command, prompt, and gate steps without agent dispatch. "
+            "Shell, init, and custom steps still execute normally."
+        ),
+    ),
 ):
     """Run a workflow from an installed ID or local YAML path."""
     from . import load_custom_steps
@@ -1324,18 +1516,26 @@ def workflow_run(
     source_path = Path(source).expanduser()
     is_file_source = source_path.suffix.lower() in (".yml", ".yaml") and source_path.is_file()
 
-    if is_file_source:
-        # When running a YAML file directly, use cwd as project root without
-        # requiring a .specify/ project directory — unless SPECIFY_INIT_DIR
-        # explicitly names a project, in which case the strict override applies.
-        override = _resolve_init_dir_override()
-        project_root = override if override is not None else Path.cwd()
-        _reject_unsafe_workflow_storage(project_root)
-    else:
-        project_root = _require_specify_project()
+    with _workflow_preflight_guard(
+        json_output and dry_run,
+        error_message="Workflow project preparation failed",
+        workflow_id=None if is_file_source else source,
+        dry_run=dry_run,
+    ):
+        if is_file_source:
+            # When running a YAML file directly, use cwd as project root without
+            # requiring a .specify/ project directory — unless SPECIFY_INIT_DIR
+            # explicitly names a project, in which case the strict override applies.
+            override = _resolve_init_dir_override()
+            project_root = override if override is not None else Path.cwd()
+            _reject_unsafe_workflow_storage(project_root)
+        else:
+            project_root = _require_specify_project()
 
-    load_custom_steps(project_root)
-    engine = WorkflowEngine(project_root)
+        # Custom modules are allowed to execute import-time code. Keep any
+        # incidental output on stderr so JSON stdout remains one object.
+        load_custom_steps(project_root)
+        engine = WorkflowEngine(project_root)
     if not json_output:
         # Escape the literal bracket (\[) so Rich renders `[<step id>]` instead
         # of parsing it as a style tag named after the step id -- which it
@@ -1352,54 +1552,68 @@ def workflow_run(
 
     err = _error_console(json_output)
 
-    registered_id: str | None = None
-    registry_root = project_root
-    if not is_file_source:
-        # Reject path-equivalent spellings ("align-wf/", "align-wf/.") that
-        # would miss the registry lookup yet still load the installed file,
-        # bypassing the disabled check below.
-        if source in _RESERVED_WORKFLOW_IDS or not _WORKFLOW_ID_PATTERN.fullmatch(source):
-            err.print(
-                f"[red]Error:[/red] Invalid workflow ID: {_escape_markup(repr(source))}"
-            )
+    with _workflow_preflight_guard(
+        json_output and dry_run,
+        error_message="Workflow source validation failed",
+        workflow_id=None if is_file_source else source,
+        dry_run=dry_run,
+    ):
+        registered_id: str | None = None
+        registry_root = project_root
+        if not is_file_source:
+            # Reject path-equivalent spellings ("align-wf/", "align-wf/.") that
+            # would miss the registry lookup yet still load the installed file,
+            # bypassing the disabled check below.
+            if source in _RESERVED_WORKFLOW_IDS or not _WORKFLOW_ID_PATTERN.fullmatch(source):
+                err.print(
+                    f"[red]Error:[/red] Invalid workflow ID: {_escape_markup(repr(source))}"
+                )
+                raise typer.Exit(1)
+            registered_id = source
+        else:
+            # A direct YAML path may still point at an installed workflow's own
+            # file (lexically, or via a symlinked alias pointing into installed
+            # storage); map it back to its owning project and ID so the
+            # disabled check below can't be silently bypassed.
+            owner_root, owner_id = _resolve_installed_workflow_ownership(source_path, err)
+            if owner_id is not None:
+                registry_root = owner_root
+                registered_id = owner_id
+
+        if registered_id is not None:
+            _require_enabled_workflow(registry_root, registered_id, err)
+
+    with _workflow_preflight_guard(
+        json_output and dry_run,
+        error_message="Workflow loading or validation failed",
+        workflow_id=registered_id or (None if is_file_source else source),
+        dry_run=dry_run,
+    ):
+        try:
+            definition = engine.load_workflow(source_path if is_file_source else source)
+        except FileNotFoundError:
+            err.print(f"[red]Error:[/red] Workflow not found: {_escape_markup(source)}")
             raise typer.Exit(1)
-        registered_id = source
-    else:
-        # A direct YAML path may still point at an installed workflow's own
-        # file (lexically, or via a symlinked alias pointing into installed
-        # storage); map it back to its owning project and ID so the
-        # disabled check below can't be silently bypassed.
-        owner_root, owner_id = _resolve_installed_workflow_ownership(source_path, err)
-        if owner_id is not None:
-            registry_root = owner_root
-            registered_id = owner_id
+        except ValueError as exc:
+            err.print(f"[red]Error:[/red] Invalid workflow: {_escape_markup(str(exc))}")
+            raise typer.Exit(1)
 
-    if registered_id is not None:
-        _require_enabled_workflow(registry_root, registered_id, err)
+        # Validate
+        errors = engine.validate(definition)
+        if errors:
+            err.print("[red]Workflow validation failed:[/red]")
+            for verr in errors:
+                err.print(f"  • {_escape_markup(str(verr))}")
+            raise typer.Exit(1)
 
-    try:
-        definition = engine.load_workflow(source_path if is_file_source else source)
-    except FileNotFoundError:
-        err.print(f"[red]Error:[/red] Workflow not found: {source}")
-        raise typer.Exit(1)
-    except ValueError as exc:
-        err.print(f"[red]Error:[/red] Invalid workflow: {exc}")
-        raise typer.Exit(1)
-
-    # Validate
-    errors = engine.validate(definition)
-    if errors:
-        err.print("[red]Workflow validation failed:[/red]")
-        for verr in errors:
-            err.print(f"  • {_escape_markup(str(verr))}")
-        raise typer.Exit(1)
-
-    # Parse inputs
-    inputs = _parse_input_values(input_values, json_output=json_output)
+        # Parse inputs
+        inputs = _parse_input_values(input_values, json_output=json_output)
 
     if not json_output:
         console.print(f"\n[bold cyan]Running workflow:[/bold cyan] {definition.name} ({definition.id})")
         console.print(f"[dim]Version: {definition.version}[/dim]\n")
+        if dry_run:
+            _print_dry_run_warning()
 
     try:
         with _stdout_to_stderr_when(json_output):
@@ -1422,17 +1636,41 @@ def workflow_run(
                     and not _same_existing_path(registry_root, project_root)
                     else None
                 ),
+                dry_run=dry_run,
             )
     except ValueError as exc:
-        err.print(f"[red]Error:[/red] {exc}")
+        partial_state = _exception_run_state(exc)
+        if json_output:
+            _emit_workflow_json(
+                _workflow_exception_payload(
+                    exc, workflow_id=definition.id, dry_run=dry_run
+                )
+            )
+        else:
+            if getattr(partial_state, "dry_run", False):
+                _print_dry_run_previews(partial_state)
+            err.print(f"[red]Error:[/red] {_escape_markup(str(exc))}")
         raise typer.Exit(1)
     except Exception as exc:
-        err.print(f"[red]Workflow failed:[/red] {exc}")
+        partial_state = _exception_run_state(exc)
+        if json_output:
+            _emit_workflow_json(
+                _workflow_exception_payload(
+                    exc, workflow_id=definition.id, dry_run=dry_run
+                )
+            )
+        else:
+            if getattr(partial_state, "dry_run", False):
+                _print_dry_run_previews(partial_state)
+            err.print(f"[red]Workflow failed:[/red] {_escape_markup(str(exc))}")
         raise typer.Exit(1)
 
     if json_output:
         _emit_workflow_json(_workflow_run_payload(state))
         raise typer.Exit(_run_outcome_exit_code(state.status.value))
+
+    if state.dry_run:
+        _print_dry_run_previews(state)
 
     status_colors = {
         "completed": "green",
@@ -1470,9 +1708,13 @@ def workflow_resume(
     from . import load_custom_steps
     from .engine import RunState, WorkflowEngine
 
-    project_root = _require_specify_project()
-    load_custom_steps(project_root)
-    engine = WorkflowEngine(project_root)
+    with _workflow_preflight_guard(
+        False,
+        error_message="Workflow resume project preparation failed",
+        run_id=run_id,
+    ):
+        project_root = _require_specify_project()
+        engine = WorkflowEngine(project_root)
     if not json_output:
         # Escape the literal bracket (\[) so Rich renders `[<step id>]` instead
         # of parsing it as a style tag named after the step id -- which it
@@ -1487,7 +1729,6 @@ def workflow_resume(
             f"{_escape_markup(str(label))} \u2026"
         )
 
-    inputs = _parse_input_values(input_values, json_output=json_output)
     err = _error_console(json_output)
 
     # Pre-load the persisted run state so a run started from an installed
@@ -1497,57 +1738,117 @@ def workflow_resume(
     # guard `workflow run` enforces. Runs without installed_workflow_id
     # (a direct/non-installed source, or a run persisted before this field
     # existed) are unaffected and resume exactly as before.
-    try:
-        pre_state = RunState.load(run_id, project_root)
-    except FileNotFoundError:
-        err.print(f"[red]Error:[/red] Run not found: {run_id}")
-        raise typer.Exit(1)
-    except ValueError as exc:
-        err.print(f"[red]Error:[/red] {_escape_markup(str(exc))}")
-        raise typer.Exit(1)
-    except OSError as exc:
-        err.print(f"[red]Resume failed:[/red] {_escape_markup(str(exc))}")
-        raise typer.Exit(1)
-
-    if pre_state.installed_workflow_id is not None:
+    with _workflow_preflight_guard(
+        False,
+        error_message="Workflow run state could not be loaded",
+        run_id=run_id,
+    ):
         try:
-            owner_root = _resolve_run_owner_root(
-                pre_state.installed_registry_root, project_root
-            )
+            pre_state = RunState.load(run_id, project_root)
+        except FileNotFoundError:
+            err.print(f"[red]Error:[/red] Run not found: {_escape_markup(run_id)}")
+            raise typer.Exit(1)
         except ValueError as exc:
             err.print(f"[red]Error:[/red] {_escape_markup(str(exc))}")
             raise typer.Exit(1)
-        _require_enabled_workflow(
-            owner_root, pre_state.installed_workflow_id, err
-        )
-    elif not pre_state.installed_origin_tracked:
-        if _require_enabled_workflow(
-            project_root, pre_state.workflow_id, err
-        ):
-            pre_state.installed_workflow_id = pre_state.workflow_id
-        pre_state.installed_origin_tracked = True
-        try:
-            pre_state.save()
         except OSError as exc:
             err.print(f"[red]Resume failed:[/red] {_escape_markup(str(exc))}")
             raise typer.Exit(1)
 
+    with _workflow_preflight_guard(
+        json_output and pre_state.dry_run,
+        error_message="Workflow resume validation failed",
+        workflow_id=pre_state.workflow_id,
+        run_id=run_id,
+        dry_run=pre_state.dry_run,
+        fallback_state=pre_state,
+    ):
+        # Once the persisted mode is known, dry-run JSON can safely isolate
+        # import-time output without widening the legacy non-dry error contract.
+        load_custom_steps(project_root)
+        if pre_state.installed_workflow_id is not None:
+            try:
+                owner_root = _resolve_run_owner_root(
+                    pre_state.installed_registry_root, project_root
+                )
+            except ValueError as exc:
+                err.print(f"[red]Error:[/red] {_escape_markup(str(exc))}")
+                raise typer.Exit(1)
+            _require_enabled_workflow(
+                owner_root, pre_state.installed_workflow_id, err
+            )
+        elif not pre_state.installed_origin_tracked:
+            if _require_enabled_workflow(
+                project_root, pre_state.workflow_id, err
+            ):
+                pre_state.installed_workflow_id = pre_state.workflow_id
+            pre_state.installed_origin_tracked = True
+            try:
+                pre_state.save()
+            except OSError as exc:
+                err.print(f"[red]Resume failed:[/red] {_escape_markup(str(exc))}")
+                raise typer.Exit(1)
+
+        inputs = _parse_input_values(input_values, json_output=json_output)
+
+    if pre_state.dry_run and not json_output:
+        _print_dry_run_warning()
+
     try:
         with _stdout_to_stderr_when(json_output):
             state = engine.resume(run_id, inputs or None)
-    except FileNotFoundError:
-        err.print(f"[red]Error:[/red] Run not found: {run_id}")
+    except FileNotFoundError as exc:
+        if json_output:
+            _emit_workflow_json(
+                _workflow_exception_payload(
+                    exc,
+                    workflow_id=pre_state.workflow_id,
+                    dry_run=pre_state.dry_run,
+                    fallback_state=pre_state,
+                )
+            )
+        else:
+            err.print(f"[red]Error:[/red] Run not found: {_escape_markup(run_id)}")
         raise typer.Exit(1)
     except ValueError as exc:
-        err.print(f"[red]Error:[/red] {_escape_markup(str(exc))}")
+        partial_state = _exception_run_state(exc) or pre_state
+        if json_output:
+            _emit_workflow_json(
+                _workflow_exception_payload(
+                    exc,
+                    workflow_id=pre_state.workflow_id,
+                    dry_run=pre_state.dry_run,
+                    fallback_state=pre_state,
+                )
+            )
+        else:
+            if getattr(partial_state, "dry_run", False):
+                _print_dry_run_previews(partial_state)
+            err.print(f"[red]Error:[/red] {_escape_markup(str(exc))}")
         raise typer.Exit(1)
     except Exception as exc:
-        err.print(f"[red]Resume failed:[/red] {_escape_markup(str(exc))}")
+        partial_state = _exception_run_state(exc) or pre_state
+        if json_output:
+            _emit_workflow_json(
+                _workflow_exception_payload(
+                    exc,
+                    workflow_id=pre_state.workflow_id,
+                    dry_run=pre_state.dry_run,
+                    fallback_state=pre_state,
+                )
+            )
+        else:
+            if getattr(partial_state, "dry_run", False):
+                _print_dry_run_previews(partial_state)
+            err.print(f"[red]Resume failed:[/red] {_escape_markup(str(exc))}")
         raise typer.Exit(1)
 
     if json_output:
         _emit_workflow_json(_workflow_run_payload(state))
         raise typer.Exit(_run_outcome_exit_code(state.status.value))
+
+    if state.dry_run:
+        _print_dry_run_previews(state)
 
     status_colors = {
         "completed": "green",
@@ -1599,7 +1900,7 @@ def workflow_status(
             # Build on the shared run/resume payload so the common fields
             # (including current_step_index) stay identical across commands.
             payload = {
-                **_workflow_run_payload(state),
+                **_workflow_run_payload(state, include_previews=False),
                 "created_at": state.created_at,
                 "updated_at": state.updated_at,
                 "steps": {

--- a/src/specify_cli/workflows/base.py
+++ b/src/specify_cli/workflows/base.py
@@ -80,6 +80,11 @@ class StepContext:
     #: Source directory of the workflow definition file.
     workflow_dir: str | None = None
 
+    #: Preview agent-facing command, prompt, and gate steps without dispatching
+    #: an integration CLI or waiting for interactive gate input. Other step
+    #: types keep their normal behavior.
+    dry_run: bool = False
+
 
 @dataclass
 class StepResult:

--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -603,6 +603,7 @@ class RunState:
         installed_workflow_id: str | None = None,
         installed_registry_root: str | None = None,
         installed_origin_tracked: bool = True,
+        dry_run: bool = False,
     ) -> None:
         # ``run_id is None`` (omitted) → auto-generate. An explicit empty
         # string is *not* the same as "omitted" and must be validated like
@@ -617,6 +618,8 @@ class RunState:
         self._validate_installed_origin(
             installed_workflow_id, installed_registry_root
         )
+        if not isinstance(dry_run, bool):
+            raise ValueError("Invalid run state: 'dry_run' must be a boolean")
         self.workflow_id = workflow_id
         self.project_root = project_root or Path(".")
         # Identifies the installed workflow (if any) this run was started
@@ -630,10 +633,15 @@ class RunState:
         self.installed_workflow_id = installed_workflow_id
         self.installed_registry_root = installed_registry_root
         self.installed_origin_tracked = installed_origin_tracked
+        self.dry_run = dry_run
         self.status = RunStatus.CREATED
         self.current_step_index = 0
         self.current_step_id: str | None = None
         self.step_results: dict[str, dict[str, Any]] = {}
+        # Dry-run previews need an execution log separate from step_results:
+        # loop aliases overwrite prior results, and concurrent fan-out inserts
+        # results in completion order rather than declared item order.
+        self.dry_run_previews: list[dict[str, Any]] = []
         # Guards step_results mutation and save() so a concurrent fan-out cannot
         # mutate the dict while save() is serializing it (which would raise
         # "dictionary changed size during iteration").
@@ -676,6 +684,52 @@ class RunState:
             if step_id in self.step_results:
                 self.step_results[step_id]["output"] = output
 
+    def record_dry_run_preview(
+        self,
+        order: tuple[int, ...],
+        step_id: str,
+        step_type: str,
+        output: dict[str, Any],
+    ) -> None:
+        """Record one resolved preview with a deterministic workflow order.
+
+        Resuming a nested failure replays its top-level parent. Replace an
+        existing record at the same order so repeated resumes do not accumulate
+        duplicate previews for the same logical execution slot.
+        """
+        record = {
+            "order": list(order),
+            "step_id": step_id,
+            "type": step_type,
+            "output": output,
+        }
+        with self._lock:
+            for index, existing in enumerate(self.dry_run_previews):
+                if isinstance(existing, dict) and existing.get("order") == record["order"]:
+                    self.dry_run_previews[index] = record
+                    break
+            else:
+                self.dry_run_previews.append(record)
+
+    def discard_dry_run_previews(self, order_prefix: tuple[int, ...]) -> None:
+        """Drop previews below a workflow position before replaying it.
+
+        Resume may take a different control-flow branch after inputs change.
+        Clearing the replayed subtree prevents previews from the old branch
+        surviving merely because the new branch has fewer agent-facing steps.
+        """
+        prefix = list(order_prefix)
+        with self._lock:
+            self.dry_run_previews = [
+                record
+                for record in self.dry_run_previews
+                if not (
+                    isinstance(record, dict)
+                    and isinstance(record.get("order"), list)
+                    and record["order"][: len(prefix)] == prefix
+                )
+            ]
+
     def save(self) -> None:
         """Persist current state to disk.
 
@@ -696,10 +750,12 @@ class RunState:
                 "workflow_id": self.workflow_id,
                 "installed_workflow_id": self.installed_workflow_id,
                 "installed_registry_root": self.installed_registry_root,
+                "dry_run": self.dry_run,
                 "status": self.status.value,
                 "current_step_index": self.current_step_index,
                 "current_step_id": self.current_step_id,
                 "step_results": self.step_results,
+                "dry_run_previews": self.dry_run_previews,
                 "workflow_dir": self.workflow_dir,
                 "created_at": self.created_at,
                 "updated_at": self.updated_at,
@@ -781,6 +837,14 @@ class RunState:
 
         installed_workflow_id = state_data.get("installed_workflow_id")
         installed_registry_root = state_data.get("installed_registry_root")
+        dry_run = state_data.get("dry_run", False)
+        if not isinstance(dry_run, bool):
+            raise ValueError("Invalid run state: 'dry_run' must be a boolean")
+        dry_run_previews = state_data.get("dry_run_previews", [])
+        if not isinstance(dry_run_previews, list):
+            raise ValueError(
+                "Invalid run state: 'dry_run_previews' must be a list"
+            )
 
         state = cls(
             run_id=state_data["run_id"],
@@ -789,11 +853,13 @@ class RunState:
             installed_workflow_id=installed_workflow_id,
             installed_registry_root=installed_registry_root,
             installed_origin_tracked=has_installed_workflow_id,
+            dry_run=dry_run,
         )
         state.status = RunStatus(state_data["status"])
         state.current_step_index = state_data.get("current_step_index", 0)
         state.current_step_id = state_data.get("current_step_id")
         state.step_results = state_data.get("step_results", {})
+        state.dry_run_previews = dry_run_previews
         state.workflow_dir = state_data.get("workflow_dir")
         state.created_at = state_data.get("created_at", "")
         state.updated_at = state_data.get("updated_at", "")
@@ -908,6 +974,7 @@ class WorkflowEngine:
         run_id: str | None = None,
         installed_workflow_id: str | None = None,
         installed_registry_root: Path | None = None,
+        dry_run: bool = False,
     ) -> RunState:
         """Execute a workflow definition.
 
@@ -919,6 +986,10 @@ class WorkflowEngine:
             User-provided input values.
         run_id:
             Optional run ID (uses SPECKIT_WORKFLOW_RUN_ID when set, otherwise auto-generated).
+        dry_run:
+            Preview built-in command, prompt, and gate steps without dispatching
+            an integration CLI or waiting for gate input. Shell, init, and custom
+            steps keep their normal behavior. The flag is persisted for resume.
         installed_workflow_id, installed_registry_root:
             When the run was started from an installed workflow (as opposed
             to a direct/non-installed YAML source), identifies it and its
@@ -948,6 +1019,7 @@ class WorkflowEngine:
                 if installed_registry_root is not None
                 else None
             ),
+            dry_run=dry_run,
         )
 
         # Persist a copy of the workflow definition so resume can
@@ -980,6 +1052,7 @@ class WorkflowEngine:
             project_root=str(self.project_root),
             run_id=state.run_id,
             workflow_dir=workflow_dir,
+            dry_run=dry_run,
         )
 
         # Execute steps
@@ -995,6 +1068,13 @@ class WorkflowEngine:
             state.error = str(exc)
             state.append_log({"event": "workflow_failed", "error": str(exc)})
             state.save()
+            if state.dry_run:
+                try:
+                    setattr(exc, "_speckit_workflow_state", state)
+                except Exception:
+                    # A custom exception may forbid dynamic attributes. The
+                    # original failure must remain authoritative in that case.
+                    pass
             raise
 
         if state.status == RunStatus.RUNNING:
@@ -1047,12 +1127,17 @@ class WorkflowEngine:
             project_root=str(self.project_root),
             run_id=state.run_id,
             workflow_dir=state.workflow_dir,
+            dry_run=state.dry_run,
         )
 
         from . import STEP_REGISTRY
 
         state.error = None
         state.status = RunStatus.RUNNING
+        if state.dry_run:
+            # The current top-level step is replayed on resume. Its nested
+            # branch may differ when the caller supplies updated inputs.
+            state.discard_dry_run_previews((state.current_step_index,))
         state.save()
 
         # Resume from the current step — re-execute it so gates
@@ -1075,6 +1160,13 @@ class WorkflowEngine:
             state.error = str(exc)
             state.append_log({"event": "resume_failed", "error": str(exc)})
             state.save()
+            if state.dry_run:
+                try:
+                    setattr(exc, "_speckit_workflow_state", state)
+                except Exception:
+                    # Preserve the original exception when attaching diagnostic
+                    # state is not supported by a custom exception class.
+                    pass
             raise
 
         if state.status == RunStatus.RUNNING:
@@ -1107,11 +1199,17 @@ class WorkflowEngine:
         registry: dict[str, Any],
         *,
         step_offset: int = 0,
+        order_prefix: tuple[int, ...] = (),
     ) -> None:
         """Execute a list of steps sequentially."""
         for i, step_config in enumerate(steps):
             step_id = step_config.get("id", f"step-{i}")
             step_type = step_config.get("type", "command")
+            step_order = (
+                (*order_prefix, i)
+                if order_prefix
+                else (step_offset + i if step_offset >= 0 else i,)
+            )
 
             state.current_step_id = step_id
             if step_offset >= 0:
@@ -1163,6 +1261,10 @@ class WorkflowEngine:
                 "error": result.error,
             }
             self._record_result(context, state, step_id, step_data)
+            if context.dry_run and result.output.get("dry_run") is True:
+                state.record_dry_run_preview(
+                    step_order, str(step_id), str(step_type), result.output
+                )
 
             state.append_log(
                 {
@@ -1250,6 +1352,7 @@ class WorkflowEngine:
                 self._execute_steps(
                     result.next_steps, context, state, registry,
                     step_offset=-1,
+                    order_prefix=(*step_order, 0),
                 )
                 if state.status in (
                     RunStatus.PAUSED,
@@ -1292,6 +1395,11 @@ class WorkflowEngine:
                             self._execute_steps(
                                 [ns_copy], context, state, registry,
                                 step_offset=-1,
+                                order_prefix=(
+                                    *step_order,
+                                    _loop_iter + 1,
+                                    ns_idx,
+                                ),
                             )
                             if state.status in (
                                 RunStatus.PAUSED,
@@ -1317,6 +1425,7 @@ class WorkflowEngine:
                     fan_out_results = self._run_fan_out(
                         items, template, step_id, context, state, registry,
                         result.output.get("max_concurrency", 1),
+                        preview_order=step_order,
                     )
                     context.item = None
                     # Preserve original output and add collected results
@@ -1346,6 +1455,8 @@ class WorkflowEngine:
         state: RunState,
         registry: dict[str, Any],
         max_concurrency: Any,
+        *,
+        preview_order: tuple[int, ...] = (),
     ) -> list[Any]:
         """Run a fan-out template once per item; return per-item outputs in item order.
 
@@ -1394,6 +1505,7 @@ class WorkflowEngine:
             item_step["id"] = item_id(idx)
             self._execute_steps(
                 [item_step], item_ctx, state, registry, step_offset=-1,
+                order_prefix=(*preview_order, idx),
             )
             # Read back through the context that was actually executed against,
             # not the outer closure — clearer and robust if StepContext copying

--- a/src/specify_cli/workflows/steps/command/__init__.py
+++ b/src/specify_cli/workflows/steps/command/__init__.py
@@ -128,12 +128,7 @@ class CommandStep(StepBase):
             )
         options.update(step_options)
 
-        # Attempt CLI dispatch
         args_str = str(resolved_input.get("args", ""))
-        dispatch_result = self._try_dispatch(
-            command, integration, model, args_str, context
-        )
-
         output: dict[str, Any] = {
             "command": command,
             "integration": integration,
@@ -141,6 +136,37 @@ class CommandStep(StepBase):
             "options": options,
             "input": resolved_input,
         }
+
+        if context.dry_run:
+            preview = {
+                "type": "command",
+                "command": command,
+                "integration": integration,
+                "model": model,
+                "options": options,
+                "input": resolved_input,
+            }
+            output.update(
+                {
+                    "exit_code": 0,
+                    "stdout": "",
+                    "stderr": "",
+                    "dispatched": False,
+                    "dry_run": True,
+                    "dry_run_preview": preview,
+                    "dry_run_message": (
+                        f"[DRY RUN] command={command!r}; "
+                        f"integration={integration!r}; model={model!r}; "
+                        f"options={options!r}; input={resolved_input!r}"
+                    ),
+                }
+            )
+            return StepResult(status=StepStatus.COMPLETED, output=output)
+
+        # Attempt CLI dispatch only after validation and expression resolution.
+        dispatch_result = self._try_dispatch(
+            command, integration, model, args_str, context
+        )
 
         if dispatch_result is not None:
             output["exit_code"] = dispatch_result["exit_code"]

--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -138,6 +138,32 @@ class GateStep(StepBase):
             "choice": None,
         }
 
+        if context.dry_run:
+            choice = self._first_non_reject_option(options)
+            preview = {
+                "type": "gate",
+                "message": message,
+                "options": options,
+                "on_reject": on_reject,
+                "show_file": show_file,
+                "verdict_input": verdict_input,
+                "choice": choice,
+            }
+            output.update(
+                {
+                    "choice": choice,
+                    "dry_run": True,
+                    "dry_run_preview": preview,
+                    "dry_run_message": (
+                        f"[DRY RUN] gate skipped; would choose {choice!r}: "
+                        f"{message}"
+                        if choice is not None
+                        else f"[DRY RUN] gate skipped; no non-reject option: {message}"
+                    ),
+                }
+            )
+            return StepResult(status=StepStatus.COMPLETED, output=output)
+
         choice: str | None = None
         bound_verdict_input: str | None = None
         if verdict_input is not None:
@@ -206,6 +232,18 @@ class GateStep(StepBase):
             return StepResult(status=StepStatus.COMPLETED, output=output)
 
         return StepResult(status=StepStatus.COMPLETED, output=output)
+
+    @staticmethod
+    def _first_non_reject_option(options: list[str]) -> str | None:
+        """Choose a deterministic preview branch without selecting rejection."""
+        return next(
+            (
+                option
+                for option in options
+                if option.strip().casefold() not in {"reject", "abort"}
+            ),
+            None,
+        )
 
     @classmethod
     def _compose_prompt(cls, message: object, show_file: str | None) -> str:

--- a/src/specify_cli/workflows/steps/prompt/__init__.py
+++ b/src/specify_cli/workflows/steps/prompt/__init__.py
@@ -98,17 +98,41 @@ class PromptStep(StepBase):
         if timeout_error is not None:
             return StepResult(status=StepStatus.FAILED, error=timeout_error)
 
-        # Attempt CLI dispatch
         timeout = config.get("timeout", 300)
-        dispatch_result = self._try_dispatch(
-            prompt, integration, model, context, timeout=timeout
-        )
-
         output: dict[str, Any] = {
             "prompt": prompt,
             "integration": integration,
             "model": model,
         }
+
+        if context.dry_run:
+            preview = {
+                "type": "prompt",
+                "prompt": prompt,
+                "integration": integration,
+                "model": model,
+                "timeout": timeout,
+            }
+            output.update(
+                {
+                    "exit_code": 0,
+                    "stdout": "",
+                    "stderr": "",
+                    "dispatched": False,
+                    "dry_run": True,
+                    "dry_run_preview": preview,
+                    "dry_run_message": (
+                        f"[DRY RUN] prompt; integration={integration!r}; "
+                        f"model={model!r}; timeout={timeout!r}; content={prompt!r}"
+                    ),
+                }
+            )
+            return StepResult(status=StepStatus.COMPLETED, output=output)
+
+        # Attempt CLI dispatch only after validation and expression resolution.
+        dispatch_result = self._try_dispatch(
+            prompt, integration, model, context, timeout=timeout
+        )
 
         if dispatch_result is not None:
             output["exit_code"] = dispatch_result["exit_code"]

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -158,6 +158,7 @@ class TestBaseClasses:
         assert ctx.item is None
         assert ctx.fan_in == {}
         assert ctx.default_integration is None
+        assert ctx.dry_run is False
 
     def test_step_context_with_data(self):
         from specify_cli.workflows.base import StepContext
@@ -997,6 +998,43 @@ class TestCommandStep:
         assert result.output["integration"] == "claude"
         assert result.output["input"]["args"] == "login"
 
+    def test_dry_run_resolves_input_without_dispatch(self, monkeypatch):
+        from specify_cli.workflows.base import StepContext, StepStatus
+        from specify_cli.workflows.steps.command import CommandStep
+
+        def fail_dispatch(*_args, **_kwargs):
+            pytest.fail("CommandStep attempted agent dispatch during a dry run")
+
+        monkeypatch.setattr(CommandStep, "_try_dispatch", fail_dispatch)
+        result = CommandStep().execute(
+            {
+                "id": "specify",
+                "command": "speckit.specify",
+                "input": {"args": "{{ inputs.feature }}"},
+            },
+            StepContext(
+                inputs={"feature": "add login"},
+                default_integration="claude",
+                dry_run=True,
+            ),
+        )
+
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["input"]["args"] == "add login"
+        assert result.output["exit_code"] == 0
+        assert result.output["dispatched"] is False
+        assert result.output["dry_run"] is True
+        assert "speckit.specify" in result.output["dry_run_message"]
+        assert "add login" in result.output["dry_run_message"]
+        assert result.output["dry_run_preview"] == {
+            "type": "command",
+            "command": "speckit.specify",
+            "integration": "claude",
+            "model": None,
+            "options": {},
+            "input": {"args": "add login"},
+        }
+
     def test_try_dispatch_resolves_rovodev_via_acli(self, tmp_path):
         """When acli is installed, rovodev dispatch succeeds via acli."""
         from unittest.mock import patch, MagicMock
@@ -1409,6 +1447,41 @@ class TestPromptStep:
         assert result.output["prompt"] == "Review auth.py for security issues"
         assert result.output["integration"] == "claude"
         assert result.output["dispatched"] is False
+
+    def test_dry_run_resolves_prompt_without_dispatch(self, monkeypatch):
+        from specify_cli.workflows.base import StepContext, StepStatus
+        from specify_cli.workflows.steps.prompt import PromptStep
+
+        def fail_dispatch(*_args, **_kwargs):
+            pytest.fail("PromptStep attempted agent dispatch during a dry run")
+
+        monkeypatch.setattr(PromptStep, "_try_dispatch", fail_dispatch)
+        result = PromptStep().execute(
+            {
+                "id": "review",
+                "type": "prompt",
+                "prompt": "Review {{ inputs.file }} [literally]",
+            },
+            StepContext(
+                inputs={"file": "auth.py"},
+                default_integration="claude",
+                dry_run=True,
+            ),
+        )
+
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["prompt"] == "Review auth.py [literally]"
+        assert result.output["exit_code"] == 0
+        assert result.output["dispatched"] is False
+        assert result.output["dry_run"] is True
+        assert "Review auth.py [literally]" in result.output["dry_run_message"]
+        assert result.output["dry_run_preview"] == {
+            "type": "prompt",
+            "prompt": "Review auth.py [literally]",
+            "integration": "claude",
+            "model": None,
+            "timeout": 300,
+        }
 
     def test_execute_non_string_integration_fails_cleanly(self):
         """A non-string integration must FAIL the step cleanly, not crash with
@@ -2209,6 +2282,31 @@ class TestInitStep:
         assert result.status == StepStatus.COMPLETED
         assert (tmp_path / "demo" / ".specify").is_dir()
 
+    def test_dry_run_does_not_short_circuit_init(self, tmp_path, monkeypatch):
+        from specify_cli.workflows.base import StepContext, StepStatus
+        from specify_cli.workflows.steps.init import InitStep
+
+        calls = []
+
+        def fake_run_init(argv, context):
+            calls.append((argv, context.dry_run))
+            return 0, "initialized", ""
+
+        monkeypatch.setattr(InitStep, "_run_init", staticmethod(fake_run_init))
+        result = InitStep().execute(
+            {
+                "id": "bootstrap",
+                "project": "demo",
+                "integration": "copilot",
+                "script": "py",
+            },
+            StepContext(project_root=str(tmp_path), dry_run=True),
+        )
+
+        assert result.status == StepStatus.COMPLETED
+        assert calls == [(result.output["argv"], True)]
+        assert result.output["stdout"] == "initialized"
+
     def test_invalid_integration_fails(self, tmp_path):
         from specify_cli.workflows.steps.init import InitStep
         from specify_cli.workflows.base import StepContext, StepStatus
@@ -2354,6 +2452,44 @@ class TestGateStep:
         assert result.status == StepStatus.PAUSED
         assert result.output["message"] == "Review the spec."
         assert result.output["options"] == ["approve", "reject"]
+
+    def test_dry_run_skips_prompt_and_chooses_non_reject_option(
+        self, monkeypatch
+    ):
+        from specify_cli.workflows.base import StepContext, StepStatus
+        from specify_cli.workflows.steps.gate import GateStep
+
+        monkeypatch.setattr(
+            GateStep,
+            "_prompt",
+            lambda *_args, **_kwargs: pytest.fail(
+                "GateStep prompted for input during a dry run"
+            ),
+        )
+        result = GateStep().execute(
+            {
+                "id": "review",
+                "message": "Review [the spec].",
+                "options": [" Reject ", "Approve", "abort"],
+                "on_reject": "abort",
+            },
+            StepContext(dry_run=True),
+        )
+
+        assert result.status == StepStatus.COMPLETED
+        assert result.output["message"] == "Review [the spec]."
+        assert result.output["choice"] == "Approve"
+        assert result.output["dry_run"] is True
+        assert "Approve" in result.output["dry_run_message"]
+        assert result.output["dry_run_preview"] == {
+            "type": "gate",
+            "message": "Review [the spec].",
+            "options": [" Reject ", "Approve", "abort"],
+            "on_reject": "abort",
+            "show_file": None,
+            "verdict_input": None,
+            "choice": "Approve",
+        }
 
     @pytest.mark.parametrize(
         "inputs", [{}, {"spec_verdict": None}, {"spec_verdict": ""}]
@@ -4204,7 +4340,10 @@ class TestWorkflowDefinition:
         # execute()/resume() run UNVALIDATED definitions; a non-mapping `inputs:`
         # block (list/null) is stored raw and would crash _resolve_inputs at
         # `.items()`. It must be treated as "no inputs" instead.
-        from specify_cli.workflows.engine import WorkflowDefinition, WorkflowEngine
+        from specify_cli.workflows.engine import (
+            WorkflowDefinition,
+            WorkflowEngine,
+        )
 
         definition = WorkflowDefinition.from_string(block)
         resolved = WorkflowEngine()._resolve_inputs(definition, {})  # must not raise
@@ -5090,6 +5229,322 @@ steps:
         assert "step-one" in state.step_results
         assert state.step_results["step-one"]["output"]["command"] == "speckit.specify"
         assert state.step_results["step-one"]["output"]["input"]["args"] == "login"
+
+    def test_execute_dry_run_propagates_to_agent_steps(
+        self, project_dir, monkeypatch
+    ):
+        from specify_cli.workflows.base import RunStatus
+        from specify_cli.workflows.engine import WorkflowDefinition, WorkflowEngine
+        from specify_cli.workflows.steps.command import CommandStep
+        from specify_cli.workflows.steps.prompt import PromptStep
+
+        def fail_dispatch(*_args, **_kwargs):
+            pytest.fail("Workflow engine attempted agent dispatch during a dry run")
+
+        monkeypatch.setattr(CommandStep, "_try_dispatch", fail_dispatch)
+        monkeypatch.setattr(PromptStep, "_try_dispatch", fail_dispatch)
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "dry-run-engine"
+  name: "Dry Run Engine"
+  version: "1.0.0"
+  integration: claude
+inputs:
+  feature:
+    type: string
+    default: "add login"
+steps:
+  - id: specify
+    command: speckit.specify
+    input:
+      args: "{{ inputs.feature }}"
+  - id: review
+    type: prompt
+    prompt: "Review {{ inputs.feature }}"
+  - id: approve
+    type: gate
+    message: "Approve the plan?"
+    options: [approve, reject]
+""")
+
+        state = WorkflowEngine(project_dir).execute(
+            definition, dry_run=True, run_id="dry-run-engine"
+        )
+
+        assert state.status == RunStatus.COMPLETED
+        assert state.dry_run is True
+        assert all(
+            step["output"]["dry_run"] is True
+            for step in state.step_results.values()
+        )
+
+    def test_dry_run_keeps_shell_step_behavior_unchanged(self, project_dir):
+        from specify_cli.workflows.base import RunStatus
+        from specify_cli.workflows.engine import WorkflowDefinition, WorkflowEngine
+
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "dry-run-shell"
+  name: "Dry Run Shell"
+  version: "1.0.0"
+steps:
+  - id: shell
+    type: shell
+    run: "echo shell-still-runs"
+""")
+
+        state = WorkflowEngine(project_dir).execute(
+            definition, dry_run=True, run_id="dry-run-shell"
+        )
+
+        assert state.status == RunStatus.COMPLETED
+        assert "shell-still-runs" in state.step_results["shell"]["output"]["stdout"]
+
+    def test_dry_run_records_each_loop_preview_without_alias_duplicates(
+        self, project_dir
+    ):
+        from specify_cli.workflows._commands import _dry_run_previews
+        from specify_cli.workflows.engine import (
+            RunState,
+            WorkflowDefinition,
+            WorkflowEngine,
+        )
+
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "dry-run-loop-order"
+  name: "Dry Run Loop Order"
+  version: "1.0.0"
+  integration: claude
+steps:
+  - id: loop
+    type: while
+    condition: true
+    max_iterations: 3
+    steps:
+      - id: work
+        command: speckit.specify
+        input:
+          args: loop-call
+""")
+
+        state = WorkflowEngine(project_dir).execute(
+            definition, dry_run=True, run_id="dry-loop"
+        )
+
+        assert [preview["step_id"] for preview in _dry_run_previews(state)] == [
+            "work",
+            "loop:work:1",
+            "loop:work:2",
+        ]
+        reloaded = RunState.load(state.run_id, project_dir)
+        assert [preview["step_id"] for preview in _dry_run_previews(reloaded)] == [
+            "work",
+            "loop:work:1",
+            "loop:work:2",
+        ]
+
+    def test_concurrent_fan_out_previews_follow_item_order(
+        self, project_dir, monkeypatch
+    ):
+        import time
+
+        from specify_cli.workflows._commands import _dry_run_previews
+        from specify_cli.workflows.engine import WorkflowDefinition, WorkflowEngine
+        from specify_cli.workflows.steps.command import CommandStep
+
+        original_execute = CommandStep.execute
+
+        def delayed_execute(self, config, context):
+            time.sleep((3 - int(context.item)) * 0.03)
+            return original_execute(self, config, context)
+
+        monkeypatch.setattr(CommandStep, "execute", delayed_execute)
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "dry-run-fan-out-order"
+  name: "Dry Run Fan Out Order"
+  version: "1.0.0"
+  integration: claude
+steps:
+  - id: fan
+    type: fan-out
+    items: [0, 1, 2, 3]
+    max_concurrency: 4
+    step:
+      id: work
+      command: speckit.specify
+      input:
+        args: "{{ item }}"
+""")
+
+        state = WorkflowEngine(project_dir).execute(
+            definition, dry_run=True, run_id="dry-fan"
+        )
+        previews = _dry_run_previews(state)
+
+        assert [preview["step_id"] for preview in previews] == [
+            "fan:work:0",
+            "fan:work:1",
+            "fan:work:2",
+            "fan:work:3",
+        ]
+        assert [preview["configuration"]["input"]["args"] for preview in previews] == [
+            0,
+            1,
+            2,
+            3,
+        ]
+
+    def test_resume_restores_persisted_dry_run_without_dispatch(
+        self, project_dir, monkeypatch
+    ):
+        from specify_cli.workflows.base import RunStatus
+        from specify_cli.workflows.engine import (
+            RunState,
+            WorkflowDefinition,
+            WorkflowEngine,
+        )
+        from specify_cli.workflows.steps.command import CommandStep
+
+        workflow_text = """
+schema_version: "1.0"
+workflow:
+  id: "dry-run-resume"
+  name: "Dry Run Resume"
+  version: "1.0.0"
+  integration: claude
+steps:
+  - id: specify
+    command: speckit.specify
+    input:
+      args: "resume preview"
+"""
+        definition = WorkflowDefinition.from_string(workflow_text)
+        state = RunState(
+            run_id="dry-run-resume",
+            workflow_id=definition.id,
+            project_root=project_dir,
+            dry_run=True,
+        )
+        state.status = RunStatus.PAUSED
+        state.save()
+        (state.runs_dir / "workflow.yml").write_text(workflow_text, encoding="utf-8")
+
+        def fail_dispatch(*_args, **_kwargs):
+            pytest.fail("Resumed dry run attempted agent dispatch")
+
+        monkeypatch.setattr(CommandStep, "_try_dispatch", fail_dispatch)
+        resumed = WorkflowEngine(project_dir).resume(state.run_id)
+
+        assert resumed.status == RunStatus.COMPLETED
+        assert resumed.dry_run is True
+        assert resumed.step_results["specify"]["output"]["dry_run"] is True
+        assert "resume preview" in resumed.step_results["specify"]["output"][
+            "dry_run_message"
+        ]
+
+    def test_resume_replaces_replayed_nested_preview(self, project_dir):
+        from specify_cli.workflows._commands import _dry_run_previews
+        from specify_cli.workflows.engine import (
+            RunState,
+            WorkflowDefinition,
+            WorkflowEngine,
+        )
+
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "dry-run-nested-resume"
+  name: "Dry Run Nested Resume"
+  version: "1.0.0"
+  integration: claude
+steps:
+  - id: parent
+    type: if
+    condition: true
+    then:
+      - id: preview
+        command: speckit.specify
+        input:
+          args: nested-preview
+      - id: fail
+        type: prompt
+        prompt: "{{ steps.preview.output.stdout | from_json }}"
+""")
+        engine = WorkflowEngine(project_dir)
+
+        with pytest.raises(ValueError, match="from_json"):
+            engine.execute(definition, dry_run=True, run_id="dry-nested")
+        first = RunState.load("dry-nested", project_dir)
+        assert [item["step_id"] for item in _dry_run_previews(first)] == [
+            "preview"
+        ]
+
+        with pytest.raises(ValueError, match="from_json"):
+            engine.resume("dry-nested")
+        resumed = RunState.load("dry-nested", project_dir)
+        assert [item["step_id"] for item in _dry_run_previews(resumed)] == [
+            "preview"
+        ]
+
+    def test_resume_discards_previews_from_previous_nested_branch(
+        self, project_dir
+    ):
+        from specify_cli.workflows._commands import _dry_run_previews
+        from specify_cli.workflows.base import RunStatus
+        from specify_cli.workflows.engine import WorkflowDefinition, WorkflowEngine
+
+        definition = WorkflowDefinition.from_string("""
+schema_version: "1.0"
+workflow:
+  id: "dry-run-changed-branch"
+  name: "Dry Run Changed Branch"
+  version: "1.0.0"
+  integration: claude
+inputs:
+  branch:
+    type: string
+steps:
+  - id: parent
+    type: if
+    condition: "{{ inputs.branch == 'old' }}"
+    then:
+      - id: first-preview
+        command: speckit.specify
+      - id: second-preview
+        command: speckit.plan
+      - id: fail-old
+        type: prompt
+        prompt: stop
+        timeout: invalid
+    else:
+      - id: fail-new
+        type: prompt
+        prompt: stop
+        timeout: invalid
+""")
+        engine = WorkflowEngine(project_dir)
+
+        first = engine.execute(
+            definition,
+            {"branch": "old"},
+            dry_run=True,
+            run_id="dry-changed-branch",
+        )
+        assert first.status == RunStatus.FAILED
+        assert [item["step_id"] for item in _dry_run_previews(first)] == [
+            "first-preview",
+            "second-preview",
+        ]
+
+        resumed = engine.resume("dry-changed-branch", {"branch": "new"})
+        assert resumed.status == RunStatus.FAILED
+        assert _dry_run_previews(resumed) == []
 
     def test_execute_rejects_invalid_origin_before_creating_run_state(
         self, project_dir
@@ -6958,6 +7413,7 @@ class TestRunState:
             run_id="test-run",
             workflow_id="test-workflow",
             project_root=project_dir,
+            dry_run=True,
         )
         state.status = RunStatus.RUNNING
         state.inputs = {"name": "login"}
@@ -6975,6 +7431,43 @@ class TestRunState:
         assert loaded.status == RunStatus.RUNNING
         assert loaded.inputs == {"name": "login"}
         assert "step-one" in loaded.step_results
+        assert loaded.dry_run is True
+
+    def test_load_legacy_state_defaults_dry_run_to_false(self, project_dir):
+        from specify_cli.workflows.engine import RunState
+
+        state = RunState(
+            run_id="legacy-run",
+            workflow_id="test-workflow",
+            project_root=project_dir,
+        )
+        state.save()
+        state_path = state.runs_dir / "state.json"
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        payload.pop("dry_run", None)
+        state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = RunState.load(state.run_id, project_dir)
+
+        assert loaded.dry_run is False
+
+    @pytest.mark.parametrize("invalid", [None, 0, "false", []])
+    def test_load_rejects_non_boolean_dry_run(self, project_dir, invalid):
+        from specify_cli.workflows.engine import RunState
+
+        state = RunState(
+            run_id="invalid-dry-run",
+            workflow_id="test-workflow",
+            project_root=project_dir,
+        )
+        state.save()
+        state_path = state.runs_dir / "state.json"
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        payload["dry_run"] = invalid
+        state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="dry_run.*boolean"):
+            RunState.load(state.run_id, project_dir)
 
     def test_load_not_found(self, project_dir):
         from specify_cli.workflows.engine import RunState
@@ -11203,6 +11696,387 @@ class TestWorkflowStepStartProgressLine:
 
         resumed = runner.invoke(app, ["workflow", "resume", run_id])
         assert "[boom]" in resumed.stdout
+
+
+class TestWorkflowDryRunCli:
+    """CLI contract for Issue #2661's workflow-only dry-run mode."""
+
+    _WF_AGENT_STEPS = """
+schema_version: "1.0"
+workflow:
+  id: "dry-run-cli"
+  name: "Dry Run CLI"
+  version: "1.0.0"
+  integration: claude
+inputs:
+  feature:
+    type: string
+    default: "add [literal] login"
+steps:
+  - id: specify
+    command: speckit.specify
+    options:
+      temperature: 0.2
+    input:
+      1: numeric-key
+      args: "{{ inputs.feature }}"
+      artifact: "{{ inputs.feature }}"
+  - id: review
+    type: prompt
+    prompt: "Review {{ inputs.feature }}"
+    timeout: 42
+  - id: approve
+    type: gate
+    message: "Approve {{ inputs.feature }}?"
+    options: [approve, reject]
+    on_reject: retry
+"""
+
+    _WF_SHELL_ONLY = """
+schema_version: "1.0"
+workflow:
+  id: "dry-run-shell-only"
+  name: "Dry Run Shell Only"
+  version: "1.0.0"
+steps:
+  - id: shell
+    type: shell
+    run: "echo shell-still-runs"
+"""
+
+    _WF_PARTIAL_FAILURE = """
+schema_version: "1.0"
+workflow:
+  id: dry-run-partial-failure
+  name: Dry Run Partial Failure
+  version: "1.0.0"
+  integration: claude
+inputs:
+  count:
+    type: number
+    default: 1
+steps:
+  - id: specify
+    command: speckit.specify
+    input:
+      args: "preview before failure"
+  - id: parse
+    type: prompt
+    prompt: "{{ steps.specify.output.stdout | from_json }}"
+"""
+
+    @staticmethod
+    def _write(tmp_path, content, name="dry-run.yml"):
+        path = tmp_path / name
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    @staticmethod
+    def _forbid_agent_dispatch(monkeypatch):
+        from specify_cli.workflows.steps.command import CommandStep
+        from specify_cli.workflows.steps.prompt import PromptStep
+
+        def fail_dispatch(*_args, **_kwargs):
+            pytest.fail("CLI dry run attempted agent dispatch")
+
+        monkeypatch.setattr(CommandStep, "_try_dispatch", fail_dispatch)
+        monkeypatch.setattr(PromptStep, "_try_dispatch", fail_dispatch)
+
+    def test_human_output_previews_agent_steps_and_escapes_markup(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        self._forbid_agent_dispatch(monkeypatch)
+        result = CliRunner().invoke(
+            app,
+            [
+                "workflow",
+                "run",
+                str(self._write(tmp_path, self._WF_AGENT_STEPS)),
+                "--dry-run",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "DRY RUN" in result.stdout
+        assert "shell, init, and custom steps still execute" in " ".join(
+            result.stdout.split()
+        )
+        assert "Dry-run previews:" in result.stdout
+        assert "speckit.specify" in result.stdout
+        assert "add [literal] login" in result.stdout
+        normalized = " ".join(result.stdout.split())
+        assert '"options": ["approve","reject"]' in normalized
+        assert '"on_reject": "retry"' in normalized
+        assert "Status: completed" in result.stdout
+
+    def test_json_output_is_one_object_with_structured_previews(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        self._forbid_agent_dispatch(monkeypatch)
+        result = CliRunner().invoke(
+            app,
+            [
+                "workflow",
+                "run",
+                str(self._write(tmp_path, self._WF_AGENT_STEPS, "dry-run-json.yml")),
+                "--dry-run",
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "\x1b" not in result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "completed"
+        assert payload["dry_run"] is True
+        assert [preview["step_id"] for preview in payload["previews"]] == [
+            "specify",
+            "review",
+            "approve",
+        ]
+        assert "add [literal] login" in payload["previews"][0]["message"]
+        assert payload["previews"][0]["type"] == "command"
+        assert payload["previews"][0]["configuration"] == {
+            "command": "speckit.specify",
+            "integration": "claude",
+            "model": None,
+            "options": {"temperature": 0.2},
+            "input": {
+                "1": "numeric-key",
+                "args": "add [literal] login",
+                "artifact": "add [literal] login",
+            },
+        }
+        assert payload["previews"][1]["configuration"]["timeout"] == 42
+        assert payload["previews"][2]["configuration"]["on_reject"] == "retry"
+
+    def test_shell_only_run_does_not_print_empty_preview_section(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app,
+            [
+                "workflow",
+                "run",
+                str(self._write(tmp_path, self._WF_SHELL_ONLY, "dry-run-shell.yml")),
+                "--dry-run",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "Dry-run previews:" not in result.stdout
+
+    def test_json_preflight_failures_still_emit_one_object(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        invalid = tmp_path / "invalid.yml"
+        invalid.write_text("workflow: [", encoding="utf-8")
+        valid = self._write(
+            tmp_path, self._WF_SHELL_ONLY, "valid-for-errors.yml"
+        )
+        (tmp_path / ".specify").mkdir(exist_ok=True)
+        cases = [
+            ["workflow", "run", str(invalid), "--dry-run", "--json"],
+            [
+                "workflow",
+                "run",
+                str(valid),
+                "--input",
+                "missing-equals",
+                "--dry-run",
+                "--json",
+            ],
+            ["workflow", "run", "../invalid-id", "--dry-run", "--json"],
+        ]
+
+        for args in cases:
+            result = CliRunner().invoke(app, args, catch_exceptions=False)
+            assert result.exit_code == 1, args
+            assert "\x1b" not in result.stdout
+            payload = json.loads(result.stdout)
+            assert payload["status"] == "failed"
+            assert isinstance(payload["error"], str) and payload["error"]
+
+    def test_custom_step_import_output_does_not_pollute_json(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+        from specify_cli.workflows import STEP_REGISTRY
+
+        monkeypatch.chdir(tmp_path)
+        type_key = "dry-run-noisy-import"
+        step_dir = (
+            tmp_path / ".specify" / "workflows" / "steps" / type_key
+        )
+        step_dir.mkdir(parents=True)
+        (step_dir / "step.yml").write_text(
+            "schema_version: '1.0'\n"
+            "step:\n"
+            f"  type_key: {type_key}\n"
+            "  name: Noisy import\n"
+            "  version: '1.0.0'\n",
+            encoding="utf-8",
+        )
+        (step_dir / "__init__.py").write_text(
+            "print('CUSTOM-IMPORT-NOISE')\n"
+            "from specify_cli.workflows.base import StepBase, StepResult\n"
+            "class NoisyStep(StepBase):\n"
+            f"    type_key = {type_key!r}\n"
+            "    def execute(self, config, context):\n"
+            "        return StepResult()\n",
+            encoding="utf-8",
+        )
+
+        try:
+            result = CliRunner().invoke(
+                app,
+                [
+                    "workflow",
+                    "run",
+                    str(self._write(tmp_path, self._WF_SHELL_ONLY, "noisy.yml")),
+                    "--dry-run",
+                    "--json",
+                ],
+                catch_exceptions=False,
+            )
+        finally:
+            STEP_REGISTRY.pop(type_key, None)
+
+        assert result.exit_code == 0
+        assert "CUSTOM-IMPORT-NOISE" not in result.stdout
+        assert json.loads(result.stdout)["status"] == "completed"
+
+    def test_partial_previews_survive_engine_exception_in_human_and_json_modes(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        self._forbid_agent_dispatch(monkeypatch)
+        path = self._write(
+            tmp_path, self._WF_PARTIAL_FAILURE, "dry-run-partial.yml"
+        )
+        runner = CliRunner()
+
+        human = runner.invoke(
+            app,
+            ["workflow", "run", str(path), "--dry-run"],
+            catch_exceptions=False,
+        )
+        assert human.exit_code == 1
+        assert "Dry-run previews:" in human.stdout
+        assert "preview before failure" in human.stdout
+        assert "from_json" in human.stdout
+
+        machine = runner.invoke(
+            app,
+            ["workflow", "run", str(path), "--dry-run", "--json"],
+            catch_exceptions=False,
+        )
+        assert machine.exit_code == 1
+        assert "\x1b" not in machine.stdout
+        payload = json.loads(machine.stdout)
+        run_id = payload["run_id"]
+        assert payload["status"] == "failed"
+        assert payload["dry_run"] is True
+        assert payload["previews"][0]["step_id"] == "specify"
+
+        preflight_human = runner.invoke(
+            app,
+            ["workflow", "resume", run_id, "--input", "count=not-a-number"],
+            catch_exceptions=False,
+        )
+        assert preflight_human.exit_code == 1
+        assert "Dry-run previews:" in preflight_human.stdout
+        assert "preview before failure" in preflight_human.stdout
+
+        preflight_machine = runner.invoke(
+            app,
+            [
+                "workflow",
+                "resume",
+                run_id,
+                "--input",
+                "count=not-a-number",
+                "--json",
+            ],
+            catch_exceptions=False,
+        )
+        assert preflight_machine.exit_code == 1
+        preflight_payload = json.loads(preflight_machine.stdout)
+        assert preflight_payload["run_id"] == run_id
+        assert preflight_payload["current_step_id"] == "parse"
+        assert preflight_payload["previews"][0]["step_id"] == "specify"
+        assert "from_json" in payload["error"]
+
+    def test_resume_keeps_dry_run_warning_previews_and_json_contract(
+        self, tmp_path, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+
+        monkeypatch.chdir(tmp_path)
+        self._forbid_agent_dispatch(monkeypatch)
+        path = self._write(tmp_path, self._WF_PARTIAL_FAILURE, "dry-run-resume.yml")
+        runner = CliRunner()
+        first = runner.invoke(
+            app,
+            ["workflow", "run", str(path), "--dry-run", "--json"],
+            catch_exceptions=False,
+        )
+        run_id = json.loads(first.stdout)["run_id"]
+
+        human = runner.invoke(
+            app,
+            ["workflow", "resume", run_id],
+            catch_exceptions=False,
+        )
+        assert human.exit_code == 1
+        assert "DRY RUN" in human.stdout
+        assert "shell, init, and custom steps still execute" in " ".join(
+            human.stdout.split()
+        )
+        assert "Dry-run previews:" in human.stdout
+        assert "preview before failure" in human.stdout
+
+        machine = runner.invoke(
+            app,
+            ["workflow", "resume", run_id, "--json"],
+            catch_exceptions=False,
+        )
+        assert machine.exit_code == 1
+        payload = json.loads(machine.stdout)
+        assert payload["status"] == "failed"
+        assert payload["dry_run"] is True
+        assert payload["previews"][0]["step_id"] == "specify"
 
 
 class TestWorkflowRunExitCodes:


### PR DESCRIPTION
## Description

Add `specify workflow run --dry-run` so contributors can inspect resolved, agent-facing workflow configuration before allowing an integration CLI to run.

The dry-run mode:

- resolves and previews built-in `command`, `prompt`, and `gate` steps without agent dispatch or interactive gate input
- persists across `workflow resume`
- emits ordered structured previews in human and JSON output, including previews completed before a later failure
- keeps loop and concurrent fan-out preview ordering deterministic
- removes stale nested previews when a resumed run takes a different branch

Dry-run is deliberately not a side-effect-free sandbox. Built-in `shell` and `init` steps, along with custom step types, retain their normal behavior; the CLI and documentation warn about this before execution.

Closes #2661

## Testing

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

Additional validation performed on Windows:

- `uv sync --extra test`
- `uv pip install -e ".[test]"`
- `uv pip install -e .`
- affected workflow, CLI, engine, state, project-outside-run, and agent consistency tests: `239 passed, 3 skipped`
- `tests/test_workflows.py`: `910 passed, 7 skipped`; 20 tests could not create their symlink fixtures because this Windows session lacks symlink privilege (`WinError 1314`)
- Ruff 0.15.0 and `git diff --check`
- disposable Codex-integration sample project: human and JSON dry-runs completed with six ordered previews; an invocation sentinel confirmed that the integration executable was not called, state persisted `dry_run: true`, and no spec artifact was created

The monolithic `.venv\Scripts\python -m pytest tests -q` command exceeded the local runner time limit. The final commit was therefore also exercised through disjoint test-directory partitions: 6,103 passed, 178 skipped, and 130 Windows symlink/locale/MSYS parity or scope-disjoint failures. These failures were not baseline-confirmed against the parent commit, so this PR does not claim a fully green local suite.

The contributor confirmed completing line-by-line review and hands-on validation before this PR was opened.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

OpenAI Codex was used to inspect repository guidance and Issue/PR history, implement the workflow dry-run behavior, documentation, and regression tests, run automated tests, execute the disposable Codex-integration sentinel E2E, rebase onto current upstream, and prepare this pull request. The contributor subsequently performed the required human review and validation.
