### PR TITLE
fix(extensions): start fresh on a non-UTF-8 extension registry

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -641,8 +641,12 @@ class ExtensionRegistry:
             if not isinstance(data.get("extensions"), dict):
                 data["extensions"] = {}
             return data
-        except (json.JSONDecodeError, FileNotFoundError):
-            # Corrupted or missing registry, start fresh
+        except (json.JSONDecodeError, UnicodeDecodeError, FileNotFoundError):
+            # Corrupted or missing registry, start fresh. A registry whose
+            # bytes cannot be decoded as UTF-8 is the same corruption class
+            # as malformed JSON — only the exception type differs. OSError is
+            # deliberately not caught: the data may be intact on disk, and
+            # starting fresh would let a later _save() wipe it.
             return {"schema_version": self.SCHEMA_VERSION, "extensions": {}}
 
     def _save(self):

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -4259,11 +4259,11 @@ class ConfigManager:
         Returns an empty list if the registry is missing or corrupted
         (fresh project, ad-hoc test harness) so ``_get_env_config`` degrades
         to its pre-fix behaviour rather than crashing. ``UnicodeError`` is
-        caught alongside ``OSError`` because ``ExtensionRegistry._load()``
-        opens the file in text mode and only handles ``JSONDecodeError`` /
-        ``FileNotFoundError``, so a registry file with non-UTF-8 bytes would
-        otherwise surface a ``UnicodeDecodeError`` here and break *every*
-        config read instead of degrading gracefully.
+        caught alongside ``OSError`` as defense in depth:
+        ``ExtensionRegistry._load()`` now starts fresh on a non-UTF-8
+        registry itself, but this scan must degrade gracefully even if that
+        contract regresses, because a failure here would break *every*
+        config read.
 
         Used by ``_get_env_config`` to detect env vars whose remainder claims
         a longer, sibling-owned prefix (e.g. ``SPECKIT_GIT_HOOKS_URL`` is

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -10472,10 +10472,10 @@ class TestConfigManagerCrossExtensionEnvLeak:
     def test_non_utf8_registry_does_not_crash(self, tmp_path, monkeypatch):
         """A registry file with invalid text encoding must NOT propagate
         ``UnicodeDecodeError`` out of the sibling scan and abort every
-        config read. ``ExtensionRegistry._load()`` catches ``JSONDecodeError``
-        / ``FileNotFoundError`` only, so ``_sibling_extension_ids`` must
-        additionally swallow ``UnicodeError`` and degrade to the documented
-        pre-fix behaviour.
+        config read. ``ExtensionRegistry._load()`` now starts fresh on a
+        non-UTF-8 registry itself, but ``_sibling_extension_ids`` keeps
+        swallowing ``UnicodeError`` as defense in depth so a regression of
+        that contract still degrades to the documented pre-fix behaviour.
         """
         extensions_dir = tmp_path / ".specify" / "extensions"
         extensions_dir.mkdir(parents=True)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1241,6 +1241,28 @@ class TestExtensionRegistry:
         result = registry.list()
         assert result == {}
 
+    def test_load_starts_fresh_for_non_utf8_registry(self, temp_dir):
+        """A registry file with undecodable bytes must start fresh, not raise.
+
+        ``_load()`` documents "Corrupted or missing registry, start fresh" and
+        already treats malformed JSON that way, but a registry whose *bytes*
+        cannot be decoded as UTF-8 raised a raw ``UnicodeDecodeError`` from the
+        same boundary — the same corruption class reaching a different
+        exception type.
+        """
+        extensions_dir = temp_dir / "extensions"
+        extensions_dir.mkdir()
+        (extensions_dir / ExtensionRegistry.REGISTRY_FILE).write_bytes(
+            b"\xff\xfe not utf-8 \xc3\x28"
+        )
+
+        registry = ExtensionRegistry(extensions_dir)
+
+        assert registry.data == {
+            "schema_version": ExtensionRegistry.SCHEMA_VERSION,
+            "extensions": {},
+        }
+
 
 # ===== ExtensionManager Tests =====
 


### PR DESCRIPTION
## Description

`ExtensionRegistry._load()` catches `json.JSONDecodeError` and `FileNotFoundError` to start fresh on a corrupted or missing `.specify/extensions/.registry`, but a registry file containing invalid UTF-8 bytes raises `UnicodeDecodeError` **before** JSON parsing begins — crashing every extension command with a raw traceback.

**Repro on main:**
```bash
printf '\xff\xfe' > .specify/extensions/.registry
specify extension list
# UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0
```

**Fix:** catch `UnicodeDecodeError` in the same clause — undecodable bytes are the same corruption class as unparseable JSON. `OSError` deliberately stays uncaught: the data may be intact on disk, and starting fresh would let a later `_save()` wipe it (same fail-closed reasoning as the workflow catalog cache loader).

The existing test `test_non_utf8_registry_does_not_crash` documents that `_sibling_extension_ids` works *around* this gap; this PR fixes the source so the workaround is consistent with `_load()` itself.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,310 passed, 176 skipped)
- [x] New regression test `test_load_starts_fresh_for_non_utf8_registry` (fails on main, passes with fix)
- [x] `ruff check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: Claude Fable 5) under human direction; TDD (failing test first), full suite and lint verified locally. Commit includes `Assisted-by`/`Co-authored-by` trailers.
