### PR TITLE
fix(claude): make argument-hint injection fold-aware for long descriptions

### DIFF
--- a/src/specify_cli/integrations/claude/__init__.py
+++ b/src/specify_cli/integrations/claude/__init__.py
@@ -70,11 +70,13 @@ class ClaudeIntegration(SkillsIntegration):
         """Insert ``argument-hint`` after the ``description:`` scalar in YAML frontmatter.
 
         A long ``description`` gets folded by the YAML dumper across
-        indented continuation lines (plain or quoted). Inserting the new
-        line right after the *first* line of that scalar — instead of after
-        the whole scalar — either produces invalid YAML or gets silently
-        absorbed into the description string (#4044), so every continuation
-        line (anything more indented than the key itself) is skipped first.
+        indented continuation lines (plain or quoted), and an embedded
+        paragraph break can add unindented blank lines inside a quoted
+        scalar. Inserting the new line right after the *first* line of
+        that scalar — instead of after the whole scalar — either produces
+        invalid YAML or gets silently absorbed into the description
+        string (#4044), so every continuation line (indented, or blank)
+        is skipped first.
 
         Skips injection if ``argument-hint:`` already exists in the
         frontmatter to avoid duplicate keys.
@@ -113,7 +115,11 @@ class ClaudeIntegration(SkillsIntegration):
                 i += 1
                 # Skip past folded/quoted continuation lines of the scalar
                 # before inserting, so the new key lands after it ends.
-                while i < n and lines[i][:1] in (" ", "\t"):
+                # Blank lines count too: PyYAML emits unindented blank
+                # lines for embedded "\n\n" inside a quoted scalar.
+                while i < n and (
+                    lines[i][:1] in (" ", "\t") or lines[i].rstrip("\r\n") == ""
+                ):
                     out.append(lines[i])
                     i += 1
                 # Preserve the exact line-ending style (\r\n vs \n)

--- a/src/specify_cli/integrations/claude/__init__.py
+++ b/src/specify_cli/integrations/claude/__init__.py
@@ -67,7 +67,14 @@ class ClaudeIntegration(SkillsIntegration):
 
     @staticmethod
     def inject_argument_hint(content: str, hint: str) -> str:
-        """Insert ``argument-hint`` after the first ``description:`` in YAML frontmatter.
+        """Insert ``argument-hint`` after the ``description:`` scalar in YAML frontmatter.
+
+        A long ``description`` gets folded by the YAML dumper across
+        indented continuation lines (plain or quoted). Inserting the new
+        line right after the *first* line of that scalar — instead of after
+        the whole scalar — either produces invalid YAML or gets silently
+        absorbed into the description string (#4044), so every continuation
+        line (anything more indented than the key itself) is skipped first.
 
         Skips injection if ``argument-hint:`` already exists in the
         frontmatter to avoid duplicate keys.
@@ -90,15 +97,25 @@ class ClaudeIntegration(SkillsIntegration):
         in_fm = False
         dash_count = 0
         injected = False
-        for line in lines:
+        i = 0
+        n = len(lines)
+        while i < n:
+            line = lines[i]
             stripped = line.rstrip("\n\r")
             if stripped == "---":
                 dash_count += 1
                 in_fm = dash_count == 1
                 out.append(line)
+                i += 1
                 continue
             if in_fm and not injected and stripped.startswith("description:"):
                 out.append(line)
+                i += 1
+                # Skip past folded/quoted continuation lines of the scalar
+                # before inserting, so the new key lands after it ends.
+                while i < n and lines[i][:1] in (" ", "\t"):
+                    out.append(lines[i])
+                    i += 1
                 # Preserve the exact line-ending style (\r\n vs \n)
                 if line.endswith("\r\n"):
                     eol = "\r\n"
@@ -111,6 +128,7 @@ class ClaudeIntegration(SkillsIntegration):
                 injected = True
                 continue
             out.append(line)
+            i += 1
         return "".join(out)
 
     def _render_skill(self, template_name: str, frontmatter: dict[str, Any], body: str) -> str:

--- a/tests/integrations/test_integration_claude.py
+++ b/tests/integrations/test_integration_claude.py
@@ -451,6 +451,61 @@ class TestClaudeArgumentHints:
         hint_count = sum(1 for ln in lines if ln.startswith("argument-hint:"))
         assert hint_count == 1
 
+    def test_inject_argument_hint_survives_folded_description(self):
+        """A long description folded across lines must not corrupt the YAML (#4044).
+
+        A description long enough for the YAML dumper to fold it into a
+        multi-line plain scalar previously had ``argument-hint:`` spliced
+        into the *middle* of that scalar, producing invalid YAML.
+        """
+        from specify_cli.integrations.claude import ClaudeIntegration
+
+        frontmatter = {
+            "name": "speckit-specify",
+            "description": (
+                "Create or update the feature specification from a natural "
+                "language feature description. Also accepts an issue URL "
+                "resolved via gh CLI (demo customization)."
+            ),
+            "compatibility": "Requires spec-kit project structure with .specify/ directory",
+        }
+        frontmatter_text = yaml.safe_dump(
+            frontmatter, sort_keys=False, allow_unicode=True
+        ).strip()
+        content = f"---\n{frontmatter_text}\n---\n\nBody text\n"
+        assert "\n  " in content, "fixture description must actually fold across lines"
+
+        result = ClaudeIntegration.inject_argument_hint(content, "Describe the feature")
+
+        parsed = yaml.safe_load(result.split("---")[1])
+        assert parsed["argument-hint"] == "Describe the feature"
+        assert parsed["description"] == frontmatter["description"]
+
+    def test_inject_argument_hint_survives_quoted_folded_description(self):
+        """A folded description forced into quotes must not absorb the hint (#4044)."""
+        from specify_cli.integrations.claude import ClaudeIntegration
+
+        frontmatter = {
+            "name": "speckit-specify",
+            "description": (
+                "Create or update the feature specification from a natural "
+                "language feature description. Also accepts a GitHub "
+                "issue/PR URL or #N reference resolved via gh CLI (demo)."
+            ),
+            "compatibility": "Requires spec-kit project structure with .specify/ directory",
+        }
+        frontmatter_text = yaml.safe_dump(
+            frontmatter, sort_keys=False, allow_unicode=True
+        ).strip()
+        content = f"---\n{frontmatter_text}\n---\n\nBody text\n"
+        assert "\n  " in content, "fixture description must actually fold across lines"
+
+        result = ClaudeIntegration.inject_argument_hint(content, "Describe the feature")
+
+        parsed = yaml.safe_load(result.split("---")[1])
+        assert parsed["argument-hint"] == "Describe the feature"
+        assert parsed["description"] == frontmatter["description"]
+
 
 class TestClaudeDisableModelInvocation:
     """Verify disable-model-invocation is false for Claude skills."""

--- a/tests/integrations/test_integration_claude.py
+++ b/tests/integrations/test_integration_claude.py
@@ -506,6 +506,38 @@ class TestClaudeArgumentHints:
         assert parsed["argument-hint"] == "Describe the feature"
         assert parsed["description"] == frontmatter["description"]
 
+    def test_inject_argument_hint_survives_multi_paragraph_description(self):
+        """A description with an embedded blank line must not absorb the hint.
+
+        PyYAML serializes an embedded ``\\n\\n`` inside a quoted scalar as
+        unindented blank lines, not indented ones, so a fix that only skips
+        indented continuation lines still fails on this case.
+        """
+        from specify_cli.integrations.claude import ClaudeIntegration
+
+        frontmatter = {
+            "name": "speckit-specify",
+            "description": (
+                "First paragraph of a fairly long description that will "
+                "need to wrap across multiple lines when dumped by PyYAML."
+                "\n\n"
+                "Second paragraph continues the description after a blank "
+                "line separator to force embedded newlines in the scalar."
+            ),
+            "compatibility": "Requires spec-kit project structure with .specify/ directory",
+        }
+        frontmatter_text = yaml.safe_dump(
+            frontmatter, sort_keys=False, allow_unicode=True
+        ).strip()
+        content = f"---\n{frontmatter_text}\n---\n\nBody text\n"
+        assert "\n\n" in frontmatter_text, "fixture must produce a blank continuation line"
+
+        result = ClaudeIntegration.inject_argument_hint(content, "Describe the feature")
+
+        parsed = yaml.safe_load(result.split("---")[1])
+        assert parsed["argument-hint"] == "Describe the feature"
+        assert parsed["description"] == frontmatter["description"]
+
 
 class TestClaudeDisableModelInvocation:
     """Verify disable-model-invocation is false for Claude skills."""


### PR DESCRIPTION
## Summary

Fixes #4044 — `ClaudeIntegration.inject_argument_hint` spliced `argument-hint: "..."` in as a raw text line immediately after the *first* line starting with `description:`. That's safe for a short, single-line description, but when a description is long enough for the YAML dumper to fold it across multiple indented continuation lines, the splice landed **inside** that scalar instead of after it:

- Plain (unquoted) folded scalar → invalid YAML (`yaml.parser.ParserError`).
- Quoted folded scalar → parses, but `argument-hint` doesn't exist as a key — its line is silently absorbed into the `description` string.

This is the case #3996 didn't cover: bundled core commands carry no `argument-hint` in their source frontmatter, so `CommandRegistrar.apply_argument_hint`'s structural inheritance path is a no-op for them, and this raw-text fallback in `post_process_skill_content` is what actually runs for every core Claude skill.

## Fix

`inject_argument_hint` now skips past every continuation line of the `description` scalar (anything more indented than the `description:` key itself — this covers both plain and quoted folded styles) before inserting `argument-hint:`, so the new key always lands after the whole scalar ends rather than in the middle of it. No change to the injected line's format (`argument-hint: "<hint>"`), so short, non-folding descriptions behave exactly as before.

## Test plan

Added two regression tests in `tests/integrations/test_integration_claude.py::TestClaudeArgumentHints` that build frontmatter with a ~150+ char description via `yaml.safe_dump` (reproducing the fold from the issue) for both the plain and forced-quoted cases, run it through `inject_argument_hint`, and assert the result is valid YAML with `argument-hint` present as its own key and `description` unchanged.

Confirmed both new tests fail against the pre-fix code with exactly the two failure modes from the issue:

```
FAILED test_inject_argument_hint_survives_folded_description
  yaml.parser.ParserError: while parsing a block mapping
  ... expected <block end>, but found '<scalar>'

FAILED test_inject_argument_hint_survives_quoted_folded_description
  KeyError: 'argument-hint'
```

With the fix:

```
tests/integrations/test_integration_claude.py .......................... [ 61%]
................                                                         [100%]
============================== 42 passed in 1.35s ==============================
```

Full suite (`pytest tests -q`): 6786 passed, 9 skipped, 10 failed — all 10 failures reproduce identically on unmodified `main` (composed-template python/shell parity and a rich-markup width assertion, unrelated to this change and to the Claude integration).

`ruff check` on both changed files reports the same 17 pre-existing findings as on unmodified `main`; none introduced by this diff.

## AI assistance disclosure

This PR was written by an autonomous AI coding agent (Claude, via an agent harness), including the diagnosis, fix, and regression tests. It was validated by running the reproduction from the issue, the existing and new test suites, and by confirming pre-existing failures reproduce unmodified on `main`.
