### PR TITLE
fix(presets): start fresh on a non-UTF-8 preset registry

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -531,7 +531,12 @@ class PresetRegistry:
             if not isinstance(data.get("presets"), dict):
                 data["presets"] = {}
             return data
-        except (json.JSONDecodeError, FileNotFoundError):
+        except (json.JSONDecodeError, UnicodeDecodeError, FileNotFoundError):
+            # Corrupted or missing registry, start fresh. A registry whose
+            # bytes cannot be decoded as UTF-8 is the same corruption class
+            # as malformed JSON — only the exception type differs. OSError is
+            # deliberately not caught: the data may be intact on disk, and
+            # starting fresh would let a later _save() wipe it.
             return {
                 "schema_version": self.SCHEMA_VERSION,
                 "presets": {}

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -484,6 +484,27 @@ class TestPresetRegistry:
         assert registry.list() == {}
         assert not registry.is_installed("test-pack")
 
+    def test_load_starts_fresh_for_non_utf8_registry(self, temp_dir):
+        """A registry file with undecodable bytes must start fresh, not raise.
+
+        ``_load()`` already treats malformed JSON as "corrupted registry,
+        start fresh", but a registry whose *bytes* cannot be decoded as UTF-8
+        raised a raw ``UnicodeDecodeError`` from the same boundary — the same
+        corruption class reaching a different exception type.
+        """
+        packs_dir = temp_dir / "packs"
+        packs_dir.mkdir()
+        (packs_dir / PresetRegistry.REGISTRY_FILE).write_bytes(
+            b"\xff\xfe not utf-8 \xc3\x28"
+        )
+
+        registry = PresetRegistry(packs_dir)
+
+        assert registry.data == {
+            "schema_version": PresetRegistry.SCHEMA_VERSION,
+            "presets": {},
+        }
+
     def test_add_and_get(self, temp_dir):
         """Test adding and retrieving a pack."""
         packs_dir = temp_dir / "packs"


### PR DESCRIPTION
## Description

`PresetRegistry._load()` catches `json.JSONDecodeError` and `FileNotFoundError` to start fresh on a corrupted or missing `.specify/presets/.registry`, but a registry file containing invalid UTF-8 bytes raises `UnicodeDecodeError` **before** JSON parsing begins — crashing every preset command with a raw traceback.

**Repro on main:**
```bash
printf '\xff\xfe' > .specify/presets/.registry
specify preset list
# UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0
```

**Fix:** catch `UnicodeDecodeError` in the same clause — undecodable bytes are the same corruption class as unparseable JSON. `OSError` deliberately stays uncaught: the data may be intact on disk, and starting fresh would let a later `_save()` wipe it (same fail-closed reasoning as the workflow catalog cache loader).

Exact twin of the extension-registry gap (#3954), kept as a separate PR per bug for isolated review/revert.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,310 passed, 176 skipped)
- [x] New regression test `test_load_starts_fresh_for_non_utf8_registry` (fails on main, passes with fix)
- [x] `ruff check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: Claude Fable 5) under human direction; TDD (failing test first), full suite and lint verified locally. Commit includes `Assisted-by`/`Co-authored-by` trailers.
