### PR TITLE
docs: clarify agent PR review prioritization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,6 +509,11 @@ When an issue exists, include its number immediately after the prefix — this i
 
 Disclosure is **continuous**, not a one-time event. A single AI-disclosure paragraph in the PR body does **not** cover the commits and replies you add during review rounds. Each of the following must independently attest to agent authorship.
 
+### Opening pull requests
+
+- Before opening a pull request, check whether the account that will file it already has three open pull requests in this repository.
+- If so, alert the user that additional submissions may receive lower review priority and ask for explicit permission to proceed. Do not assume consent.
+
 ### Commits
 
 - **Every commit you author must carry an `Assisted-by:` trailer** identifying the agent and whether it acted autonomously or under direct human supervision, for example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,8 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 - Test your changes with the Spec-Driven Development workflow to ensure compatibility.
 
+Accounts with three open pull requests may continue submitting changes, but additional submissions may be placed behind contributions from other authors in the review queue. Coding agents should disclose this possibility and obtain the filer's confirmation before opening another pull request.
+
 ### Branch naming
 
 We recommend naming branches as `<type>/<number>-<short-slug>`, where `<number>` is the issue or PR number (whichever comes first) and `<type>` is one of:


### PR DESCRIPTION
## Summary

- explain that accounts with three open pull requests may have additional submissions placed later in the review queue
- require coding agents to warn the filer and obtain explicit permission before opening another pull request

## Testing

Not run (documentation-only change).

## AI disclosure

This pull request was authored autonomously by GitHub Copilot (GPT-5.6 Sol) on behalf of @mnriem.