### PR TITLE
docs: clarify where to find spec examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,9 +283,11 @@ specify bundle validate --path ./my-bundle      # structural + reference checks
 specify bundle build --path ./my-bundle         # produce a versioned .zip artifact
 ```
 
-Four ready-to-read example manifests live under
+Four ready-to-read example bundle manifests live under
 [`examples/bundles/`](examples/bundles/) (product manager, business analyst,
-security researcher, developer).
+security researcher, developer). These are bundle packaging examples, not
+filled generated feature specs; for end-to-end community examples, see the
+[community walkthroughs](https://github.github.io/spec-kit/community/walkthroughs.html).
 
 Key guarantees: `info` shows exactly what `install` adds (transparency);
 installs are idempotent and confined to the project root; `remove` never touches

--- a/docs/community/walkthroughs.md
+++ b/docs/community/walkthroughs.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > Community walkthroughs are independently created and maintained by their respective authors. They are **not reviewed, nor endorsed, nor supported by GitHub**. Review their content before following along and use at your own discretion.
 
-See Spec-Driven Development in action across different scenarios with these community-contributed walkthroughs:
+See Spec-Driven Development in action across different scenarios with these community-contributed walkthroughs. They are useful read-only examples of completed flows, but they are not official golden outputs for generated specs, plans, or tasks.
 
 - **[Greenfield .NET CLI tool](https://github.com/mnriem/spec-kit-dotnet-cli-demo)** — Builds a Timezone Utility as a .NET single-binary CLI tool from a blank directory, covering the full spec-kit workflow: constitution, specify, plan, tasks, and multi-pass implement using GitHub Copilot agents.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,8 +5,7 @@ This guide will help you get started with Spec-Driven Development using Spec Kit
 > [!NOTE]
 > Automation scripts are provided as Bash (`.sh`), PowerShell (`.ps1`), and Python (`.py`) variants. Interactive `specify init` prompts you to choose one; non-interactive runs default to a shell variant for your OS. Pass `--script sh|ps|py` to select explicitly.
 
-> [!NOTE]
-> Commands are shown here in `/speckit.*` form, but the exact invocation depends on your agent. Some skills-based agents use `$speckit-*` (e.g. Codex, ZCode) or `/skill:speckit-*` (e.g. Kimi). Use whichever form your agent exposes — the steps are otherwise identical.
+Commands are shown here in `/speckit.*` form, but the exact invocation depends on your agent. Some skills-based agents use `$speckit-*` (e.g. Codex, ZCode) or `/skill:speckit-*` (e.g. Kimi). Use whichever form your agent exposes — the steps are otherwise identical.
 
 ## Recommended Process
 
@@ -136,5 +135,6 @@ Checks the codebase against the spec, plan, and tasks. If it finds gaps, it appe
 
 - See the [Agentic SDD](reference/agentic-sdd.md) reference for full detail on every command
 - Read the [complete methodology](https://github.com/github/spec-kit/blob/main/spec-driven.md) for in-depth guidance
-- Check out [more examples](https://github.com/github/spec-kit/tree/main/templates) in the repository
+- Compare the [core templates](https://github.com/github/spec-kit/tree/main/templates) with
+  [community walkthroughs](community/walkthroughs.md) to see how Spec-Driven Development is used in real projects
 - Explore the [source code on GitHub](https://github.com/github/spec-kit)


### PR DESCRIPTION
## Summary

Clarifies that `examples/bundles/` contains bundle manifests rather than filled generated feature specs, and points readers from the README and Quick Start toward community walkthroughs for read-only end-to-end examples.

Related to discussion #4037.

## Testing

- `git diff --check`
- `npx --no-install markdownlint-cli2 README.md docs/quickstart.md docs/community/walkthroughs.md`
