### PR TITLE
fix(bundler): pass explicit option values when delegating to `workflow_add`

### DIFF
--- a/src/specify_cli/bundler/services/primitives.py
+++ b/src/specify_cli/bundler/services/primitives.py
@@ -337,7 +337,16 @@ class _WorkflowKindManager:
         with _chdir(self._root):
             _delegate_command(
                 "install", f"workflow '{component.id}'",
-                lambda: workflow_add(component.id),
+                # Pass the options explicitly. Called in-process rather than
+                # through Typer, an omitted ``typer.Option`` parameter keeps its
+                # ``OptionInfo`` sentinel as the value -- which is TRUTHY and is
+                # not ``None`` -- so ``workflow_add``'s ``if dev:`` took the
+                # local-path branch for every catalog install and failed with
+                # "--dev source must be a workflow YAML file ...". It is the only
+                # one of the four delegated commands that declares options;
+                # workflow_remove / workflow_step_add / workflow_step_remove take
+                # a bare ``typer.Argument`` and are safe as written.
+                lambda: workflow_add(component.id, dev=False, from_url=None),
             )
 
     def refresh(self, component: ComponentRef) -> None:

--- a/src/specify_cli/bundler/services/primitives.py
+++ b/src/specify_cli/bundler/services/primitives.py
@@ -347,6 +347,15 @@ class _WorkflowKindManager:
         with _chdir(self._root):
             _delegate_command(
                 "install", f"workflow '{component.id}'",
+                # Pass the options explicitly. Called in-process rather than
+                # through Typer, an omitted ``typer.Option`` parameter keeps its
+                # ``OptionInfo`` sentinel as the value -- which is TRUTHY and is
+                # not ``None`` -- so ``workflow_add``'s ``if dev:`` took the
+                # local-path branch for every catalog install and failed with
+                # "--dev source must be a workflow YAML file ...". It is the only
+                # one of the four delegated commands that declares options;
+                # workflow_remove / workflow_step_add / workflow_step_remove take
+                # a bare ``typer.Argument`` and are safe as written.
                 lambda: workflow_add(component.id, dev=False, from_url=None),
             )
 

--- a/tests/unit/test_bundler_primitives.py
+++ b/tests/unit/test_bundler_primitives.py
@@ -78,12 +78,48 @@ def test_offline_workflow_allows_bundled(tmp_path: Path, monkeypatch):
         assets, "_locate_bundled_workflow", lambda wid: tmp_path / "wf"
     )
     calls: list[str] = []
-    monkeypatch.setattr(specify_cli, "workflow_add", lambda wid: calls.append(wid))
+    monkeypatch.setattr(
+        specify_cli, "workflow_add", lambda wid, **kwargs: calls.append(wid)
+    )
 
     manager = primitive_manager("workflows", tmp_path, allow_network=False)
     manager.install(_component("workflows", "bundled-wf"))
 
     assert calls == ["bundled-wf"]
