### PR TITLE
Add Command Code integration to spec-kit

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_request.yml
+++ b/.github/ISSUE_TEMPLATE/agent_request.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for requesting a new agent! Before submitting, please check if the agent is already supported.
 
-        **Currently supported agents**: Alquimia AI, Amp, Antigravity, Auggie CLI, Claude Code, Cline, CodeBuddy, Codex CLI, Cursor, Devin for Terminal, Factory Droid, Firebender, Forge, Gemini CLI, GitHub Copilot, Goose, Grok Build, Hermes Agent, IBM Bob, Junie, Kilo Code, Kimi Code, Kiro CLI, Lingma, Mistral Vibe, Oh My Pi, opencode, Pi Coding Agent, Qoder CLI, Qwen Code, RovoDev ACLI, SHAI, Tabnine CLI, Trae, ZCode, Zed
+        **Currently supported agents**: Alquimia AI, Amp, Antigravity, Auggie CLI, Claude Code, Cline, CodeBuddy, Codex CLI, Command Code, Cursor, Devin for Terminal, Factory Droid, Firebender, Forge, Gemini CLI, GitHub Copilot, Goose, Grok Build, Hermes Agent, IBM Bob, Junie, Kilo Code, Kimi Code, Kiro CLI, Lingma, Mistral Vibe, Oh My Pi, opencode, Pi Coding Agent, Qoder CLI, Qwen Code, RovoDev ACLI, SHAI, Tabnine CLI, Trae, ZCode, Zed
 
   - type: input
     id: agent-name

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -70,6 +70,7 @@ body:
         - Cline
         - CodeBuddy
         - Codex CLI
+        - Command Code
         - Cursor
         - Devin for Terminal
         - Factory Droid

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -64,6 +64,7 @@ body:
         - Cline
         - CodeBuddy
         - Codex CLI
+        - Command Code
         - Cursor
         - Devin for Terminal
         - Factory Droid

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Bare `specify self upgrade` executes immediately, matching the no-prompt behavio
 
 ### 3. Establish project principles
 
-Launch your coding agent in the project directory. Most agents expose spec-kit as `/speckit.*` slash commands; Codex CLI in skills mode uses `$speckit-*` instead; GitHub Copilot CLI uses `/agents` to select the agent or address it directly in a prompt.
+Launch your coding agent in the project directory. Most agents expose spec-kit as `/speckit.*` slash commands; Codex CLI and Command Code in skills mode use `$speckit-*` instead; GitHub Copilot CLI uses `/agents` to select the agent or address it directly in a prompt.
 
 Use the **`/speckit.constitution`** command to create your project's governing principles and development guidelines that will guide all subsequent development.
 

