### PR TITLE
[extension] Add SpecAssay Check extension to community catalog

### DIFF
--- a/docs/community/extensions.md
+++ b/docs/community/extensions.md
@@ -145,6 +145,7 @@ The following community-contributed extensions are available in [`catalog.commun
 | Spec Validate | Comprehension validation, review gating, and approval state for spec-kit artifacts — staged quizzes, peer review SLA, and a hard gate before /speckit.implement | `process` | Read+Write | [spec-kit-spec-validate](https://github.com/aeltayeb/spec-kit-spec-validate) |
 | Spec-Kit BDD | ATDD/BDD extension: convert specs to Gherkin scenarios, scaffold step definitions, and verify acceptance test coverage | `process` | Read+Write | [spec-kit-bdd](https://github.com/RSginer/spec-kit-bdd) |
 | Spec2Cloud | Spec-driven workflow tuned for shipping to Azure | `process` | Read+Write | [spec2cloud](https://github.com/Azure-Samples/Spec2Cloud) |
+| SpecAssay Check | Gate 2 refuses silent gaps and emits a trace-manifest (`trace-manifest.json`) | `visibility` | Read+Write | [specassay](https://github.com/rdryfoos/specassay) |
 | SpecKit Companion | Live spec-driven progress — lifecycle capture, status, resume, and a turbo pipeline profile | `visibility` | Read+Write | [speckit-companion](https://github.com/alfredoperez/speckit-companion) |
 | SpecKit Grill Me | Exhaustively resolve specification ambiguities and decisions before planning | `process` | Read+Write | [speckit-grill-me](https://github.com/yoshi1220/speckit-grill-me) |
 | SpecTest | Auto-generate test scaffolds from spec criteria, map coverage, and find untested requirements | `code` | Read+Write | [spec-kit-spectest](https://github.com/Quratulain-bilal/spec-kit-spectest) |

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-08-11T00:00:00Z",
+  "updated_at": "2026-08-12T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "adrkit": {
@@ -4147,6 +4147,40 @@
       "stars": 0,
       "created_at": "2026-04-30T00:00:00Z",
       "updated_at": "2026-04-30T00:00:00Z"
+    },
+    "specassay-check": {
+      "name": "SpecAssay Check",
+      "id": "specassay-check",
+      "description": "Gate 2 refuses silent gaps and emits a trace-manifest (`trace-manifest.json`).",
+      "author": "Rik Dryfoos",
+      "version": "0.3.1",
+      "download_url": "https://github.com/rdryfoos/specassay/releases/download/v0.3.1/specassay-check-0.3.1.zip",
+      "repository": "https://github.com/rdryfoos/specassay",
+      "homepage": "https://www.specassay.com",
+      "documentation": "https://github.com/rdryfoos/specassay/blob/main/extensions/specassay-check/README.md",
+      "changelog": "https://github.com/rdryfoos/specassay/blob/main/CHANGELOG.md",
+      "license": "MIT",
+      "category": "visibility",
+      "effect": "read-write",
+      "requires": {
+        "speckit_version": ">=0.14.0"
+      },
+      "provides": {
+        "commands": 1,
+        "hooks": 1
+      },
+      "tags": [
+        "traceability",
+        "gate",
+        "ci",
+        "governance",
+        "sdd"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-08-12T00:00:00Z",
+      "updated_at": "2026-08-12T00:00:00Z"
     },
     "speckit-superpowers-bridge": {
       "name": "Superpowers Implementation Bridge",


### PR DESCRIPTION
## Summary

Adds the `specassay-check` extension submitted in #4057 to the community extension catalog, following the process documented in `.github/workflows/add-community-extension.md` and `docs/community/extensions.md`.

- `extensions/catalog.community.json`: new `specassay-check` entry, inserted alphabetically by ID after `spec2cloud`. Top-level `updated_at` bumped to today's date.
- `docs/community/extensions.md`: new row in the community extensions table, alphabetical by extension name (after "Spec2Cloud").

## Validation performed (per the submission checklist in the workflow doc)

- **Extension ID**: `specassay-check` matches `^[a-z][a-z0-9-]*$`.
- **Version**: `0.3.1` — valid semver.
- **Repository**: https://github.com/rdryfoos/specassay exists, is public, MIT-licensed, and contains a root `README.md` and `LICENSE`, plus `extensions/specassay-check/extension.yml` and `extensions/specassay-check/README.md`.
- **`extension.yml`** matches the submission exactly: id `specassay-check`, name `SpecAssay Check`, version `0.3.1`, author `Rik Dryfoos`, license `MIT`, `speckit_version: >=0.14.0`, category `visibility`, effect `read-write`, 1 command (`speckit.specassay-check.gate`) and 1 hook (`after_implement`) — matching the issue's "Number of Commands: 1" / "Number of Hooks: 1". The manifest's `requires.tools` list is empty, consistent with the issue's own "Proposed Catalog Entry" JSON block (which also omits a `tools` array), so no `tools` array was added to the catalog entry.
- **Documentation URL** (`extensions/specassay-check/README.md`) matches the submitted Documentation URL exactly.
- **Release/download URL**: tag `v0.3.1` exists on the repo with asset `specassay-check-0.3.1.zip` attached at the exact submitted download URL (`https://github.com/<owner>/<repo>/releases/download/<tag>/<asset>.zip` pattern).
- **Tags**: 5 tags (`traceability`, `gate`, `ci`, `governance`, `sdd`), matches submission and manifest.
- **Checklists**: every box in "Testing Checklist" and "Submission Requirements" is checked.

## Test plan

```
$ python3 -c "import json; json.load(open('extensions/catalog.community.json')); print('Valid JSON')"
Valid JSON

$ .venv/bin/python -m pytest tests/contract/test_catalog_schema.py tests/test_github_workflows.py -q
============================= test session starts ==============================
collected 46 items
tests/contract/test_catalog_schema.py .................................. [ 73%]
........                                                                 [ 91%]
tests/test_github_workflows.py ....                                      [100%]
============================== 46 passed in 0.73s ==============================

$ .venv/bin/python -m pytest tests -q
10 failed, 6787 passed, 9 skipped in 396.62s
```

The 10 failing tests (composed-template parity tests in `test_check_prerequisites_python_parity.py`, `test_create_new_feature_python_parity.py`, `test_resolve_template_python_parity.py`, `test_setup_plan_python_parity.py`, `test_setup_tasks_python_parity.py`, plus `TestInstalledPresetRichMarkup::test_resolve_accepts_dotted_command_name`) fail identically on unmodified `main` (verified by `git stash`ing this change and re-running two of them) — pre-existing, unrelated to this catalog-only change.

Lint:

```
$ uvx ruff@0.15.0 check src tests
All checks passed!
```

(No source code changed — lint run for completeness per CONTRIBUTING.md.)

`git diff --check` reports no whitespace errors.

Closes #4057

cc @rdryfoos

## AI disclosure

This catalog addition was prepared autonomously by an AI coding agent (Claude, Anthropic, model claude-sonnet-5) acting on the repository's own community-extension submission process (`.github/workflows/add-community-extension.md`), including fetching and cross-checking the submitter's repository, release, and manifest against the issue form before editing the catalog files. The commit carries an `Assisted-by:` trailer per this repo's `AGENTS.md` disclosure requirements.
