### PR TITLE
fix: make _safe_write_json actually atomic with mkstemp + os.replace

### DIFF
--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -2017,8 +2017,9 @@ def _safe_write_json(dst: Path, data: dict) -> None:
     fd, tmp = tempfile.mkstemp(
         dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
     )
-    os.chmod(tmp, 0o644)
     try:
+        if dst.exists() and hasattr(os, "fchmod"):
+            os.fchmod(fd, dst.stat(follow_symlinks=False).st_mode & 0o7777)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
             f.write("\n")

--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -17,6 +17,7 @@ import shutil
 import sys
 import subprocess
 import platform
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -2010,10 +2011,23 @@ def _load_user_json(path: Path) -> dict | None:
 
 
 def _safe_write_json(dst: Path, data: dict) -> None:
-    """Write *data* as JSON to *dst* after validating the destination (#12)."""
+    """Write *data* as JSON to *dst* atomically after validating the destination (#12)."""
     _ensure_safe_destination(dst)
     dst.parent.mkdir(parents=True, exist_ok=True)
-    dst.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    fd, tmp = tempfile.mkstemp(
+        dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, dst)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _ensure_safe_destination(dst: Path) -> None:

--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -2017,6 +2017,7 @@ def _safe_write_json(dst: Path, data: dict) -> None:
     fd, tmp = tempfile.mkstemp(
         dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
     )
+    os.chmod(tmp, 0o644)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)


### PR DESCRIPTION
## Problem

Despite its name, _safe_write_json used write_text() which truncates the file before writing. A crash or power loss mid-write leaves a partial JSON file. This function is called by _merge_copilot_json, _merge_opencode_plugin_ref, etc., meaning all Copilot and OpenCode event config writes were non-atomic.

## Fix

Now uses 	empfile.mkstemp + os.replace for atomic writes, matching the pattern used in _utils.py, shared_infra.py, and other safe-write utilities in the codebase.