### PR TITLE
fix(alquimia): render `/speckit-<name>` invocations for the skills-only Alquimia agent

### DIFF
--- a/src/specify_cli/_invocation_style.py
+++ b/src/specify_cli/_invocation_style.py
@@ -18,6 +18,7 @@ ALWAYS_SLASH_AGENTS: frozenset[str] = frozenset({"devin", "droid", "grok", "trae
 CONDITIONAL_SLASH_AGENTS: frozenset[str] = frozenset(
     {
         "agy",
+        "alquimia",
         "bob",
         "claude",
         "copilot",

--- a/tests/integrations/test_integration_alquimia.py
+++ b/tests/integrations/test_integration_alquimia.py
@@ -37,6 +37,36 @@ class TestAlquimiaAIIntegration:
         assert integration.config["requires_cli"] is True
         assert integration.multi_install_safe is True
 
+    def test_is_slash_skills_agent(self):
+        """Alquimia installs `.alquimia/skills/speckit-<name>/SKILL.md`, so the
+        invocation helper must report the hyphenated form when skills are on.
+
+        It was the only `SkillsIntegration` subclass absent from every set in
+        `_invocation_style`, so `is_slash_skills_agent` returned False and the
+        two callers that consult it — `HookExecutor._render_hook_invocation`
+        and `specify init`'s Next Steps panel — emitted the dotted
+        `/speckit.<name>` form Alquimia never registers.
+        """
+        from specify_cli._invocation_style import is_slash_skills_agent
+
+        assert is_slash_skills_agent("alquimia", True) is True
+        # Conditional, not always: with skills disabled the dotted form is
+        # correct, which is what distinguishes this from an ALWAYS_SLASH agent.
+        assert is_slash_skills_agent("alquimia", False) is False
+
+    def test_build_command_invocation_matches_the_invocation_helper(self):
+        """The integration's own renderer and the helper must agree.
+
+        `SkillsIntegration.build_command_invocation` already returned
+        `/speckit-plan`; only the helper disagreed, which is why the two
+        outputs diverged for the same on-disk layout.
+        """
+        from specify_cli._invocation_style import is_slash_skills_agent
+
+        integration = get_integration("alquimia")
+        assert integration.build_command_invocation("plan") == "/speckit-plan"
+        assert is_slash_skills_agent("alquimia", True) is True
+
     def test_build_exec_args_uses_headless_prompt_flag(self):
         """Workflow dispatch relies on the inherited
         ``SkillsIntegration.build_exec_args()`` — pin its argv shape so a

--- a/tests/integrations/test_integration_alquimia.py
+++ b/tests/integrations/test_integration_alquimia.py
@@ -50,9 +50,72 @@ class TestAlquimiaAIIntegration:
         from specify_cli._invocation_style import is_slash_skills_agent
 
         assert is_slash_skills_agent("alquimia", True) is True
-        # Conditional, not always: with skills disabled the dotted form is
-        # correct, which is what distinguishes this from an ALWAYS_SLASH agent.
+        # Conditional, not always -- matching every other skills-only agent.
+        # This is NOT a claim that the dotted form is ever right for Alquimia:
+        # it never is. It is that the `False` argument is unreachable for a
+        # skills-only integration, because `ai_skills` is persisted straight
+        # from `is_skills_mode()`, which `SkillsIntegration` returns
+        # unconditionally. `test_ai_skills_is_always_persisted_for_alquimia`
+        # and `test_classified_like_its_skills_only_peers` pin both halves.
         assert is_slash_skills_agent("alquimia", False) is False
+
+    def test_ai_skills_is_always_persisted_for_alquimia(self):
+        """The conditional resolves to True for every real Alquimia project.
+
+        Both writers of `ai_skills` key off `integration.is_skills_mode(...)`
+        (`commands/init.py` on init, `integrations/_helpers.py` on
+        install/use/upgrade), and `SkillsIntegration.is_skills_mode` returns
+        True unconditionally. So `is_ai_skills_enabled(opts)` is True for any
+        Alquimia project written by any supported path, and the conditional
+        classification behaves exactly like an always-slash one.
+        """
+        integration = get_integration("alquimia")
+        assert integration.is_skills_mode() is True
+        assert integration.is_skills_mode({}, project_root=None) is True
+
+    def test_classified_like_its_skills_only_peers(self):
+        """Alquimia must sit in the same set as the other skills-only agents.
+
+        Being a `SkillsIntegration` does not by itself imply always-slash:
+        `ALWAYS_SLASH_AGENTS` and `CONDITIONAL_SLASH_AGENTS` are *both* full of
+        `SkillsIntegration` subclasses. What the conditional set actually holds
+        is the agents whose skills mode is recorded in init options, which is
+        where Alquimia belongs. Moving it alone to the always set would make it
+        inconsistent with five identical peers for no behavioural gain.
+        """
+        from specify_cli._invocation_style import (
+            ALWAYS_SLASH_AGENTS,
+            CONDITIONAL_SLASH_AGENTS,
+        )
+
+        peers = {"rovodev", "agy", "hermes", "lingma", "vibe"}
+        assert peers <= CONDITIONAL_SLASH_AGENTS
+        assert "alquimia" in CONDITIONAL_SLASH_AGENTS
+        assert "alquimia" not in ALWAYS_SLASH_AGENTS
+
+    def test_never_renders_the_dotted_form_in_either_skills_state(self):
+        """No reachable path may emit `/speckit.<name>` for Alquimia.
+
+        The helper returning False is not the last word: the remaining consumer
+        (`_register_extension_skills`'s command-ref resolution) falls through to
+        `integration.build_command_invocation`, which `SkillsIntegration`
+        overrides to emit the hyphenated skill form. This pins that fallback so
+        the dotted form cannot reappear from that direction either.
+        """
+        from specify_cli._invocation_style import (
+            is_dollar_skills_agent,
+            is_slash_skills_agent,
+        )
+
+        integration = get_integration("alquimia")
+        for skills_enabled in (True, False):
+            if is_dollar_skills_agent("alquimia", skills_enabled):
+                rendered = "$speckit-git-commit"
+            elif is_slash_skills_agent("alquimia", skills_enabled):
+                rendered = "/speckit-git-commit"
+            else:
+                rendered = integration.build_command_invocation("speckit.git.commit")
+            assert rendered == "/speckit-git-commit", skills_enabled
 
     def test_build_command_invocation_matches_the_invocation_helper(self):
         """The integration's own renderer and the helper must agree.

--- a/tests/integrations/test_integration_alquimia.py
+++ b/tests/integrations/test_integration_alquimia.py
@@ -50,13 +50,17 @@ class TestAlquimiaAIIntegration:
         from specify_cli._invocation_style import is_slash_skills_agent
 
         assert is_slash_skills_agent("alquimia", True) is True
-        # Conditional, not always -- matching every other skills-only agent.
+        # Conditional, not always -- matching the other *conditionally
+        # classified* skills-only agents. Being skills-only does not by itself
+        # imply always-slash: Droid, Grok, Trae and Zed are skills-only too and
+        # sit in `ALWAYS_SLASH_AGENTS`.
+        #
         # This is NOT a claim that the dotted form is ever right for Alquimia:
-        # it never is. It is that the `False` argument is unreachable for a
-        # skills-only integration, because `ai_skills` is persisted straight
-        # from `is_skills_mode()`, which `SkillsIntegration` returns
-        # unconditionally. `test_ai_skills_is_always_persisted_for_alquimia`
-        # and `test_classified_like_its_skills_only_peers` pin both halves.
+        # it never is. It records what the function returns. The `False`
+        # argument does not arise in practice because `ai_skills` is persisted
+        # straight from `is_skills_mode()`, which `SkillsIntegration` returns
+        # unconditionally -- see
+        # `test_ai_skills_is_always_persisted_for_alquimia`.
         assert is_slash_skills_agent("alquimia", False) is False
 
     def test_ai_skills_is_always_persisted_for_alquimia(self):
@@ -67,7 +71,12 @@ class TestAlquimiaAIIntegration:
         install/use/upgrade), and `SkillsIntegration.is_skills_mode` returns
         True unconditionally. So `is_ai_skills_enabled(opts)` is True for any
         Alquimia project written by any supported path, and the conditional
-        classification behaves exactly like an always-slash one.
+        classification behaves exactly like an always-slash one *for Alquimia*.
+
+        This is deliberately not offered as a discriminator between the two
+        sets: every `SkillsIntegration` subclass records `ai_skills` the same
+        way, including the always-slash ones, so persistence does not tell the
+        sets apart. It says only that the conditional is satisfied here.
         """
         integration = get_integration("alquimia")
         assert integration.is_skills_mode() is True
@@ -77,11 +86,15 @@ class TestAlquimiaAIIntegration:
         """Alquimia must sit in the same set as the other skills-only agents.
 
         Being a `SkillsIntegration` does not by itself imply always-slash:
-        `ALWAYS_SLASH_AGENTS` and `CONDITIONAL_SLASH_AGENTS` are *both* full of
-        `SkillsIntegration` subclasses. What the conditional set actually holds
-        is the agents whose skills mode is recorded in init options, which is
-        where Alquimia belongs. Moving it alone to the always set would make it
-        inconsistent with five identical peers for no behavioural gain.
+        `ALWAYS_SLASH_AGENTS` (Droid, Grok, Trae, Zed) and
+        `CONDITIONAL_SLASH_AGENTS` are *both* full of `SkillsIntegration`
+        subclasses, and nothing in the code distinguishes them -- the split is
+        a conventional grouping, not a rule the code enforces. For a
+        skills-only integration the two are behaviourally equivalent anyway,
+        since `ai_skills` is always recorded. Alquimia is grouped with the
+        conditionally classified skills-only agents; moving it alone to the
+        always set would split it from five identical peers for no behavioural
+        gain.
         """
         from specify_cli._invocation_style import (
             ALWAYS_SLASH_AGENTS,
@@ -93,29 +106,30 @@ class TestAlquimiaAIIntegration:
         assert "alquimia" in CONDITIONAL_SLASH_AGENTS
         assert "alquimia" not in ALWAYS_SLASH_AGENTS
 
-    def test_never_renders_the_dotted_form_in_either_skills_state(self):
-        """No reachable path may emit `/speckit.<name>` for Alquimia.
+    def test_hook_invocation_renders_the_hyphenated_form(
+        self, tmp_path, monkeypatch
+    ):
+        """The real hook renderer must emit `/speckit-git-commit`.
 
-        The helper returning False is not the last word: the remaining consumer
-        (`_register_extension_skills`'s command-ref resolution) falls through to
-        `integration.build_command_invocation`, which `SkillsIntegration`
-        overrides to emit the hyphenated skill form. This pins that fallback so
-        the dotted form cannot reappear from that direction either.
+        This drives `HookExecutor._render_hook_invocation` -- one of the two
+        production consumers of `is_slash_skills_agent` -- rather than
+        re-deciding the branch in the test. Its non-slash path ends at
+        `return f"/{command_id}"`, so before this change the renderer emitted
+        the dotted `/speckit.git.commit`, a command Alquimia never registers.
         """
-        from specify_cli._invocation_style import (
-            is_dollar_skills_agent,
-            is_slash_skills_agent,
+        import specify_cli
+        from specify_cli.extensions import HookExecutor
+
+        monkeypatch.setattr(
+            specify_cli,
+            "load_init_options",
+            lambda _root: {"ai": "alquimia", "ai_skills": True},
         )
 
-        integration = get_integration("alquimia")
-        for skills_enabled in (True, False):
-            if is_dollar_skills_agent("alquimia", skills_enabled):
-                rendered = "$speckit-git-commit"
-            elif is_slash_skills_agent("alquimia", skills_enabled):
-                rendered = "/speckit-git-commit"
-            else:
-                rendered = integration.build_command_invocation("speckit.git.commit")
-            assert rendered == "/speckit-git-commit", skills_enabled
+        rendered = HookExecutor(tmp_path)._render_hook_invocation("speckit.git.commit")
+
+        assert rendered == "/speckit-git-commit"
+        assert "/speckit." not in rendered
 
     def test_build_command_invocation_matches_the_invocation_helper(self):
         """The integration's own renderer and the helper must agree.


### PR DESCRIPTION
## Problem

`alquimia` is the **only** one of the 19 `SkillsIntegration` subclasses absent from every set in `_invocation_style.py` (`ALWAYS_SLASH_AGENTS` / `CONDITIONAL_SLASH_AGENTS` / `DOLLAR_SKILLS_AGENTS` / `SKILL_COLON_AGENTS`).

I checked that programmatically rather than by eye:

```
SkillsIntegration subclasses NOT in any invocation set: ['alquimia']
total in sets: 18
```

It installs `.alquimia/skills/speckit-<name>/SKILL.md`, and its own inherited `build_command_invocation()` already returns `/speckit-plan`. But `is_slash_skills_agent("alquimia", True)` returned `False`, so the two callers that consult the helper fell through to the dotted form Alquimia never registers:

- `HookExecutor._render_hook_invocation` (`extensions/__init__.py`) → `/speckit.plan`
- `specify init`'s Next Steps panel (`commands/init.py`) → `/speckit.plan`

So the integration's own renderer and the shared helper disagreed for the same on-disk layout.

## Reproduction on current `main` (bf88c9f9)

Real `specify init --here --integration <agent> --script sh --ignore-agent-tools`:

```
BEFORE
  alquimia -> 2.1 /speckit.constitution      <-- wrong
  droid    -> 2.1 /speckit-constitution

AFTER
  alquimia -> 2.1 /speckit-constitution
  droid    -> 2.1 /speckit-constitution
```

Both agents produce an identical `.../skills/speckit-*/SKILL.md` layout, so there is no basis for the difference.

## Which set — a judgment call, stated plainly

I put it in **`CONDITIONAL_SLASH_AGENTS`**, not `ALWAYS_SLASH_AGENTS`, and I want to be explicit that this is a choice rather than something the code forces:

- Every `ALWAYS_SLASH` member has `commands_subdir: "skills"` — but so does `claude`, which is `CONDITIONAL`, so that field is not the discriminator.
- Neither `alquimia` nor `droid` nor `claude` declares an `options()` mode toggle, so that isn't either.
- `specify init` writes `ai_skills: true` for alquimia (verified), so `CONDITIONAL` fixes the real path.

`CONDITIONAL` is the conservative option: it renders the hyphenated form only when skills are actually enabled, so it stays correct if alquimia ever gains a commands mode. If you'd rather it be `ALWAYS` alongside the other skills-only agents, that's a one-word change and I'm happy to make it.

## Note on scope

The third consumer, `_resolve_command_ref_tokens`, already falls back to `integration.build_command_invocation()` and was therefore always correct — this changes nothing there.

## Verification

- **Fail-before / pass-after:** 2 new-vs-baseline failures with the source reverted → **38 passed** with the fix.
- After the change, no `SkillsIntegration` subclass is unmapped: `SkillsIntegration subclasses still missing: NONE`.
- Scoped regression over `tests/integrations`: no new failures vs a clean-`main` baseline captured on `bf88c9f9` (18 pre-existing in scope, all Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

Tests mirror `test_integration_droid.py::TestDroidIntegration::test_is_slash_skills_agent`, including the disabled case that distinguishes conditional from always.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*