### PR TITLE
test(presets): normalize whitespace in resolve output assertion to prevent terminal line-wrap failures

### DIFF
--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -13672,7 +13672,7 @@ class TestInstalledPresetRichMarkup:
         )
 
         assert result.exit_code == 0, (result.output, result.exception)
-        assert "constitution.md" in strip_ansi(result.output)
+        assert "constitution.md" in "".join(strip_ansi(result.output).split())
 
     def test_resolve_rejects_empty_command_segments(self, project_dir):
         """Dotted command identifiers cannot contain empty path-like segments."""


### PR DESCRIPTION
### Summary
- In `tests/test_presets.py::TestInstalledPresetRichMarkup::test_resolve_accepts_dotted_command_name`, the assertion `assert "constitution.md" in strip_ansi(result.output)` failed when running in environments with constrained terminal column widths or long paths because Rich console output wrapped `templates/commands/constituti\non.md` across lines.
- Normalize whitespace in the stripped output before asserting substring inclusion, ensuring test determinism regardless of path length or terminal width.