### PR TITLE
Remove auto-assign from catalog submission workflow

### DIFF
--- a/.github/workflows/catalog-assign.yml
+++ b/.github/workflows/catalog-assign.yml
@@ -1,11 +1,11 @@
-name: "Catalog: Auto-assign submission"
+name: "Catalog: Notify submission"
 
 on:
   issues:
     types: [opened, labeled]
 
 jobs:
-  assign:
+  notify:
     if: >
       (github.event.action == 'opened' && (
         contains(github.event.issue.labels.*.name, 'extension-submission') ||
@@ -24,23 +24,7 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            const issue = context.payload.issue;
-            const assigned = (issue.assignees || []).map(a => a.login);
             const marker = '<!-- catalog-assign-bot -->';
-
-            // Assign mnriem if not already assigned
-            if (!assigned.includes('mnriem')) {
-              try {
-                await github.rest.issues.addAssignees({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  assignees: ['mnriem'],
-                });
-              } catch (e) {
-                console.log(`Warning: could not assign mnriem: ${e.message}`);
-              }
-            }
 
             // Post team notification if not already posted
             const comments = await github.paginate(


### PR DESCRIPTION
## Summary

Removes the auto-assign logic from the catalog submission workflow (`.github/workflows/catalog-assign.yml`). Catalog submission issues (extension/preset/bundle) previously auto-assigned `mnriem` on every submission. Since GitHub issues cannot be assigned to a team, this drops the individual auto-assign and relies solely on the existing team notification comment (`cc @github/spec-kit-maintainers`).

## Changes

- Removed the block that added `mnriem` as an assignee.
- Kept the de-duplicated `cc @github/spec-kit-maintainers` notification comment.
- Renamed the workflow (`Catalog: Notify submission`) and job (`notify`) to reflect its notification-only purpose.

Trigger conditions and permissions are unchanged.

## AI disclosure

This change was generated by GitHub Copilot (model: Claude Opus 4.8) under human supervision, on behalf of @mnriem.