### PR TITLE
fix(workflows): require a `cases` block on switch steps

### DIFF
--- a/src/specify_cli/workflows/steps/switch/__init__.py
+++ b/src/specify_cli/workflows/steps/switch/__init__.py
@@ -96,6 +96,19 @@ class SwitchStep(StepBase):
                 f"Switch step {config.get('id', '?')!r} is missing "
                 f"'expression' field."
             )
+        # Every other control-flow step requires its branch payload: ``if``
+        # requires ``then``, ``fan-out`` requires ``items`` and ``step``,
+        # ``fan-in`` a non-empty ``wait_for``, ``gate`` a ``message``. Without
+        # the same check, a switch whose ``cases:`` block is missing or mistyped
+        # (``case:`` is the obvious slip) validates clean and then reports
+        # COMPLETED with ``matched_case: "__default__"`` -- a default it may not
+        # even declare -- having dispatched nothing. That is the "silent empty
+        # result + COMPLETED" wiring bug the fan-in guard exists to prevent.
+        if "cases" not in config:
+            errors.append(
+                f"Switch step {config.get('id', '?')!r} is missing "
+                f"'cases' field."
+            )
         cases = config.get("cases", {})
         if not isinstance(cases, dict):
             errors.append(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3309,6 +3309,38 @@ class TestSwitchStep:
         errors = step.validate({"id": "test", "cases": {}})
         assert any("missing 'expression'" in e for e in errors)
 
+    def test_validate_missing_cases(self):
+        """`cases` is the switch's branch payload and must be required.
+
+        Every other control-flow step requires its own: `if` requires `then`,
+        `fan-out` requires `items` and `step`, `fan-in` a non-empty `wait_for`,
+        `gate` a `message`. Without it, a `case:` typo validated clean and then
+        reported COMPLETED with `matched_case: "__default__"` having dispatched
+        nothing.
+        """
+        from specify_cli.workflows.steps.switch import SwitchStep
+
+        step = SwitchStep()
+
+        # Absent entirely.
+        errors = step.validate({"id": "route", "expression": "{{ inputs.x }}"})
+        assert any("missing 'cases'" in e for e in errors), errors
+
+        # The realistic slip: `case:` instead of `cases:`.
+        errors = step.validate(
+            {"id": "route", "expression": "{{ inputs.x }}", "case": {"a": []}}
+        )
+        assert any("missing 'cases'" in e for e in errors), errors
+
+    def test_validate_accepts_an_empty_cases_mapping(self):
+        """An explicitly declared but empty `cases:` is still a declaration."""
+        from specify_cli.workflows.steps.switch import SwitchStep
+
+        errors = SwitchStep().validate(
+            {"id": "route", "expression": "{{ inputs.x }}", "cases": {}}
+        )
+        assert not any("missing 'cases'" in e for e in errors), errors
+
     def test_validate_invalid_cases_and_default(self):
         from specify_cli.workflows.steps.switch import SwitchStep
 


### PR DESCRIPTION
## Problem

`SwitchStep.validate` requires `expression` and type-checks `cases`/`default`, but never checks that `cases` is **present**. It is the only control-flow step whose branch payload is optional:

| step | required branch payload |
|---|---|
| `if` | `then` |
| `fan-out` | `items` **and** `step` |
| `fan-in` | non-empty `wait_for` |
| `gate` | `message` |
| `while` / `do-while` | `condition` |
| **`switch`** | **— none —** |

## Reproduction on current `main` (bf88c9f9)

```
sibling contrast:
  if   missing then : ["If step 'x' is missing 'then' field."]
  fanout missing all: ["Fan-out step 'y' is missing 'items' field.",
                       "Fan-out step 'y' is missing 'step' field ..."]

switch:
  typo `case:` not `cases:` -> []          <-- validates clean
  no cases key at all       -> []          <-- validates clean

  execute -> status=completed matched='__default__' next=[]
```

So a `case:`/`cases:` typo passes `specify workflow validate` with zero errors, then at run time reports **COMPLETED** with `matched_case: "__default__"` — a default it does not even declare — having dispatched nothing. The whole run reports success while the branch never executed.

That is precisely the "silent empty result + COMPLETED" wiring bug the fan-in `wait_for` guard and the engine's fan-in check exist to prevent.

## Fix

One presence check, mirroring the sibling steps' wording.

**Narrow.** An explicitly declared but empty `cases: {}` is still a declaration and stays valid — pinned by `test_validate_accepts_an_empty_cases_mapping`. Only configs that never declared the block at all become errors, and those already do nothing at run time.

## Verification

- **Fail-before / pass-after** on a targeted scope (`-k "Switch or validate or Validat"`): **1 failed → 202 passed**.
- `tests/workflows` → 171 passed, 10 failed, matching the clean-`main` baseline exactly.
- `uvx ruff@0.15.0 check src tests` → clean
- Tests go into the **existing** `TestSwitchStep` class, next to `test_validate_missing_expression`.

**A note on the full-file run.** `tests/test_workflows.py` is intermittently flaky on Windows — a rotating handful of tests (`TestFanOutConcurrency`, `TestContextWorkflowDir`, `TestContinueOnError`, `TestWorkflowRunExitCodes`) fail on different runs and pass in isolation, from `os.replace PermissionError`. I confirmed this is unrelated to this change: `test_sequential_and_concurrent_agree` fails **2 of 4 runs on clean `main`** and passes 4/4 with this patch applied, and the two other flagged tests pass in isolation. Hence the targeted verification above.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*