### PR TITLE
fix(bundler): reject non-UTF-8 zipped manifests consistently

### DIFF
--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -752,8 +752,6 @@ def _local_manifest_source(arg: str):
         return BundleManifest.from_file(manifest_path)
 
     if candidate.suffix == ".zip":
-        import io
-
         import yaml as _yaml
 
         from ..._download_security import open_zip_bounded, read_zip_member_limited
@@ -771,8 +769,20 @@ def _local_manifest_source(arg: str):
                 error_type=BundlerError,
                 label="bundle manifest",
             )
+        # The bounded-zip helpers above keep archive failures inside the
+        # BundlerError contract, but the manifest bytes need the same
+        # treatment as yamlio.load_yaml: decode as UTF-8 explicitly —
+        # feeding PyYAML the byte stream would let its Reader auto-detect
+        # a UTF-16 BOM and accept a manifest the directory and bundle.yml
+        # sources reject.
         try:
-            data = _yaml.safe_load(io.BytesIO(raw))
+            text = raw.decode("utf-8")
+        except UnicodeError as exc:
+            raise BundlerError(
+                f"Could not read bundle.yml inside '{candidate}': {exc}"
+            ) from exc
+        try:
+            data = _yaml.safe_load(text)
         except _yaml.YAMLError as exc:
             # The sibling directory/bundle.yml branches reach YAML through
             # load_yaml(), which turns a parse failure into a BundlerError. This

--- a/tests/integration/test_bundler_local_install.py
+++ b/tests/integration/test_bundler_local_install.py
@@ -62,6 +62,39 @@ def test_local_source_rejects_unknown_file(tmp_path: Path):
         _local_manifest_source(str(weird))
 
 
+def test_local_source_zip_non_utf8_manifest_raises_bundler_error(tmp_path: Path):
+    """Undecodable bundle.yml bytes inside a .zip must raise BundlerError.
+
+    The manifest bytes are decoded as UTF-8 explicitly, matching
+    ``yamlio.load_yaml``'s "Could not read ..." contract, instead of
+    escaping as a raw ``UnicodeDecodeError``/``ReaderError`` traceback.
+    """
+    artifact = tmp_path / "demo.zip"
+    with zipfile.ZipFile(artifact, "w") as archive:
+        archive.writestr("bundle.yml", b"\xff\xfe bundle \xc3\x28\n")
+
+    with pytest.raises(BundlerError, match="Could not read"):
+        _local_manifest_source(str(artifact))
+
+
+def test_local_source_zip_utf16_manifest_rejected_like_directory(tmp_path: Path):
+    """A well-formed UTF-16 manifest must fail the same way in a .zip.
+
+    ``yamlio.load_yaml`` decodes strictly as UTF-8, so a UTF-16 bundle.yml
+    (the realistic PowerShell ``Out-File`` output) is rejected when read
+    from a directory. Feeding the zip bytes straight to PyYAML would let
+    its Reader honour the UTF-16 BOM and *accept* the same manifest,
+    making zip and directory sources diverge.
+    """
+    artifact = tmp_path / "demo.zip"
+    manifest_text = "bundle:\n  id: demo-bundle\n  version: 1.0.0\n"
+    with zipfile.ZipFile(artifact, "w") as archive:
+        archive.writestr("bundle.yml", manifest_text.encode("utf-16"))
+
+    with pytest.raises(BundlerError, match="Could not read"):
+        _local_manifest_source(str(artifact))
+
+
 def test_install_bundled_extension_from_zip_offline(tmp_path: Path):
     """End-to-end: build → install (offline, local .zip) → list → remove."""
     project = make_project(tmp_path / "proj")


### PR DESCRIPTION
## Description

A local bundle directory or plain `bundle.yml` is decoded strictly as UTF-8 through `yamlio.load_yaml`, but the `.zip` path feeds raw bytes to PyYAML. PyYAML auto-detects a UTF-16 BOM, so a UTF-16 manifest rejected by the other two local-source paths is silently accepted from a zip. Other undecodable bytes also surface through PyYAML instead of the shared `Could not read ...` contract.

**Fix:** decode the bounded zip member explicitly as UTF-8 before parsing. Decode failures now raise `BundlerError` with the same `Could not read` wording as `yamlio`; YAML parse handling remains from #4013.

This PR originally also wrapped malformed YAML. #4013 merged that independently, so the branch was rebased and that overlapping commit/test was dropped. The remaining one-commit diff only covers the still-missing encoding consistency.

## Testing

- [x] Full suite on rebased head: 6,462 passed, 177 skipped
- [x] Two regression tests: invalid UTF-8 bytes and well-formed UTF-16 manifest
- [x] `uvx ruff@0.15.0 check src tests`
- [x] `git diff --check`

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: Claude Fable 5) under human direction; TDD, full suite, lint, rebase, and final diff review completed locally. Commit includes `Assisted-by`/`Co-authored-by` trailers.