### PR TITLE
fix(workflows): reject malformed step catalog roots on add

### DIFF
--- a/src/specify_cli/workflows/catalog.py
+++ b/src/specify_cli/workflows/catalog.py
@@ -1394,12 +1394,14 @@ class StepCatalog:
         data: dict[str, Any] = {"catalogs": []}
         if config_path.exists():
             try:
-                raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+                raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
             except (yaml.YAMLError, OSError, UnicodeDecodeError) as exc:
                 raise StepValidationError(
                     f"Catalog config file is unreadable or malformed: {exc}"
                 ) from exc
-            if not isinstance(raw, dict):
+            if raw is None:
+                raw = {}
+            elif not isinstance(raw, dict):
                 raise StepValidationError(
                     "Catalog config file is corrupted (expected a mapping)."
                 )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -9090,6 +9090,23 @@ class TestStepCatalog:
         assert len(data["catalogs"]) == 1
         assert data["catalogs"][0]["url"] == "https://example.com/steps.json"
 
+    @pytest.mark.parametrize("bad", [[], False, 0, ""])
+    def test_add_catalog_rejects_falsy_non_mapping_config(
+        self, project_dir, bad
+    ):
+        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
+
+        config_path = project_dir / ".specify" / "step-catalogs.yml"
+        original = yaml.safe_dump(bad)
+        config_path.write_text(original, encoding="utf-8")
+
+        with pytest.raises(StepValidationError, match="expected a mapping"):
+            StepCatalog(project_dir).add_catalog(
+                "https://example.com/steps.json", "my-steps"
+            )
+
+        assert config_path.read_text(encoding="utf-8") == original
+
     def test_add_catalog_duplicate_rejected(self, project_dir):
         from specify_cli.workflows.catalog import StepCatalog, StepValidationError
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -8829,6 +8829,23 @@ class TestStepCatalog:
         assert len(data["catalogs"]) == 1
         assert data["catalogs"][0]["url"] == "https://example.com/steps.json"
 
+    @pytest.mark.parametrize("bad", [[], False, 0, ""])
+    def test_add_catalog_rejects_falsy_non_mapping_config(
+        self, project_dir, bad
+    ):
+        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
+
+        config_path = project_dir / ".specify" / "step-catalogs.yml"
+        original = yaml.safe_dump(bad)
+        config_path.write_text(original, encoding="utf-8")
+
+        with pytest.raises(StepValidationError, match="expected a mapping"):
+            StepCatalog(project_dir).add_catalog(
+                "https://example.com/steps.json", "my-steps"
+            )
+
+        assert config_path.read_text(encoding="utf-8") == original
+
     def test_add_catalog_duplicate_rejected(self, project_dir):
         from specify_cli.workflows.catalog import StepCatalog, StepValidationError
 


### PR DESCRIPTION
## Description

`StepCatalog.add_catalog()` treated any falsy parsed YAML root as an empty mapping. A config containing `[]`, `0`, `false`, or an empty string was therefore overwritten when adding a catalog instead of being reported as corrupt.

This distinguishes empty/null documents from present non-mapping roots and preserves malformed files unchanged.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,655 passed, 177 skipped)
- [x] Added parameterized regressions for falsy non-mapping config roots
- [x] `uvx ruff@0.15.0 check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: GPT-5.6 Sol) under human direction; failing regressions were added before the fix, then the full suite and lint were run locally. Commit includes `Assisted-by` and `Co-authored-by` trailers.