### PR TITLE
chore(catalog): bump companion 0.11.0 → 0.20.1

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -943,8 +943,8 @@
       "id": "companion",
       "description": "Live spec-driven progress for SpecKit Companion — lifecycle capture, status, resume, and composable commands you can customize with hooks and recipes.",
       "author": "alfredoperez",
-      "version": "0.11.0",
-      "download_url": "https://github.com/alfredoperez/speckit-companion/releases/download/speckit-ext-v0.11.0/companion-0.11.0.zip",
+      "version": "0.20.1",
+      "download_url": "https://github.com/alfredoperez/speckit-companion/releases/download/speckit-ext-v0.20.1/companion-0.20.1.zip",
       "repository": "https://github.com/alfredoperez/speckit-companion",
       "homepage": "https://github.com/alfredoperez/speckit-companion/tree/main/speckit-extension",
       "documentation": "https://github.com/alfredoperez/speckit-companion/blob/main/speckit-extension/README.md",
@@ -953,13 +953,13 @@
       "category": "visibility",
       "effect": "read-write",
       "requires": {
-        "speckit_version": ">=0.9.5",
+        "speckit_version": ">=0.9.5.dev0",
         "tools": [
           { "name": "python3", "required": false }
         ]
       },
       "provides": {
-        "commands": 13,
+        "commands": 18,
         "hooks": 4
       },
       "tags": [
@@ -974,7 +974,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-06-11T00:00:00Z",
-      "updated_at": "2026-06-24T00:00:00Z"
+      "updated_at": "2026-08-01T00:00:00Z"
     },
     "conduct": {
       "name": "Conduct Extension",


### PR DESCRIPTION
Refreshes the existing **companion** community-catalog entry, which had fallen behind (listed `0.11.0`, current release `0.20.1`).

One entry changed — `extensions/catalog.community.json` → `companion`:

- `version`: `0.11.0` → `0.20.1`
- `download_url` → `…/releases/download/speckit-ext-v0.20.1/companion-0.20.1.zip` (version-pinned, verified returns 200)
- `requires.speckit_version`: `>=0.9.5` → `>=0.9.5.dev0` (re-synced from `extension.yml`)
- `provides.commands`: `13` → `18` (re-synced)
- `updated_at` refreshed

No other entries touched. `documentation` / `homepage` / `changelog` URLs are unchanged (they're `main` blob links). Changelog for this release: https://github.com/alfredoperez/speckit-companion/blob/main/speckit-extension/CHANGELOG.md