### PR TITLE
fix(bundler): reject non-string manifest list members

### DIFF
--- a/src/specify_cli/bundler/models/manifest.py
+++ b/src/specify_cli/bundler/models/manifest.py
@@ -247,7 +247,9 @@ def _parse_str_list(raw: Any, field_name: str) -> tuple[str, ...]:
         return ()
     if isinstance(raw, (str, bytes)) or not isinstance(raw, (list, tuple)):
         raise BundlerError(f"'{field_name}' must be a list of strings when present.")
-    return tuple(str(item) for item in raw)
+    if any(not isinstance(item, str) for item in raw):
+        raise BundlerError(f"'{field_name}' must be a list of strings when present.")
+    return tuple(raw)
 
 
 def _parse_refs(kind: str, raw: Any) -> list[ComponentRef]:

--- a/src/specify_cli/bundler/models/manifest.py
+++ b/src/specify_cli/bundler/models/manifest.py
@@ -237,11 +237,11 @@ def _text(raw: Any) -> str:
 
 
 def _parse_str_list(raw: Any, field_name: str) -> tuple[str, ...]:
-    """Coerce a manifest list-of-strings field into a tuple of strings.
+    """Parse a manifest list-of-strings field into a tuple of strings.
 
     Rejects a bare string/bytes (which would otherwise be iterated
-    character-by-character) and any non-list/tuple, matching the manifest
-    contract (``string[]``).
+    character-by-character), any non-list/tuple, and any non-string member,
+    matching the manifest contract (``string[]``).
     """
     if raw is None:
         return ()

--- a/tests/contract/test_manifest_schema.py
+++ b/tests/contract/test_manifest_schema.py
@@ -165,6 +165,25 @@ def test_string_mcp_rejected_not_split_per_character():
         BundleManifest.from_dict(data)
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("tags", [1]),
+        ("requires.tools", [False]),
+        ("requires.mcp", [{}]),
+    ],
+)
+def test_string_list_fields_reject_non_string_members(field, value):
+    data = valid_manifest_dict()
+    if field == "tags":
+        data["tags"] = value
+    else:
+        data["requires"][field.split(".", 1)[1]] = value
+
+    with pytest.raises(BundlerError, match="must be a list of strings"):
+        BundleManifest.from_dict(data)
+
+
 def test_string_integration_rejected_not_silently_dropped():
     # A present-but-non-mapping 'integration' (a bare string) was silently
     # dropped, leaving the bundle wrongly integration-agnostic. Reject it like


### PR DESCRIPTION
## Description

Bundle manifest fields declared as string arrays (`tags`, `requires.tools`, and `requires.mcp`) currently coerce every member with `str()`. Invalid values such as integers, booleans, and objects therefore enter the model as plausible strings instead of failing schema validation.

This validates each member and preserves valid strings without coercion.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,654 passed, 177 skipped)
- [x] Added contract regressions for non-string tags, tools, and MCP entries
- [x] `uvx ruff@0.15.0 check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: GPT-5.6 Sol) under human direction; failing contract regressions were added before the fix, then the full suite and lint were run locally. Commit includes `Assisted-by` and `Co-authored-by` trailers.