### PR TITLE
fix: add ValueError guard for timeout in _build_opencode_plugin

### DIFF
--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -1614,7 +1614,10 @@ def _build_opencode_plugin(
             # S3: thread the per-handler timeout (seconds) to runEvent so the
             # execFileSync cap and dispatcher arg match the configuration
             # instead of a fixed 60000ms / 120s.
-            timeout_sec = int(cfg.get("timeout", 60))
+            try:
+                timeout_sec = int(cfg.get("timeout", 60))
+            except (TypeError, ValueError):
+                timeout_sec = 60
             if native.startswith("tool.execute."):
                 if matcher and matcher != "*":
                     tools = [t.strip().strip('"') for t in matcher.split("|")]

--- a/tests/integrations/test_events.py
+++ b/tests/integrations/test_events.py
@@ -890,6 +890,25 @@ class TestOpencodePluginMerging:
         assert "runEvent('speckit.x" not in content
         assert json.dumps("ed'it") in content
 
+    def test_opencode_non_numeric_timeout_uses_default(self, tmp_path):
+        """A non-numeric timeout value in event config must not crash
+        _build_opencode_plugin; it should fall back to the default (60s)."""
+        integration = OpencodeIntegration()
+        manifest = MagicMock(spec=IntegrationManifest)
+        manifest.files = {}
+        manifest.record_file = MagicMock()
+        manifest.record_existing = MagicMock()
+
+        events = {
+            "pre_tool_use": [{"command": "speckit.tdd.validate", "timeout": "not-a-number"}],
+        }
+        # Must not raise TypeError or ValueError
+        install_integration_events(integration, tmp_path, manifest, events)
+        plugin_path = tmp_path / ".opencode/plugin/speckit-events.ts"
+        assert plugin_path.is_file()
+        content = plugin_path.read_text()
+        assert "speckit.tdd.validate" in content
+
 
 # -- Command runner test (core execution) -----------------------------------
 


### PR DESCRIPTION
## Problem

int(cfg.get('timeout', 60)) crashes with an unhandled ValueError when a user provides a non-numeric timeout value in event configuration. Two other call sites in the same file already handle this gracefully with 	ry/except (TypeError, ValueError).

## Fix

Added the same 	ry/except guard, making the third call site consistent.