### PR TITLE
fix(presets): reject malformed catalog roots during mutation

### DIFF
--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -757,10 +757,15 @@ def preset_catalog_add(
     # Load existing config
     if config_path.exists():
         try:
-            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         except Exception as e:
             config_label = _display_project_path(project_root, config_path)
             console.print(f"[red]Error:[/red] Failed to read {_escape_markup(str(config_label))}: {_escape_markup(str(e))}")
+            raise typer.Exit(1)
+        if config is None:
+            config = {}
+        elif not isinstance(config, dict):
+            console.print("[red]Error:[/red] Invalid catalog config: expected a mapping.")
             raise typer.Exit(1)
     else:
         config = {}
@@ -817,9 +822,14 @@ def preset_catalog_remove(
         raise typer.Exit(1)
 
     try:
-        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     except Exception as e:
         console.print(f"[red]Error:[/red] Failed to read preset catalog config: {e}")
+        raise typer.Exit(1)
+    if config is None:
+        config = {}
+    elif not isinstance(config, dict):
+        console.print("[red]Error:[/red] Invalid catalog config: expected a mapping.")
         raise typer.Exit(1)
 
     catalogs = config.get("catalogs", [])

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -3274,6 +3274,38 @@ class TestPresetCatalogMultiCatalog:
         assert result.exit_code == 1
         assert "[/red]absent" in result.output
 
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [
+                "preset",
+                "catalog",
+                "add",
+                "https://example.com/catalog.json",
+                "--name",
+                "example",
+            ],
+            ["preset", "catalog", "remove", "example"],
+        ],
+    )
+    def test_catalog_mutation_rejects_non_mapping_config_root(
+        self, project_dir, args
+    ):
+        from typer.testing import CliRunner
+        from unittest.mock import patch
+        from specify_cli import app
+
+        config_path = project_dir / ".specify" / "preset-catalogs.yml"
+        original = "[]\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        with patch.object(Path, "cwd", return_value=project_dir):
+            result = CliRunner().invoke(app, args)
+
+        assert result.exit_code == 1
+        assert "expected a mapping" in result.output
+        assert config_path.read_text(encoding="utf-8") == original
+
     def test_env_var_overrides_catalogs(self, project_dir, monkeypatch):
         """Test that SPECKIT_PRESET_CATALOG_URL env var overrides defaults."""
         monkeypatch.setenv(


### PR DESCRIPTION
## Description

Preset catalog add/remove commands assume the YAML document root is a mapping. A sequence or scalar root therefore raises a raw type error instead of reporting corrupt configuration, and mutation must not rewrite that file.

This validates the root shape before reading or changing catalog entries. Empty and null documents retain their existing empty-config behavior.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,653 passed, 177 skipped)
- [x] Added parameterized add/remove regressions for non-mapping YAML roots
- [x] `uvx ruff@0.15.0 check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: GPT-5.6 Sol) under human direction; failing regressions were added before the fix, then the full suite and lint were run locally. Commit includes `Assisted-by` and `Co-authored-by` trailers.