### PR TITLE
fix(presets): reject falsy malformed catalog roots on load

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -4276,11 +4276,13 @@ class PresetCatalog:
         if not config_path.exists():
             return None
         try:
-            data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         except (yaml.YAMLError, OSError, UnicodeError) as e:
             raise PresetValidationError(
                 f"Failed to read catalog config {config_path}: {e}"
             )
+        if data is None:
+            return None
         if not isinstance(data, dict):
             raise PresetValidationError(
                 f"Invalid catalog config {config_path}: expected a mapping at root, got {type(data).__name__}"

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -3324,6 +3324,17 @@ class TestPresetCatalogMultiCatalog:
         result = catalog._load_catalog_config(config_path)
         assert result is None
 
+    @pytest.mark.parametrize("bad", [[], False, 0, ""])
+    def test_load_catalog_config_rejects_falsy_non_mapping_root(
+        self, project_dir, bad
+    ):
+        config_path = project_dir / ".specify" / "preset-catalogs.yml"
+        config_path.write_text(yaml.safe_dump(bad), encoding="utf-8")
+
+        catalog = PresetCatalog(project_dir)
+        with pytest.raises(PresetValidationError, match="expected a mapping"):
+            catalog._load_catalog_config(config_path)
+
     def test_load_catalog_config_invalid_yaml(self, project_dir):
         """Test loading invalid YAML raises error."""
         config_path = project_dir / ".specify" / "preset-catalogs.yml"


### PR DESCRIPTION
## Description

`PresetCatalog._load_catalog_config()` used `yaml.safe_load(...) or {}`, so falsy non-mapping documents such as `[]`, `0`, `false`, and an empty string were silently accepted as empty configuration. That hides corrupt catalog files and makes them behave differently from truthy malformed roots.

This preserves the existing empty/null no-op while rejecting every present non-mapping root consistently.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,655 passed, 177 skipped)
- [x] Added regressions for four falsy non-mapping YAML roots
- [x] `uvx ruff@0.15.0 check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: GPT-5.6 Sol) under human direction; failing regressions were added before the fix, then the full suite and lint were run locally. Commit includes `Assisted-by` and `Co-authored-by` trailers.