### PR TITLE
fix(extensions): correct Atlas display name

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -463,7 +463,7 @@
       "updated_at": "2026-08-17T00:00:00Z"
     },
     "atlas": {
-      "name": "spec-kit-atlas",
+      "name": "Atlas",
       "id": "atlas",
       "description": "Synthesize spec-kit specs into faithful, interactive architecture storybooks & doc portals.",
       "author": "Ash Brener",


### PR DESCRIPTION
Closes #4196

Update the existing `atlas` community catalog entry to use the human-readable display name `Atlas`. All other metadata remains unchanged.

## Testing

- [x] `python -m json.tool extensions/catalog.community.json`
- [x] `git diff --check`
- [ ] Full pytest suite — collection is currently blocked because `specify_cli` is not installed in this environment.

## AI assistance disclosure

I used ChatGPT to review the contribution guidelines, inspect issue #4196, make this one-line catalog change, and validate the JSON. I reviewed the diff and testing result before opening this PR.