### PR TITLE
fix(rovodev): guard non-string prompt names when merging `prompts.yml`

### DIFF
--- a/src/specify_cli/integrations/rovodev/__init__.py
+++ b/src/specify_cli/integrations/rovodev/__init__.py
@@ -179,6 +179,17 @@ class RovodevIntegration(SkillsIntegration):
 
         for entry in existing:
             name = entry.get("name", "")
+            # ``prompts.yml`` is user-editable, and ``_read_prompts_yml`` only
+            # filters at the entry level -- it never validates the entry's
+            # ``name``. A YAML sequence or mapping there is unhashable, so this
+            # dict-membership test raised a raw ``TypeError`` out of ``setup()``
+            # and aborted every ``specify init`` / ``integration install`` for
+            # rovodev on that project, leaving prompts.yml unwritten. A
+            # non-string name can never match a generated entry, so treat it
+            # like any other unmatched entry and preserve it verbatim.
+            if not isinstance(name, str):
+                merged.append(entry)
+                continue
             if name in generated_by_name:
                 merged.append(generated_by_name[name])
                 seen.add(name)

--- a/tests/integrations/test_integration_rovodev.py
+++ b/tests/integrations/test_integration_rovodev.py
@@ -155,6 +155,45 @@ class TestRovodevIntegration:
                 f"{prompt_file} has unexpected wrapper format"
             )
 
+    @pytest.mark.parametrize(
+        "bad_name",
+        [["speckit-plan", "speckit-tasks"], {"a": 1}],
+        ids=["sequence", "mapping"],
+    )
+    def test_prompts_manifest_merge_tolerates_non_scalar_name(
+        self, tmp_path, bad_name
+    ):
+        """An unhashable `name` in a user-edited prompts.yml must not crash setup.
+
+        `_read_prompts_yml` only filters at the entry level, never validating
+        the entry's `name`, so a YAML sequence or mapping there reached a dict
+        membership test and raised a raw `TypeError: unhashable type` out of
+        `setup()` — aborting every `specify init` / `integration install` for
+        rovodev on that project and leaving prompts.yml unwritten.
+        """
+        impl = get_integration(self.KEY)
+        manifest = IntegrationManifest(self.KEY, tmp_path)
+
+        prompts_manifest = tmp_path / ".rovodev" / "prompts.yml"
+        prompts_manifest.parent.mkdir(parents=True, exist_ok=True)
+        prompts_manifest.write_text(
+            yaml.safe_dump(
+                {"prompts": [{"name": bad_name, "content_file": "prompts/x.md"}]}
+            ),
+            encoding="utf-8",
+        )
+
+        impl.setup(tmp_path, manifest, script_type="sh")
+
+        data = yaml.safe_load(prompts_manifest.read_text(encoding="utf-8"))
+        names = [entry.get("name") for entry in data["prompts"]]
+        # The malformed user entry is preserved verbatim...
+        assert bad_name in names, names
+        # ...and the generated entries were still written.
+        assert any(
+            isinstance(n, str) and n.startswith("speckit-") for n in names
+        ), names
+
     def test_prompts_manifest_merge_preserves_user_entries(self, tmp_path):
         impl = get_integration(self.KEY)
         manifest = IntegrationManifest(self.KEY, tmp_path)


### PR DESCRIPTION
## Problem

`RovodevIntegration._read_prompts_yml` documents its contract:

> Returns an empty list if the file is missing, malformed, or contains no valid prompt entries.

But it filters only at the **entry** level (`isinstance(item, dict)`) — it never validates the entry's `name`. `_merge_prompt_entries` then does:

```python
name = entry.get("name", "")
if name in generated_by_name:      # <-- dict membership test
```

`.rovodev/prompts.yml` is user-editable, so a YAML sequence or mapping `name` reaches that unhashable-key lookup.

## Reproduction on current `main` (bf88c9f9)

```
name=list     -> TypeError: unhashable type: 'list'
name=mapping  -> TypeError: unhashable type: 'dict'
name=int      -> OK
name=null     -> OK
```

Only the unhashable shapes crash — the classic gap this repo's shape-guard vein targets.

The failure escapes `setup()` as a **raw traceback**, so every `specify init`, `integration install` and `integration upgrade` for rovodev on that project aborts, and the user's `prompts.yml` is never rewritten.

## Fix

A non-string name can never match a generated entry, so treat it like any other unmatched entry and preserve it verbatim:

```python
if not isinstance(name, str):
    merged.append(entry)
    continue
```

Verified all shapes now succeed with the user's entry intact:

```
name=list          -> OK   user entry preserved=True  total=11
name=mapping       -> OK   user entry preserved=True  total=11
name=int           -> OK   user entry preserved=True  total=11
name=null          -> OK   user entry preserved=True  total=11
name=matching str  -> OK   user entry preserved=True  total=10   <-- still merges
```

**No breaking change.** A string `name` takes the identical replace-in-place path (the matching case still collapses to 10 entries rather than 11). The only inputs whose behaviour changes are ones that previously crashed.

## Verification

- **Fail-before / pass-after:** 2 new-vs-baseline failures with the source reverted → **16 passed** with the fix.
- Parametrized over both unhashable shapes (sequence, mapping).
- Scoped regression over `tests/integrations`: no new failures vs a clean-`main` baseline captured on `bf88c9f9` (18 pre-existing, Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*