### PR TITLE
fix(events): return None for an unparseable script command

### DIFF
--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -524,7 +524,13 @@ def _resolve_event_command_argv(
     else:
         base = project_root / ".specify"
 
-    tokens = shlex.split(script_cmd, posix=(os.name != "nt"))
+    try:
+        tokens = shlex.split(script_cmd, posix=(os.name != "nt"))
+    except ValueError:
+        # Mirror the generated dispatcher's _resolve_argv: a scripts: value
+        # shlex cannot tokenize (e.g. an unclosed quote) declares no runnable
+        # script, so degrade to "no argv" instead of raising.
+        return None
     if not tokens:
         return None
     script_abs = base / tokens[0]

--- a/tests/integrations/test_events.py
+++ b/tests/integrations/test_events.py
@@ -1031,6 +1031,32 @@ class TestCommandRunner:
         assert PurePath(argv[1]).as_posix().endswith(".specify/scripts/python/boot.py")
         assert ".specify" in argv[1]
 
+    def test_unparseable_script_command_returns_none(self, tmp_path):
+        """A ``scripts:`` value shlex cannot tokenize must resolve to no argv.
+
+        The generated dispatcher's ``_resolve_argv`` twin wraps its
+        ``shlex.split`` in ``except ValueError: return None``, but the
+        CLI-side resolver did not: an unclosed quote in a ``scripts:``
+        frontmatter value raised a raw ``ValueError: No closing quotation``
+        through ``resolve_and_run_event_command`` instead of degrading to
+        "no runnable script" like every other malformed-input case here.
+        """
+        from specify_cli.events import _resolve_event_command_argv
+
+        cmd_dir = tmp_path / ".specify" / "templates" / "commands"
+        cmd_dir.mkdir(parents=True)
+        (cmd_dir / "boot.md").write_text(
+            "---\n"
+            "description: \"Boot\"\n"
+            "scripts:\n"
+            "  sh: scripts/bash/boot.sh \"unclosed\n"
+            "---\nBody\n",
+            encoding="utf-8",
+        )
+
+        argv = _resolve_event_command_argv(cmd_dir / "boot.md", tmp_path, None)
+        assert argv is None
+
     def test_ps_variant_prefixed_with_powershell_launcher(self, tmp_path):
         """S6: the ps variant prefixes argv with pwsh/powershell -File so
         subprocess.run(shell=False) can execute the .ps1 script."""


### PR DESCRIPTION
## Description

The script-command resolver splits the configured command with a bare `shlex.split()`, so a command string with unbalanced quotes (e.g. `command: "run 'oops"`) crashes event dispatch with a raw `ValueError: No closing quotation`. The dispatcher-template twin a few lines up already wraps the very same call in `try/except ValueError` and returns `None` so dispatch falls back cleanly.

**Fix:** wrap the split the same way and return `None`, restoring parity between the two paths. One malformed hook entry no longer takes down dispatch for every other hook.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,310 passed, 176 skipped)
- [x] New regression test `test_unparseable_script_command_returns_none` (fails on main, passes with fix)
- [x] `ruff check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: Claude Fable 5) under human direction; TDD (failing test first), full suite and lint verified locally. Commit includes `Assisted-by`/`Co-authored-by` trailers.