### PR TITLE
fix: use logger instead of print() in _agent_config.py

### DIFF
--- a/src/specify_cli/_agent_config.py
+++ b/src/specify_cli/_agent_config.py
@@ -1,9 +1,11 @@
 """Agent configuration constants derived from the integration registry."""
 from __future__ import annotations
 
+import logging
 import os
-import sys
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 def _build_agent_config() -> dict[str, dict[str, Any]]:
@@ -41,11 +43,11 @@ def resolve_default_init_integration() -> str:
         return DEFAULT_INIT_INTEGRATION
     if override in AGENT_CONFIG:
         return override
-    print(
-        f"Warning: {DEFAULT_INIT_INTEGRATION_ENV_VAR}='{override}' is not a "
-        f"recognized integration; falling back to '{DEFAULT_INIT_INTEGRATION}'. "
-        f"Choose from: {', '.join(sorted(AGENT_CONFIG.keys()))}.",
-        file=sys.stderr,
+    logger.warning(
+        "%s='%s' is not a recognized integration; falling back to '%s'. "
+        "Choose from: %s.",
+        DEFAULT_INIT_INTEGRATION_ENV_VAR, override,
+        DEFAULT_INIT_INTEGRATION, ', '.join(sorted(AGENT_CONFIG.keys())),
     )
     return DEFAULT_INIT_INTEGRATION
 

--- a/tests/test_agent_config_consistency.py
+++ b/tests/test_agent_config_consistency.py
@@ -438,3 +438,22 @@ class TestAgentConfigConsistency:
     def test_agent_config_includes_rovodev(self):
         """AGENT_CONFIG should include rovodev."""
         assert "rovodev" in AGENT_CONFIG
+
+
+class TestAgentConfigLoggingRegression:
+    """Regression: _agent_config.py must use logger, not print(), for warnings."""
+
+    def test_invalid_integration_uses_logger_not_print(self, caplog):
+        """Invalid integration warning must use logger.warning(), not print()."""
+        import logging
+        import os
+        from unittest.mock import patch
+
+        from specify_cli._agent_config import resolve_default_init_integration
+
+        with caplog.at_level(logging.WARNING):
+            with patch.dict(os.environ, {"SPECKIT_INTEGRATION_DEFAULT": "nonexistent"}):
+                result = resolve_default_init_integration()
+                assert result == "copilot"  # default fallback
+                assert any("nonexistent" in record.message for record in caplog.records)
+                assert any("not a recognized integration" in record.message for record in caplog.records)


### PR DESCRIPTION
## Problem

_agent_config.py used print(..., file=sys.stderr) for warnings instead of using the logging module.

## Fix

Add logging.getLogger(__name__) and replace print() with logger.warning(). Remove unused sys import.