### PR TITLE
fix: add timeout to streaming subprocess.run() in copilot dispatch_command

### DIFF
--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -307,7 +307,14 @@ class CopilotIntegration(IntegrationBase):
                     cli_args,
                     text=True,
                     cwd=cwd,
+                    timeout=timeout,
                 )
+            except subprocess.TimeoutExpired:
+                return {
+                    "exit_code": 124,
+                    "stdout": "",
+                    "stderr": f"Command timed out after {timeout}s",
+                }
             except KeyboardInterrupt:
                 return {
                     "exit_code": 130,


### PR DESCRIPTION
## Problem

The streaming branch of copilot's dispatch_command() called subprocess.run() without timeout, which could hang indefinitely if the child process stalls.

## Fix

Apply the same timeout parameter as the non-streaming branch, with proper TimeoutExpired handling.