### PR TITLE
fix: replace print() with logger.warning() in presets catalog warning

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -10,6 +10,7 @@ customize the Spec-Driven Development workflow.
 import copy
 import json
 import hashlib
+import logging
 import os
 import tempfile
 import shutil
@@ -53,6 +54,8 @@ from ..shared_infra import (
     _write_shared_text,
     verify_archive_sha256,
 )
+
+logger = logging.getLogger(__name__)
 
 
 _CONSTITUTION_PROVENANCE_FILE = ".constitution-template.json"
@@ -4256,18 +4259,15 @@ class PresetCatalog:
         Raises:
             PresetValidationError: If a catalog URL is invalid
         """
-        import sys
-
         # 1. SPECKIT_PRESET_CATALOG_URL env var replaces all defaults
         if env_value := os.environ.get("SPECKIT_PRESET_CATALOG_URL"):
             catalog_url = env_value.strip()
             self._validate_catalog_url(catalog_url)
             if catalog_url != self.DEFAULT_CATALOG_URL:
                 if not getattr(self, "_non_default_catalog_warning_shown", False):
-                    print(
-                        "Warning: Using non-default preset catalog. "
+                    logger.warning(
+                        "Using non-default preset catalog. "
                         "Only use catalogs from sources you trust.",
-                        file=sys.stderr,
                     )
                     self._non_default_catalog_warning_shown = True
             return [PresetCatalogEntry(url=catalog_url, name="custom", priority=1, install_allowed=True, description="Custom catalog via SPECKIT_PRESET_CATALOG_URL")]


### PR DESCRIPTION
## Problem

print(..., file=sys.stderr) bypasses the logging framework and cannot be silenced or redirected by consumers.

## Fix

Replaced with logger.warning() for proper log management. Removed unused sys import.