### PR TITLE
fix(presets): skip an unreadable restore source in `preset remove`

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -3393,8 +3393,19 @@ class PresetManager:
                 core_file = None
 
             if core_file:
-                # Restore from core template
-                content = core_file.read_text(encoding="utf-8")
+                # Restore from core template. An unreadable/undecodable
+                # source cannot produce restored content, so leave the
+                # existing skill untouched rather than leaking a raw
+                # OSError/UnicodeDecodeError out of `preset remove` — and
+                # rather than falling through to the rmtree below, which
+                # would delete a skill precisely when its replacement
+                # cannot be generated. Matches the `continue` guards above
+                # (unsafe name, missing subdir, foreign owner), which also
+                # skip without recording the name as mutated.
+                try:
+                    content = core_file.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
                 frontmatter, body = registrar.parse_frontmatter(content)
                 if isinstance(selected_ai, str):
                     body = registrar.resolve_skill_placeholders(
@@ -3435,7 +3446,13 @@ class PresetManager:
                 continue
 
             if extension_restore:
-                content = extension_restore["source_file"].read_text(encoding="utf-8")
+                # Same boundary as the core-template branch above: an
+                # unreadable extension source leaves the skill in place
+                # instead of crashing or being deleted.
+                try:
+                    content = extension_restore["source_file"].read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
                 frontmatter, body = registrar.parse_frontmatter(content)
                 # Mirror the register-time rewrite (#2101): resolve
                 # extension-relative subdir references (agents/,

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -3267,6 +3267,30 @@ class PresetManager:
             if source in owned_sources:
                 shutil.rmtree(skill_subdir)
 
+    @staticmethod
+    def _warn_unrestored_skill(
+        skill_name: str, source_file: Path, exc: BaseException
+    ) -> None:
+        """Warn that a skill kept preset content because its restore source is unreadable.
+
+        Skipping the restore is the safe recovery — the alternative branch
+        deletes the skill outright — but it is still a partial removal: the
+        preset directory and registry entry go away while this ``SKILL.md``
+        keeps the removed preset's content, and reconciliation never revisits
+        it because the name is left out of ``mutated_names``. Name the skill
+        and the source so the condition is actionable instead of silent.
+        """
+        import warnings
+
+        warnings.warn(
+            f"Skill '{skill_name}' still contains the removed preset's content: "
+            f"its restore source '{source_file}' could not be read "
+            f"({exc.__class__.__name__}: {exc}). The skill was left in place "
+            f"rather than deleted. Fix or remove that file and re-run "
+            f"'specify preset add'/'specify preset remove' to refresh it.",
+            stacklevel=2,
+        )
+
     def _unregister_skills_in_dir(
         self,
         skill_names: List[str],
@@ -3404,7 +3428,8 @@ class PresetManager:
                 # skip without recording the name as mutated.
                 try:
                     content = core_file.read_text(encoding="utf-8")
-                except (OSError, UnicodeDecodeError):
+                except (OSError, UnicodeDecodeError) as exc:
+                    self._warn_unrestored_skill(skill_name, core_file, exc)
                     continue
                 frontmatter, body = registrar.parse_frontmatter(content)
                 if isinstance(selected_ai, str):
@@ -3451,7 +3476,10 @@ class PresetManager:
                 # instead of crashing or being deleted.
                 try:
                     content = extension_restore["source_file"].read_text(encoding="utf-8")
-                except (OSError, UnicodeDecodeError):
+                except (OSError, UnicodeDecodeError) as exc:
+                    self._warn_unrestored_skill(
+                        skill_name, extension_restore["source_file"], exc
+                    )
                     continue
                 frontmatter, body = registrar.parse_frontmatter(content)
                 # Mirror the register-time rewrite (#2101): resolve

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -9174,6 +9174,91 @@ class TestPresetSkills:
             "---\nname: speckit-specify\n---\n\nuser-owned content\n"
         )
 
+    def test_unregister_skills_in_dir_unreadable_core_template_skips(
+        self, project_dir
+    ):
+        """An undecodable core template must not crash `preset remove`.
+
+        Every other failure in the restore loop — an unsafe registry name,
+        a missing skill subdirectory, a foreign owner — skips the skill
+        with ``continue``. The core-template read was outside that
+        boundary, so one non-UTF-8 project-owned override in
+        ``.specify/templates/commands/`` raised a raw ``UnicodeDecodeError``
+        straight out of ``PresetManager.remove()``, which has no handler
+        for it. Sibling reads of the very same directory are already
+        guarded (``_substitute_core_template``, the provenance reads in
+        ``_infer_legacy_skill_provenance``).
+        """
+        self._write_init_options(project_dir, ai="claude", ai_skills=True)
+        skills_dir = project_dir / ".claude" / "skills"
+        skill_dir = self._create_skill(
+            skills_dir, "speckit-specify", "installed content"
+        )
+        core_commands = project_dir / ".specify" / "templates" / "commands"
+        core_commands.mkdir(parents=True, exist_ok=True)
+        (core_commands / "specify.md").write_bytes(
+            b"---\ndescription: \xff\xfe not utf-8\n---\n\nCore body\n"
+        )
+
+        manager = PresetManager(project_dir)
+        mutated = manager._unregister_skills_in_dir(
+            ["speckit-specify"], skills_dir, "claude"
+        )
+
+        assert mutated == [], (
+            "a skill whose restore source could not be read was not "
+            "restored, so it must not be reported as mutated"
+        )
+        assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == (
+            "---\nname: speckit-specify\n---\n\ninstalled content\n"
+        ), (
+            "an unreadable core template must leave the skill untouched — "
+            "falling through to the rmtree branch would delete it exactly "
+            "when its replacement cannot be generated"
+        )
+
+    def test_unregister_skills_in_dir_unreadable_core_template_oserror_skips(
+        self, project_dir, monkeypatch
+    ):
+        """The same boundary must cover ``OSError`` (e.g. permission denied).
+
+        Mocked rather than chmod-based so the case also holds under
+        privileged CI, where permission bits are not enforced.
+        """
+        self._write_init_options(project_dir, ai="claude", ai_skills=True)
+        skills_dir = project_dir / ".claude" / "skills"
+        skill_dir = self._create_skill(
+            skills_dir, "speckit-specify", "installed content"
+        )
+        core_commands = project_dir / ".specify" / "templates" / "commands"
+        core_commands.mkdir(parents=True, exist_ok=True)
+        core_template = core_commands / "specify.md"
+        core_template.write_text(
+            "---\ndescription: Core specify\n---\n\nCore body\n",
+            encoding="utf-8",
+        )
+
+        original_read_text = Path.read_text
+
+        def failing_read_text(self_path, *args, **kwargs):
+            if self_path == core_template:
+                raise PermissionError(13, "Permission denied")
+            return original_read_text(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", failing_read_text)
+
+        manager = PresetManager(project_dir)
+        mutated = manager._unregister_skills_in_dir(
+            ["speckit-specify"], skills_dir, "claude"
+        )
+
+        monkeypatch.undo()
+
+        assert mutated == []
+        assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == (
+            "---\nname: speckit-specify\n---\n\ninstalled content\n"
+        )
+
     def test_unregister_skills_in_dir_rejects_absolute_registry_name(
         self, project_dir
     ):

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -9201,9 +9201,10 @@ class TestPresetSkills:
         )
 
         manager = PresetManager(project_dir)
-        mutated = manager._unregister_skills_in_dir(
-            ["speckit-specify"], skills_dir, "claude"
-        )
+        with pytest.warns(UserWarning, match="speckit-specify"):
+            mutated = manager._unregister_skills_in_dir(
+                ["speckit-specify"], skills_dir, "claude"
+            )
 
         assert mutated == [], (
             "a skill whose restore source could not be read was not "
@@ -9248,15 +9249,78 @@ class TestPresetSkills:
         monkeypatch.setattr(Path, "read_text", failing_read_text)
 
         manager = PresetManager(project_dir)
-        mutated = manager._unregister_skills_in_dir(
-            ["speckit-specify"], skills_dir, "claude"
-        )
+        with pytest.warns(UserWarning, match="speckit-specify"):
+            mutated = manager._unregister_skills_in_dir(
+                ["speckit-specify"], skills_dir, "claude"
+            )
 
         monkeypatch.undo()
 
         assert mutated == []
         assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == (
             "---\nname: speckit-specify\n---\n\ninstalled content\n"
+        )
+
+    def test_unregister_skills_in_dir_unreadable_extension_source_skips(
+        self, project_dir
+    ):
+        """The extension-restore arm needs the same boundary as the core arm.
+
+        The two restore reads are independent branches — a skill backed by an
+        installed extension never reaches the core-template read — so this
+        half of the guard can regress on its own. An undecodable extension
+        command file must warn, leave the skill byte-for-byte intact, and stay
+        out of ``mutated_names``.
+        """
+        self._write_init_options(project_dir, ai="claude", ai_skills=True)
+        skills_dir = project_dir / ".claude" / "skills"
+        skill_dir = self._create_skill(
+            skills_dir, "speckit-fakeext-cmd", "installed content"
+        )
+
+        extension_dir = project_dir / ".specify" / "extensions" / "fakeext"
+        (extension_dir / "commands").mkdir(parents=True, exist_ok=True)
+        (extension_dir / "commands" / "cmd.md").write_bytes(
+            b"---\ndescription: \xff\xfe not utf-8\n---\n\nExtension body\n"
+        )
+        extension_manifest = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "fakeext",
+                "name": "Fake Extension",
+                "version": "1.0.0",
+                "description": "Test",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "commands": [
+                    {
+                        "name": "speckit.fakeext.cmd",
+                        "file": "commands/cmd.md",
+                        "description": "Fake extension command",
+                    }
+                ]
+            },
+        }
+        with open(extension_dir / "extension.yml", "w") as f:
+            yaml.dump(extension_manifest, f)
+
+        manager = PresetManager(project_dir)
+        with pytest.warns(UserWarning, match="speckit-fakeext-cmd"):
+            mutated = manager._unregister_skills_in_dir(
+                ["speckit-fakeext-cmd"], skills_dir, "claude"
+            )
+
+        assert mutated == [], (
+            "a skill whose extension restore source could not be read was "
+            "not restored, so it must not be reported as mutated"
+        )
+        assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == (
+            "---\nname: speckit-fakeext-cmd\n---\n\ninstalled content\n"
+        ), (
+            "an unreadable extension source must leave the skill untouched — "
+            "falling through to the rmtree branch would delete it exactly "
+            "when its replacement cannot be generated"
         )
 
     def test_unregister_skills_in_dir_rejects_absolute_registry_name(


### PR DESCRIPTION
## Problem

`PresetManager._unregister_skills_in_dir` restores each preset-owned `SKILL.md` from either a core command template or an extension source. Both reads were bare:

```python
if core_file:
    # Restore from core template
    content = core_file.read_text(encoding="utf-8")   # src/specify_cli/presets/__init__.py:3397
...
if extension_restore:
    content = extension_restore["source_file"].read_text(encoding="utf-8")   # :3438
```

A file that **exists but cannot be read or decoded** — a project-owned override in `.specify/templates/commands/` saved as UTF-16/Latin-1, or one with restrictive permissions — therefore raises a raw `UnicodeDecodeError`/`OSError`. `PresetManager.remove()` has no handler for it, and neither does the `preset remove` CLI command, so `specify preset remove <id>` dies with a traceback.

Reproduced against `main`:

```
File ".../src/specify_cli/presets/__init__.py", line 3397, in _unregister_skills_in_dir
    content = core_file.read_text(encoding="utf-8")
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 17: invalid start byte
```

## Why this is a gap rather than a design choice

Every other failure in this same loop degrades with `continue` — an unsafe registry name, a missing skill subdirectory, a foreign owner. And the *sibling reads of the very same files* are already guarded:

- `_infer_legacy_skill_provenance` — `except (OSError, UnicodeDecodeError): continue` (`:2917`)
- `_delete_agent_preset_skills` — same clause (`:3253`)
- `_unregister_skills_in_dir`'s **own** ownership check a few lines above the bug — same clause (`:3345`)
- `_substitute_core_template`, which reads the identical `.specify/templates/commands/` directory, received this boundary in #3961

So within one function, the ownership read is guarded and the restore read is not. The two restore reads were the remaining gap in an otherwise-complete boundary.

## Fix

Wrap both reads, warn, and `continue`.

`continue` is deliberately the recovery, not falling through: the `else` branch below removes the skill outright (`shutil.rmtree`), so treating an unreadable source as "no source available" would **delete a user's skill at exactly the moment its replacement cannot be generated**. Skipping leaves the skill in place and keeps it out of the returned `mutated_names`, so callers don't persist a restore that never happened.

Because skipping is nonetheless a *partial* removal — the preset directory and registry entry are removed while this `SKILL.md` keeps the removed preset's content, and its absence from `mutated_names` also keeps it out of reconciliation — both arms report it through a shared `_warn_unrestored_skill` helper:

```
Skill 'speckit-specify' still contains the removed preset's content: its
restore source '<path>' could not be read (UnicodeDecodeError: ...). The
skill was left in place rather than deleted. Fix or remove that file and
re-run 'specify preset add'/'specify preset remove' to refresh it.
```

`warnings.warn` matches how the surrounding code reports non-fatal degradation that shouldn't roll back a persisted change — the reconciliation failures in `remove()`/`install_from_directory`, and the unreadable core template in `_substitute_core_template` (#3961).

## Tests

Three regression tests, one per exception arm plus one per restore branch:

- `test_unregister_skills_in_dir_unreadable_core_template_skips` — non-UTF-8 core template
- `test_unregister_skills_in_dir_unreadable_core_template_oserror_skips` — mocked `PermissionError`, so the `OSError` half is covered under privileged CI where permission bits aren't enforced
- `test_unregister_skills_in_dir_unreadable_extension_source_skips` — non-UTF-8 extension command file; the extension branch is unreachable from the core-template tests (a skill backed by an installed extension never reaches that read), so it can regress independently

All three assert the skill survives byte-for-byte, is not reported as mutated, and that the warning fires (`pytest.warns`, so dropping it fails the suite).

Verified each fails without the source change — the extension case with the raw `UnicodeDecodeError`, i.e. reproducing the crash rather than only the missing warning.

## Verification

- `pytest tests/test_presets.py` → **583 passed, 2 skipped, 7 failed**
- The 7 failures are all pre-existing Windows symlink tests requiring elevation (`test_symlinked_*`, `test_dangling_symlink_fails_closed`). Confirmed identical on a clean checkout of `main` with my changes stashed — unrelated to this PR.
- `ruff check` → All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