+
+
+def test_workflow_install_passes_explicit_typer_options(tmp_path: Path, monkeypatch):
+    """The bundler calls ``workflow_add`` in-process, so it must pass the
+    ``typer.Option`` values explicitly.
+
+    Outside Typer, an omitted option parameter keeps its ``OptionInfo``
+    sentinel as the value. That sentinel is truthy and is not ``None``, so
+    ``workflow_add``'s ``if dev:`` took the local-path branch for *every*
+    catalog install and failed with "--dev source must be a workflow YAML
+    file, supported archive, or directory containing workflow.yml".
+    """
+    import specify_cli
+    import specify_cli._assets as assets
+
+    monkeypatch.setattr(
+        assets, "_locate_bundled_workflow", lambda wid: tmp_path / "wf"
+    )
+    seen: list[dict] = []
+
+    def _capture(wid, *args, **kwargs):
+        seen.append({"id": wid, "args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(specify_cli, "workflow_add", _capture)
+
+    manager = primitive_manager("workflows", tmp_path, allow_network=False)
+    manager.install(_component("workflows", "bundled-wf"))
+
+    assert len(seen) == 1, seen
+    call = seen[0]
+    assert call["id"] == "bundled-wf"
+    # Both options must arrive as real values, never as Typer sentinels.
+    assert call["kwargs"].get("dev") is False, call["kwargs"]
+    assert call["kwargs"].get("from_url") is None, call["kwargs"]
 
 
 def test_assert_pinned_version_matches_passes():

--- a/tests/unit/test_bundler_primitives.py
+++ b/tests/unit/test_bundler_primitives.py
@@ -91,6 +91,40 @@ def test_offline_workflow_allows_bundled(tmp_path: Path, monkeypatch):
     assert calls == [("bundled-wf", False, None)]
 
 
+def test_workflow_install_passes_explicit_typer_options(tmp_path: Path, monkeypatch):
+    """The bundler calls ``workflow_add`` in-process, so it must pass the
+    ``typer.Option`` values explicitly.
+
+    Outside Typer, an omitted option parameter keeps its ``OptionInfo``
+    sentinel as the value. That sentinel is truthy and is not ``None``, so
+    ``workflow_add``'s ``if dev:`` took the local-path branch for *every*
+    catalog install and failed with "--dev source must be a workflow YAML
+    file, supported archive, or directory containing workflow.yml".
+    """
+    import specify_cli
+    import specify_cli._assets as assets
+
+    monkeypatch.setattr(
+        assets, "_locate_bundled_workflow", lambda wid: tmp_path / "wf"
+    )
+    seen: list[dict] = []
+
+    def _capture(wid, *args, **kwargs):
+        seen.append({"id": wid, "args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(specify_cli, "workflow_add", _capture)
+
+    manager = primitive_manager("workflows", tmp_path, allow_network=False)
+    manager.install(_component("workflows", "bundled-wf"))
+
+    assert len(seen) == 1, seen
+    call = seen[0]
+    assert call["id"] == "bundled-wf"
+    # Both options must arrive as real values, never as Typer sentinels.
+    assert call["kwargs"].get("dev") is False, call["kwargs"]
+    assert call["kwargs"].get("from_url") is None, call["kwargs"]
+
+
 def test_assert_pinned_version_matches_passes():
     from specify_cli.bundler.services.primitives import _assert_pinned_version
 


### PR DESCRIPTION
## Problem

**`specify bundle install` can never install a workflow component.** It fails 100% of the time, with an error about `--dev` that has nothing to do with what the user asked for.

`bundler/services/primitives.py` delegates to the Typer command callables in-process, as its module docstring describes:

```python
lambda: workflow_add(component.id)
```

But `workflow_add` declares two `typer.Option` parameters (`workflows/_commands.py:1712-1716`):

```python
def workflow_add(
    source: str = typer.Argument(..., help="Workflow ID, URL, or local path"),
    dev: bool = typer.Option(False, "--dev", ...),
    from_url: str | None = typer.Option(None, "--from", ...),
):
```

Called from Python rather than through Typer, an omitted option parameter keeps its **`OptionInfo` sentinel** as the value:

```
dev default      -> OptionInfo   truthy=True
from_url default -> OptionInfo   is None=False
```

So `if dev:` is always true and the function takes the local-path branch.

## Reproduction on current `main` (bf88c9f9)

```
>>> primitive_manager("workflows", project, allow_network=True).install(
...     ComponentRef(kind="workflows", id="code-review", version="1.0.0"))

Error: --dev source must be a workflow YAML file, supported archive, or
directory containing workflow.yml: code-review

BundlerError: Failed to install workflow 'code-review'.
```

The catalog install path is unreachable.

## Why only this call site

A signature survey of all four delegated callables:

| callable | parameters |
|---|---|
| `workflow_add` | `source=ArgumentInfo, dev=OptionInfo, from_url=OptionInfo` |
| `workflow_remove` | `workflow_id=ArgumentInfo` |
| `workflow_step_add` | `step_id=ArgumentInfo` |
| `workflow_step_remove` | `step_id=ArgumentInfo` |

`workflow_add` is the **only** one that declares options, and it is the only call site that omits them — so the other three are safe exactly as written, and this fix is correctly scoped to one line.

## Fix

```python
lambda: workflow_add(component.id, dev=False, from_url=None),
```

**No breaking change.** No input that works today behaves differently — today *every* bundler workflow install fails; afterwards it reaches the catalog path the code always intended.

## Verification

- **Fail-before / pass-after:** the new test fails on unpatched `src` and passes with the fix — **1 failed → 21 passed**.
- The new test asserts the *values*, not just the call: `dev is False` and `from_url is None`, so a future regression to sentinels is caught rather than silently swallowed by a `**kwargs` stub.
- One existing stub (`lambda wid: ...`) had to accept the kwargs; I made it capture them instead of discarding them.
- Scoped regression over `tests/unit`: no new failures vs a clean-`main` baseline captured on `bf88c9f9`.
- `uvx ruff@0.15.0 check src tests` → clean

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*