### PR TITLE
fix(bundler): re-read the step registry when rolling back a failed step refresh

### DIFF
--- a/src/specify_cli/bundler/services/primitives.py
+++ b/src/specify_cli/bundler/services/primitives.py
@@ -442,7 +442,16 @@ class _StepKindManager:
 
                 current = StepRegistry(self._root)
                 if metadata is not None and not current.is_installed(component.id):
-                    current.add(component.id, metadata)
+                    # Restore the saved entry verbatim rather than via ``add()``,
+                    # which would rewrite the metadata it is meant to roll back:
+                    # this registry is freshly constructed *after*
+                    # ``self.remove()`` deleted the entry, so ``add()`` sees no
+                    # existing record and stamps ``installed_at`` with
+                    # ``datetime.now()`` (it also overwrites ``updated_at``
+                    # unconditionally). ``workflow_step_remove`` bypasses
+                    # ``add()`` for exactly this reason.
+                    current.data["steps"][component.id] = metadata
+                    current.save()
                 raise
         finally:
             shutil.rmtree(backup_dir.parent, ignore_errors=True)

--- a/src/specify_cli/bundler/services/primitives.py
+++ b/src/specify_cli/bundler/services/primitives.py
@@ -428,8 +428,21 @@ class _StepKindManager:
             except BundlerError:
                 if backup_dir.exists():
                     shutil.copytree(backup_dir, step_dir, dirs_exist_ok=True)
-                if metadata is not None and not self._registry.is_installed(component.id):
-                    self._registry.add(component.id, metadata)
+                # Re-read the registry: ``StepRegistry`` snapshots the file once
+                # in ``__init__`` (``self.data = self._load()``) and
+                # ``is_installed`` only consults that snapshot. ``self.remove()``
+                # above has already deleted the entry from disk, but
+                # ``self._registry``'s snapshot still contains it -- so the
+                # guard was always False here and the restore never ran, in
+                # exactly the failure case it was written for. The step package
+                # came back but stayed unregistered: ``workflow step list``
+                # stopped showing it and ``workflow step add`` then refused with
+                # "Step directory already exists".
+                from ...workflows.catalog import StepRegistry
+
+                current = StepRegistry(self._root)
+                if metadata is not None and not current.is_installed(component.id):
+                    current.add(component.id, metadata)
                 raise
         finally:
             shutil.rmtree(backup_dir.parent, ignore_errors=True)

--- a/tests/unit/test_bundler_primitives.py
+++ b/tests/unit/test_bundler_primitives.py
@@ -334,3 +334,65 @@ def _plan(manifest):
         effective_integration=None,
         components=components,
     )
+
+
+def test_step_refresh_restores_registry_entry_when_reinstall_fails(
+    tmp_path: Path, monkeypatch
+):
+    """A failed step refresh must leave the registry entry restored.
+
+    ``refresh`` keeps a backup and restores it "if the remove+reinstall path
+    fails", but the registry half of that rollback was unreachable:
+    ``StepRegistry`` snapshots the file once in ``__init__`` and
+    ``is_installed`` reads only that snapshot, so after ``self.remove()``
+    deleted the entry from disk the stale snapshot still reported it as
+    installed and ``not ...is_installed(...)`` was always False.
+
+    The step package came back but stayed unregistered — ``workflow step
+    list`` stopped showing it, and ``workflow step add`` then refused with
+    "Step directory already exists".
+    """
+    import json
+
+    import specify_cli
+    from specify_cli.workflows.catalog import StepRegistry
+
+    steps_dir = tmp_path / ".specify" / "workflows" / "steps"
+    (steps_dir / "my-step").mkdir(parents=True)
+    (steps_dir / "my-step" / "step.yml").write_text(
+        "step:\n  type_key: my-step\n", encoding="utf-8"
+    )
+    (steps_dir / "my-step" / "__init__.py").write_text("", encoding="utf-8")
+    (steps_dir / StepRegistry.REGISTRY_FILE).write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "steps": {
+                    "my-step": {
+                        "name": "My Step",
+                        "version": "1.0.0",
+                        "type_key": "my-step",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert StepRegistry(tmp_path).is_installed("my-step")
+
+    # Removal succeeds (real code path); only the re-install fails, which is
+    # what a catalog 404 / size-limit / type_key mismatch produces.
+    def _boom(step_id, *args, **kwargs):
+        raise BundlerError(f"Failed to install step '{step_id}'.")
+
+    monkeypatch.setattr(specify_cli, "workflow_step_add", _boom)
+
+    manager = primitive_manager("steps", tmp_path, allow_network=True)
+    with pytest.raises(BundlerError):
+        manager.refresh(_component("steps", "my-step"))
+
+    # Read the registry fresh from disk — the point of the fix.
+    assert StepRegistry(tmp_path).is_installed("my-step"), (
+        steps_dir / StepRegistry.REGISTRY_FILE
+    ).read_text(encoding="utf-8")

--- a/tests/unit/test_bundler_primitives.py
+++ b/tests/unit/test_bundler_primitives.py
@@ -372,6 +372,11 @@ def test_step_refresh_restores_registry_entry_when_reinstall_fails(
                         "name": "My Step",
                         "version": "1.0.0",
                         "type_key": "my-step",
+                        # Distinctive past timestamps: a rollback must put the
+                        # entry back verbatim, and ``StepRegistry.add()`` would
+                        # silently replace both of these with ``now``.
+                        "installed_at": "2020-01-01T00:00:00+00:00",
+                        "updated_at": "2020-02-02T00:00:00+00:00",
                     }
                 },
             }