--- a/docs/reference/integrations.md
+++ b/docs/reference/integrations.md
@@ -14,6 +14,7 @@ The Specify CLI supports a wide range of AI coding agents. When you run `specify
 | [Cline](https://github.com/cline/cline)                                              | `cline`          | IDE-based agent                                                                                                                           |
 | [CodeBuddy CLI](https://www.codebuddy.cn/docs/cli/installation)                      | `codebuddy`      |                                                                                                                                           |
 | [Codex CLI](https://github.com/openai/codex)                                         | `codex`          | Skills-based integration; installs skills into `.agents/skills` and invokes them as `$speckit-<command>` |
+| [Command Code](https://commandcode.ai/docs)                                          | `command-code`   | Skills-based integration; installs skills into `.commandcode/skills/` and invokes them as `$speckit-<command>` |
 | [Cursor](https://cursor.sh/)                                                         | `cursor-agent`   |                                                                                                                                           |
 | [Devin for Terminal](https://cli.devin.ai/docs)                                      | `devin`          | Skills-based integration; installs skills into `.devin/skills/` and invokes them as `/speckit-<command>` |
 | [Factory Droid](https://docs.factory.ai/cli/getting-started/overview)               | `droid`          | Skills-based integration; installs skills into `.factory/skills/` and invokes them as `/speckit-<command>`                               |
@@ -279,6 +280,7 @@ The currently declared multi-install safe integrations are:
 | `cline` | `.clinerules/workflows` |
 | `codebuddy` | `.codebuddy/commands` |
 | `codex` | `.agents/skills` |
+| `command-code` | `.commandcode/skills` |
 | `cursor-agent` | `.cursor/skills` |
 | `droid` | `.factory/skills` |
 | `firebender` | `.firebender/commands` |

--- a/integrations/catalog.json
+++ b/integrations/catalog.json
@@ -84,6 +84,15 @@
       "repository": "https://github.com/github/spec-kit",
       "tags": ["cli", "skills"]
     },
+    "command-code": {
+      "id": "command-code",
+      "name": "Command Code",
+      "version": "1.0.0",
+      "description": "Command Code CLI skills-based integration",
+      "author": "spec-kit-core",
+      "repository": "https://github.com/github/spec-kit",
+      "tags": ["cli", "skills"]
+    },
     "devin": {
       "id": "devin",
       "name": "Devin for Terminal",

--- a/src/specify_cli/_invocation_style.py
+++ b/src/specify_cli/_invocation_style.py
@@ -9,7 +9,7 @@ and ``specify init``'s next-steps output stay consistent.
 from __future__ import annotations
 
 # Agents that render $speckit-<name> (chat invocation) when in skills mode.
-DOLLAR_SKILLS_AGENTS: frozenset[str] = frozenset({"codex", "zcode"})
+DOLLAR_SKILLS_AGENTS: frozenset[str] = frozenset({"codex", "zcode", "command-code"})
 
 # Agents that always render /speckit-<name>, regardless of ai_skills.
 ALWAYS_SLASH_AGENTS: frozenset[str] = frozenset({"devin", "droid", "grok", "trae", "zed"})

--- a/src/specify_cli/integrations/__init__.py
+++ b/src/specify_cli/integrations/__init__.py
@@ -56,6 +56,7 @@ def _register_builtins() -> None:
     from .cline import ClineIntegration
     from .codebuddy import CodebuddyIntegration
     from .codex import CodexIntegration
+    from .command_code import CommandCodeIntegration
     from .copilot import CopilotIntegration
     from .cursor_agent import CursorAgentIntegration
     from .devin import DevinIntegration
@@ -95,6 +96,7 @@ def _register_builtins() -> None:
     _register(ClineIntegration())
     _register(CodebuddyIntegration())
     _register(CodexIntegration())
+    _register(CommandCodeIntegration())
     _register(CopilotIntegration())
     _register(CursorAgentIntegration())
     _register(DevinIntegration())

--- a/src/specify_cli/integrations/command_code/__init__.py
+++ b/src/specify_cli/integrations/command_code/__init__.py
@@ -1,0 +1,41 @@
+"""Command Code integration — skills-based agent.
+
+Command Code loads agent skills from ``.commandcode/skills/speckit-<name>/SKILL.md``
+(project) or ``~/.commandcode/skills/`` (personal). Skills are invoked in chat
+with ``$speckit-<name>``.
+"""
+
+from __future__ import annotations
+
+from ..base import IntegrationOption, SkillsIntegration
+
+
+class CommandCodeIntegration(SkillsIntegration):
+    """Integration for Command Code CLI."""
+
+    key = "command-code"
+    config = {
+        "name": "Command Code",
+        "folder": ".commandcode/",
+        "commands_subdir": "skills",
+        "install_url": "https://commandcode.ai/docs",
+        "requires_cli": True,
+    }
+    registrar_config = {
+        "dir": ".commandcode/skills",
+        "format": "markdown",
+        "args": "$ARGUMENTS",
+        "extension": "/SKILL.md",
+    }
+    multi_install_safe = True
+
+    @classmethod
+    def options(cls) -> list[IntegrationOption]:
+        return [
+            IntegrationOption(
+                "--skills",
+                is_flag=True,
+                default=True,
+                help="Install as agent skills (default for Command Code)",
+            ),
+        ]

--- a/tests/integrations/test_integration_command_code.py
+++ b/tests/integrations/test_integration_command_code.py
@@ -1,0 +1,47 @@
+"""Tests for CommandCodeIntegration — skills-based integration (Command Code)."""
+
+from .test_integration_base_skills import SkillsIntegrationTests
+
+
+class TestCommandCodeIntegration(SkillsIntegrationTests):
+    KEY = "command-code"
+    FOLDER = ".commandcode/"
+    COMMANDS_SUBDIR = "skills"
+    REGISTRAR_DIR = ".commandcode/skills"
+
+
+class TestCommandCodeInvocation:
+    """Command Code renders $speckit-* chat invocations (like Codex/ZCode)."""
+
+    def test_next_steps_show_dollar_skill_invocation(self, tmp_path):
+        import os
+
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+
+        project = tmp_path / "command-code-next-steps"
+        project.mkdir()
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(project)
+            runner = CliRunner()
+            result = runner.invoke(
+                app,
+                [
+                    "init",
+                    "--here",
+                    "--integration",
+                    "command-code",
+                    "--ignore-agent-tools",
+                    "--script",
+                    "sh",
+                ],
+                catch_exceptions=False,
+            )
+        finally:
+            os.chdir(old_cwd)
+
+        assert result.exit_code == 0
+        assert "$speckit-constitution" in result.output
+        assert "/speckit.constitution" not in result.output

--- a/tests/integrations/test_registry.py
+++ b/tests/integrations/test_registry.py
@@ -28,7 +28,7 @@ ALL_INTEGRATION_KEYS = [
     "gemini", "tabnine",
     # Stage 5 — skills, generic & option-driven integrations
     "codex", "kimi", "agy", "zed", "generic",
-    "droid",
+    "droid", "command-code",
 ]
 
 

--- a/tests/test_agent_config_consistency.py
+++ b/tests/test_agent_config_consistency.py
@@ -21,6 +21,7 @@ ISSUE_TEMPLATE_AGENT_KEYS = [
     "cline",
     "codebuddy",
     "codex",
+    "command-code",
     "cursor-agent",
     "devin",
     "droid",


### PR DESCRIPTION
## Summary

Adds **Command Code** as a first-class built-in integration so Spec Kit can be installed into Command Code with:

```
specify init my-project --integration command-code
```

Command Code discovers agent skills from `.commandcode/skills/<name>/SKILL.md` (project) or `~/.commandcode/skills/` (personal), which matches the `speckit-<name>/SKILL.md` layout Spec Kit's `SkillsIntegration` base class generates. Skills are invoked in chat as `$speckit-<command>` (dollar-prefix chat invocation, like Codex/ZCode).

## Changes

- **New integration class** `CommandCodeIntegration` (`src/specify_cli/integrations/command_code/__init__.py`), a `SkillsIntegration` subclass:
  - Installs skills into `.commandcode/skills/`
  - `requires_cli: True` (CLI is `cmdc`/`command-code` on PATH; supports `-p`/`--output-format json` dispatch)
  - Declared **multi-install safe** (static, isolated `.commandcode/` agent root), so it can coexist with Claude Code, Codex, etc.
- **Registry**: registered in `_register_builtins()` (import + `_register()`) and added to `integrations/catalog.json`.
- **Invocation style**: added `command-code` to `DOLLAR_SKILLS_AGENTS` so `specify init` next-steps and hook references render `$speckit-*`.
- **Tests**: `tests/integrations/test_integration_command_code.py` reuses the `SkillsIntegrationTests` mixin (setup/teardown, file inventory, frontmatter, uninstall round-trip, multi-install) plus a `$speckit-*` next-steps invocation test; `command-code` added to `ALL_INTEGRATION_KEYS` in `test_registry.py`.
- **Docs**: README note and `docs/reference/integrations.md` (supported-agents table + multi-install-safe table).

## Verification

- `pytest tests/integrations/test_integration_command_code.py` — **31 passed**
- `pytest tests/integrations/test_registry.py` — **664 passed** (includes multi-install-safe contracts)
- Full `tests/integrations` suite — all files green (only pre-existing skips/warnings)
- Manual smoke test:

```
specify init smoke-test-proj --integration command-code --script sh
```

Produced `.commandcode/skills/speckit-{analyze,checklist,clarify,constitution,converge,implement,plan,specify,tasks,taskstoissues}/SKILL.md` and next-steps showing `$speckit-constitution`, `$speckit-specify`, etc. (no `/speckit.constitution`).
