### PR TITLE
fix(workflows): clean up download temp file on interrupt or typer.Exit

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -1708,6 +1708,24 @@ def workflow_list():
         console.print()
 
 
+def _cleanup_download_tmp_path(tmp_path: Path | None) -> None:
+    """Best-effort unlink of a partially-downloaded workflow temp file.
+
+    A cleanup ``OSError`` here must never replace/mask whatever error or
+    interrupt is already propagating -- warn about it and keep going.
+    """
+    if tmp_path is None:
+        return
+    try:
+        tmp_path.unlink(missing_ok=True)
+    except OSError as cleanup_exc:
+        console.print(
+            "[yellow]Warning:[/yellow] Could not remove temporary "
+            f"workflow download file: {_escape_markup(str(cleanup_exc))} "
+            f"(path: {_escape_markup(str(tmp_path))})"
+        )
+
+
 @workflow_app.command("add")
 def workflow_add(
     source: str = typer.Argument(..., help="Workflow ID, URL, or local path"),
@@ -2037,23 +2055,23 @@ def workflow_add(
                             _enforce_workflow_yaml_size(downloaded_content)
                     tmp.write(downloaded_content)
         except typer.Exit:
+            _cleanup_download_tmp_path(tmp_path)
             raise
         except Exception as exc:
-            if tmp_path is not None:
-                # A cleanup failure here must never replace/mask the
-                # original download error below with a raw, unhandled
-                # OSError -- warn about it and keep going, exactly like the
-                # later post-install finally cleanup does.
-                try:
-                    tmp_path.unlink(missing_ok=True)
-                except OSError as cleanup_exc:
-                    console.print(
-                        "[yellow]Warning:[/yellow] Could not remove temporary "
-                        f"workflow download file: {_escape_markup(str(cleanup_exc))} "
-                        f"(path: {_escape_markup(str(tmp_path))})"
-                    )
+            # A cleanup failure here must never replace/mask the
+            # original download error below with a raw, unhandled
+            # OSError -- warn about it and keep going, exactly like the
+            # later post-install finally cleanup does.
+            _cleanup_download_tmp_path(tmp_path)
             console.print(f"[red]Error:[/red] Failed to download workflow: {_escape_markup(str(exc))}")
             raise typer.Exit(1)
+        except BaseException:
+            # Covers KeyboardInterrupt and other non-Exception exits: the
+            # temp file is already created on disk (delete=False) by this
+            # point, so an interrupt during the size-limited read must still
+            # unlink it rather than leaking it to the system temp directory.
+            _cleanup_download_tmp_path(tmp_path)
+            raise
         try:
             if downloaded_archive_format is None:
                 _validate_and_install_local(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -12343,6 +12343,46 @@ steps:
         leaked = list(scratch_tmp.glob("*.yml"))
         assert leaked == [], f"leaked temp files: {leaked}"
 
+    def test_add_from_url_interrupt_during_read_leaves_no_temp_file(
+        self, project_dir, monkeypatch, tmp_path
+    ):
+        """A KeyboardInterrupt while streaming the response body must still
+        unlink the already-created (delete=False) temp file. Unlike a
+        download ``ValueError``, ``KeyboardInterrupt`` is a ``BaseException``
+        and is not caught by ``except Exception`` -- only a ``BaseException``
+        handler around the temp-file lifetime can clean it up."""
+        import tempfile as tempfile_mod
+        from unittest.mock import patch
+        from typer.testing import CliRunner
+        from specify_cli import app
+        from specify_cli.workflows import _commands as wf_commands
+
+        monkeypatch.chdir(project_dir)
+        scratch_tmp = tmp_path / "scratch-tmp"
+        scratch_tmp.mkdir()
+        monkeypatch.setattr(tempfile_mod, "tempdir", str(scratch_tmp))
+
+        def _boom(*args, **kwargs):
+            raise KeyboardInterrupt()
+
+        monkeypatch.setattr(wf_commands, "_read_response_within_limit", _boom)
+        body = b"id: align-wf\n"
+        runner = CliRunner()
+        with patch(
+            "specify_cli.authentication.http.open_url",
+            side_effect=lambda url, timeout=None, extra_headers=None, redirect_validator=None: self._FakeResponse(
+                body, url
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["workflow", "add", "align-wf", "--from", "https://example.com/workflow.yml"],
+                input="y\n",
+            )
+        assert result.exit_code != 0
+        leaked = list(scratch_tmp.glob("*.yml"))
+        assert leaked == [], f"leaked temp files: {leaked}"
+
     def test_add_from_url_oversized_content_length_leaves_no_temp_file(
         self, project_dir, monkeypatch, tmp_path
     ):


### PR DESCRIPTION
## Description

Fixes #4132.

`specify workflow add <url>` streams the download into a
`tempfile.NamedTemporaryFile(..., delete=False)`. The file is created on
disk immediately (before any bytes are written), so any exit after that
point is supposed to clean it up.

Two exit paths skipped that cleanup:

1. `except typer.Exit: raise` re-raised without unlinking `tmp_path`.
2. `KeyboardInterrupt` is a `BaseException`, not an `Exception`, so
   pressing Ctrl+C during the size-limited read wasn't caught by the
   existing `except Exception` handler at all — the temp file leaked
   silently.

The later `finally: tmp_path.unlink(...)` only runs once installation has
started, i.e. after a successful download — it never covers these two
paths.

## Fix

Factored the existing unlink-with-warn logic into a small
`_cleanup_download_tmp_path()` helper, and added a `except BaseException`
handler alongside the existing `except typer.Exit` and `except Exception`
handlers so any exit after the temp file is created — error, clean exit,
or interrupt — unlinks it.

## Testing

Added `test_add_from_url_interrupt_during_read_leaves_no_temp_file` in
`tests/test_workflows.py`, which simulates a `KeyboardInterrupt` raised
mid-read and asserts no temp file is left behind.

Confirmed the new test fails without the fix (`git checkout HEAD~1 --
src/specify_cli/workflows/_commands.py`, rerun, restore):

```
FAILED tests/test_workflows.py::TestWorkflowCliAlignment::test_add_from_url_interrupt_during_read_leaves_no_temp_file
E   AssertionError: leaked temp files: [PosixPath('.../scratch-tmp/tmpmxi012rd.yml')]
```

With the fix:

```
tests/test_workflows.py::TestWorkflowCliAlignment::test_add_from_url_interrupt_during_read_leaves_no_temp_file PASSED
1 passed, 929 deselected in 2.78s
```

Full workflow suite:

```
.venv/bin/python -m pytest tests/test_workflows.py -q
929 passed, 1 skipped in 15.50s
```

Full test suite:

```
.venv/bin/python -m pytest tests -q
10 failed, 6921 passed, 9 skipped, 48 warnings in 467.78s
```

The 10 failures are pre-existing and unrelated to this change (template
composition / python-parity / terminal-width-dependent Rich formatting
tests in `test_check_prerequisites_python_parity.py`,
`test_create_new_feature_python_parity.py`, `test_presets.py`,
`test_resolve_template_python_parity.py`, `test_setup_plan_python_parity.py`,
`test_setup_tasks_python_parity.py`). Verified they fail identically on
this same environment with the fix reverted (unmodified tree), so they
are environment-specific and not caused by this change.

Lint:

```
uvx ruff@0.15.0 check src tests
All checks passed!
```

Agent config consistency:

```
.venv/bin/python -m pytest tests/test_agent_config_consistency.py -q
28 passed
```

## AI Disclosure

This PR was written by an autonomous AI coding agent (Claude, Anthropic)
acting on behalf of the repository owner. The agent read the issue,
identified the missing `BaseException`/`typer.Exit` cleanup paths,
implemented the minimal fix, added a regression test, verified the test
fails without the fix and passes with it, and ran the project's lint and
test suites as described above.
