### PR TITLE
fix: keep long frontmatter values on a single line

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -157,7 +157,11 @@ class CommandRegistrar:
             return ""
 
         yaml_str = yaml.dump(
-            fm, default_flow_style=False, sort_keys=False, allow_unicode=True
+            fm,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            width=float("inf"),
         )
         return f"---\n{yaml_str}---\n"
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -17,6 +17,7 @@ import platform
 import tempfile
 import shutil
 import tomllib
+import yaml
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime, timezone
@@ -2995,6 +2996,30 @@ Real body starts here.
 
         assert "Prüfe Konformität" in output
         assert "\\u" not in output
+
+    def test_render_frontmatter_keeps_long_description_on_one_line(self):
+        """A long description must not be folded across lines.
+
+        PyYAML wraps plain scalars at ~80 columns by default, which splits a
+        long ``description`` onto a continuation line. The YAML stays valid,
+        but the rendered frontmatter then differs in shape from the
+        hand-written core command templates, where ``description`` is always a
+        single line -- and consumers that read frontmatter line-wise see a
+        truncated description followed by a stray line.
+        """
+        long_description = (
+            "Execute the implementation plan by processing and executing all "
+            "tasks defined in tasks.md"
+        )
+        frontmatter = {"name": "speckit-implement", "description": long_description}
+
+        registrar = CommandRegistrar()
+        output = registrar.render_frontmatter(frontmatter)
+
+        assert f"description: {long_description}\n" in output
+
+        body = output.split("---\n")[1]
+        assert yaml.safe_load(body)["description"] == long_description
 
     def test_adjust_script_paths_does_not_mutate_input(self):
         """Path adjustments should not mutate caller-owned frontmatter dicts."""


### PR DESCRIPTION
`CommandRegistrar.render_frontmatter` (`src/specify_cli/agents.py`) calls `yaml.dump()` without `width=`, so PyYAML applies its default ~80-column wrap and folds long scalars onto a continuation line.

A `description` longer than roughly 80 characters renders as:

```yaml
---
name: speckit-implement
description: Execute the implementation plan by processing and executing all tasks
  defined in tasks.md
---
```

### Why this is worth fixing

The YAML stays valid and round-trips faithfully through `yaml.safe_load`, so this is **not** data loss — I want to be accurate about the severity. It is a shape inconsistency, with real consequences:

- Hand-written core command templates always keep `description` on a single line, so preset- and extension-rendered commands don't match the files sitting beside them in the same directory.
- Consumers that read frontmatter line-wise rather than with a YAML parser see the description truncated at the fold, followed by a stray line. Spec Kit itself hand-builds SKILL.md frontmatter in the skills path (#3391), so that's not a hypothetical class of consumer.
- `speckit.implement`'s own description is 89 characters, so any preset overriding it hits this immediately.

### The change

`width=float("inf")` disables line-wrapping only. Escaping, quoting, and the handling of genuinely multi-line values are unchanged — PyYAML selects the scalar style before applying width.

### Verification

- Added a regression test that fails without the change (asserts the description survives on one line *and* still parses).
- Full suite: **6354 passed**. Four failures in `tests/integrations/test_integration_subcommand.py` reproduce on a clean checkout of `main` as well (ANSI escapes in captured output) and are unrelated to this change.

### Reproduction

```bash
specify preset add --dev <preset with an 89-char command description>
cat .claude/skills/speckit-<name>/SKILL.md   # description folded across two lines
```