### PR TITLE
fix(events): skip unreadable extension manifests

### DIFF
--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -1014,7 +1014,7 @@ def collect_extension_events(project_root: Path) -> ResolvedEvents:
                 continue
             try:
                 data = yaml.safe_load(ext_yml.read_text(encoding="utf-8")) or {}
-            except (UnicodeDecodeError, yaml.YAMLError):
+            except (OSError, UnicodeDecodeError, yaml.YAMLError):
                 continue
             if not isinstance(data, dict):
                 continue

--- a/tests/integrations/test_events.py
+++ b/tests/integrations/test_events.py
@@ -188,6 +188,22 @@ class TestCollectExtensionEvents:
 
         assert collect_extension_events(tmp_path) == {}
 
+    def test_unreadable_manifest_skipped(self, tmp_path, monkeypatch):
+        ext_dir = tmp_path / ".specify" / "extensions" / "my-ext"
+        ext_dir.mkdir(parents=True)
+        manifest = ext_dir / "extension.yml"
+        manifest.write_text("events: {}\n", encoding="utf-8")
+        real_read_text = Path.read_text
+
+        def unreadable(path, *args, **kwargs):
+            if path == manifest:
+                raise OSError("simulated read failure")
+            return real_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", unreadable)
+
+        assert collect_extension_events(tmp_path) == {}
+
     def test_event_command_ref_canonicalized_via_manifest(self, tmp_path):
         """R1: events are read from a validated ExtensionManifest, so an
         obsolete command ref (e.g. my-ext.boot) is canonicalized


### PR DESCRIPTION
## Description

The raw-manifest fallback in `collect_extension_events()` skips malformed YAML and undecodable text, but an `OSError` from reading the same optional `extension.yml` escapes and aborts event collection.

This handles read failures at the existing best-effort boundary, so one inaccessible extension manifest does not block events from the rest of the project.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,652 passed, 177 skipped)
- [x] Added an unreadable-manifest regression using a targeted `Path.read_text` failure
- [x] `uvx ruff@0.15.0 check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: GPT-5.6 Sol) under human direction; a failing regression was added before the fix, then the full suite and lint were run locally. Commit includes `Assisted-by` and `Co-authored-by` trailers.