### PR TITLE
fix(powershell): stop `create-new-feature.ps1` crashing on a description with no ASCII words

### DIFF
--- a/scripts/powershell/create-new-feature.ps1
+++ b/scripts/powershell/create-new-feature.ps1
@@ -162,7 +162,14 @@ function Get-BranchName {
     } else {
         # Fallback to original logic if no meaningful words found
         $result = ConvertTo-CleanBranchName -Name $Description
-        $fallbackWords = ($result -split '-') | Where-Object { $_ } | Select-Object -First 3
+        # @() keeps this an array. ConvertTo-CleanBranchName blanks every
+        # non-[a-z0-9] character, so a description written in a non-Latin script
+        # (or made only of punctuation) leaves nothing for the pipeline to
+        # emit -- it yields $null, and [string]::Join on $null throws
+        # ArgumentNullException. With $ErrorActionPreference = 'Stop' that is
+        # terminating, so the script died with a .NET stack trace and exit 1
+        # where the bash and Python twins both return an empty suffix.
+        $fallbackWords = @(($result -split '-') | Where-Object { $_ } | Select-Object -First 3)
         return [string]::Join('-', $fallbackWords)
     }
 }

--- a/tests/test_create_new_feature_python_parity.py
+++ b/tests/test_create_new_feature_python_parity.py
@@ -1065,3 +1065,56 @@ def test_all_variants_corrected_prefix_skips_timestamp_collision(repo: Path) -> 
     assert json_stdout(py)["FEATURE_NUM"] == "20260320"
     for result in (bash, ps, py):
         assert "using 20260320 instead" in result.stderr
+
+
+@pytest.mark.skipif(not HAS_POWERSHELL, reason="no PowerShell available")
+@pytest.mark.parametrize(
+    "description",
+    ["!!! ??? ***", "добавить", "添加用户"],
+    ids=["punctuation_only", "cyrillic", "han"],
+)
+def test_powershell_survives_description_with_no_ascii_words(
+    tmp_path: Path, description: str
+):
+    """A description with no [a-z0-9] characters must not crash the PS twin.
+
+    ``ConvertTo-CleanBranchName`` blanks every non-ASCII character, so the
+    fallback pipeline yields nothing and ``[string]::Join`` received ``$null``
+    — an ArgumentNullException, made terminating by
+    ``$ErrorActionPreference = 'Stop'``. The script died with a .NET stack
+    trace and exit 1 where the bash and Python twins both return an empty
+    suffix. This fires for any feature phrased in a non-Latin script.
+    """
+    repo = _setup_repo(tmp_path)
+
+    ps = run(ps_cmd(repo, SCRIPT, "-Json", "-DryRun", description), repo)
+
+    assert ps.returncode == 0, ps.stderr
+    assert "ArgumentNullException" not in ps.stderr
+    assert "Join" not in ps.stderr
+    assert json_stdout(ps)["BRANCH_NAME"] == "001-"
+
+
+@requires_bash
+@pytest.mark.skipif(not HAS_POWERSHELL, reason="no PowerShell available")
+def test_no_ascii_word_description_matches_across_twins(tmp_path: Path):
+    """All three twins agree on the branch name for such a description."""
+    description = "добавить"
+
+    bash_repo = _setup_repo(tmp_path, "b")
+    py_repo = _setup_repo(tmp_path, "p")
+    ps_repo = _setup_repo(tmp_path, "s")
+
+    bash = run(bash_cmd(bash_repo, SCRIPT, "--json", "--dry-run", description), bash_repo)
+    py = run(py_cmd(py_repo, SCRIPT, "--json", "--dry-run", description), py_repo)
+    ps = run(ps_cmd(ps_repo, SCRIPT, "-Json", "-DryRun", description), ps_repo)
+
+    assert bash.returncode == py.returncode == ps.returncode == 0, (
+        bash.stderr, py.stderr, ps.stderr,
+    )
+    names = {
+        json_stdout(bash)["BRANCH_NAME"],
+        json_stdout(py)["BRANCH_NAME"],
+        json_stdout(ps)["BRANCH_NAME"],
+    }
+    assert names == {"001-"}, names


### PR DESCRIPTION
## Problem

`Get-BranchName`'s fallback branch assumes the pipeline yields at least one element:

```powershell
$result = ConvertTo-CleanBranchName -Name $Description
$fallbackWords = ($result -split '-') | Where-Object { $_ } | Select-Object -First 3
return [string]::Join('-', $fallbackWords)
```

`ConvertTo-CleanBranchName` does `$Description.ToLower() -replace '[^a-z0-9\s]', ' '`, which blanks **every non-ASCII character**. So a description written in any non-Latin script leaves nothing for the pipeline to emit:

- the pipeline yields nothing → `$fallbackWords` is `$null`
- `[string]::Join('-', $null)` throws `ArgumentNullException`
- `$ErrorActionPreference = 'Stop'` makes it **terminating**

The script dies with a .NET stack trace, empty stdout, exit 1.

## Reproduction on current `main` (bf88c9f9)

All three twins installed into one project, same args, same cwd:

```
desc = 'добавить авторизацию'
  bash rc=0  BRANCH_NAME='001-'
  py   rc=0  BRANCH_NAME='001-'
  ps   rc=1  Exception calling "Join" with "2" argument(s):
             "Value cannot be null. Parameter name: values"
```

Identical for `添加用户认证` and `'!!! ??? ***'`. The bash and Python twins both return an empty suffix and succeed.

**This hits every PowerShell user who phrases a feature in their own language** — Cyrillic, Han, Kana, Arabic, Greek, Hebrew — plus punctuation-only and accent-only descriptions.

## Fix

Wrap the pipeline in `@()` so it stays an array. Verified at the primitive level:

```
unwrapped, empty result: type=NULL       Join -> THROWS MethodInvocationException
wrapped   with @():      type=Object[]   Join -> ''        (count=0)
normal case 'a-to-the-of':               Join -> 'a-to-the'   (unchanged)
```

After the fix, the same three descriptions:

```
  rc=0  {"BRANCH_NAME":"001-", ...}      x3
  rc=0  {"BRANCH_NAME":"001-user-authentication", ...}   (normal case unchanged)
```

**No breaking change.** The only inputs whose behaviour changes are ones that today raise and exit 1. The file stays **ASCII-only** (verified 0 non-ASCII bytes) so `tests/test_ps1_encoding.py::test_ps1_file_is_ascii_only` still passes.

## Verification

- **Fail-before / pass-after:** 3 new-vs-baseline failures with the source reverted → **10 passed, 44 skipped** with the fix.
- Two tests added: a parametrized PS-only crash guard (punctuation / Cyrillic / Han), and a three-way parity test asserting bash, Python and PowerShell all produce `001-` for the same input.
- Scoped regression: no new failures vs a clean-`main` baseline captured on `bf88c9f9`.
- `uvx ruff@0.15.0 check src tests` → clean

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main` with real `powershell.exe`.*