### PR TITLE
fix(utils): narrow bare except Exception in merge_json_files

### DIFF
--- a/src/specify_cli/_utils.py
+++ b/src/specify_cli/_utils.py
@@ -249,7 +249,7 @@ def merge_json_files(existing_path: Path, new_content: Any, verbose: bool = Fals
         except FileNotFoundError:
             # Handle race condition where file is deleted after exists() check
             exists = False
-        except Exception as e:
+        except (OSError, ValueError) as e:
             if verbose:
                 console.print(f"[yellow]Warning: Could not read or parse existing JSON in {existing_path.name} ({e}).[/yellow]")
             # Skip merge to preserve existing file if unparseable or inaccessible (e.g. PermissionError)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -212,3 +212,29 @@ def test_handle_vscode_settings_propagates_programming_errors(tmp_path):
             )
     finally:
         utils_mod.merge_json_files = original_merge
+
+
+def test_merge_json_files_propagates_programming_errors(tmp_path, monkeypatch):
+    """Unexpected programming errors reading the existing file must propagate.
+
+    ``merge_json_files``'s own read of the existing JSON file caught bare
+    ``Exception`` around ``json5.load``, so a real bug there (e.g. a
+    ``TypeError``) was silently treated the same as a normal parse failure --
+    ``None`` returned, existing settings preserved, nothing logged unless
+    ``verbose``. Only ``OSError`` (inaccessible file) and ``ValueError``
+    (malformed JSON5 -- json5's decode error is a ``ValueError`` subclass)
+    are expected outcomes here; anything else must propagate, matching the
+    narrowing already applied to the caller, ``handle_vscode_settings``.
+    """
+    existing_file = tmp_path / "settings.json"
+    existing_file.write_text('{"a": 1}\n', encoding="utf-8")
+
+    import specify_cli._utils as utils_mod
+
+    def _boom(*_a, **_kw):
+        raise TypeError("boom")
+
+    monkeypatch.setattr(utils_mod.json5, "load", _boom)
+
+    with pytest.raises(TypeError):
+        merge_json_files(existing_file, {"b": 2})


### PR DESCRIPTION
## Summary

`merge_json_files`'s read of the existing JSON file wraps `json5.load` in a bare `except Exception as e:` that returns `None` (meaning "preserve existing settings, skip merge") on *any* failure — including a real programming bug like a `TypeError`/`AttributeError`, which is silently treated identically to an expected I/O or parse error and, without `verbose`, surfaces nothing at all.

The only expected outcomes for this block are:
- `OSError` — the file is inaccessible (already special-cased for `FileNotFoundError` just above)
- `ValueError` — malformed JSON5 (json5's decode error is a `ValueError` subclass)

Anything else should propagate instead of being swallowed as if it were a parse failure.

This is the same bug, same fix shape, as its caller `handle_vscode_settings`, whose own bare `except Exception` was narrowed to `(OSError, ValueError, KeyError)` in commit 16f4577 (#3844) with the identical rationale — "let programming errors like TypeError or AttributeError propagate while still handling expected I/O and parse errors gracefully." That PR's own regression test monkeypatched `merge_json_files` itself to prove the *caller's* narrowing works, but the callee it monkeypatched around still had the original bare-except bug.

## Test plan

- [x] Added `test_merge_json_files_propagates_programming_errors` to `tests/test_merge.py`, monkeypatching `json5.load` to raise `TypeError` and asserting it propagates out of `merge_json_files` instead of returning `None`
- [x] Verified the new test fails without the fix (`DID NOT RAISE <class 'TypeError'>`) and passes with it
- [x] `pytest tests/test_merge.py` — 13 passed
- [x] `ruff check` on both changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
