### PR TITLE
fix(extensions): reject duplicate provides.templates/scripts names

### DIFF
--- a/extensions/EXTENSION-DEVELOPMENT-GUIDE.md
+++ b/extensions/EXTENSION-DEVELOPMENT-GUIDE.md
@@ -177,11 +177,16 @@ Compatibility requirements.
 
 What the extension provides.
 
-**Optional sub-fields** (at least one of `commands`, `templates`, `scripts`, `hooks`, or `events` is required):
+**Optional sub-fields:**
 
 - `commands`: Array of command objects
 - `templates`: Array of template objects
 - `scripts`: Array of script objects
+
+`hooks` and `events` are separate top-level manifest fields (siblings of
+`provides`, not nested under it — see [`hooks`](#hooks) below). At least one
+of `provides.commands`, `provides.templates`, `provides.scripts`, `hooks`, or
+`events` is required.
 
 **Command object**:
 

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -577,8 +577,13 @@ class ExtensionManifest:
         behavior for extension layers in presets/__init__.py). A present
         'strategy' key is rejected rather than silently ignored, so an author
         who copies a preset-style entry gets a clear error instead of a
-        silently-dropped field.
+        silently-dropped field. Duplicate names within a section are also
+        rejected: the resolver returns the first matching entry by name
+        (``PresetResolver._extension_manifest_declared_template``), so a
+        later duplicate would be silently unreachable while still being
+        exposed by ``ExtensionManifest.templates``/``.scripts``.
         """
+        seen_names: set[str] = set()
         for entry in entries:
             if not isinstance(entry, dict):
                 raise ValidationError(
@@ -597,6 +602,11 @@ class ExtensionManifest:
                     f"Invalid {singular} name '{name}': "
                     "must be lowercase alphanumeric with hyphens only"
                 )
+            if name in seen_names:
+                raise ValidationError(
+                    f"Duplicate {singular} name '{name}' in 'provides.{section}'"
+                )
+            seen_names.add(name)
 
             file_value = entry["file"]
             reason = relative_extension_path_violation(file_value)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1163,6 +1163,29 @@ class TestExtensionManifestTemplatesAndScripts:
             ExtensionManifest(manifest_path)
 
     @pytest.mark.parametrize("section", ["templates", "scripts"])
+    def test_provides_entry_duplicate_name_rejected(self, temp_dir, valid_manifest_data, section):
+        """Two entries in the same section sharing a name are rejected.
+
+        The resolver (PresetResolver._extension_manifest_declared_template)
+        returns the first entry matching a name, so a later duplicate would
+        be silently unreachable while still counted by ExtensionManifest
+        properties -- reject it up front instead.
+        """
+        import yaml
+
+        valid_manifest_data["provides"][section] = [
+            {"name": "dup", "file": f"{section}/a.txt"},
+            {"name": "dup", "file": f"{section}/b.txt"},
+        ]
+
+        manifest_path = temp_dir / "extension.yml"
+        with open(manifest_path, 'w', encoding="utf-8") as f:
+            yaml.dump(valid_manifest_data, f)
+
+        with pytest.raises(ValidationError, match=f"Duplicate .* name 'dup' in 'provides.{section}'"):
+            ExtensionManifest(manifest_path)
+
+    @pytest.mark.parametrize("section", ["templates", "scripts"])
     def test_provides_entry_path_traversal_rejected(self, temp_dir, valid_manifest_data, section):
         """The 'file' field is checked with the same path-safety policy as commands."""
         import yaml


### PR DESCRIPTION
## Summary

Follow-up to #4012 (#4010), which merged before the last round of Copilot review feedback could be addressed. This carries forward the two outstanding items that are still valid against `main`:

- `provides.templates`/`provides.scripts` entries with a duplicate `name` within the same section are now rejected with a `ValidationError`. The resolver (`PresetResolver._extension_manifest_declared_template`) returns the first entry matching a name, so a later duplicate was silently unreachable while still being exposed by `ExtensionManifest.templates`/`.scripts` — this closes that gap at manifest-validation time instead. Added parametrized regression tests for both `templates` and `scripts`.
- `extensions/EXTENSION-DEVELOPMENT-GUIDE.md`'s `provides` section now distinguishes its own sub-fields (`commands`/`templates`/`scripts`) from `hooks`/`events`, which are top-level manifest fields read from the manifest root, not nested under `provides` — the prior wording could lead an author to indent them under `provides`, where they wouldn't satisfy validation.

The other two items from that last review round were doc-only / description-only and don't apply here: #4012's PR description has already been corrected in place, and the AGENTS.md acceptance-criterion item was intentionally left alone since that file documents only the AI-agent integration subsystem, not the extension system (which has its own docs, already updated).

## Testing

New parametrized test `test_provides_entry_duplicate_name_rejected` in `tests/test_extensions.py::TestExtensionManifestTemplatesAndScripts` covers both `templates` and `scripts`. Confirmed it fails with `DID NOT RAISE ValidationError` against the pre-fix source (`git checkout HEAD~1 -- src/specify_cli/extensions/__init__.py`), then passes after restoring the fix.

```
$ .venv/bin/python -m pytest tests/test_extensions.py tests/test_presets.py -q
====================== 1110 passed, 2 warnings in 11.30s ======================

$ uvx ruff@0.15.0 check src tests
All checks passed!
```

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by Claude Code (model: Claude Sonnet 5) under human direction, in response to outstanding automated review feedback on #4012 that had not been incorporated before that PR merged.