### PR TITLE
fix(extensions): start fresh on a non-UTF-8 extension registry

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -660,8 +660,13 @@ class ExtensionRegistry:
             if not isinstance(data.get("extensions"), dict):
                 data["extensions"] = {}
             return data
-        except (json.JSONDecodeError, FileNotFoundError):
-            # Corrupted or missing registry, start fresh
+        except (json.JSONDecodeError, UnicodeDecodeError, FileNotFoundError):
+            # Corrupted or missing registry, start fresh. A registry whose
+            # bytes cannot be decoded as UTF-8 is the same corruption class as
+            # malformed JSON — only the exception type differs, and it is
+            # raised by the text-mode read before JSON parsing begins. OSError
+            # is deliberately not caught: the data may be intact on disk, and
+            # starting fresh would let a later _save() wipe it.
             return {"schema_version": self.SCHEMA_VERSION, "extensions": {}}
 
     def _save(self):
@@ -4310,11 +4315,10 @@ class ConfigManager:
         Returns an empty list if the registry is missing or corrupted
         (fresh project, ad-hoc test harness) so ``_get_env_config`` degrades
         to its pre-fix behaviour rather than crashing. ``UnicodeError`` is
-        caught alongside ``OSError`` because ``ExtensionRegistry._load()``
-        opens the file in text mode and only handles ``JSONDecodeError`` /
-        ``FileNotFoundError``, so a registry file with non-UTF-8 bytes would
-        otherwise surface a ``UnicodeDecodeError`` here and break *every*
-        config read instead of degrading gracefully.
+        kept alongside ``OSError`` as belt-and-braces: ``_load()`` now starts
+        fresh on non-UTF-8 registry bytes itself, but catching it here too
+        keeps this call site degrading gracefully rather than breaking *every*
+        config read if that handling ever regresses.
 
         Used by ``_get_env_config`` to detect env vars whose remainder claims
         a longer, sibling-owned prefix (e.g. ``SPECKIT_GIT_HOOKS_URL`` is

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1291,6 +1291,31 @@ class TestExtensionRegistry:
         result = registry.list()
         assert result == {}
 
+    def test_load_starts_fresh_for_non_utf8_registry(self, temp_dir):
+        """A registry file with undecodable bytes must start fresh, not raise.
+
+        ``_load()`` already treats malformed JSON as "corrupted registry,
+        start fresh", but a registry whose *bytes* cannot be decoded as UTF-8
+        raised a raw ``UnicodeDecodeError`` from the text-mode read before
+        JSON parsing began — the same corruption class reaching a different
+        exception type. Because the registry is loaded in ``__init__``, that
+        traceback broke *every* extension command on the project.
+        """
+        extensions_dir = temp_dir / "extensions"
+        extensions_dir.mkdir()
+        (extensions_dir / ExtensionRegistry.REGISTRY_FILE).write_bytes(
+            b"\xff\xfe not utf-8 \xc3\x28"
+        )
+
+        registry = ExtensionRegistry(extensions_dir)
+
+        assert registry.data == {
+            "schema_version": ExtensionRegistry.SCHEMA_VERSION,
+            "extensions": {},
+        }
+        assert registry.list() == {}
+        assert not registry.is_installed("test-ext")
+
 
 # ===== ExtensionManager Tests =====
 


### PR DESCRIPTION
## Problem

`ExtensionRegistry._load()` treats a corrupted registry as "start fresh", but only for two exception types:

```python
except (json.JSONDecodeError, FileNotFoundError):
    # Corrupted or missing registry, start fresh
```

A `.specify/extensions/.registry` file containing invalid UTF-8 bytes raises `UnicodeDecodeError` from the text-mode read *before* JSON parsing begins, so it escapes that clause. Because the registry is loaded in `__init__`, the bare traceback breaks **every** extension command on the project:

```console
$ specify extension list
...
  File ".../specify_cli/extensions/__init__.py", line 655, in _load
    data = json.load(f)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```

`ExtensionRegistry` is also constructed from `events.py` and from two places in `presets/__init__.py`, so the crash reaches beyond the `extension` command group.

## Fix

Catch `UnicodeDecodeError` in the same clause — undecodable bytes are the same corruption class as unparseable JSON, only the exception type differs.

`OSError` stays uncaught on purpose: the data may be intact on disk, and starting fresh would let a later `_save()` wipe it (same fail-closed reasoning as the workflow catalog cache loader).

After the fix the command degrades gracefully:

```console
$ specify extension list
No extensions installed.
```

## Relationship to #3955

This is the exact twin of the `PresetRegistry._load()` fix merged in #3955. The two registries are parallel implementations of the same pattern and only the preset side was corrected there; this applies the identical one-line change plus rationale comment to the extension side.

Notably, `_get_installed_sibling_ids()` already documented and worked around this precise gap at its own call site:

> `UnicodeError` is caught alongside `OSError` because `ExtensionRegistry._load()` opens the file in text mode and only handles `JSONDecodeError` / `FileNotFoundError`, so a registry file with non-UTF-8 bytes would otherwise surface a `UnicodeDecodeError` here and break *every* config read instead of degrading gracefully.

That comment is updated to reflect that `_load()` now handles the case itself; the local catch is kept as belt-and-braces against regression.

## Testing

Added `test_load_starts_fresh_for_non_utf8_registry`, mirroring the #3955 preset test: writes undecodable bytes to `.registry`, then asserts the registry starts fresh and `list()` / `is_installed()` behave.

Verified the test genuinely covers the fix — with `src/specify_cli/extensions/__init__.py` reverted it fails with the original `UnicodeDecodeError`, and passes with the fix applied.

`pytest tests/test_extensions.py` → 489 passed. `pytest tests/test_presets.py tests/integrations/test_events.py` → 678 passed. The only failures in either run are pre-existing symlink tests that require Windows elevation (`WinError 1314`) and fail identically on a clean checkout. `ruff check` passes on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
