### PR TITLE
fix(powershell): stop Out-Null swallowing setup-tasks AVAILABLE_DOCS lines

### DIFF
--- a/scripts/powershell/setup-tasks.ps1
+++ b/scripts/powershell/setup-tasks.ps1
@@ -81,8 +81,13 @@ if ($Json) {
     Write-Output "FEATURE_DIR: $($paths.FEATURE_DIR)"
     Write-Output "TASKS_TEMPLATE: $(if ($tasksTemplate) { $tasksTemplate } else { 'not found' })"
     Write-Output "AVAILABLE_DOCS:"
-    Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Out-Null
-    Test-FileExists -Path $paths.DATA_MODEL -Description 'data-model.md' | Out-Null
-    Test-DirHasFiles -Path $paths.CONTRACTS_DIR -Description 'contracts/' | Out-Null
-    Test-FileExists -Path $paths.QUICKSTART -Description 'quickstart.md' | Out-Null
+    # These helpers report their line with Write-Output and ALSO return a
+    # bool, both on the Success stream, so 'Out-Null' discarded the report
+    # line along with the return value and left AVAILABLE_DOCS empty. Drop
+    # only the boolean so the per-document lines reach stdout like the
+    # bash and Python twins.
+    Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Where-Object { $_ -isnot [bool] }
+    Test-FileExists -Path $paths.DATA_MODEL -Description 'data-model.md' | Where-Object { $_ -isnot [bool] }
+    Test-DirHasFiles -Path $paths.CONTRACTS_DIR -Description 'contracts/' | Where-Object { $_ -isnot [bool] }
+    Test-FileExists -Path $paths.QUICKSTART -Description 'quickstart.md' | Where-Object { $_ -isnot [bool] }
 }

--- a/tests/test_setup_tasks.py
+++ b/tests/test_setup_tasks.py
@@ -797,6 +797,39 @@ def test_setup_tasks_ps_missing_template_errors(tasks_repo: Path) -> None:
 
 
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_setup_tasks_ps_text_output_lists_available_docs(tasks_repo: Path) -> None:
+    """Text mode must print a status line per document, like the bash/Python twins.
+
+    `Test-FileExists` / `Test-DirHasFiles` report their line with `Write-Output`
+    and ALSO `return $true/$false`, both on the Success stream. Piping the whole
+    call to `| Out-Null` discarded the boolean AND the report line, so
+    `AVAILABLE_DOCS:` was emitted with nothing under it.
+    """
+    feat = _minimal_feature(tasks_repo)
+    (feat / "research.md").write_text("# research\n", encoding="utf-8")
+
+    script = tasks_repo / ".specify" / "scripts" / "powershell" / "setup-tasks.ps1"
+    exe = "pwsh" if HAS_PWSH else _WINDOWS_POWERSHELL
+
+    result = subprocess.run(
+        [exe, "-NoProfile", "-File", str(script)],
+        cwd=tasks_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "AVAILABLE_DOCS:" in result.stdout
+    for doc in ("research.md", "data-model.md", "contracts/", "quickstart.md"):
+        assert doc in result.stdout, (doc, result.stdout)
+    normalized = result.stdout.replace("\r\n", "\n")
+    assert "[OK] research.md" in normalized, normalized
+    assert "[FAIL] data-model.md" in normalized, normalized
+
+
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 def test_powershell_command_hint_normalizes_mixed_separators(
     tasks_repo: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

`Test-FileExists` / `Test-DirHasFiles` (in `scripts/powershell/common.ps1`) report their status line with `Write-Output` and *also* `return $true`/`$false` — both land on the PowerShell Success stream. `setup-tasks.ps1`'s text-mode branch piped each call to `| Out-Null` to discard the boolean, which discards the whole stream item, report line included:

```
BEFORE (measured, powershell.exe -NoProfile -File ...):
  FEATURE_DIR:...\specs\001-my-feature
  TASKS_TEMPLATE:...\tasks-template.md
  AVAILABLE_DOCS:
  (3 lines)

AFTER:
  FEATURE_DIR:...\specs\001-my-feature
  TASKS_TEMPLATE:...\tasks-template.md
  AVAILABLE_DOCS:
    [OK] research.md
    [FAIL] data-model.md
    [FAIL] contracts/
    [FAIL] quickstart.md
  (7 lines)
```

The bash twin (`scripts/bash/setup-tasks.sh`) lists every document under `AVAILABLE_DOCS:`, so the PowerShell variant was silently returning less information for the same project state.

This is the exact same bug, same shared helpers, as the one just fixed in the sibling script `check-prerequisites.ps1` (commit 2b36f0c, #3891) — same day's fix even documents `Test-FileExists`/`Test-DirHasFiles`'s dual-stream behavior in a comment. `setup-tasks.ps1` calls the identical two helpers the identical way and was left with the identical bug. Fix mirrors that PR exactly: replace `| Out-Null` with `| Where-Object { $_ -isnot [bool] }` so the report line passes through and only the boolean is dropped.

## Test plan

- [x] Added `test_setup_tasks_ps_text_output_lists_available_docs` to `tests/test_setup_tasks.py` (mirrors the PS text-mode test added for `check-prerequisites.ps1` in #3891)
- [x] Verified the new test fails without the fix (`AVAILABLE_DOCS:` printed with no lines under it) and passes with it
- [x] `pytest tests/test_setup_tasks.py` — 11 passed, 19 skipped (no pwsh in some environments), 1 pre-existing failure unrelated to this change (`test_setup_tasks_ps_core_template_resolved` — a JSON-encoding quirk in `-Json` mode under Windows PowerShell 5.1, reproduces identically on unmodified `upstream/main`)
- [x] Verified `scripts/powershell/setup-tasks.ps1` stays ASCII-only (0 non-ASCII bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
