### PR TITLE
fix(console): fail fast in select_with_arrows when stdin is not a TTY

### DIFF
--- a/src/specify_cli/_console.py
+++ b/src/specify_cli/_console.py
@@ -162,6 +162,12 @@ def select_with_arrows(
 
     Returns:
         Selected option key
+
+    Raises:
+        ValueError: If stdin is not a TTY and no ``default_key`` is given —
+            the interactive loop would otherwise block forever waiting for
+            keypresses that will never arrive (agent harness, CI, piped
+            input). See issue #4152.
     """
     if not options:
         raise ValueError("select_with_arrows() requires at least one option.")
@@ -171,6 +177,17 @@ def select_with_arrows(
         selected_index = option_keys.index(default_key)
     else:
         selected_index = 0
+
+    # Fail fast in non-interactive environments instead of hanging on
+    # readkey() forever. With a default, resolve to it immediately.
+    if not sys.stdin.isatty():
+        if default_key and default_key in option_keys:
+            return default_key
+        raise ValueError(
+            "select_with_arrows() requires an interactive TTY, but stdin is "
+            "not a terminal. Pass an explicit option flag to pre-answer this "
+            "selection, or run in an interactive session."
+        )
 
     selected_key = None
 

--- a/tests/test_console_non_interactive.py
+++ b/tests/test_console_non_interactive.py
@@ -1,0 +1,54 @@
+"""
+Tests for non-interactive (no-TTY) behavior of select_with_arrows.
+
+When stdin is not a TTY (agent harness, CI, piped input), the interactive
+arrow-key selector must fail fast with a clear error instead of blocking
+forever on readkey(). See issue #4152.
+"""
+
+import sys
+
+import pytest
+
+from specify_cli._console import select_with_arrows
+
+
+class FakeStdin:
+    """Stdin-like object that reports not a TTY."""
+
+    def isatty(self) -> bool:
+        return False
+
+
+def test_select_with_arrows_fails_fast_without_tty_and_no_default(monkeypatch):
+    monkeypatch.setattr("sys.stdin", FakeStdin())
+    with pytest.raises(ValueError, match="not a terminal"):
+        select_with_arrows({"a": "option a", "b": "option b"})
+
+
+def test_select_with_arrows_uses_default_without_tty(monkeypatch):
+    monkeypatch.setattr("sys.stdin", FakeStdin())
+    # With a default, no-TTY should resolve to the default (no hang).
+    result = select_with_arrows(
+        {"a": "option a", "b": "option b"},
+        default_key="b",
+    )
+    assert result == "b"
+
+
+def test_select_with_arrows_still_interactive_with_tty(monkeypatch):
+    """With a real TTY, the interactive loop is untouched."""
+    real_stdin = sys.stdin
+
+    class RealStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr("sys.stdin", RealStdin())
+    # Simulate a single 'enter' keypress on the first get_key() call.
+    import specify_cli._console as console
+
+    monkeypatch.setattr(console, "get_key", lambda: "enter")
+    result = select_with_arrows({"a": "option a"})
+    assert result == "a"
+    monkeypatch.setattr("sys.stdin", real_stdin)


### PR DESCRIPTION
Fixes #4152

## Problem

`specify init` can hang **indefinitely** at arrow-key selection prompts when stdin is not attached to a TTY (agent harness, CI, piped input). `select_with_arrows` blocks in `readkey()` waiting for keypresses that never arrive — no timeout, no error, no output. This matters because agent-driven workflows are precisely the environments with no TTY, and Spec Kit is a natural fit for them.

## Fix (defense in depth)

`select_with_arrows` now detects non-interactive stdin (`sys.stdin.isatty()`) and:

1. **Resolves to `default_key` immediately** when one is provided — making a fully scripted init expressible without needing a flag for every prompt (issue option 2).
2. **Raises `ValueError`** naming the missing interactive session when no default exists — fail fast with an actionable message instead of hanging (issue option 1).

Both call sites in `init.py` already guard with `_stdin_is_interactive()`, so this change cannot alter existing behavior for guarded paths — it closes the hang for **any future or unguarded caller** of the selector (issue: "there is no flag that reaches every prompt").

## Tests

New file `tests/test_console_non_interactive.py` (3 tests):

- **no-TTY without default** → raises `ValueError` ("not a terminal")
- **no-TTY with default** → resolves to the default (no hang)
- **TTY path** → interactive loop untouched (get_key mocked to Enter)

Verified: `8/8` console tests green. `tests/integrations/test_cli.py` failures are **pre-existing in this environment** (84 failures with and without this change — identical count), so no regressions introduced.
