### PR TITLE
fix(workflows): report malformed step roots on remove

### DIFF
--- a/src/specify_cli/workflows/catalog.py
+++ b/src/specify_cli/workflows/catalog.py
@@ -1463,12 +1463,14 @@ class StepCatalog:
             raise StepValidationError("No step catalog config file found.")
 
         try:
-            data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         except (yaml.YAMLError, OSError, UnicodeDecodeError) as exc:
             raise StepValidationError(
                 f"Catalog config file is unreadable or malformed: {exc}"
             ) from exc
-        if not isinstance(data, dict):
+        if data is None:
+            data = {}
+        elif not isinstance(data, dict):
             raise StepValidationError(
                 "Catalog config file is corrupted (expected a mapping)."
             )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -8861,6 +8861,18 @@ class TestStepCatalog:
         with pytest.raises(StepValidationError, match="out of range"):
             catalog.remove_catalog(5)
 
+    @pytest.mark.parametrize("bad", [[], False, 0, ""])
+    def test_remove_catalog_rejects_falsy_non_mapping_config(
+        self, project_dir, bad
+    ):
+        from specify_cli.workflows.catalog import StepCatalog, StepValidationError
+
+        config_path = project_dir / ".specify" / "step-catalogs.yml"
+        config_path.write_text(yaml.safe_dump(bad), encoding="utf-8")
+
+        with pytest.raises(StepValidationError, match="expected a mapping"):
+            StepCatalog(project_dir).remove_catalog(0)
+
     def test_remove_catalog_no_config(self, project_dir):
         from specify_cli.workflows.catalog import StepCatalog, StepValidationError
 


### PR DESCRIPTION
## Description

`StepCatalog.remove_catalog()` assumes the parsed YAML root is a mapping. Falsy non-mapping documents can therefore produce a misleading empty-catalog error instead of reporting the corrupt configuration.

This validates the document root before catalog lookup and preserves the malformed file unchanged.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest` (6,655 passed, 177 skipped)
- [x] Added parameterized remove regressions for falsy non-mapping roots
- [x] `uvx ruff@0.15.0 check src tests` clean

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by GitHub Copilot CLI (model: GPT-5.6 Sol) under human direction; failing regressions were added before the fix, then the full suite and lint were run locally. Commit includes `Assisted-by` and `Co-authored-by` trailers.