@@ -379,6 +384,7 @@ def test_step_refresh_restores_registry_entry_when_reinstall_fails(
         encoding="utf-8",
     )
 
+    seeded = StepRegistry(tmp_path).get("my-step")
     assert StepRegistry(tmp_path).is_installed("my-step")
 
     # Removal succeeds (real code path); only the re-install fails, which is
@@ -393,6 +399,10 @@ def test_step_refresh_restores_registry_entry_when_reinstall_fails(
         manager.refresh(_component("steps", "my-step"))
 
     # Read the registry fresh from disk — the point of the fix.
-    assert StepRegistry(tmp_path).is_installed("my-step"), (
+    restored = StepRegistry(tmp_path)
+    assert restored.is_installed("my-step"), (
         steps_dir / StepRegistry.REGISTRY_FILE
     ).read_text(encoding="utf-8")
+    # A rollback must be a rollback: the entry comes back byte-for-byte, not
+    # re-registered with fresh ``installed_at`` / ``updated_at`` stamps.
+    assert restored.get("my-step") == seeded


### PR DESCRIPTION
## Problem

`_StepKindManager.refresh` documents its own contract:

> Preserve an existing step until we've validated we can perform refresh. For already-installed steps, keep a backup and restore it if the remove+reinstall path fails.

The package half of that rollback works. The **registry** half is dead code:

```python
except BundlerError:
    if backup_dir.exists():
        shutil.copytree(backup_dir, step_dir, dirs_exist_ok=True)
    if metadata is not None and not self._registry.is_installed(component.id):
        self._registry.add(component.id, metadata)
    raise
```

`StepRegistry.__init__` snapshots the file **once** (`self.data = self._load()`) and `is_installed` reads only that snapshot.

## Reproduction on current `main` (bf88c9f9)

```
snapshot at construction:            is_installed('my-step') = True
after the entry is deleted on disk:  same object             = True   <-- stale
a fresh StepRegistry reads truth:                            = False
```

By the time the rollback runs, `self.remove(component)` has already deleted the entry from disk via `workflow_step_remove` — but `self._registry`'s snapshot still contains it. So `not self._registry.is_installed(...)` is **always False**, and the restore never executes, in precisely the failure case it exists for.

## Why it matters

After a failed `specify bundle update`, the user is left in a broken half-state: the step package is back on disk but **unregistered**.

- `specify workflow step list` no longer shows it
- the workflow engine cannot resolve the step type
- a later `specify workflow step add <id>` refuses with *"Step directory already exists"*

…leaving them to clean up by hand.

## Fix

Read the registry fresh at rollback time, so `is_installed` reflects what `remove()` actually did. The lazy import matches this class's own style — `__init__` imports `StepRegistry` the same way.

**No breaking change.** Nothing on any success path is touched; only the already-failing rollback branch changes, and it changes from silently doing nothing to doing what it says.

## Verification

- **Fail-before / pass-after:** the new test fails on unpatched `src` (`assert StepRegistry(tmp_path).is_installed("my-step")` with the on-disk registry showing `"steps": {}`) and passes with the fix — **1 failed → 21 passed**.
- The test exercises the real removal path and fails only the re-install, which is what a catalog 404 / size-limit / `type_key` mismatch produces.
- Scoped regression over `tests/unit`: no new failures vs a clean-`main` baseline captured on `bf88c9f9`.
- `uvx ruff@0.15.0 check src tests` → clean

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*