### PR TITLE
fix(events): skip an unreadable command template

### DIFF
--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -548,7 +548,15 @@ def _resolve_event_command_argv(
     """
     from .integrations.base import IntegrationBase
 
-    content = template_path.read_text(encoding="utf-8")
+    try:
+        content = template_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        # An unreadable or undecodable template cannot declare a runnable
+        # script. Degrade to "no argv" like every other failure in this
+        # resolver (missing frontmatter, malformed YAML, absent scripts)
+        # instead of leaking a raw traceback through
+        # resolve_and_run_event_command.
+        return None
     m = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
     if not m:
         return None

--- a/tests/integrations/test_events.py
+++ b/tests/integrations/test_events.py
@@ -1287,6 +1287,31 @@ class TestCommandRunner:
         argv = _resolve_event_command_argv(cmd_dir / "boot.md", tmp_path, None)
         assert argv is None
 
+    def test_permission_denied_template_returns_none(self, tmp_path, monkeypatch):
+        """The same boundary must cover ``OSError`` (e.g. permission denied).
+
+        Mocked rather than chmod-based so the case also holds under
+        privileged CI where permission bits are not enforced.
+        """
+        from specify_cli.events import _resolve_event_command_argv
+
+        cmd_dir = tmp_path / ".specify" / "templates" / "commands"
+        cmd_dir.mkdir(parents=True)
+        template = cmd_dir / "boot.md"
+        template.write_text("---\ndescription: Boot\n---\nBody\n")
+
+        original_read_text = Path.read_text
+
+        def failing_read_text(self_path, *args, **kwargs):
+            if self_path == template:
+                raise PermissionError(13, "Permission denied")
+            return original_read_text(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", failing_read_text)
+
+        argv = _resolve_event_command_argv(template, tmp_path, None)
+        assert argv is None
+
     def test_ps_variant_prefixed_with_powershell_launcher(self, tmp_path):
         """S6: the ps variant prefixes argv with pwsh/powershell -File so
         subprocess.run(shell=False) can execute the .ps1 script."""

--- a/tests/integrations/test_events.py
+++ b/tests/integrations/test_events.py
@@ -1263,6 +1263,28 @@ class TestCommandRunner:
         )
 
         argv = _resolve_event_command_argv(cmd_dir / "boot.md", tmp_path, None)
+
+        assert argv is None
+
+    def test_unreadable_template_returns_none(self, tmp_path):
+        """A command template that cannot be read must resolve to no argv.
+
+        Every other failure inside ``_resolve_event_command_argv`` — missing
+        frontmatter, malformed YAML, absent scripts — degrades to ``None`` so
+        the dispatcher treats the command as declaring no runnable script.
+        The initial ``read_text`` was the one step outside that boundary: a
+        non-UTF-8 template raised a raw ``UnicodeDecodeError`` through
+        ``resolve_and_run_event_command`` and out of ``specify event run``.
+        """
+        from specify_cli.events import _resolve_event_command_argv
+
+        cmd_dir = tmp_path / ".specify" / "templates" / "commands"
+        cmd_dir.mkdir(parents=True)
+        (cmd_dir / "boot.md").write_bytes(
+            b"---\ndescription: \"B\xff\xfeoot\"\n---\nBody\n"
+        )
+
+        argv = _resolve_event_command_argv(cmd_dir / "boot.md", tmp_path, None)
         assert argv is None
 
     def test_ps_variant_prefixed_with_powershell_launcher(self, tmp_path):


### PR DESCRIPTION
## Description

The event command runner reads the resolved command template with a bare `read_text()`, so a template file that **exists but cannot be read or decoded** (permission error, non-UTF-8 bytes) crashes event dispatch with a raw `OSError`/`UnicodeDecodeError`. Every sibling failure in this path — missing template, unresolvable command — already returns `None` so the dispatcher falls back cleanly.

**Fix:** wrap the read and return `None` on `(OSError, UnicodeDecodeError)`, matching the sibling contract. An unreadable template now behaves exactly like a missing one.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,310 passed, 176 skipped)
- [x] New regression test `test_unreadable_template_returns_none` (fails on main, passes with fix)
- [x] `ruff check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: Claude Fable 5) under human direction; TDD (failing test first), full suite and lint verified locally. Commit includes `Assisted-by`/`Co-authored-by` trailers.