### PR TITLE
fix(workflows): keep non-ASCII text readable in written overlay files

### DIFF
--- a/src/specify_cli/workflows/overlays/_commands.py
+++ b/src/specify_cli/workflows/overlays/_commands.py
@@ -214,7 +214,15 @@ def workflow_overlay_add(
         existed_before = target_path.exists()
         staged = _stage_workflow_file(target_path.parent)
         try:
-            staged.write_bytes(yaml.safe_dump(data, sort_keys=False).encode("utf-8"))
+            # ``allow_unicode=True`` matches every other YAML writer in the
+            # repo. Without it every non-ASCII character in a hand-authored
+            # overlay is rewritten as a ``\uXXXX`` escape, so merely toggling
+            # an overlay makes the user's own file unreadable.
+            staged.write_bytes(
+                yaml.safe_dump(data, sort_keys=False, allow_unicode=True).encode(
+                    "utf-8"
+                )
+            )
             backup = _commit_workflow_file(staged, target_path, existed_before)
         except BaseException:
             _safe_discard_staged_workflow_file(
@@ -267,7 +275,15 @@ def _update_overlay_field(
         existed_before = path.exists()
         staged = _stage_workflow_file(path.parent)
         try:
-            staged.write_bytes(yaml.safe_dump(data, sort_keys=False).encode("utf-8"))
+            # ``allow_unicode=True`` matches every other YAML writer in the
+            # repo. Without it every non-ASCII character in a hand-authored
+            # overlay is rewritten as a ``\uXXXX`` escape, so merely toggling
+            # an overlay makes the user's own file unreadable.
+            staged.write_bytes(
+                yaml.safe_dump(data, sort_keys=False, allow_unicode=True).encode(
+                    "utf-8"
+                )
+            )
             backup = _commit_workflow_file(staged, path, existed_before)
         except BaseException:
             _safe_discard_staged_workflow_file(staged, path.parent, existed_before)

--- a/tests/workflows/test_overlay_commands.py
+++ b/tests/workflows/test_overlay_commands.py
@@ -220,6 +220,115 @@ class TestOverlayCli:
         assert result.exit_code == 1
         assert "must be >= 1" in result.output
 
+    def test_overlay_add_keeps_non_ascii_text_readable(
+        self, project_dir, monkeypatch
+    ):
+        """``overlay add`` must not escape non-ASCII text in the written file.
+
+        Overlay files are documented as hand-authored, so writing them back
+        with ``\\uXXXX`` escapes makes the user's own file unreadable.
+        """
+        monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)
+        _write_workflow(
+            project_dir,
+            "wf",
+            {
+                "schema_version": "1.0",
+                "workflow": {"id": "wf", "name": "WF", "version": "1.0.0"},
+                "steps": [{"id": "a", "type": "command", "command": "echo"}],
+            },
+        )
+        message = "Revisar el plan — ¿aprobar? 日本語"
+        overlay_file = project_dir / "overlay.yml"
+        overlay_file.write_text(
+            yaml.safe_dump(
+                {
+                    "id": "ov1",
+                    "extends": "wf",
+                    "priority": 10,
+                    "edits": [
+                        {
+                            "operation": "replace",
+                            "anchor": "a",
+                            "step": {
+                                "id": "a",
+                                "type": "gate",
+                                "message": message,
+                                "options": ["approve"],
+                            },
+                        }
+                    ],
+                },
+                allow_unicode=True,
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(app, ["workflow", "overlay", "add", str(overlay_file)])
+        assert result.exit_code == 0, result.output
+
+        installed = (
+            project_dir / ".specify" / "workflows" / "overlays" / "wf" / "ov1.yml"
+        )
+        text = installed.read_text(encoding="utf-8")
+        assert message in text, text
+        assert "\\u" not in text and "\\x" not in text, text
+        # The value must still round-trip identically.
+        data = yaml.safe_load(text)
+        assert data["edits"][0]["step"]["message"] == message
+
+    def test_overlay_set_priority_keeps_non_ascii_text_readable(
+        self, project_dir, monkeypatch
+    ):
+        """Toggling an overlay must not mangle non-ASCII text already in it."""
+        monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)
+        _write_workflow(
+            project_dir,
+            "wf",
+            {
+                "schema_version": "1.0",
+                "workflow": {"id": "wf", "name": "WF", "version": "1.0.0"},
+                "steps": [{"id": "a", "type": "command", "command": "echo"}],
+            },
+        )
+        message = "Revisar el plan — ¿aprobar? 日本語"
+        _write_overlay(
+            project_dir,
+            "wf",
+            "ov1",
+            {
+                "id": "ov1",
+                "extends": "wf",
+                "priority": 10,
+                "edits": [
+                    {
+                        "operation": "replace",
+                        "anchor": "a",
+                        "step": {
+                            "id": "a",
+                            "type": "gate",
+                            "message": message,
+                            "options": ["approve"],
+                        },
+                    }
+                ],
+            },
+        )
+
+        result = runner.invoke(
+            app, ["workflow", "overlay", "set-priority", "wf", "ov1", "20"]
+        )
+        assert result.exit_code == 0, result.output
+
+        text = (
+            project_dir / ".specify" / "workflows" / "overlays" / "wf" / "ov1.yml"
+        ).read_text(encoding="utf-8")
+        assert message in text, text
+        assert "\\u" not in text and "\\x" not in text, text
+        data = yaml.safe_load(text)
+        assert data["priority"] == 20
+        assert data["edits"][0]["step"]["message"] == message
+
     def test_overlay_set_priority(self, project_dir, monkeypatch):
         monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)
         _write_workflow(


### PR DESCRIPTION
## Problem

Both overlay writers in `overlays/_commands.py` (lines 217 and 270 — the only two `yaml.safe_dump` calls in the module) omit `allow_unicode=True`:

```python
staged.write_bytes(yaml.safe_dump(data, sort_keys=False).encode("utf-8"))
```

So every non-ASCII character in a user's overlay is rewritten as a `\uXXXX` / `\xNN` escape inside a double-quoted scalar.

Every other YAML writer in the repo already passes `allow_unicode=True`:

```
src/specify_cli/agents.py:163
src/specify_cli/bundler/lib/yamlio.py:91
src/specify_cli/extensions/_commands.py:530, 568
src/specify_cli/extensions/__init__.py:4800
src/specify_cli/integrations/base.py:69, 1429, 1440
```

## Why it matters

Overlay files are explicitly **hand-authored and hand-edited** — `docs/reference/workflows.md` documents the file format and tells users to write these files. `overlay add`, `enable`, `disable` and `set-priority` all round-trip the file through `safe_dump`, so merely *toggling* an overlay mangles a UTF-8 file the user wrote by hand.

## Reproduction on current `main`

Source overlay written in UTF-8 with `message: "Revisar el plan — ¿aprobar? 日本語"`, then `specify workflow overlay add overlay.yml`:

```yaml
id: revisar
extends: wf
priority: 10
edits:
- replace: a
  step:
    id: a
    type: gate
    message: "Revisar el plan — \xBFaprobar? 日本語"
    options:
    - approve
```

The value still parses back identically, so this is **not corruption** — it is the loss of a documented, hand-edited file's legibility, the same thing `allow_unicode=True` is already there to prevent everywhere else.

## Verification

- **Fail-before / pass-after:** 2 new-vs-baseline failures with the source reverted → **25 passed** with the fix.
- One test per writer: `overlay add` (the install path) and `overlay set-priority` (the `_update_overlay_field` round-trip path).
- Each asserts both that the text survives readable **and** that it still round-trips to the identical value through `yaml.safe_load`.
- Scoped regression over `tests/workflows`: no new failures vs a clean-`main` baseline (10 pre-existing, Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

**No breaking change.** `allow_unicode` only affects how characters are *encoded* in the output; the parsed value is byte-identical either way (both new tests assert this explicitly), and files are already written as UTF-8 via `.encode("utf-8")`. Pure-ASCII overlays — the overwhelming majority — produce identical bytes.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*