### PR TITLE
fix(presets): fail closed on unreadable provenance

### DIFF
--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -107,7 +107,7 @@ def _constitution_provenance_matches_preset(
         return False
     try:
         metadata = json.loads(provenance.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         return False
     return (
         isinstance(metadata, dict)

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -784,6 +784,30 @@ class TestPresetRegistry:
 # ===== PresetManager Tests =====
 
 
+def test_unreadable_constitution_provenance_fails_closed(
+    project_dir, monkeypatch
+):
+    from specify_cli.presets import _constitution_provenance_matches_preset
+
+    memory = project_dir / ".specify" / "memory" / "constitution.md"
+    memory.parent.mkdir(parents=True, exist_ok=True)
+    memory.write_text("# Constitution\n", encoding="utf-8")
+    provenance = memory.parent / ".constitution-template.json"
+    provenance.write_text("{}", encoding="utf-8")
+    real_read_text = Path.read_text
+
+    def unreadable(path, *args, **kwargs):
+        if path == provenance:
+            raise OSError("simulated read failure")
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", unreadable)
+
+    assert not _constitution_provenance_matches_preset(
+        project_dir, memory, "example", "1.0.0"
+    )
+
+
 class TestPresetManager:
     """Test PresetManager installation and removal."""
 


### PR DESCRIPTION
## Description

`_constitution_provenance_matches_preset()` already treats missing, invalid JSON, and undecodable provenance as a non-match, but an `OSError` while reading the same metadata escapes and can interrupt preset handling.

This fails closed for read errors as well: unreadable provenance never authorizes a preset match.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,652 passed, 177 skipped)
- [x] Added a direct unreadable-provenance regression using a targeted `Path.read_text` failure
- [x] `uvx ruff@0.15.0 check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: GPT-5.6 Sol) under human direction; a failing regression was added before the fix, then the full suite and lint were run locally. Commit includes `Assisted-by` and `Co-authored-by` trailers.