### PR TITLE
fix(workflows): validate non-string step types

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -366,6 +366,17 @@ def _validate_steps(
 
         # Determine step type
         step_type = step_config.get("type", "command")
+        if not isinstance(step_type, str):
+            # Registry keys are strings. Checking an unhashable YAML value
+            # (for example ``type: [shell]`` or a mapping) against the set
+            # below raises a raw TypeError before validation can report the
+            # authoring mistake. Guard every non-string shape first, matching
+            # the typed validation already applied to workflow and step IDs.
+            errors.append(
+                f"Step {step_id!r}: 'type' must be a string, got "
+                f"{type(step_type).__name__} ({step_type!r})."
+            )
+            continue
         if step_type not in _get_valid_step_types():
             errors.append(
                 f"Step {step_id!r} has invalid type {step_type!r}."

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -4565,6 +4565,29 @@ steps:
         errors = validate_workflow(definition)
         assert any("invalid type" in e.lower() for e in errors)
 
+    @pytest.mark.parametrize("step_type", [["shell"], {"name": "shell"}])
+    def test_non_string_step_type_reports_error(self, step_type):
+        """Unhashable YAML values must not crash registry membership checks."""
+        from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
+
+        definition = WorkflowDefinition(
+            {
+                "workflow": {
+                    "id": "test",
+                    "name": "Test",
+                    "version": "1.0.0",
+                },
+                "steps": [{"id": "bad", "type": step_type}],
+            }
+        )
+
+        errors = validate_workflow(definition)
+
+        assert errors == [
+            f"Step 'bad': 'type' must be a string, got "
+            f"{type(step_type).__name__} ({step_type!r})."
+        ]
+
     def test_nested_step_validation(self):
         from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
 


### PR DESCRIPTION
## Description

A workflow step whose YAML `type` is a sequence or mapping currently reaches the step-registry membership check and raises a raw `TypeError` because the value is unhashable. This prevents `workflow run`, validation, and installation paths from reporting their normal actionable configuration errors.

This change validates that every step `type` is a string before registry lookup. Unknown string types keep the existing `invalid type` behavior, while list/mapping values now produce a typed validation error instead of a traceback.

## Testing

- [x] Tested locally with `.venv\Scripts\specify.exe --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample workflow

Validation performed:

- `.venv\Scripts\python -m pytest tests/test_workflows.py -k "invalid_step_type or non_string_step_type_reports_error" -q` — 3 passed
- `.venv\Scripts\python -m pytest tests/test_workflows.py -q -k "not symlink and not cross_project_registry_root"` — 886 passed, 7 skipped, 36 deselected
- Full `tests/test_workflows.py` — 902 passed, 7 skipped; 20 environment-only failures because this Windows session lacks symlink privilege (`WinError 1314`)
- `uvx ruff@0.15.0 check src tests` — passed
- `.venv\Scripts\python -m compileall -q src` — passed
- CLI repro with `type: [shell]` — exits 1 with `'type' must be a string, got list` and no traceback

The repository-wide suite was also attempted, but the local command runner timed out before completion; CI should provide the complete platform matrix.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

OpenAI Codex (GPT-5, autonomous) independently identified the bug, authored the code and regression tests, ran the validations listed above, and prepared this pull request on behalf of @NgoQuocViet2001. The operator requested autonomous repository improvements and approved this candidate; the operator did not manually author or line-by-line review the change.