### PR TITLE
Update Jira Sync extension catalog to v0.5.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -2181,8 +2181,8 @@
       "id": "jira-sync",
       "description": "An idempotent, drift-aware, fail-closed reconcile engine that mirrors spec-kit specs into Jira (Epic per repo, Story per spec, Subtask per phase).",
       "author": "Ash Brener",
-      "version": "0.4.0",
-      "download_url": "https://github.com/ashbrener/spec-kit-jira-sync/archive/refs/tags/v0.4.0.zip",
+      "version": "0.5.0",
+      "download_url": "https://github.com/ashbrener/spec-kit-jira-sync/archive/refs/tags/v0.5.0.zip",
       "repository": "https://github.com/ashbrener/spec-kit-jira-sync",
       "homepage": "https://github.com/ashbrener/spec-kit-jira-sync",
       "documentation": "https://github.com/ashbrener/spec-kit-jira-sync/blob/main/README.md",
@@ -2203,7 +2203,7 @@
       },
       "provides": {
         "commands": 4,
-        "hooks": 0
+        "hooks": 6
       },
       "tags": [
         "issue-tracking",
@@ -2216,7 +2216,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-06-08T00:00:00Z",
-      "updated_at": "2026-06-24T00:00:00Z"
+      "updated_at": "2026-08-12T00:00:00Z"
     },
     "keel": {
       "name": "Keel Discovery",


### PR DESCRIPTION
## Summary
- update the `jira-sync` community catalog entry to v0.5.0
- update the download URL and catalog timestamp
- align the hook count with the v0.5.0 extension manifest, which declares six lifecycle hooks

## Validation
- `jq -e ... extensions/catalog.community.json`
- `.venv/bin/python -m json.tool extensions/catalog.community.json > /tmp/extensions-catalog.community.json.formatted`
- `git diff --check -- extensions/catalog.community.json`
- `.venv/bin/python -m pytest tests/test_extensions.py::TestExtensionCatalog -q`
- `.venv/bin/python -m pytest tests/test_github_workflows.py -q`

Closes #4099