### PR TITLE
fix: use atomic writes for composed preset command files

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -67,8 +67,9 @@ def _atomic_write_text(path: Path, content: str) -> None:
     fd, tmp = tempfile.mkstemp(
         dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
     )
-    os.chmod(tmp, 0o644)
     try:
+        if path.exists() and hasattr(os, "fchmod"):
+            os.fchmod(fd, path.stat(follow_symlinks=False).st_mode & 0o7777)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
         os.replace(tmp, path)

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -67,6 +67,7 @@ def _atomic_write_text(path: Path, content: str) -> None:
     fd, tmp = tempfile.mkstemp(
         dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
     )
+    os.chmod(tmp, 0o644)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -62,6 +62,23 @@ def _content_sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically via mkstemp + os.replace."""
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 def _constitution_is_generated(
     project_root: Path,
     memory_constitution: Path,
@@ -848,7 +865,7 @@ class PresetManager:
                             composed_dir = preset_dir / ".composed"
                             composed_dir.mkdir(parents=True, exist_ok=True)
                         composed_file = composed_dir / f"{cmd['name']}.md"
-                        composed_file.write_text(composed, encoding="utf-8")
+                        _atomic_write_text(composed_file, composed)
                         commands_to_register.append({
                             **cmd,
                             "file": f".composed/{cmd['name']}.md",
@@ -1838,7 +1855,7 @@ class PresetManager:
                             composed_dir = pack_dir / ".composed"
                             composed_dir.mkdir(parents=True, exist_ok=True)
                             composed_file = composed_dir / f"{cmd_name}.md"
-                            composed_file.write_text(composed, encoding="utf-8")
+                            _atomic_write_text(composed_file, composed)
                             written = self._register_for_non_skill_agents(
                                 registrar,
                                 [{**tmpl, "file": f".composed/{cmd_name}.md"}],
@@ -1858,7 +1875,7 @@ class PresetManager:
                     shared_composed = self.presets_dir / ".composed"
                     shared_composed.mkdir(parents=True, exist_ok=True)
                     composed_file = shared_composed / f"{cmd_name}.md"
-                    composed_file.write_text(composed, encoding="utf-8")
+                    _atomic_write_text(composed_file, composed)
                     source = layers[0]["source"]
                     if source.startswith("extension:"):
                         source_id = source.split(":", 1)[1].split(" ", 1)[0]


### PR DESCRIPTION
## Problem

Three write_text() calls for composed command files were not atomic. A crash mid-write leaves a partial .md file which can cause errors when the command is later read.

## Fix

Now uses a shared _atomic_write_text helper with 	empfile.mkstemp + os.replace.