### PR TITLE
fix(bundler): treat an explicit-null records field as missing, not the text `"None"`

### DIFF
--- a/src/specify_cli/bundler/models/records.py
+++ b/src/specify_cli/bundler/models/records.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from .. import BundlerError
 from ..lib.yamlio import dump_json, ensure_within, load_json
-from .manifest import COMPONENT_KINDS, ComponentRef
+from .manifest import COMPONENT_KINDS, ComponentRef, _text
 
 RECORDS_FILENAME = "bundle-records.json"
 RECORDS_SCHEMA_VERSION = "1.0"
@@ -65,8 +65,14 @@ class InstalledBundleRecord:
             raise BundlerError(
                 "Corrupt record: 'contributed_components' must be a list."
             )
-        bundle_id = str(data.get("bundle_id", "")).strip()
-        version = str(data.get("version", "")).strip()
+        # ``.get(key, "")`` defaults only a *missing* key. A key that is
+        # present but null -- how a hand-edited or corrupt record spells an
+        # empty field -- yields ``None``, and ``str(None)`` is the non-empty
+        # literal ``"None"``, which sails past the required-field checks
+        # below. Reuse the manifest's ``_text`` so records and bundle.yml
+        # agree on what an explicit null means.
+        bundle_id = _text(data.get("bundle_id"))
+        version = _text(data.get("version"))
         if not bundle_id:
             raise BundlerError(
                 "Corrupt records file: an installed-bundle record is missing "
@@ -80,7 +86,7 @@ class InstalledBundleRecord:
         return cls(
             bundle_id=bundle_id,
             version=version,
-            installed_at=str(data.get("installed_at", "")).strip(),
+            installed_at=_text(data.get("installed_at")),
             contributed_components=tuple(
                 _component_from_dict(c) for c in components_raw
             ),
@@ -201,8 +207,8 @@ def _component_to_dict(ref: ComponentRef) -> dict[str, Any]:
 def _component_from_dict(data: Any) -> ComponentRef:
     if not isinstance(data, dict):
         raise BundlerError("Each contributed component must be a mapping.")
-    kind = str(data.get("kind", "")).strip()
-    cid = str(data.get("id", "")).strip()
+    kind = _text(data.get("kind"))
+    cid = _text(data.get("id"))
     if kind not in COMPONENT_KINDS:
         raise BundlerError(
             f"Corrupt records file: component 'kind' must be one of "

--- a/tests/unit/test_bundler_records.py
+++ b/tests/unit/test_bundler_records.py
@@ -209,3 +209,73 @@ def test_load_records_accepts_forward_compatible_minor_schema(tmp_path: Path):
     payload = {"schema_version": "1.5", "bundles": []}
     records_path(tmp_path).write_text(json.dumps(payload), encoding="utf-8")
     assert load_records(tmp_path) == []
+
+
+@pytest.mark.parametrize(
+    "field,message",
+    [
+        ("bundle_id", "missing its 'bundle_id'"),
+        ("version", "missing its 'version'"),
+    ],
+)
+def test_load_records_rejects_explicit_null_record_field(
+    tmp_path: Path, field: str, message: str
+):
+    """An explicit JSON ``null`` is how a corrupt record spells an empty field.
+
+    ``str(data.get(field, ""))`` defaults only a *missing* key, so a
+    present-but-null value became the literal text ``"None"`` — non-empty, so
+    it sailed past the required-field checks and the record was accepted as a
+    bundle actually named ``"None"``. Mirrors ``manifest._text``.
+    """
+    (tmp_path / ".specify").mkdir()
+    record = {"bundle_id": "a", "version": "1.0.0", "contributed_components": []}
+    record[field] = None
+    payload = {"schema_version": "1.0", "bundles": [record]}
+    records_path(tmp_path).write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(BundlerError, match=message):
+        load_records(tmp_path)
+
+
+def test_load_records_rejects_explicit_null_component_id(tmp_path: Path):
+    """A null component id became ``"None"`` and entered the refcount.
+
+    ``components_still_needed`` would then report a phantom
+    ``('presets', 'None')`` as protected.
+    """
+    (tmp_path / ".specify").mkdir()
+    payload = {
+        "schema_version": "1.0",
+        "bundles": [
+            {
+                "bundle_id": "a",
+                "version": "1.0.0",
+                "contributed_components": [{"kind": "presets", "id": None}],
+            }
+        ],
+    }
+    records_path(tmp_path).write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(BundlerError, match="missing its 'id'"):
+        load_records(tmp_path)
+
+
+def test_load_records_accepts_explicit_null_installed_at(tmp_path: Path):
+    """``installed_at`` is optional, so a null must become "" — not "None"."""
+    (tmp_path / ".specify").mkdir()
+    payload = {
+        "schema_version": "1.0",
+        "bundles": [
+            {
+                "bundle_id": "a",
+                "version": "1.0.0",
+                "installed_at": None,
+                "contributed_components": [],
+            }
+        ],
+    }
+    records_path(tmp_path).write_text(json.dumps(payload), encoding="utf-8")
+
+    records = load_records(tmp_path)
+    assert records[0].installed_at == ""


### PR DESCRIPTION
## Problem

`InstalledBundleRecord.from_dict` and `_component_from_dict` read the required fields with:

```python
str(data.get("bundle_id", "")).strip()
```

The `""` default covers only a **missing** key. A key that is *present but null* — how a hand-edited or corrupt `.specify/bundle-records.json` spells an empty field — yields `None`, and `str(None)` is the literal `"None"`. That text is non-empty, so it sails straight past the `if not bundle_id:` / `if not version:` / `if not cid:` guards that exist precisely to reject such a file.

## Reproduction on current `main` (bf88c9f9)

```
bundle_id=null -> ACCEPTED: bundle_id='None' version='1.0.0'
version=null   -> ACCEPTED: bundle_id='a'    version='None'
id=null        -> ACCEPTED: components=[('presets', 'None')]
```

The record is accepted as a bundle literally **named `None` at version `None`**, contributing a component whose id is `None`.

That phantom is not inert: it feeds the collateral-protection refcount, so `components_still_needed()` reports `('presets', 'None')` as protected, and `install_bundle()`'s `other_tracked` set will attribute real components to it.

## Fix

Reuse `_text` from the sibling parser in the same package. Its docstring describes this exact trap:

> A `.get(key, "")` default only covers a *missing* key. A key that is present but null — how YAML spells an empty field (`author:` with nothing after it) — yields `None`, and `str(None)` is the literal `"None"`. That text is non-empty, so it sailed past the `if not value` required-field checks…

This is the second half of a hardening sweep that was already applied here in part: the falsy-non-list guards landed in this file as **#3666**, and the explicit-null fix landed for `bundle.yml` as **#3798** — but was never mirrored into `records.py`. Using the shared helper keeps the two parsers from drifting again.

**No breaking change.** Only null-valued inputs behave differently; every string input is byte-identical. `installed_at` is optional, so its null correctly becomes `""` rather than an error — pinned by a test.

## Verification

- **Fail-before / pass-after:** 4 new-vs-baseline failures with the source reverted, all passing with the fix — **5 failed → 1 failed** (that one is a pre-existing Windows symlink test).
- Normal records still load unchanged: `bundle_id='demo' version='1.0.0' comps=[('presets','p1')]`.
- Scoped regression over `tests/unit`: no new failures vs a clean-`main` baseline captured on `bf88c9f9`.
- `uvx ruff@0.15.0 check src tests` → clean

Tests sit beside the existing `test_load_records_rejects_record_missing_bundle_id` / `_missing_version` / `_rejects_component_missing_id`, which cover the missing-key half of the same contract.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*