### PR TITLE
Add SpecAssay bundle to community catalog

### DIFF
--- a/bundles/catalog.community.json
+++ b/bundles/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-07-22T00:00:00Z",
+  "updated_at": "2026-08-11T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/bundles/catalog.community.json",
   "bundles": {
     "sicario-spec": {
@@ -28,6 +28,34 @@
         "compliance",
         "appsec",
         "threat-modeling"
+      ],
+      "verified": false
+    },
+    "specassay": {
+      "name": "SpecAssay",
+      "id": "specassay",
+      "version": "0.3.1",
+      "role": "developer",
+      "description": "Durable-ID promotion for stock Spec Kit: templates, Gate 2 refusal, and trace-manifest emission.",
+      "author": "Rik Dryfoos",
+      "license": "MIT",
+      "download_url": "https://github.com/rdryfoos/specassay/releases/download/v0.3.1/specassay-0.3.1.zip",
+      "repository": "https://github.com/rdryfoos/specassay",
+      "requires": {
+        "speckit_version": ">=0.14.0"
+      },
+      "provides": {
+        "extensions": 1,
+        "presets": 1,
+        "steps": 0,
+        "workflows": 0
+      },
+      "tags": [
+        "traceability",
+        "governance",
+        "durable-ids",
+        "gate",
+        "sdd"
       ],
       "verified": false
     }

--- a/docs/community/bundles.md
+++ b/docs/community/bundles.md
@@ -10,6 +10,7 @@ Accepted community bundle entries are published in [`bundles/catalog.community.j
 | Bundle | Purpose | Role or team | Provides | Required catalogs | URL |
 |--------|---------|--------------|----------|-------------------|-----|
 | SicarioSpec Security & Governance Bundle | Secure-by-default governance bundle for GitHub Spec Kit. Enforces data classification, threat modeling, and code-owned verification gates. | `security-engineer` | 1 extension, 11 presets | Documented | [sicario-spec](https://github.com/dfirs1car1o/sicario-spec) |
+| SpecAssay | Durable-ID promotion for stock Spec Kit: templates, Gate 2 refusal, and trace-manifest emission. | `developer` | 1 extension, 1 preset | Documented | [specassay](https://github.com/rdryfoos/specassay) |
 
 ## What to Submit
 


### PR DESCRIPTION
## Summary

Adds the `specassay` bundle submitted in #4059 to the community bundle catalog, following the process documented in `.github/workflows/add-community-bundle.md` and `docs/community/bundles.md`.

- `bundles/catalog.community.json`: new `specassay` entry, inserted alphabetically after `sicario-spec`. `verified` is `false`, as required for all community entries. Top-level `updated_at` bumped to today's date.
- `docs/community/bundles.md`: new row in the community bundles table, alphabetical by bundle name.

## Validation performed (per the submission checklist in the workflow doc)

- **Repository**: https://github.com/rdryfoos/specassay exists, is MIT-licensed, and contains `bundle.yml`, `README.md`, and `LICENSE`.
- **`bundle.yml`** matches the submission exactly: id `specassay`, name `SpecAssay`, version `0.3.1`, role `developer`, author `Rik Dryfoos`, license `MIT`, `speckit_version: >=0.14.0`, and provides 1 preset (`specassay@0.2.0`) + 1 extension (`specassay-check@0.3.1`) — matching the proposed catalog entry's `provides` counts.
- **Release artifact**: tag `v0.3.1` exists on the repo with asset `specassay-0.3.1.zip` attached at the exact submitted download URL.
- **Documentation URL** (`README.md`) explains the bundle's role, installed components, and install steps (including catalog-add commands for the required companion catalogs).
- **Required component catalogs**: the submission lists and documents `extensions.json` and `presets.json` at `raw.githubusercontent.com/rdryfoos/specassay/main/catalogs/...`; both are reachable and contain the `specassay-check` extension and `specassay` preset entries respectively, consistent with `bundle.yml`.
- **Tags**: 5 lowercase tags, matches submission and manifest.
- **Checklists**: every box in "Testing Checklist" and "Submission Requirements" is checked, and Testing Details describe validate/build/install/clean-project testing.

## Test plan

```
$ python3 -c "import json; json.load(open('bundles/catalog.community.json')); print('Valid JSON')"
Valid JSON

$ .venv/bin/python -m pytest tests/contract/test_catalog_schema.py tests/test_github_workflows.py -q
============================= test session starts ==============================
collected 46 items
tests/contract/test_catalog_schema.py .................................. [ 73%]
........                                                                 [ 91%]
tests/test_github_workflows.py ....                                      [100%]
============================== 46 passed in 0.29s ==============================
```

`tests/contract/test_catalog_schema.py::test_repository_community_bundle_catalog_matches_contract` reads this exact file and asserts every entry parses under the `CatalogEntry` schema and has `verified is False`. As a sanity check that this test actually catches a bad entry (not just a vacuous pass), I temporarily set the new entry's `verified` to `true` and reran that one test — it failed with `assert False`, as expected — then reverted to `verified: false` before committing.

Also ran the wider bundler unit suite touching this file/schema:

```
$ .venv/bin/python -m pytest tests/unit/test_bundler_adapters.py tests/unit/test_bundler_records.py -q
============================== 42 passed in 0.26s ==============================
```

Lint:

```
$ uvx ruff@0.15.0 check src tests
All checks passed!
```

(No source code changed — lint run for completeness per CONTRIBUTING.md.)

`git diff --check` reports no whitespace errors.

Closes #4059

cc @rdryfoos

## AI disclosure

This catalog addition was prepared autonomously by an AI coding agent (Claude, Anthropic) acting on the repository's own community-bundle submission process (`.github/workflows/add-community-bundle.md`), including fetching and cross-checking the submitter's repository, release, and manifest against the issue form before editing the catalog files.
