### PR TITLE
docs: document installing specify-cli from a custom package index

### DIFF
--- a/docs/install/pypi.md
+++ b/docs/install/pypi.md
@@ -54,7 +54,7 @@ pip install specify-cli --index-url https://your-index.example.com/pypi/simple/
 ```
 
 > [!NOTE]
-> The same index configuration applies to pinned installs, upgrades (`--force`/`--upgrade`), and one-time usage — set the environment variable or flag on those commands too. If your index requires authentication, follow your tool's documentation for supplying credentials (for example, embedding them in the URL or using a keyring/netrc), and avoid committing secrets. For fully offline installs, see the [air-gapped installation guide](air-gapped.md).
+> The same index configuration applies to pinned installs, upgrades (`--force`/`--upgrade`), and one-time usage — set the environment variable or flag on those commands too. If your index requires authentication, follow your tool's documentation and prefer credential environment variables, keyring, or netrc; do not embed secrets in command-line URLs because they can leak through shell history, process listings, or logs. Avoid committing secrets. For fully offline installs, see the [air-gapped installation guide](air-gapped.md).
 
 ## Verify
 

--- a/docs/install/pypi.md
+++ b/docs/install/pypi.md
@@ -35,6 +35,27 @@ pipx install specify-cli==0.12.11
 pip install specify-cli==0.12.11
 ```
 
+## Install from a custom or private package index
+
+Some environments (corporate networks, mirrors, proxies, or artifact feeds) require installing `specify-cli` from a package index other than the default public PyPI. Each Python tool exposes a way to point at a different index — configure it before running the install commands above. Substitute your own index URL for the placeholder shown here.
+
+```bash
+# uv — via environment variable (applies to the whole command)
+UV_DEFAULT_INDEX=https://your-index.example.com/pypi/simple/ uv tool install specify-cli
+
+# uv — via flag
+uv tool install --default-index https://your-index.example.com/pypi/simple/ specify-cli
+
+# pipx — pass a pip argument through
+pipx install specify-cli --index-url https://your-index.example.com/pypi/simple/
+
+# pip
+pip install specify-cli --index-url https://your-index.example.com/pypi/simple/
+```
+
+> [!NOTE]
+> The same index configuration applies to pinned installs, upgrades (`--force`/`--upgrade`), and one-time usage — set the environment variable or flag on those commands too. If your index requires authentication, follow your tool's documentation for supplying credentials (for example, embedding them in the URL or using a keyring/netrc), and avoid committing secrets. For fully offline installs, see the [air-gapped installation guide](air-gapped.md).
+
 ## Verify
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,7 +50,7 @@ pipx install specify-cli
 pip install specify-cli
 ```
 
-To install a specific release, pin the version — for example `uv tool install specify-cli==0.12.11`. See the [PyPI installation guide](install/pypi.md) for details, including how to upgrade.
+To install a specific release, pin the version — for example `uv tool install specify-cli==0.12.11`. See the [PyPI installation guide](install/pypi.md) for details, including how to upgrade and how to [install from a custom or private package index](install/pypi.md#install-from-a-custom-or-private-package-index).
 
 ### One-time Usage
 


### PR DESCRIPTION
## Summary

Adds documentation for installing `specify-cli` from a custom or private package index (corporate mirrors, proxies, artifact feeds), which is not currently covered in the install docs.

- New **"Install from a custom or private package index"** section in `docs/install/pypi.md` showing how to point `uv` (both `UV_DEFAULT_INDEX=` env var and `--default-index` flag), `pipx`, and `pip` at a non-default index, using a placeholder URL.
- Notes that the same config applies to pinned installs, upgrades, and one-time usage, plus a pointer to authentication and the air-gapped guide.
- Links to the new section from the main `docs/installation.md`.

Docs-only change — no code or behavior affected.

## Disclosure

This PR was authored by GitHub Copilot (model: Claude Opus 4.8) acting autonomously on behalf of @mnriem.