### PR TITLE
fix: make _merge_toml_fragment and _remove_toml_entries use atomic writes

### DIFF
--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -1731,8 +1731,9 @@ def _merge_toml_fragment(dst: Path, fragment: str) -> None:
     fd, tmp = tempfile.mkstemp(
         dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
     )
-    os.chmod(tmp, 0o644)
     try:
+        if dst.exists() and hasattr(os, "fchmod"):
+            os.fchmod(fd, dst.stat(follow_symlinks=False).st_mode & 0o7777)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(existing.rstrip() + "\n\n" + fragment + "\n")
         os.replace(tmp, dst)
@@ -1774,8 +1775,9 @@ def _remove_toml_entries(dst: Path) -> bool:
     fd, tmp = tempfile.mkstemp(
         dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
     )
-    os.chmod(tmp, 0o644)
     try:
+        if dst.exists() and hasattr(os, "fchmod"):
+            os.fchmod(fd, dst.stat(follow_symlinks=False).st_mode & 0o7777)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(cleaned)
         os.replace(tmp, dst)

--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -1731,6 +1731,7 @@ def _merge_toml_fragment(dst: Path, fragment: str) -> None:
     fd, tmp = tempfile.mkstemp(
         dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
     )
+    os.chmod(tmp, 0o644)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(existing.rstrip() + "\n\n" + fragment + "\n")
@@ -1773,6 +1774,7 @@ def _remove_toml_entries(dst: Path) -> bool:
     fd, tmp = tempfile.mkstemp(
         dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
     )
+    os.chmod(tmp, 0o644)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(cleaned)

--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -17,6 +17,7 @@ import shutil
 import sys
 import subprocess
 import platform
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -1727,7 +1728,19 @@ def _merge_toml_fragment(dst: Path, fragment: str) -> None:
         flags=re.DOTALL,
     )
     dst.parent.mkdir(parents=True, exist_ok=True)
-    dst.write_text(existing.rstrip() + "\n\n" + fragment + "\n", encoding="utf-8")
+    fd, tmp = tempfile.mkstemp(
+        dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(existing.rstrip() + "\n\n" + fragment + "\n")
+        os.replace(tmp, dst)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _remove_toml_entries(dst: Path) -> bool:
@@ -1757,7 +1770,19 @@ def _remove_toml_entries(dst: Path) -> bool:
     if not stripped:
         dst.unlink(missing_ok=True)
         return True
-    dst.write_text(cleaned, encoding="utf-8")
+    fd, tmp = tempfile.mkstemp(
+        dir=str(dst.parent), prefix=f".{dst.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(cleaned)
+        os.replace(tmp, dst)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
     return False
 
 


### PR DESCRIPTION
## Problem

Both _merge_toml_fragment and _remove_toml_entries used write_text() which truncates the file before writing. A crash or power loss mid-write leaves a partial TOML file.

## Fix

Now uses 	empfile.mkstemp + os.replace for atomic writes, matching the pattern used elsewhere in the codebase.