### PR TITLE
Allow overriding default init integration via SPECKIT_DEFAULT_INIT_IN…

### DIFF
--- a/src/specify_cli/_agent_config.py
+++ b/src/specify_cli/_agent_config.py
@@ -15,7 +15,9 @@ def _build_agent_config() -> dict[str, dict[str, Any]]:
 
 AGENT_CONFIG: dict[str, dict[str, Any]] = _build_agent_config()
 
-DEFAULT_INIT_INTEGRATION = "copilot"
+import os
+
+DEFAULT_INIT_INTEGRATION = os.environ.get("SPECKIT_DEFAULT_INIT_INTEGRATION", "copilot")
 
 SCRIPT_TYPE_CHOICES: dict[str, str] = {
     "sh": "POSIX Shell (bash/zsh)",


### PR DESCRIPTION
…TEGRATION env var

## Description

<!-- What does this PR do? Why is it needed? -->
see title

## Testing

<!-- How did you test your changes? -->

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

<!-- If you used AI, briefly describe how (e.g., "Code generated by Copilot", "Consulted ChatGPT for approach"): -->
Told Copilot to edit the file instead of doing it myself