### PR TITLE
chore(catalog): bump maqa to v0.1.5 in community catalog

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -2633,8 +2633,8 @@
       "id": "maqa",
       "description": "Coordinator → feature → QA agent workflow with parallel worktree-based implementation. Language-agnostic. Auto-detects installed board plugins (Trello, Linear, GitHub Projects, Jira, Azure DevOps). Optional CI gate.",
       "author": "GenieRobot",
-      "version": "0.1.3",
-      "download_url": "https://github.com/GenieRobot/spec-kit-maqa-ext/releases/download/maqa-v0.1.3/maqa.zip",
+      "version": "0.1.5",
+      "download_url": "https://github.com/GenieRobot/spec-kit-maqa-ext/releases/download/maqa-v0.1.5/maqa.zip",
       "repository": "https://github.com/GenieRobot/spec-kit-maqa-ext",
       "homepage": "https://github.com/GenieRobot/spec-kit-maqa-ext",
       "documentation": "https://github.com/GenieRobot/spec-kit-maqa-ext/blob/main/README.md",
@@ -2661,7 +2661,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-03-26T00:00:00Z",
-      "updated_at": "2026-03-27T00:00:00Z"
+      "updated_at": "2026-03-28T00:00:00Z"
     },
     "maqa-azure-devops": {
       "name": "MAQA Azure DevOps Integration",


### PR DESCRIPTION
## Summary
- The community catalog's `maqa` entry was stale at v0.1.3; the extension has since shipped v0.1.4 and v0.1.5 (see [CHANGELOG](https://github.com/GenieRobot/spec-kit-maqa-ext/blob/main/CHANGELOG.md)).
- Updates `version`, `download_url`, and `updated_at` to match the current [maqa-v0.1.5 release](https://github.com/GenieRobot/spec-kit-maqa-ext/releases/tag/maqa-v0.1.5).
- Minimal diff — only the `maqa` entry's three fields change; no other catalog entries touched.

## Test plan
- [x] `download_url` resolves to a real, published release asset (`maqa-v0.1.5/maqa.zip`)
- [x] Verified via `python -m json.tool` that `catalog.community.json` remains valid JSON after the edit