### PR TITLE
fix(bundle): wrap malformed YAML in a local .zip bundle manifest

### DIFF
--- a/src/specify_cli/commands/bundle/__init__.py
+++ b/src/specify_cli/commands/bundle/__init__.py
@@ -771,7 +771,17 @@ def _local_manifest_source(arg: str):
                 error_type=BundlerError,
                 label="bundle manifest",
             )
-        data = _yaml.safe_load(io.BytesIO(raw))
+        try:
+            data = _yaml.safe_load(io.BytesIO(raw))
+        except _yaml.YAMLError as exc:
+            # The sibling directory/bundle.yml branches reach YAML through
+            # load_yaml(), which turns a parse failure into a BundlerError. This
+            # branch parses inline, so without this it raises a raw YAMLError --
+            # neither a ValueError nor an OSError -- which escapes
+            # bundle_install()'s `except BundlerError` as a traceback.
+            raise BundlerError(
+                f"Invalid YAML in bundle.yml inside '{candidate}': {exc}"
+            ) from exc
         return BundleManifest.from_dict(data)
 
     if candidate.name == "bundle.yml" or candidate.suffix in (".yml", ".yaml"):

--- a/tests/integration/test_bundler_local_install.py
+++ b/tests/integration/test_bundler_local_install.py
@@ -186,6 +186,50 @@ def test_local_zip_uses_bounded_archive_open(tmp_path: Path):
         _local_manifest_source(str(artifact))
 
 
+def test_local_zip_wraps_malformed_manifest_yaml(tmp_path: Path):
+    """A malformed bundle.yml inside a .zip must raise BundlerError.
+
+    The zip branch parses YAML inline rather than through load_yaml(), so the
+    raw yaml.YAMLError used to escape. It is neither a ValueError nor an
+    OSError, so nothing upstream caught it.
+    """
+    artifact = tmp_path / "bad-manifest.zip"
+    with zipfile.ZipFile(artifact, "w") as archive:
+        archive.writestr("bundle.yml", "bundle: [unclosed\n  id: demo\n")
+
+    with pytest.raises(BundlerError, match="Invalid YAML"):
+        _local_manifest_source(str(artifact))
+
+
+def test_malformed_manifest_yaml_fails_alike_for_every_local_source(tmp_path: Path):
+    """`bundle install` reports malformed YAML the same way for all 3 sources.
+
+    Directory and bundle.yml sources already exited 1 with an "Invalid YAML"
+    message; the .zip source dumped a yaml.parser.ParserError traceback.
+    """
+    bad_yaml = "bundle: [unclosed\n  id: demo\n"
+
+    directory = tmp_path / "dir-src"
+    directory.mkdir()
+    (directory / "bundle.yml").write_text(bad_yaml, encoding="utf-8")
+
+    manifest_file = tmp_path / "standalone.yml"
+    manifest_file.write_text(bad_yaml, encoding="utf-8")
+
+    artifact = tmp_path / "artifact.zip"
+    with zipfile.ZipFile(artifact, "w") as archive:
+        archive.writestr("bundle.yml", bad_yaml)
+
+    runner = CliRunner()
+    for source in (directory, manifest_file, artifact):
+        result = runner.invoke(app, ["bundle", "install", str(source)])
+        assert result.exit_code == 1, f"{source.name}: {result.output}"
+        assert result.exception is None or isinstance(
+            result.exception, SystemExit
+        ), f"{source.name} leaked {type(result.exception).__name__}"
+        assert "Invalid YAML" in result.output, f"{source.name}: {result.output}"
+
+
 def test_invalid_local_manifest_is_rejected_before_project_init(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Problem

`_local_manifest_source` accepts three local bundle sources. Two of them reach YAML through `BundleManifest.from_file` → `load_yaml`, which wraps a parse failure:

```python
try:
    has_node = yaml.compose(text) is not None
    data = yaml.safe_load(text)
except yaml.YAMLError as exc:
    raise BundlerError(f"Invalid YAML in {path}: {exc}") from exc
```

The `.zip` branch parses inline instead, with no guard:

```python
data = _yaml.safe_load(io.BytesIO(raw))
return BundleManifest.from_dict(data)
```

`yaml.YAMLError` derives **directly from `Exception`** — it is neither a `ValueError` nor an `OSError`:

```
yaml.error.YAMLError -> Exception -> BaseException -> object
```

So it slips past `bundle_install`'s `except BundlerError` and surfaces as a raw traceback.

## Reproduction

```bash
python -c "import zipfile; zipfile.ZipFile('bad.zip','w').writestr('bundle.yml','bundle: [unclosed\n  id: x\n')"
specify bundle install ./bad.zip
```

For the *identical* malformed `bundle.yml`, the three local sources disagree:

| Source | Result |
|---|---|
| `./bundle-dir` | `Error: Invalid YAML in bundle.yml: ...` — exit 1 |
| `./bundle.yml` | `Error: Invalid YAML in standalone.yml: ...` — exit 1 |
| `./bundle.zip` | **`yaml.parser.ParserError` traceback** |

## Why this is the local path's bug, not a missing global handler

The remote counterpart of this exact call — `_download_manifest`, which parses a manifest fetched from a catalog — already handles it, and even names the exception explicitly:

```python
except _yaml.YAMLError as exc:
    raise BundlerError(
        f"Downloaded content for bundle '{entry_id}' from {_source_desc} "
        f"is not valid YAML: {exc}"
    ) from exc
```

So the same corrupt manifest is reported cleanly when it arrives over the network but crashes when installed from disk. This fix brings the local branch in line with both its in-function siblings and its remote twin.

## Tests

Two regression tests in `tests/integration/test_bundler_local_install.py`:

- `test_local_zip_wraps_malformed_manifest_yaml` — pins the `BundlerError` contract on the zip branch.
- `test_malformed_manifest_yaml_fails_alike_for_every_local_source` — drives all three local sources through the CLI and asserts they now fail identically. This is the one that encodes the actual invariant; on `main` it fails with `artifact.zip leaked ParserError` while the other two sources pass.

Both fail before the change and pass after. `tests/integration/test_bundler_local_install.py` + `tests/contract/test_bundle_cli.py`: 49 passed. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
