### PR TITLE
fix(workflows): require a `steps` body on while and do-while loops

### DIFF
--- a/src/specify_cli/workflows/steps/do_while/__init__.py
+++ b/src/specify_cli/workflows/steps/do_while/__init__.py
@@ -98,6 +98,14 @@ class DoWhileStep(StepBase):
                     f"Do-while step {config.get('id', '?')!r}: "
                     f"'max_iterations' must be an integer >= 1."
                 )
+        if "steps" not in config:
+            # This step's own docstring promises "The first invocation always
+            # returns the nested steps for execution" -- with no body it
+            # validated clean and then returned none, so the loop never ran even
+            # once. See the matching guard in the ``while`` step.
+            errors.append(
+                f"Do-while step {config.get('id', '?')!r} is missing 'steps' field."
+            )
         nested = config.get("steps", [])
         if not isinstance(nested, list):
             errors.append(

--- a/src/specify_cli/workflows/steps/while_loop/__init__.py
+++ b/src/specify_cli/workflows/steps/while_loop/__init__.py
@@ -107,6 +107,18 @@ class WhileStep(StepBase):
                     f"While step {config.get('id', '?')!r}: "
                     f"'max_iterations' must be an integer >= 1."
                 )
+        if "steps" not in config:
+            # A loop with no body is never what the author meant, but it used to
+            # validate clean and then report COMPLETED at run time while
+            # returning no next_steps -- so the engine's ``if result.next_steps:``
+            # block never fired and the loop the workflow is built around never
+            # ran once. The mistype is easy: fan-out's payload key is the
+            # singular ``step:``, so writing ``step:`` on a ``while`` produced a
+            # silent no-op. ``if`` already requires ``then`` and fan-out already
+            # requires both ``items`` and ``step``; require a body here too.
+            errors.append(
+                f"While step {config.get('id', '?')!r} is missing 'steps' field."
+            )
         nested = config.get("steps", [])
         if not isinstance(nested, list):
             errors.append(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3411,6 +3411,33 @@ class TestWhileStep:
         assert any("missing 'condition'" in e for e in errors)
         # max_iterations is optional (defaults to 10)
 
+    def test_validate_requires_steps_body(self):
+        """A while loop with no body must be rejected, not silently a no-op.
+
+        Without this, ``step:`` written instead of ``steps:`` -- an easy slip,
+        since fan-out's payload key really is the singular ``step:`` -- passed
+        ``specify workflow validate`` with zero errors, and then reported
+        COMPLETED at run time while returning no ``next_steps``, so the loop
+        never ran even once.
+        """
+        from specify_cli.workflows.base import StepContext, StepStatus
+        from specify_cli.workflows.steps.while_loop import WhileStep
+
+        step = WhileStep()
+        config = {
+            "id": "retry",
+            "condition": "true",
+            # The mistype: singular 'step' instead of 'steps'.
+            "step": {"id": "x", "type": "command", "command": "echo"},
+        }
+        errors = step.validate(config)
+        assert errors == ["While step 'retry' is missing 'steps' field."], errors
+
+        # Demonstrates why it matters: execution is a silent no-op.
+        result = step.execute(config, StepContext())
+        assert result.status == StepStatus.COMPLETED
+        assert result.next_steps == []
+
     @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, 1.5])
     def test_validate_rejects_non_string_non_bool_condition(self, bad):
         from specify_cli.workflows.steps.while_loop import WhileStep
@@ -3542,6 +3569,25 @@ class TestDoWhileStep:
         errors = step.validate({"id": "test", "steps": []})
         assert any("missing 'condition'" in e for e in errors)
         # max_iterations is optional (defaults to 10)
+
+    def test_validate_requires_steps_body(self):
+        """A do-while with no body must be rejected, not silently a no-op.
+
+        The step's own docstring promises "The first invocation always returns
+        the nested steps for execution" -- with no body it validated clean and
+        then returned none, so the loop never ran even once.
+        """
+        from specify_cli.workflows.base import StepContext, StepStatus
+        from specify_cli.workflows.steps.do_while import DoWhileStep
+
+        step = DoWhileStep()
+        config = {"id": "refine", "condition": "true", "max_iterations": 3}
+        errors = step.validate(config)
+        assert errors == ["Do-while step 'refine' is missing 'steps' field."], errors
+
+        result = step.execute(config, StepContext())
+        assert result.status == StepStatus.COMPLETED
+        assert result.next_steps == []
 
     @pytest.mark.parametrize("bad", [["a", "b"], {"k": "v"}, 5, 1.5])
     def test_validate_rejects_non_string_non_bool_condition(self, bad):


### PR DESCRIPTION
## Problem

Both loop steps type-check `steps` (`'steps' must be a list`) but never require it to be **present**, so an absent body silently becomes `[]`.

Every sibling control-flow step already requires its body:

| step | required body key | enforced |
|---|---|---|
| `if` | `then` | ✅ `if_then/__init__.py:84` |
| `fan-out` | `items` + `step` | ✅ `fan_out/__init__.py:87, 92` |
| `while` | `steps` | ❌ |
| `do-while` | `steps` | ❌ |

The mistype is unusually easy here: the fan-out step's own payload key is the **singular** `step:` while the loops use `steps:`.

## Reproduction on current `main`

```
A. while, body key typo'd as singular step:
   validate: []
   execute : StepStatus.COMPLETED | next_steps = []
B. do-while, no steps at all:
   validate: []
   execute : StepStatus.COMPLETED | next_steps = []
```

`specify workflow validate` reports **zero errors**. At run time the step reports COMPLETED while returning no `next_steps`, so the engine's `if result.next_steps:` block never fires and the retry loop the workflow is built around **never runs even once** — a silent no-op with no diagnostic anywhere.

For `do-while` this also contradicts the step's own docstring: *"The first invocation always returns the nested steps for execution."*

## Fix

Add the missing presence check to both `validate()` methods, worded to match the existing `if` step's message.

## Behaviour change — disclosed

A workflow that today declares a `while`/`do-while` with **no** `steps` key now fails `specify workflow validate` instead of passing. That is the point of the fix: such a loop is already a guaranteed no-op, so the change converts a silent misconfiguration into a clear error rather than altering any working behaviour. Runtime execution is untouched.

I scanned every workflow-shaped YAML in the repo — **0 bodyless loops**, so no in-tree workflow or template is affected. An explicitly empty `steps: []` still validates exactly as before.

## Verification

- **Fail-before / pass-after:** with **both** source files reverted to `upstream/main`, the 2 new tests fail → **37 passed** with the fix.
- Scoped regression across the loop/validate/engine surface (`tests/test_workflows.py` + `tests/workflows`, `-k "While or DoWhile or Loop or loop or Validat or validate or Engine"`): **283 passed**.
- Both existing `test_validate_missing_fields` tests already pass `"steps": []`, so they are unaffected.
- Each new test also asserts the *consequence* — that execution is a silent no-op — not just the message.
- `uvx ruff@0.15.0 check src tests` → clean

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*