### PR TITLE
chore(catalog): bump reconcile extension to v1.1.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-08-04T00:00:00Z",
+  "updated_at": "2026-08-09T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "adrkit": {
@@ -3406,8 +3406,8 @@
       "id": "reconcile",
       "description": "Reconcile implementation drift by surgically updating the feature's own spec, plan, and tasks.",
       "author": "Stanislav Deviatov",
-      "version": "1.0.0",
-      "download_url": "https://github.com/stn1slv/spec-kit-reconcile/archive/refs/tags/v1.0.0.zip",
+      "version": "1.1.0",
+      "download_url": "https://github.com/stn1slv/spec-kit-reconcile/archive/refs/tags/v1.1.0.zip",
       "repository": "https://github.com/stn1slv/spec-kit-reconcile",
       "homepage": "https://github.com/stn1slv/spec-kit-reconcile",
       "documentation": "https://github.com/stn1slv/spec-kit-reconcile/blob/main/README.md",
@@ -3432,7 +3432,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-03-14T00:00:00Z",
-      "updated_at": "2026-03-14T00:00:00Z"
+      "updated_at": "2026-08-09T00:00:00Z"
     },
     "red-team": {
       "name": "Red Team",


### PR DESCRIPTION
Closes #4024.

Updates the `reconcile` entry in `extensions/catalog.community.json` to point at the new [v1.1.0 release](https://github.com/stn1slv/spec-kit-reconcile/releases/tag/v1.1.0), per the update request in #4024. This is a catalog data update only, not a new submission — the extension is already listed at version 1.0.0.

## Catalog changes

| Field | Before | After |
|---|---|---|
| `version` | 1.0.0 | **1.1.0** |
| `download_url` | …/v1.0.0.zip | **…/v1.1.0.zip** |
| `updated_at` | 2026-03-14 | **2026-08-09** (release publish date) |

Everything else (`provides.commands`, `provides.hooks`, `tags`, `license`, etc.) is unchanged, since 1.1.0 does not add new commands or hooks — it reworks how the existing single command behaves (drops the `[P]` marker, targets the real template headings/sections, honors scope modifiers, and makes re-runs idempotent), per the issue body and the extension's own CHANGELOG.

Top-level catalog `updated_at` bumped `2026-08-04 → 2026-08-09` to match, following the same convention as prior catalog bump PRs (e.g. #2613).

## Verification

- `python3 -c "import json; json.load(open('extensions/catalog.community.json'))"` → valid JSON.
- Download URL: `curl -sL -o /dev/null -w '%{http_code}' https://github.com/stn1slv/spec-kit-reconcile/archive/refs/tags/v1.1.0.zip` → `200`.
- GitHub API confirms the `v1.1.0` tag/release exists and was published 2026-08-09.
- `.venv/bin/python -m pytest tests -q` → **6628 passed, 9 skipped** (full suite, unaffected by this data-only change).
- `.venv/bin/python -m pytest tests/contract/test_catalog_schema.py -q` → **42 passed**.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code), including verifying the upstream release and making the catalog edit. A human reviewed the diff before pushing.
