### PR TITLE
fix(cline): stop unrelated prose from suppressing the hook command note

### DIFF
--- a/src/specify_cli/integrations/cline/__init__.py
+++ b/src/specify_cli/integrations/cline/__init__.py
@@ -101,14 +101,25 @@ class ClineIntegration(MarkdownIntegration):
 
         Targets the line ``- For each executable hook, output the following``
         and inserts the note on the line before it, matching its indentation.
-        Skips if the note is already present.
+        Skips individual instructions that already have the note immediately
+        above them.
         """
-        if "replace dots" in content:
-            return content
+        note = _HOOK_COMMAND_NOTE.rstrip("\n")
 
         def repl(m: re.Match[str]) -> str:
             indent = m.group(1)
             instruction = m.group(2)
+            # Check the line immediately above this instruction, mirroring the
+            # shared ``SkillsIntegration`` helper. The previous whole-document
+            # ``if "replace dots" in content`` scan meant any command or
+            # extension markdown whose prose merely contained that phrase lost
+            # the note entirely -- leaving the agent told to emit a dotted
+            # ``/speckit.git.commit``, which Cline never registers -- and a
+            # document with one already-noted section never got a note on a
+            # second, un-noted one.
+            previous_lines = content[:m.start()].splitlines()
+            if previous_lines and previous_lines[-1] == indent + note:
+                return m.group(0)
             # ``eol`` is empty when the regex matched via ``$`` because the
             # instruction was the final line of a file with no trailing
             # newline. Default to ``\n`` so the note never collapses onto
@@ -116,15 +127,20 @@ class ClineIntegration(MarkdownIntegration):
             eol = m.group(3) or "\n"
             return (
                 indent
-                + _HOOK_COMMAND_NOTE.rstrip("\n")
+                + note
                 + eol
                 + indent
                 + instruction
                 + eol
             )
 
+        # ``[ \t]*`` rather than ``\s*``: ``\s`` matches newlines, so the
+        # captured "indent" could swallow a preceding blank line and the note
+        # was then emitted with a spurious blank line between it and the
+        # instruction. This also matches the shared base helper, without which
+        # the per-instruction check above cannot line up.
         return re.sub(
-            r"(?m)^(\s*)(- For each executable hook, output the following[^\r\n]*)(\r\n|\n|$)",
+            r"(?m)^([ \t]*)(- For each executable hook, output the following[^\r\n]*)(\r\n|\n|$)",
             repl,
             content,
         )

--- a/tests/integrations/test_integration_cline.py
+++ b/tests/integrations/test_integration_cline.py
@@ -106,6 +106,59 @@ class TestClineIntegration(MarkdownIntegrationTests):
         # Instruction stays on its own line rather than being mashed onto the note.
         assert "\n- For each executable hook, output the following:" in injected
 
+    def test_cline_hook_note_not_suppressed_by_unrelated_prose(self):
+        """Unrelated prose must not suppress the note for a real instruction.
+
+        The idempotency guard used to be a whole-document substring scan
+        (``if "replace dots" in content``), so any command or extension
+        markdown whose prose merely contained that phrase lost the note
+        entirely -- leaving the agent told to emit ``/speckit.git.commit``,
+        a dotted command Cline never registers.
+        """
+        cline = get_integration("cline")
+        content = (
+            "# DB extension command\n\n"
+            "When normalizing table names, replace dots with underscores.\n\n"
+            "## Pre-Execution Hooks\n"
+            "- For each executable hook, output the following:\n"
+        )
+        injected = cline._inject_hook_command_note(content)
+        assert "`/speckit-git-commit`" in injected, injected
+        # The user's own prose is untouched.
+        assert "replace dots with underscores" in injected
+
+    def test_cline_hook_note_added_to_every_un_noted_instruction(self):
+        """A second, un-noted hook section must still get its own note."""
+        cline = get_integration("cline")
+        instruction = "- For each executable hook, output the following:\n"
+        # Section 1 already carries the note; section 2 does not.
+        first = cline._inject_hook_command_note("## Hooks A\n" + instruction)
+        content = first + "\n## Hooks B\n" + instruction
+
+        injected = cline._inject_hook_command_note(content)
+        assert injected.count("replace dots (`.`) with hyphens (`-`)") == 2, injected
+        # Still idempotent: re-running adds nothing.
+        assert cline._inject_hook_command_note(injected) == injected
+
+    def test_cline_hook_note_sits_directly_above_indented_instruction(self):
+        """No blank line may be inserted between the note and the instruction.
+
+        The regex captured indentation with ``\\s*``, which matches newlines,
+        so a preceding blank line was swallowed into the "indent" and re-emitted
+        between the note and the instruction.
+        """
+        cline = get_integration("cline")
+        content = "## Hooks\n\n  - For each executable hook, output the following:\n"
+        injected = cline._inject_hook_command_note(content)
+        lines = injected.splitlines()
+        instruction_idx = next(
+            i for i, line in enumerate(lines) if "For each executable hook" in line
+        )
+        assert "replace dots" in lines[instruction_idx - 1], injected
+        # Indentation is preserved on both lines.
+        assert lines[instruction_idx].startswith("  - For each")
+        assert lines[instruction_idx - 1].startswith("  - When constructing")
+
     # -- Overrides for MarkdownIntegrationTests ---------------------------
 
     def test_setup_creates_files(self, tmp_path):


### PR DESCRIPTION
## Problem

`ClineIntegration._inject_hook_command_note` guards idempotency with a **whole-document substring scan**:

```python
if "replace dots" in content:
    return content
```

The shared `SkillsIntegration._inject_hook_command_note` helper (`base.py:1637-1642`) instead compares only the line immediately above each match:

```python
previous_lines = content[:m.start()].splitlines()
if previous_lines and previous_lines[-1] == indent + note:
    return m.group(0)
```

Cline never picked up that change.

## Reproduction on current `main`

```
A. unrelated prose -> note injected? False      (base: True)
B. two hook sections, one already noted -> notes: 1   (want 2)
C. indented instruction after a blank line:
   '## Hooks\n\n  <note>\n\n  - For each executable hook, ...'   <-- spurious blank line
```

**(a)** Any command or extension markdown whose prose happens to contain the phrase *"replace dots"* — e.g. `"When normalizing table names, replace dots with underscores."` — loses the note entirely. The generated workflow then tells the agent to emit `/speckit.git.commit`, a **dotted command Cline never registers** (Cline installs `speckit-git-commit.md`). The note exists precisely to prevent that.

**(b)** A document with one already-noted hook section never gets a note on a second, un-noted one — exactly the case the base helper was changed to handle.

**(c)** Secondary: cline's regex captures indentation with `^(\s*)` where the base uses `^([ \t]*)`. Because `\s` matches newlines, the captured "indent" can swallow a preceding blank line, which is then re-emitted **between** the note and the instruction. The per-instruction check cannot line up until this is fixed, so both belong in one change.

## Fix

Adopt the base helper's per-instruction check and its `[ \t]*` capture. After the fix:

```
A. unrelated prose -> note injected? True
B. two sections -> notes: 2 (want 2)
C. indented+blank -> note sits directly above the instruction, indentation preserved
D. idempotent -> True
```

## Verification

- **Fail-before / pass-after:** 3 new-vs-baseline failures with the source reverted → **35 passed** with the fix.
- Idempotency is asserted explicitly (re-running on already-noted content is a no-op) — the property the old guard was there to provide is kept.
- Full `tests/integrations` scope: **18 failed, 2627 passed** — identical to the clean-`main` baseline's 18 (all Windows symlink-privilege), plus my 3 new tests.
- `uvx ruff@0.15.0 check src tests` → clean

**No breaking change.** Content that already has the note above every instruction is returned byte-identical; only documents that were previously *missing* a note now gain one.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*