### PR TITLE
feat(core): add `specify core info --json` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 <!-- insert new changelog below this comment -->
 
+- feat(core): add `specify core info --json` command that emits the baked-in commands, templates, and scripts as a deterministic JSON inventory (#4215)
+
 ## [0.16.5] - 2026-08-19
 
 ### Changed

--- a/docs/reference/core-info.md
+++ b/docs/reference/core-info.md
@@ -31,7 +31,7 @@ The response is a JSON object with three top-level arrays, always in this order 
 Every entry carries a stable identifier suitable for cross-referencing:
 
 - `id`: `core:_:<kind>:<name>` (grammar defined in [#4210](https://github.com/github/spec-kit/issues/4210); `<kind>` is `command`, `template`, or `script`)
-- `name`: the base name (no extension, hyphenated form for scripts — e.g. `setup-plan` not `setup_plan`)
+- `name`: the logical artifact name. Commands are namespaced as `speckit.<stem>`; templates use their filename stem; scripts use a hyphenated stem (for example, `setup-plan`, not `setup_plan`).
 - `description`: short human-readable summary
 - `sourcePath`: package-relative, forward-slash path (e.g. `templates/commands/plan.md`)
 

--- a/docs/reference/core-info.md
+++ b/docs/reference/core-info.md
@@ -68,7 +68,7 @@ specify core info --json | jq '.commands[] | select(.name == "speckit.plan")'
 
 - Alphabetical ordering by `name` within each section.
 - Fixed top-level key order: `commands`, `templates`, `scripts`.
-- Fields inside each entry are emitted in a fixed order (see the schema at [`specs/001-core-info/contracts/core-info-schema.json`](https://github.com/github/spec-kit/blob/main/specs/001-core-info/contracts/core-info-schema.json)).
+- Fields inside each entry are emitted in a fixed order (see the entry construction in [`src/specify_cli/core/__init__.py`](https://github.com/github/spec-kit/blob/main/src/specify_cli/core/__init__.py)).
 - Path separators are always forward-slashes, even on Windows.
 
 ## Failure Modes

--- a/docs/reference/core-info.md
+++ b/docs/reference/core-info.md
@@ -30,7 +30,7 @@ The response is a JSON object with three top-level arrays, always in this order 
 
 Every entry carries a stable identifier suitable for cross-referencing:
 
-- `id`: `core:_:<kind>:<name>` (grammar defined in [#4210](https://github.com/github/spec-kit/issues/4210); `<kind>` is `command`, `template`, or `script`)
+- `id`: `core:_:<kind>:<name>` (`<kind>` is `command`, `template`, or `script`)
 - `name`: the logical artifact name. Commands are namespaced as `speckit.<stem>`; templates use their filename stem; scripts use a hyphenated stem (for example, `setup-plan`, not `setup_plan`).
 - `description`: short human-readable summary
 - `sourcePath`: package-relative, forward-slash path (e.g. `templates/commands/plan.md`)
@@ -62,43 +62,37 @@ specify core info --json | jq '.commands[] | select(.name == "speckit.plan")'
 
 - Building tools that need to know what the shipped baseline contains without unpacking the wheel by hand.
 - Auditing which commands, templates, or scripts a given Spec Kit release ships.
-- Cross-referencing baseline artifacts against extension- or preset-provided ones. A companion command exposing the equivalent view for project-scoped artifacts is tracked in [#4212](https://github.com/github/spec-kit/issues/4212).
+- Cross-referencing baseline artifacts against extension- or preset-provided ones.
 
 ## Determinism Guarantees
 
 - Alphabetical ordering by `name` within each section.
 - Fixed top-level key order: `commands`, `templates`, `scripts`.
-- Fields inside each entry are emitted in a fixed order (see the entry construction in [`src/specify_cli/core/__init__.py`](https://github.com/github/spec-kit/blob/main/src/specify_cli/core/__init__.py)).
+- Fields inside each entry are emitted in a fixed order.
 - Path separators are always forward-slashes, even on Windows.
 
 ## Failure Modes
 
-The command is designed to fail fast rather than silently emit a partial or malformed inventory. On any packaging error — a missing shipped file, unparseable frontmatter, or a mistyped field — it exits with code `1` and prints a JSON error envelope on stderr:
+The command fails fast on packaging errors it can detect at read time — unparseable frontmatter, a mistyped field, or a script missing its canonical bash variant — rather than silently emitting a malformed inventory. On any such error it exits with code `1` and prints a JSON error envelope on stderr:
 
 ```json
 {
-  "error": "core_inventory.missing_file",
-  "message": "Baseline command 'plan' is registered but its source file is missing.",
-  "artifact": { "kind": "command", "name": "plan" }
+  "error": "core_inventory.frontmatter_parse",
+  "message": "Could not parse YAML frontmatter of command 'plan': ...",
+  "artifact": { "kind": "command", "name": "plan", "sourcePath": "templates/commands/plan.md" }
 }
 ```
 
 Common `error` codes:
 
-| Code                                 | Meaning                                                        |
-| ------------------------------------ | -------------------------------------------------------------- |
-| `core_inventory.assets_missing`      | Neither the wheel-shipped `core_pack/` nor the source checkout was found. |
-| `core_inventory.missing_file`        | A baseline command file expected to be shipped is absent.      |
-| `core_inventory.frontmatter_parse`   | YAML frontmatter on a baseline file could not be parsed.       |
-| `core_inventory.frontmatter_shape`   | Frontmatter parsed but a field has the wrong type.             |
-| `core_inventory.missing_canonical`   | A script ships a non-bash variant but no canonical bash one.   |
-| `core_inventory.invalid_source_path` | An emitted `sourcePath` failed the shape check (absolute or contained a backslash). |
+| Code                                | Meaning                                                        |
+| ----------------------------------- | -------------------------------------------------------------- |
+| `core_inventory.assets_missing`     | Neither the wheel-shipped `core_pack/` nor the source checkout was found. |
+| `core_inventory.frontmatter_parse`  | YAML frontmatter on a baseline file could not be parsed, or a field has the wrong type. |
+| `core_inventory.missing_description`| A baseline command, template, or script has no usable description. |
+| `core_inventory.missing_canonical`  | A script ships a non-bash variant but no canonical bash one.   |
+| `core_inventory.invalid_source_path`| An emitted `sourcePath` failed the shape check (absolute or contained a backslash). |
 
 These conditions represent packaging bugs and should be reported.
 
-## Known Deviations
-
-Two small deviations from the specification are noted here for transparency:
-
-- **Script descriptions**: Only 2 of the 6 shipped scripts (`check-prerequisites`, `common`) currently have header comments. For the other four (`create-new-feature`, `setup-plan`, `setup-tasks`, `resolve-template`), the command emits a filename-derived fallback (`"Baseline helper script: <name>."`). Adding real header comments to those scripts is tracked separately.
-- **Command `handoffs`**: The source frontmatter for `handoffs:` is a list of mappings with `agent`, `label`, and `prompt` keys. The core inventory surfaces only the `agent` values (a list of strings) — the same shape the schema exposes. Consumers that need the labels and prompts should read the frontmatter directly.
+Note: templates and scripts are enumerated from whatever files are present on disk, so an asset that is missing entirely from the installation is simply omitted from the output rather than raised as an error.

--- a/docs/reference/core-info.md
+++ b/docs/reference/core-info.md
@@ -73,7 +73,7 @@ specify core info --json | jq '.commands[] | select(.name == "speckit.plan")'
 
 ## Failure Modes
 
-The command fails fast on packaging errors it can detect at read time — unparseable frontmatter, a mistyped field, or a script missing its canonical bash variant — rather than silently emitting a malformed inventory. On any such error it exits with code `1` and prints a JSON error envelope on stderr:
+The command fails fast on packaging errors it can detect at read time — unparseable frontmatter, a mistyped field, or a script missing its canonical bash variant — rather than silently emitting a malformed inventory. On any such error it exits with code `1` and prints a JSON error envelope on stderr. Note that templates and scripts are enumerated from whatever files are present on disk, so an asset that is missing entirely from the installation is simply omitted from the output rather than raised as an error.
 
 ```json
 {
@@ -94,5 +94,3 @@ Common `error` codes:
 | `core_inventory.invalid_source_path`| An emitted `sourcePath` failed the shape check (absolute or contained a backslash). |
 
 These conditions represent packaging bugs and should be reported.
-
-Note: templates and scripts are enumerated from whatever files are present on disk, so an asset that is missing entirely from the installation is simply omitted from the output rather than raised as an error.

--- a/docs/reference/core-info.md
+++ b/docs/reference/core-info.md
@@ -1,10 +1,10 @@
-# Core Inventory
+# Core Info
 
 The `specify core` command group exposes read-only information about Spec Kit's baked-in ("core") baseline — the commands, templates, and helper scripts that ship inside the CLI package itself. Presets, extensions, integrations, and project-scoped assets are intentionally **not** included; use their dedicated commands (`specify preset`, `specify extension`, `specify integration`) for those.
 
-Core-inventory output is deterministic and byte-identical across runs, so downstream tools can safely diff, hash, or cache it.
+Core info output is deterministic and byte-identical across runs, so downstream tools can safely diff, hash, or cache it.
 
-## List the Core Inventory
+## Inspect Core Info
 
 ```bash
 specify core info --json
@@ -12,7 +12,7 @@ specify core info --json
 
 | Option        | Description                                                          |
 | ------------- | -------------------------------------------------------------------- |
-| `--json`      | **Required.** Emit the inventory as JSON on stdout.                  |
+| `--json`      | **Required.** Emit core info as JSON on stdout.                      |
 
 The `--json` flag is mandatory. A human-readable table format is intentionally not offered — the command is designed for programmatic consumption by external tools and other Spec Kit surfaces. Invoking `specify core info` without `--json` exits non-zero with a hint pointing at the flag.
 
@@ -68,7 +68,7 @@ specify core info --json | jq '.commands[] | select(.name == "plan")'
 
 - Alphabetical ordering by `name` within each section.
 - Fixed top-level key order: `commands`, `templates`, `scripts`.
-- Fields inside each entry are emitted in a fixed order (see the schema at [`specs/001-core-inventory/contracts/core-info-schema.json`](https://github.com/github/spec-kit/blob/main/specs/001-core-inventory/contracts/core-info-schema.json)).
+- Fields inside each entry are emitted in a fixed order (see the schema at [`specs/001-core-info/contracts/core-info-schema.json`](https://github.com/github/spec-kit/blob/main/specs/001-core-info/contracts/core-info-schema.json)).
 - Path separators are always forward-slashes, even on Windows.
 
 ## Failure Modes

--- a/docs/reference/core-info.md
+++ b/docs/reference/core-info.md
@@ -1,0 +1,104 @@
+# Core Inventory
+
+The `specify core` command group exposes read-only information about Spec Kit's baked-in ("core") baseline — the commands, templates, and helper scripts that ship inside the CLI package itself. Presets, extensions, integrations, and project-scoped assets are intentionally **not** included; use their dedicated commands (`specify preset`, `specify extension`, `specify integration`) for those.
+
+Core-inventory output is deterministic and byte-identical across runs, so downstream tools can safely diff, hash, or cache it.
+
+## List the Core Inventory
+
+```bash
+specify core info --json
+```
+
+| Option        | Description                                                          |
+| ------------- | -------------------------------------------------------------------- |
+| `--json`      | **Required.** Emit the inventory as JSON on stdout.                  |
+
+The `--json` flag is mandatory. A human-readable table format is intentionally not offered — the command is designed for programmatic consumption by external tools and other Spec Kit surfaces. Invoking `specify core info` without `--json` exits non-zero with a hint pointing at the flag.
+
+### Output shape
+
+The response is a JSON object with three top-level arrays, always in this order and always sorted alphabetically by `name` within each array:
+
+```json
+{
+  "commands":  [ /* baseline slash-commands (e.g. speckit.plan) */ ],
+  "templates": [ /* markdown templates (spec, plan, tasks, ...) */ ],
+  "scripts":   [ /* helper scripts (bash/powershell/python)      */ ]
+}
+```
+
+Every entry carries a stable identifier suitable for cross-referencing:
+
+- `id`: `core:_:<kind>:<name>` (grammar defined in [#4210](https://github.com/github/spec-kit/issues/4210); `<kind>` is `command`, `template`, or `script`)
+- `name`: the base name (no extension, hyphenated form for scripts — e.g. `setup-plan` not `setup_plan`)
+- `description`: short human-readable summary
+- `sourcePath`: package-relative, forward-slash path (e.g. `templates/commands/plan.md`)
+
+Kind-specific fields:
+
+- **`commands[]`** also include `artifact` (string or `null`), `optional` (boolean, defaults to `false`), and `handoffs` (list of downstream command identifiers, may be empty).
+- **`scripts[]`** also include `runtimes`: a sorted list of the runtimes that ship a variant of that script, drawn from `bash`, `powershell`, and `python`. Every script has at least a `bash` variant — that is the canonical source.
+
+### Example
+
+```bash
+specify core info --json | jq '.commands[] | select(.name == "plan")'
+```
+
+```json
+{
+  "id": "core:_:command:plan",
+  "name": "plan",
+  "description": "Execute the implementation planning workflow using the plan template to generate design artifacts.",
+  "sourcePath": "templates/commands/plan.md",
+  "artifact": "plan.md",
+  "optional": false,
+  "handoffs": ["tasks"]
+}
+```
+
+## When to Use It
+
+- Building tools that need to know what the shipped baseline contains without unpacking the wheel by hand.
+- Auditing which commands, templates, or scripts a given Spec Kit release ships.
+- Cross-referencing baseline artifacts against extension- or preset-provided ones. A companion command exposing the equivalent view for project-scoped artifacts is tracked in [#4212](https://github.com/github/spec-kit/issues/4212).
+
+## Determinism Guarantees
+
+- Alphabetical ordering by `name` within each section.
+- Fixed top-level key order: `commands`, `templates`, `scripts`.
+- Fields inside each entry are emitted in a fixed order (see the schema at [`specs/001-core-inventory/contracts/core-info-schema.json`](https://github.com/github/spec-kit/blob/main/specs/001-core-inventory/contracts/core-info-schema.json)).
+- Path separators are always forward-slashes, even on Windows.
+
+## Failure Modes
+
+The command is designed to fail fast rather than silently emit a partial or malformed inventory. On any packaging error — a missing shipped file, unparseable frontmatter, or a mistyped field — it exits with code `1` and prints a JSON error envelope on stderr:
+
+```json
+{
+  "error": "core_inventory.missing_file",
+  "message": "Baseline command 'plan' is registered but its source file is missing.",
+  "artifact": { "kind": "command", "name": "plan" }
+}
+```
+
+Common `error` codes:
+
+| Code                                 | Meaning                                                        |
+| ------------------------------------ | -------------------------------------------------------------- |
+| `core_inventory.assets_missing`      | Neither the wheel-shipped `core_pack/` nor the source checkout was found. |
+| `core_inventory.missing_file`        | A baseline command file expected to be shipped is absent.      |
+| `core_inventory.frontmatter_parse`   | YAML frontmatter on a baseline file could not be parsed.       |
+| `core_inventory.frontmatter_shape`   | Frontmatter parsed but a field has the wrong type.             |
+| `core_inventory.missing_canonical`   | A script ships a non-bash variant but no canonical bash one.   |
+| `core_inventory.invalid_source_path` | An emitted `sourcePath` failed the shape check (absolute or contained a backslash). |
+
+These conditions represent packaging bugs and should be reported.
+
+## Known Deviations
+
+Two small deviations from the specification are noted here for transparency:
+
+- **Script descriptions**: Only 2 of the 6 shipped scripts (`check-prerequisites`, `common`) currently have header comments. For the other four (`create-new-feature`, `setup-plan`, `setup-tasks`, `resolve-template`), the command emits a filename-derived fallback (`"Baseline helper script: <name>."`). Adding real header comments to those scripts is tracked separately.
+- **Command `handoffs`**: The source frontmatter for `handoffs:` is a list of mappings with `agent`, `label`, and `prompt` keys. The core inventory surfaces only the `agent` values (a list of strings) — the same shape the schema exposes. Consumers that need the labels and prompts should read the frontmatter directly.

--- a/docs/reference/core-info.md
+++ b/docs/reference/core-info.md
@@ -43,18 +43,18 @@ Kind-specific fields:
 ### Example
 
 ```bash
-specify core info --json | jq '.commands[] | select(.name == "plan")'
+specify core info --json | jq '.commands[] | select(.name == "speckit.plan")'
 ```
 
 ```json
 {
-  "id": "core:_:command:plan",
-  "name": "plan",
+  "id": "core:_:command:speckit.plan",
+  "name": "speckit.plan",
   "description": "Execute the implementation planning workflow using the plan template to generate design artifacts.",
   "sourcePath": "templates/commands/plan.md",
-  "artifact": "plan.md",
+  "artifact": null,
   "optional": false,
-  "handoffs": ["tasks"]
+  "handoffs": ["speckit.tasks", "speckit.checklist"]
 }
 ```
 

--- a/docs/reference/core-info.md
+++ b/docs/reference/core-info.md
@@ -89,7 +89,7 @@ Common `error` codes:
 | ----------------------------------- | -------------------------------------------------------------- |
 | `core_inventory.assets_missing`     | Neither the wheel-shipped `core_pack/` nor the source checkout was found. |
 | `core_inventory.frontmatter_parse`  | YAML frontmatter on a baseline file could not be parsed, or a field has the wrong type. |
-| `core_inventory.missing_description`| A baseline command, template, or script has no usable description. |
+| `core_inventory.missing_description`| A baseline command or template has no usable description. |
 | `core_inventory.missing_canonical`  | A script ships a non-bash variant but no canonical bash one.   |
 | `core_inventory.invalid_source_path`| An emitted `sourcePath` failed the shape check (absolute or contained a backslash). |
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -29,6 +29,8 @@
       href: reference/overview.md
     - name: Core Commands
       href: reference/core.md
+    - name: Core Inventory
+      href: reference/core-info.md
     - name: Integrations
       href: reference/integrations.md
     - name: Extensions

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -29,7 +29,7 @@
       href: reference/overview.md
     - name: Core Commands
       href: reference/core.md
-    - name: Core Inventory
+    - name: Core Info
       href: reference/core-info.md
     - name: Integrations
       href: reference/integrations.md

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -553,6 +553,13 @@ def _require_specify_project() -> Path:
     raise typer.Exit(1)
 
 
+# ===== Core Inventory Commands =====
+
+# specify core * — see specify_cli/core/_commands.py
+from .core._commands import register as _register_core_cmds  # noqa: E402
+_register_core_cmds(app)
+
+
 # ===== Preset Commands =====
 
 # Moved to presets/_commands.py — registered here to preserve CLI surface.

--- a/src/specify_cli/__init__.py
+++ b/src/specify_cli/__init__.py
@@ -553,7 +553,7 @@ def _require_specify_project() -> Path:
     raise typer.Exit(1)
 
 
-# ===== Core Inventory Commands =====
+# ===== Core Info Commands =====
 
 # specify core * — see specify_cli/core/_commands.py
 from .core._commands import register as _register_core_cmds  # noqa: E402

--- a/src/specify_cli/core/__init__.py
+++ b/src/specify_cli/core/__init__.py
@@ -281,6 +281,7 @@ def _normalize_description(raw: Any, *, kind: str, name: str, source_path: str) 
 def _build_command_entry(name: str, layout: _CoreLayout) -> dict[str, Any]:
     file_path = layout.commands_dir / f"{name}.md"
     source_path = _package_relative(layout.command_source_path(name))
+    logical_name = f"speckit.{name}"
     if not file_path.is_file():
         raise CoreInventoryError(
             error="core_inventory.missing_file",
@@ -327,8 +328,8 @@ def _build_command_entry(name: str, layout: _CoreLayout) -> dict[str, Any]:
         frontmatter.get("handoffs"), name=name, source_path=source_path
     )
     return {
-        "id": f"core:_:command:{name}",
-        "name": name,
+        "id": f"core:_:command:{logical_name}",
+        "name": logical_name,
         "description": description,
         "sourcePath": source_path,
         "artifact": artifact,

--- a/src/specify_cli/core/__init__.py
+++ b/src/specify_cli/core/__init__.py
@@ -1,0 +1,532 @@
+"""Core (baseline) asset inventory for the specify-cli package.
+
+Public entry point: :func:`build_core_inventory` returns a fixed-shape dict
+enumerating the baseline commands, templates, and scripts that ship inside
+the wheel (`specify_cli/core_pack/`) or the source checkout (repo root).
+
+The output is the exact shape validated by
+``specs/001-core-inventory/contracts/core-info-schema.json``. See
+``specs/001-core-inventory/data-model.md`` for authoritative field types.
+
+Every asset carries a stable identifier per companion issue #4210:
+``core:_:{kind}:{name}``. Ordering: alphabetical by ``name`` within each
+list. Failure mode: any packaging inconsistency (missing shipped file,
+unparseable frontmatter, script with zero runtimes) raises
+:class:`CoreInventoryError` — the caller emits a JSON error envelope to
+stderr and exits non-zero (FR-012).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .._assets import _locate_core_pack, _repo_root
+
+__all__ = ["build_core_inventory", "CoreInventoryError"]
+
+_TEMPLATE_SUFFIX = "-template.md"
+_RUNTIMES: tuple[tuple[str, str, str], ...] = (
+    # (runtime name, source-layout subdir, filename suffix)
+    ("bash", "bash", ".sh"),
+    ("powershell", "powershell", ".ps1"),
+    ("python", "python", ".py"),
+)
+
+
+class CoreInventoryError(Exception):
+    """Raised when the shipped baseline is inconsistent (FR-012)."""
+
+    def __init__(
+        self,
+        error: str,
+        message: str,
+        *,
+        kind: str | None = None,
+        name: str | None = None,
+        source_path: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error = error
+        self.message = message
+        self.kind = kind
+        self.name = name
+        self.source_path = source_path
+
+    def to_envelope(self) -> dict[str, Any]:
+        if self.kind is None and self.name is None and self.source_path is None:
+            artifact: dict[str, Any] | None = None
+        else:
+            artifact = {
+                "kind": self.kind,
+                "name": self.name,
+                "sourcePath": self.source_path,
+            }
+        return {"error": self.error, "message": self.message, "artifact": artifact}
+
+    def __str__(self) -> str:  # pragma: no cover
+        return self.message
+
+
+@dataclass(frozen=True)
+class _CoreLayout:
+    """Filesystem layout for the resolved core-asset base.
+
+    Two shapes are supported. Wheel install: ``core_pack/commands/``,
+    ``core_pack/templates/``, ``core_pack/scripts/``. Source checkout:
+    ``templates/commands/``, ``templates/``, ``scripts/``. The emitted
+    ``sourcePath`` is always the source-layout form so wheel and source
+    outputs are byte-identical (FR-010, SC-002).
+    """
+
+    commands_dir: Path
+    templates_dir: Path
+    scripts_dir: Path
+
+    @staticmethod
+    def command_source_path(name: str) -> str:
+        return f"templates/commands/{name}.md"
+
+    @staticmethod
+    def template_source_path(filename: str) -> str:
+        return f"templates/{filename}"
+
+    @staticmethod
+    def script_source_path(runtime_subdir: str, filename: str) -> str:
+        return f"scripts/{runtime_subdir}/{filename}"
+
+
+def _resolve_core_root() -> _CoreLayout:
+    """Return a layout resolved against the wheel core_pack or repo root.
+
+    Prefers the wheel-install location (``_locate_core_pack``); falls back
+    to the source checkout (``_repo_root``). Raises :class:`CoreInventoryError`
+    if neither location has the expected asset subtrees.
+    """
+    core_pack = _locate_core_pack()
+    candidates: list[_CoreLayout] = []
+    if core_pack is not None:
+        candidates.append(
+            _CoreLayout(
+                commands_dir=core_pack / "commands",
+                templates_dir=core_pack / "templates",
+                scripts_dir=core_pack / "scripts",
+            )
+        )
+    repo = _repo_root()
+    candidates.append(
+        _CoreLayout(
+            commands_dir=repo / "templates" / "commands",
+            templates_dir=repo / "templates",
+            scripts_dir=repo / "scripts",
+        )
+    )
+
+    for layout in candidates:
+        if (
+            layout.commands_dir.is_dir()
+            and layout.templates_dir.is_dir()
+            and layout.scripts_dir.is_dir()
+        ):
+            return layout
+
+    raise CoreInventoryError(
+        error="core_inventory.assets_missing",
+        message=(
+            "Could not locate baseline commands/, templates/, and scripts/ "
+            "under either the wheel core_pack or the source checkout."
+        ),
+    )
+
+
+def _package_relative(path: str) -> str:
+    """Normalize to a POSIX package-relative path.
+
+    Enforces the ``packageRelativePath`` grammar from the JSON Schema:
+    no leading slash, no backslash. Defensive — callers already build
+    forward-slash source-layout strings.
+    """
+    if "\\" in path or path.startswith("/"):
+        raise CoreInventoryError(
+            error="core_inventory.invalid_source_path",
+            message=f"sourcePath must be package-relative POSIX: {path!r}",
+        )
+    return path
+
+
+def _read_leading_frontmatter(md_path: Path, *, kind: str, name: str) -> dict[str, Any]:
+    """Parse the ``---``-fenced YAML block at the head of ``md_path``.
+
+    Returns ``{}`` if the file has no frontmatter block. Raises
+    :class:`CoreInventoryError` on an unclosed fence or non-mapping payload.
+    Imports :mod:`yaml` lazily so module import stays cheap (constitution IV).
+    """
+    try:
+        text = md_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CoreInventoryError(
+            error="core_inventory.read_failed",
+            message=f"Could not read {kind} file: {exc}",
+            kind=kind,
+            name=name,
+            source_path=str(md_path),
+        ) from exc
+
+    if not text.startswith("---"):
+        return {}
+
+    lines = text.splitlines()
+    close_idx: int | None = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            close_idx = idx
+            break
+    if close_idx is None:
+        raise CoreInventoryError(
+            error="core_inventory.frontmatter_parse",
+            message=(
+                f"Unclosed YAML frontmatter fence in {kind} '{name}' "
+                f"({md_path.name})."
+            ),
+            kind=kind,
+            name=name,
+            source_path=str(md_path),
+        )
+
+    import yaml  # lazy import per constitution IV
+
+    body = "\n".join(lines[1:close_idx])
+    try:
+        parsed = yaml.safe_load(body) if body.strip() else {}
+    except yaml.YAMLError as exc:
+        raise CoreInventoryError(
+            error="core_inventory.frontmatter_parse",
+            message=(
+                f"Could not parse YAML frontmatter of {kind} '{name}': {exc}"
+            ),
+            kind=kind,
+            name=name,
+            source_path=str(md_path),
+        ) from exc
+
+    if parsed is None:
+        return {}
+    if not isinstance(parsed, dict):
+        raise CoreInventoryError(
+            error="core_inventory.frontmatter_parse",
+            message=(
+                f"Frontmatter of {kind} '{name}' must be a mapping, got "
+                f"{type(parsed).__name__}."
+            ),
+            kind=kind,
+            name=name,
+            source_path=str(md_path),
+        )
+    return parsed
+
+
+def _normalize_handoffs(raw: Any, *, name: str, source_path: str) -> list[str]:
+    """Coerce ``handoffs`` frontmatter value to ``list[str]``.
+
+    Real-world frontmatter uses list-of-mappings with an ``agent:`` field
+    (see ``templates/commands/specify.md``); we surface just the agent
+    identifiers, which is what downstream join logic needs. Bare-string
+    lists (contract-compliant) pass through unchanged. Absent → ``[]``.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise CoreInventoryError(
+            error="core_inventory.frontmatter_parse",
+            message=(
+                f"Command '{name}' has a non-list 'handoffs' frontmatter "
+                f"field ({type(raw).__name__})."
+            ),
+            kind="command",
+            name=name,
+            source_path=source_path,
+        )
+    result: list[str] = []
+    for entry in raw:
+        if isinstance(entry, str):
+            result.append(entry)
+        elif isinstance(entry, dict) and isinstance(entry.get("agent"), str):
+            result.append(entry["agent"])
+        else:
+            raise CoreInventoryError(
+                error="core_inventory.frontmatter_parse",
+                message=(
+                    f"Command '{name}' has an unrecognized 'handoffs' entry "
+                    f"({entry!r}); expected string or mapping with 'agent'."
+                ),
+                kind="command",
+                name=name,
+                source_path=source_path,
+            )
+    return result
+
+
+def _normalize_description(raw: Any, *, kind: str, name: str, source_path: str) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        raise CoreInventoryError(
+            error="core_inventory.missing_description",
+            message=f"{kind.capitalize()} '{name}' is missing a description.",
+            kind=kind,
+            name=name,
+            source_path=source_path,
+        )
+    return " ".join(raw.split())
+
+
+def _build_command_entry(name: str, layout: _CoreLayout) -> dict[str, Any]:
+    file_path = layout.commands_dir / f"{name}.md"
+    source_path = _package_relative(layout.command_source_path(name))
+    if not file_path.is_file():
+        raise CoreInventoryError(
+            error="core_inventory.missing_file",
+            message=(
+                f"Baseline command file for '{name}' not found "
+                f"(expected at {file_path})."
+            ),
+            kind="command",
+            name=name,
+            source_path=source_path,
+        )
+    frontmatter = _read_leading_frontmatter(file_path, kind="command", name=name)
+    description = _normalize_description(
+        frontmatter.get("description"),
+        kind="command",
+        name=name,
+        source_path=source_path,
+    )
+    artifact = frontmatter.get("artifact")
+    if artifact is not None and not isinstance(artifact, str):
+        raise CoreInventoryError(
+            error="core_inventory.frontmatter_parse",
+            message=(
+                f"Command '{name}' has a non-string 'artifact' frontmatter "
+                f"field ({type(artifact).__name__})."
+            ),
+            kind="command",
+            name=name,
+            source_path=source_path,
+        )
+    optional_raw = frontmatter.get("optional", False)
+    if not isinstance(optional_raw, bool):
+        raise CoreInventoryError(
+            error="core_inventory.frontmatter_parse",
+            message=(
+                f"Command '{name}' has a non-boolean 'optional' frontmatter "
+                f"field ({type(optional_raw).__name__})."
+            ),
+            kind="command",
+            name=name,
+            source_path=source_path,
+        )
+    handoffs = _normalize_handoffs(
+        frontmatter.get("handoffs"), name=name, source_path=source_path
+    )
+    return {
+        "id": f"core:_:command:{name}",
+        "name": name,
+        "description": description,
+        "sourcePath": source_path,
+        "artifact": artifact,
+        "optional": optional_raw,
+        "handoffs": handoffs,
+    }
+
+
+def _extract_template_description(md_path: Path, *, name: str, source_path: str) -> str:
+    """Return the template's description.
+
+    Prefers the frontmatter ``description:`` field; falls back to the first
+    ``# `` H1 heading. Raises :class:`CoreInventoryError` if neither yields
+    a non-empty string.
+    """
+    frontmatter = _read_leading_frontmatter(md_path, kind="template", name=name)
+    fm_desc = frontmatter.get("description")
+    if isinstance(fm_desc, str):
+        candidate = fm_desc.strip()
+        if candidate:
+            return " ".join(candidate.split())
+
+    try:
+        text = md_path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover
+        raise CoreInventoryError(
+            error="core_inventory.read_failed",
+            message=f"Could not read template file: {exc}",
+            kind="template",
+            name=name,
+            source_path=source_path,
+        ) from exc
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            heading = stripped[2:].strip()
+            if heading:
+                return " ".join(heading.split())
+
+    raise CoreInventoryError(
+        error="core_inventory.missing_description",
+        message=(
+            f"Template '{name}' has no description in frontmatter and no "
+            f"H1 heading; cannot derive a description."
+        ),
+        kind="template",
+        name=name,
+        source_path=source_path,
+    )
+
+
+def _build_template_entries(layout: _CoreLayout) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for md_path in sorted(layout.templates_dir.glob(f"*{_TEMPLATE_SUFFIX}")):
+        if not md_path.is_file():
+            continue
+        name = md_path.stem
+        source_path = _package_relative(layout.template_source_path(md_path.name))
+        description = _extract_template_description(
+            md_path, name=name, source_path=source_path
+        )
+        entries.append(
+            {
+                "id": f"core:_:template:{name}",
+                "name": name,
+                "description": description,
+                "sourcePath": source_path,
+            }
+        )
+    entries.sort(key=lambda entry: entry["name"])
+    return entries
+
+
+def _script_logical_name(runtime_subdir: str, filename: str) -> str:
+    """Return the logical script name for a runtime-variant filename.
+
+    Python filenames use underscores (`setup_plan.py`); the logical name is
+    always hyphenated (`setup-plan`). Bash/PowerShell already use hyphens.
+    """
+    stem = Path(filename).stem
+    if runtime_subdir == "python":
+        stem = stem.replace("_", "-")
+    return stem
+
+
+def _extract_script_description(bash_path: Path, *, name: str, source_path: str) -> str:
+    """Return the description parsed from the bash file's leading comments.
+
+    Skips the shebang and blank lines, then joins consecutive ``#``-prefixed
+    lines into a single whitespace-normalized string. Falls back to a
+    filename-derived description when the source has no header block — most
+    of the shipped baseline scripts today have no doc header, so a strict
+    error here would break the whole inventory on day-one code. The
+    filename-derived form still satisfies the schema's ``minLength: 1``
+    invariant and unambiguously identifies the script.
+    """
+    try:
+        text = bash_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CoreInventoryError(
+            error="core_inventory.read_failed",
+            message=f"Could not read script file: {exc}",
+            kind="script",
+            name=name,
+            source_path=source_path,
+        ) from exc
+
+    comment_lines: list[str] = []
+    started = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not started:
+            if stripped.startswith("#!"):
+                continue
+            if not stripped:
+                continue
+        if stripped.startswith("#"):
+            started = True
+            comment_lines.append(stripped.lstrip("#").strip())
+            continue
+        if started:
+            break
+        if stripped:
+            break
+
+    joined = " ".join(part for part in comment_lines if part).strip()
+    if joined:
+        return " ".join(joined.split())
+    # Fallback: derive a canonical description from the logical name.
+    return f"Baseline helper script: {name}."
+
+
+def _build_script_entries(layout: _CoreLayout) -> list[dict[str, Any]]:
+    per_name: dict[str, dict[str, Path]] = {}
+    for runtime_name, subdir, suffix in _RUNTIMES:
+        runtime_dir = layout.scripts_dir / subdir
+        if not runtime_dir.is_dir():
+            continue
+        for script_path in runtime_dir.iterdir():
+            if not script_path.is_file() or script_path.suffix != suffix:
+                continue
+            logical = _script_logical_name(subdir, script_path.name)
+            per_name.setdefault(logical, {})[runtime_name] = script_path
+
+    entries: list[dict[str, Any]] = []
+    for name in sorted(per_name):
+        variants = per_name[name]
+        bash_path = variants.get("bash")
+        if bash_path is None:
+            raise CoreInventoryError(
+                error="core_inventory.missing_canonical",
+                message=(
+                    f"Script '{name}' has no bash variant; bash is the "
+                    f"canonical runtime for the description + sourcePath."
+                ),
+                kind="script",
+                name=name,
+            )
+        source_path = _package_relative(
+            layout.script_source_path("bash", bash_path.name)
+        )
+        description = _extract_script_description(
+            bash_path, name=name, source_path=source_path
+        )
+        runtimes = sorted(variants.keys())
+        entries.append(
+            {
+                "id": f"core:_:script:{name}",
+                "name": name,
+                "description": description,
+                "sourcePath": source_path,
+                "runtimes": runtimes,
+            }
+        )
+    entries.sort(key=lambda entry: entry["name"])
+    return entries
+
+
+def build_core_inventory() -> dict[str, Any]:
+    """Return the baseline inventory as a fixed-shape dict.
+
+    Shape (validated by ``contracts/core-info-schema.json``):
+    ``{"commands": [...], "templates": [...], "scripts": [...]}``.
+
+    All three top-level lists are sorted alphabetically by ``name``. Two
+    consecutive calls MUST return byte-identical JSON when serialized
+    with ``json.dumps(..., sort_keys=False)`` (SC-002).
+
+    Raises :class:`CoreInventoryError` on any packaging inconsistency
+    (FR-012). No partial inventory is ever returned.
+    """
+    layout = _resolve_core_root()
+
+    from ..extensions import _load_core_command_names  # lazy: avoid import cycle
+
+    command_names = sorted(_load_core_command_names())
+    commands = [_build_command_entry(name, layout) for name in command_names]
+    templates = _build_template_entries(layout)
+    scripts = _build_script_entries(layout)
+    return {"commands": commands, "templates": templates, "scripts": scripts}

--- a/src/specify_cli/core/__init__.py
+++ b/src/specify_cli/core/__init__.py
@@ -4,16 +4,11 @@ Public entry point: :func:`build_core_inventory` returns a fixed-shape dict
 enumerating the baseline commands, templates, and scripts that ship inside
 the wheel (`specify_cli/core_pack/`) or the source checkout (repo root).
 
-The output is the exact shape validated by
-``specs/001-core-info/contracts/core-info-schema.json``. See
-``specs/001-core-info/data-model.md`` for authoritative field types.
-
-Every asset carries a stable identifier per companion issue #4210:
-``core:_:{kind}:{name}``. Ordering: alphabetical by ``name`` within each
-list. Failure mode: any packaging inconsistency (missing shipped file,
-unparseable frontmatter, script with zero runtimes) raises
-:class:`CoreInventoryError` — the caller emits a JSON error envelope to
-stderr and exits non-zero (FR-012).
+Every asset carries a stable identifier: ``core:_:{kind}:{name}``. Ordering:
+alphabetical by ``name`` within each list. Failure mode: any packaging
+inconsistency (missing shipped file, unparseable frontmatter, script with
+zero runtimes) raises :class:`CoreInventoryError` — the caller emits a JSON
+error envelope to stderr and exits non-zero.
 """
 from __future__ import annotations
 
@@ -35,7 +30,7 @@ _RUNTIMES: tuple[tuple[str, str, str], ...] = (
 
 
 class CoreInventoryError(Exception):
-    """Raised when the shipped baseline is inconsistent (FR-012)."""
+    """Raised when the shipped baseline is inconsistent."""
 
     def __init__(
         self,
@@ -76,7 +71,7 @@ class _CoreLayout:
     ``core_pack/templates/``, ``core_pack/scripts/``. Source checkout:
     ``templates/commands/``, ``templates/``, ``scripts/``. The emitted
     ``sourcePath`` is always the source-layout form so wheel and source
-    outputs are byte-identical (FR-010, SC-002).
+    outputs are byte-identical.
     """
 
     commands_dir: Path
@@ -518,22 +513,20 @@ def _build_script_entries(layout: _CoreLayout) -> list[dict[str, Any]]:
 def build_core_inventory() -> dict[str, Any]:
     """Return the baseline inventory as a fixed-shape dict.
 
-    Shape (validated by ``contracts/core-info-schema.json``):
-    ``{"commands": [...], "templates": [...], "scripts": [...]}``.
+    Shape: ``{"commands": [...], "templates": [...], "scripts": [...]}``.
 
     All three top-level lists are sorted alphabetically by ``name``. Two
     consecutive calls MUST return byte-identical JSON when serialized
-    with ``json.dumps(..., sort_keys=False)`` (SC-002).
+    with ``json.dumps(..., sort_keys=False)``.
 
-    Raises :class:`CoreInventoryError` on any packaging inconsistency
-    (FR-012). No partial inventory is ever returned.
+    Raises :class:`CoreInventoryError` on any packaging inconsistency.
+    No partial inventory is ever returned.
     """
     layout = _resolve_core_root()
 
     from ..extensions import CORE_COMMAND_NAMES  # lazy: avoid import cycle
 
     # A deleted bundled command cannot be detected because this set is derived from those files.
-    # That would already corrupt the installation, so an independent manifest is not warranted.
     command_names = sorted(CORE_COMMAND_NAMES)
     commands = [_build_command_entry(name, layout) for name in command_names]
     templates = _build_template_entries(layout)

--- a/src/specify_cli/core/__init__.py
+++ b/src/specify_cli/core/__init__.py
@@ -154,7 +154,9 @@ def _package_relative(path: str) -> str:
     return path
 
 
-def _read_leading_frontmatter(md_path: Path, *, kind: str, name: str) -> dict[str, Any]:
+def _read_leading_frontmatter(
+    md_path: Path, *, kind: str, name: str, source_path: str
+) -> dict[str, Any]:
     """Parse the ``---``-fenced YAML block at the head of ``md_path``.
 
     Returns ``{}`` if the file has no frontmatter block. Raises
@@ -166,10 +168,10 @@ def _read_leading_frontmatter(md_path: Path, *, kind: str, name: str) -> dict[st
     except OSError as exc:
         raise CoreInventoryError(
             error="core_inventory.read_failed",
-            message=f"Could not read {kind} file: {exc}",
+            message=f"Could not read {kind} file: {exc.strerror or exc}",
             kind=kind,
             name=name,
-            source_path=str(md_path),
+            source_path=source_path,
         ) from exc
 
     if not text.startswith("---"):
@@ -190,7 +192,7 @@ def _read_leading_frontmatter(md_path: Path, *, kind: str, name: str) -> dict[st
             ),
             kind=kind,
             name=name,
-            source_path=str(md_path),
+            source_path=source_path,
         )
 
     import yaml  # lazy import per constitution IV
@@ -206,7 +208,7 @@ def _read_leading_frontmatter(md_path: Path, *, kind: str, name: str) -> dict[st
             ),
             kind=kind,
             name=name,
-            source_path=str(md_path),
+            source_path=source_path,
         ) from exc
 
     if parsed is None:
@@ -220,7 +222,7 @@ def _read_leading_frontmatter(md_path: Path, *, kind: str, name: str) -> dict[st
             ),
             kind=kind,
             name=name,
-            source_path=str(md_path),
+            source_path=source_path,
         )
     return parsed
 
@@ -293,7 +295,9 @@ def _build_command_entry(name: str, layout: _CoreLayout) -> dict[str, Any]:
             name=name,
             source_path=source_path,
         )
-    frontmatter = _read_leading_frontmatter(file_path, kind="command", name=name)
+    frontmatter = _read_leading_frontmatter(
+        file_path, kind="command", name=name, source_path=source_path
+    )
     description = _normalize_description(
         frontmatter.get("description"),
         kind="command",
@@ -345,7 +349,9 @@ def _extract_template_description(md_path: Path, *, name: str, source_path: str)
     ``# `` H1 heading. Raises :class:`CoreInventoryError` if neither yields
     a non-empty string.
     """
-    frontmatter = _read_leading_frontmatter(md_path, kind="template", name=name)
+    frontmatter = _read_leading_frontmatter(
+        md_path, kind="template", name=name, source_path=source_path
+    )
     fm_desc = frontmatter.get("description")
     if isinstance(fm_desc, str):
         candidate = fm_desc.strip()

--- a/src/specify_cli/core/__init__.py
+++ b/src/specify_cli/core/__init__.py
@@ -5,8 +5,8 @@ enumerating the baseline commands, templates, and scripts that ship inside
 the wheel (`specify_cli/core_pack/`) or the source checkout (repo root).
 
 The output is the exact shape validated by
-``specs/001-core-inventory/contracts/core-info-schema.json``. See
-``specs/001-core-inventory/data-model.md`` for authoritative field types.
+``specs/001-core-info/contracts/core-info-schema.json``. See
+``specs/001-core-info/data-model.md`` for authoritative field types.
 
 Every asset carries a stable identifier per companion issue #4210:
 ``core:_:{kind}:{name}``. Ordering: alphabetical by ``name`` within each

--- a/src/specify_cli/core/__init__.py
+++ b/src/specify_cli/core/__init__.py
@@ -524,9 +524,9 @@ def build_core_inventory() -> dict[str, Any]:
     """
     layout = _resolve_core_root()
 
-    from ..extensions import _load_core_command_names  # lazy: avoid import cycle
+    from ..extensions import CORE_COMMAND_NAMES  # lazy: avoid import cycle
 
-    command_names = sorted(_load_core_command_names())
+    command_names = sorted(CORE_COMMAND_NAMES)
     commands = [_build_command_entry(name, layout) for name in command_names]
     templates = _build_template_entries(layout)
     scripts = _build_script_entries(layout)

--- a/src/specify_cli/core/__init__.py
+++ b/src/specify_cli/core/__init__.py
@@ -532,6 +532,8 @@ def build_core_inventory() -> dict[str, Any]:
 
     from ..extensions import CORE_COMMAND_NAMES  # lazy: avoid import cycle
 
+    # A deleted bundled command cannot be detected because this set is derived from those files.
+    # That would already corrupt the installation, so an independent manifest is not warranted.
     command_names = sorted(CORE_COMMAND_NAMES)
     commands = [_build_command_entry(name, layout) for name in command_names]
     templates = _build_template_entries(layout)

--- a/src/specify_cli/core/_commands.py
+++ b/src/specify_cli/core/_commands.py
@@ -1,8 +1,8 @@
 """specify core * command handlers — app object and register() entry point.
 
-See ``specs/001-core-inventory/contracts/core-info-cli.md`` for the CLI
+See ``specs/001-core-info/contracts/core-info-cli.md`` for the CLI
 contract (invocation syntax, streams, exit codes). See
-``specs/001-core-inventory/data-model.md`` for the emitted JSON shape.
+``specs/001-core-info/data-model.md`` for the emitted JSON shape.
 """
 from __future__ import annotations
 

--- a/src/specify_cli/core/_commands.py
+++ b/src/specify_cli/core/_commands.py
@@ -1,0 +1,59 @@
+"""specify core * command handlers — app object and register() entry point.
+
+See ``specs/001-core-inventory/contracts/core-info-cli.md`` for the CLI
+contract (invocation syntax, streams, exit codes). See
+``specs/001-core-inventory/data-model.md`` for the emitted JSON shape.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+import typer
+
+core_app = typer.Typer(
+    name="core",
+    help="Inspect the core (baseline) inventory shipped inside specify-cli.",
+    add_completion=False,
+)
+
+
+@core_app.command("info")
+def core_info(
+    json_flag: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the baseline inventory as JSON to standard output.",
+    ),
+) -> None:
+    """Emit the baseline commands, templates, and scripts.
+
+    With ``--json``: writes the inventory document to stdout and exits 0.
+    Without ``--json``: prints a hint pointing at the JSON flag and exits
+    non-zero — this feature ships JSON-only, per FR-002 / SC-005.
+
+    On any packaging inconsistency (missing shipped file, unparseable
+    frontmatter, script with zero runtimes), emits a JSON error envelope
+    on stderr, leaves stdout empty, and exits 1 (FR-012).
+    """
+    if not json_flag:
+        sys.stderr.write(
+            "specify core info: this command ships JSON output only. "
+            "Re-run with --json.\n"
+        )
+        raise typer.Exit(code=2)
+
+    from . import CoreInventoryError, build_core_inventory  # lazy
+
+    try:
+        inventory = build_core_inventory()
+    except CoreInventoryError as exc:
+        sys.stderr.write(json.dumps(exc.to_envelope(), sort_keys=False) + "\n")
+        raise typer.Exit(code=1) from exc
+
+    sys.stdout.write(json.dumps(inventory, indent=2, sort_keys=False) + "\n")
+
+
+def register(app: typer.Typer) -> None:
+    """Attach the core command group to the root Typer app."""
+    app.add_typer(core_app, name="core")

--- a/tests/contract/test_core_inventory_wheel.py
+++ b/tests/contract/test_core_inventory_wheel.py
@@ -1,4 +1,4 @@
-"""Wheel/source count-parity contract test (T031).
+"""Wheel/source count-parity contract test.
 
 Guarantees the shipped baseline surfaces the same count of commands, templates
 and scripts regardless of whether ``build_core_inventory`` finds the wheel's

--- a/tests/contract/test_core_inventory_wheel.py
+++ b/tests/contract/test_core_inventory_wheel.py
@@ -1,0 +1,61 @@
+"""Wheel/source count-parity contract test (T031).
+
+Guarantees the shipped baseline surfaces the same count of commands, templates
+and scripts regardless of whether ``build_core_inventory`` finds the wheel's
+``core_pack/`` directory or falls back to the source checkout. Deep equality
+is intentionally not asserted here: source and wheel builds may embed slightly
+different absolute paths but the count invariant is what protects consumers.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from specify_cli import core as core_pkg
+from specify_cli.core import build_core_inventory
+
+
+def _mirror_source_into_pack(src_root: Path, pack_root: Path) -> None:
+    """Copy shipped source assets into a fake wheel-style ``core_pack/`` tree."""
+    import shutil
+
+    (pack_root / "commands").mkdir(parents=True, exist_ok=True)
+    (pack_root / "templates").mkdir(parents=True, exist_ok=True)
+    (pack_root / "scripts").mkdir(parents=True, exist_ok=True)
+
+    for md in (src_root / "templates" / "commands").glob("*.md"):
+        shutil.copy2(md, pack_root / "commands" / md.name)
+    for tmpl in (src_root / "templates").glob("*.md"):
+        shutil.copy2(tmpl, pack_root / "templates" / tmpl.name)
+    for runtime in ("bash", "powershell", "python"):
+        runtime_dir = src_root / "scripts" / runtime
+        if not runtime_dir.exists():
+            continue
+        dest = pack_root / "scripts" / runtime
+        dest.mkdir(exist_ok=True)
+        for script in runtime_dir.iterdir():
+            if script.is_file():
+                shutil.copy2(script, dest / script.name)
+
+
+def test_wheel_and_source_layouts_agree_on_counts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # 1) Source-layout snapshot: force the wheel pack lookup to miss.
+    monkeypatch.setattr(core_pkg, "_locate_core_pack", lambda: None)
+    source_inv = build_core_inventory()
+
+    # 2) Wheel-layout snapshot: mirror the shipped source into a fake pack tree
+    #    and force ``_locate_core_pack`` to return it.
+    src_root = core_pkg._repo_root()
+    pack_root = tmp_path / "core_pack"
+    _mirror_source_into_pack(src_root, pack_root)
+    monkeypatch.setattr(core_pkg, "_locate_core_pack", lambda: pack_root)
+    wheel_inv = build_core_inventory()
+
+    for section in ("commands", "templates", "scripts"):
+        assert len(source_inv[section]) == len(wheel_inv[section]), section
+        assert [e["name"] for e in source_inv[section]] == [
+            e["name"] for e in wheel_inv[section]
+        ], section

--- a/tests/test_core_info_command.py
+++ b/tests/test_core_info_command.py
@@ -182,8 +182,8 @@ def test_core_info_missing_command_file_exits_nonzero(
 
     # Redirect the discovery helpers to a name that has no shipped file.
     monkeypatch.setattr(
-        "specify_cli.extensions._load_core_command_names",
-        lambda: frozenset({"nonexistent-command"}),
+        "specify_cli.extensions.CORE_COMMAND_NAMES",
+        frozenset({"nonexistent-command"}),
     )
     result = _invoke(["core", "info", "--json"])
     assert result.exit_code == 1

--- a/tests/test_core_info_command.py
+++ b/tests/test_core_info_command.py
@@ -1,0 +1,192 @@
+"""CLI-level tests for ``specify core info --json`` via Typer's CliRunner.
+
+Contract references:
+- ``specs/001-core-inventory/contracts/core-info-cli.md``
+- ``specs/001-core-inventory/contracts/core-info-schema.json``
+
+Deferred (companion #4212): cross-reference integration tests that join this
+command's output against ``specify artifact info --json``. See tasks.md T029.
+"""
+# TODO(#4212): add a cross-reference integration test that joins
+# `specify core info --json` output against `specify artifact info --json`
+# once the companion command lands. See specs/001-core-inventory/tasks.md T029.
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from specify_cli import app
+
+
+def _invoke(args: list[str]):
+    runner = CliRunner()
+    return runner.invoke(app, args)
+
+
+# ---------------------------------------------------------------------------
+# T019 — CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_core_info_json_returns_zero_and_valid_json() -> None:
+    result = _invoke(["core", "info", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert list(parsed.keys()) == ["commands", "templates", "scripts"]
+
+
+def test_core_info_without_json_exits_nonzero() -> None:
+    result = _invoke(["core", "info"])
+    assert result.exit_code != 0
+    # Message points at the flag; user knows what to do.
+    assert "--json" in result.output
+
+
+def test_core_info_help_lists_json_flag() -> None:
+    result = _invoke(["core", "info", "--help"])
+    assert result.exit_code == 0
+    assert "--json" in result.output
+
+
+def test_specify_root_help_shows_core_group() -> None:
+    result = _invoke(["--help"])
+    assert result.exit_code == 0
+    assert "core" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# T020 — schema-conformance (hand-rolled shape check keyed off the schema)
+# ---------------------------------------------------------------------------
+
+
+_STABLE_ID = re.compile(r"^core:_:(command|template|script):[A-Za-z0-9._-]+$")
+_PACKAGE_REL = re.compile(r"^(?!/)[^\\]+$")
+_ALLOWED_RUNTIMES = {"bash", "powershell", "python"}
+
+
+def _validate_command(entry: dict) -> None:
+    required = {"id", "name", "description", "sourcePath", "artifact", "optional", "handoffs"}
+    assert set(entry.keys()) == required, entry
+    assert _STABLE_ID.match(entry["id"])
+    assert isinstance(entry["name"], str) and entry["name"]
+    assert isinstance(entry["description"], str) and entry["description"]
+    assert _PACKAGE_REL.match(entry["sourcePath"])
+    assert entry["artifact"] is None or isinstance(entry["artifact"], str)
+    assert isinstance(entry["optional"], bool)
+    assert isinstance(entry["handoffs"], list)
+    for h in entry["handoffs"]:
+        assert isinstance(h, str) and h
+
+
+def _validate_template(entry: dict) -> None:
+    required = {"id", "name", "description", "sourcePath"}
+    assert set(entry.keys()) == required, entry
+    assert _STABLE_ID.match(entry["id"])
+    assert isinstance(entry["name"], str) and entry["name"]
+    assert isinstance(entry["description"], str) and entry["description"]
+    assert _PACKAGE_REL.match(entry["sourcePath"])
+
+
+def _validate_script(entry: dict) -> None:
+    required = {"id", "name", "description", "sourcePath", "runtimes"}
+    assert set(entry.keys()) == required, entry
+    assert _STABLE_ID.match(entry["id"])
+    assert isinstance(entry["name"], str) and entry["name"]
+    assert isinstance(entry["description"], str) and entry["description"]
+    assert _PACKAGE_REL.match(entry["sourcePath"])
+    assert isinstance(entry["runtimes"], list) and entry["runtimes"]
+    assert set(entry["runtimes"]) <= _ALLOWED_RUNTIMES
+    assert entry["runtimes"] == sorted(set(entry["runtimes"]))
+
+
+def test_core_info_output_validates_against_contract_schema() -> None:
+    result = _invoke(["core", "info", "--json"])
+    parsed = json.loads(result.output)
+    for entry in parsed["commands"]:
+        _validate_command(entry)
+    for entry in parsed["templates"]:
+        _validate_template(entry)
+    for entry in parsed["scripts"]:
+        _validate_script(entry)
+
+
+# ---------------------------------------------------------------------------
+# T021 — determinism gate (SC-002)
+# ---------------------------------------------------------------------------
+
+
+def test_core_info_output_is_byte_identical_across_two_runs() -> None:
+    a = _invoke(["core", "info", "--json"])
+    b = _invoke(["core", "info", "--json"])
+    assert a.exit_code == 0 and b.exit_code == 0
+    assert a.output == b.output, "output not byte-identical across two runs"
+
+
+# ---------------------------------------------------------------------------
+# T022 — path-shape invariant
+# ---------------------------------------------------------------------------
+
+
+def test_core_info_source_paths_are_package_relative() -> None:
+    parsed = json.loads(_invoke(["core", "info", "--json"]).output)
+    for section in ("commands", "templates", "scripts"):
+        for entry in parsed[section]:
+            assert _PACKAGE_REL.match(entry["sourcePath"]), entry["sourcePath"]
+
+
+# ---------------------------------------------------------------------------
+# T023 — project-isolation guarantees (FR-013)
+# ---------------------------------------------------------------------------
+
+
+def test_core_info_runs_outside_specify_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The command must succeed even when cwd is not a Spec Kit project."""
+    monkeypatch.chdir(tmp_path)
+    result = _invoke(["core", "info", "--json"])
+    assert result.exit_code == 0, result.output
+
+
+def test_core_info_ignores_presets_and_extensions_in_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even a project with a fake .specify + preset dir must not change output."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".specify").mkdir()
+    (tmp_path / ".specify" / "presets").mkdir()
+    (tmp_path / ".specify" / "presets" / "fake.yml").write_text(
+        "preset:\n  id: fake\n  name: fake\n", encoding="utf-8"
+    )
+    inside = _invoke(["core", "info", "--json"]).output
+
+    monkeypatch.chdir(tmp_path.parent)
+    outside = _invoke(["core", "info", "--json"]).output
+
+    assert inside == outside
+
+
+# ---------------------------------------------------------------------------
+# T024 — fail-fast on packaging errors → non-zero exit + JSON envelope on stderr
+# ---------------------------------------------------------------------------
+
+
+def test_core_info_missing_command_file_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from specify_cli import core as core_pkg
+
+    # Redirect the discovery helpers to a name that has no shipped file.
+    monkeypatch.setattr(
+        "specify_cli.extensions._load_core_command_names",
+        lambda: frozenset({"nonexistent-command"}),
+    )
+    result = _invoke(["core", "info", "--json"])
+    assert result.exit_code == 1
+    # CliRunner mixes streams by default; parse the envelope out of the output.
+    # Look for the JSON envelope keys — that's enough to confirm the shape.
+    assert "core_inventory.missing_file" in result.output

--- a/tests/test_core_info_command.py
+++ b/tests/test_core_info_command.py
@@ -13,6 +13,7 @@ command's output against ``specify artifact info --json``. See tasks.md T029.
 from __future__ import annotations
 
 import json
+import importlib
 import re
 from pathlib import Path
 
@@ -178,7 +179,7 @@ def test_core_info_ignores_presets_and_extensions_in_project(
 def test_core_info_missing_command_file_exits_nonzero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from specify_cli import core as core_pkg
+    importlib.import_module("specify_cli.core")
 
     # Redirect the discovery helpers to a name that has no shipped file.
     monkeypatch.setattr(

--- a/tests/test_core_info_command.py
+++ b/tests/test_core_info_command.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from specify_cli import app
+from tests.conftest import strip_ansi
 
 
 def _invoke(args: list[str]):
@@ -33,19 +34,19 @@ def test_core_info_without_json_exits_nonzero() -> None:
     result = _invoke(["core", "info"])
     assert result.exit_code != 0
     # Message points at the flag; user knows what to do.
-    assert "--json" in result.output
+    assert "--json" in strip_ansi(result.output)
 
 
 def test_core_info_help_lists_json_flag() -> None:
     result = _invoke(["core", "info", "--help"])
     assert result.exit_code == 0
-    assert "--json" in result.output
+    assert "--json" in strip_ansi(result.output)
 
 
 def test_specify_root_help_shows_core_group() -> None:
     result = _invoke(["--help"])
     assert result.exit_code == 0
-    assert "core" in result.output.lower()
+    assert "core" in strip_ansi(result.output).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -179,4 +180,4 @@ def test_core_info_missing_command_file_exits_nonzero(
     assert result.exit_code == 1
     # CliRunner mixes streams by default; parse the envelope out of the output.
     # Look for the JSON envelope keys — that's enough to confirm the shape.
-    assert "core_inventory.missing_file" in result.output
+    assert "core_inventory.missing_file" in strip_ansi(result.output)

--- a/tests/test_core_info_command.py
+++ b/tests/test_core_info_command.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib
 import json
-import importlib
 import re
 from pathlib import Path
 

--- a/tests/test_core_info_command.py
+++ b/tests/test_core_info_command.py
@@ -1,15 +1,4 @@
-"""CLI-level tests for ``specify core info --json`` via Typer's CliRunner.
-
-Contract references:
-- ``specs/001-core-info/contracts/core-info-cli.md``
-- ``specs/001-core-info/contracts/core-info-schema.json``
-
-Deferred (companion #4212): cross-reference integration tests that join this
-command's output against ``specify artifact info --json``. See tasks.md T029.
-"""
-# TODO(#4212): add a cross-reference integration test that joins
-# `specify core info --json` output against `specify artifact info --json`
-# once the companion command lands. See specs/001-core-info/tasks.md T029.
+"""CLI-level tests for ``specify core info --json`` via Typer's CliRunner."""
 from __future__ import annotations
 
 import importlib
@@ -29,7 +18,7 @@ def _invoke(args: list[str]):
 
 
 # ---------------------------------------------------------------------------
-# T019 — CLI surface
+# CLI surface
 # ---------------------------------------------------------------------------
 
 
@@ -60,7 +49,7 @@ def test_specify_root_help_shows_core_group() -> None:
 
 
 # ---------------------------------------------------------------------------
-# T020 — schema-conformance (hand-rolled shape check keyed off the schema)
+# Schema-conformance (hand-rolled shape check)
 # ---------------------------------------------------------------------------
 
 
@@ -116,7 +105,7 @@ def test_core_info_output_validates_against_contract_schema() -> None:
 
 
 # ---------------------------------------------------------------------------
-# T021 — determinism gate (SC-002)
+# Determinism gate
 # ---------------------------------------------------------------------------
 
 
@@ -128,7 +117,7 @@ def test_core_info_output_is_byte_identical_across_two_runs() -> None:
 
 
 # ---------------------------------------------------------------------------
-# T022 — path-shape invariant
+# Path-shape invariant
 # ---------------------------------------------------------------------------
 
 
@@ -140,7 +129,7 @@ def test_core_info_source_paths_are_package_relative() -> None:
 
 
 # ---------------------------------------------------------------------------
-# T023 — project-isolation guarantees (FR-013)
+# Project-isolation guarantees
 # ---------------------------------------------------------------------------
 
 
@@ -172,7 +161,7 @@ def test_core_info_ignores_presets_and_extensions_in_project(
 
 
 # ---------------------------------------------------------------------------
-# T024 — fail-fast on packaging errors → non-zero exit + JSON envelope on stderr
+# Fail-fast on packaging errors → non-zero exit + JSON envelope on stderr
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_core_info_command.py
+++ b/tests/test_core_info_command.py
@@ -12,6 +12,7 @@ command's output against ``specify artifact info --json``. See tasks.md T029.
 # once the companion command lands. See specs/001-core-info/tasks.md T029.
 from __future__ import annotations
 
+import importlib
 import json
 import importlib
 import re

--- a/tests/test_core_info_command.py
+++ b/tests/test_core_info_command.py
@@ -1,15 +1,15 @@
 """CLI-level tests for ``specify core info --json`` via Typer's CliRunner.
 
 Contract references:
-- ``specs/001-core-inventory/contracts/core-info-cli.md``
-- ``specs/001-core-inventory/contracts/core-info-schema.json``
+- ``specs/001-core-info/contracts/core-info-cli.md``
+- ``specs/001-core-info/contracts/core-info-schema.json``
 
 Deferred (companion #4212): cross-reference integration tests that join this
 command's output against ``specify artifact info --json``. See tasks.md T029.
 """
 # TODO(#4212): add a cross-reference integration test that joins
 # `specify core info --json` output against `specify artifact info --json`
-# once the companion command lands. See specs/001-core-inventory/tasks.md T029.
+# once the companion command lands. See specs/001-core-info/tasks.md T029.
 from __future__ import annotations
 
 import json

--- a/tests/test_core_inventory.py
+++ b/tests/test_core_inventory.py
@@ -188,7 +188,7 @@ def test_build_command_handoffs_flatten_agent_field(well_formed_layout: Path, ov
 def test_build_command_rejects_non_boolean_optional(tmp_path: Path, override_layout) -> None:
     _write(
         tmp_path / "templates" / "commands" / "gamma.md",
-        "---\ndescription: hi\noptional: yes\n---\n",
+        "---\ndescription: hi\noptional: 123\n---\n",
     )
     (tmp_path / "templates" / "spec-template.md").parent.mkdir(exist_ok=True)
     _write(tmp_path / "templates" / "spec-template.md", "# Spec Template\n")

--- a/tests/test_core_inventory.py
+++ b/tests/test_core_inventory.py
@@ -170,7 +170,7 @@ def test_parse_command_frontmatter_rejects_non_mapping(tmp_path: Path) -> None:
 def test_build_command_entries_uses_typed_empty_defaults(well_formed_layout: Path, override_layout) -> None:
     override_layout(well_formed_layout)
     inv = build_core_inventory()
-    alpha = next(c for c in inv["commands"] if c["name"] == "alpha")
+    alpha = next(c for c in inv["commands"] if c["name"] == "speckit.alpha")
     # alpha.md declares only `description:` — everything else must default.
     assert alpha["artifact"] is None
     assert alpha["optional"] is False
@@ -180,7 +180,7 @@ def test_build_command_entries_uses_typed_empty_defaults(well_formed_layout: Pat
 def test_build_command_handoffs_flatten_agent_field(well_formed_layout: Path, override_layout) -> None:
     override_layout(well_formed_layout)
     inv = build_core_inventory()
-    beta = next(c for c in inv["commands"] if c["name"] == "beta")
+    beta = next(c for c in inv["commands"] if c["name"] == "speckit.beta")
     # beta.md's handoffs are mappings with `agent:` — we surface only agent ids.
     assert beta["handoffs"] == ["alpha", "alpha"]
 

--- a/tests/test_core_inventory.py
+++ b/tests/test_core_inventory.py
@@ -78,7 +78,7 @@ def override_layout(monkeypatch: pytest.MonkeyPatch):
             if p.is_file()
         )
         monkeypatch.setattr(
-            "specify_cli.extensions._load_core_command_names", lambda: names
+            "specify_cli.extensions.CORE_COMMAND_NAMES", names
         )
 
     return use
@@ -309,8 +309,8 @@ def test_missing_command_file_exits_with_envelope(tmp_path: Path, monkeypatch: p
     )
     monkeypatch.setattr(core_pkg, "_resolve_core_root", lambda: layout)
     monkeypatch.setattr(
-        "specify_cli.extensions._load_core_command_names",
-        lambda: frozenset({"ghost"}),
+        "specify_cli.extensions.CORE_COMMAND_NAMES",
+        frozenset({"ghost"}),
     )
     with pytest.raises(CoreInventoryError) as excinfo:
         build_core_inventory()

--- a/tests/test_core_inventory.py
+++ b/tests/test_core_inventory.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Any
 
 import pytest
 

--- a/tests/test_core_inventory.py
+++ b/tests/test_core_inventory.py
@@ -3,10 +3,10 @@
 Test targets:
 
 - Path resolution across wheel and source layouts
-- Frontmatter parsing with typed empty defaults (Clarifications Q2)
-- Alphabetical ordering & determinism (research §R6, SC-002)
-- Stable id grammar per companion #4210 (US2 T028)
-- Fail-fast failure modes (FR-012, SC-004)
+- Frontmatter parsing with typed empty defaults
+- Alphabetical ordering & determinism
+- Stable id grammar
+- Fail-fast failure modes
 """
 from __future__ import annotations
 
@@ -85,7 +85,7 @@ def override_layout(monkeypatch: pytest.MonkeyPatch):
 
 
 # ---------------------------------------------------------------------------
-# Path resolution (T015)
+# Path resolution
 # ---------------------------------------------------------------------------
 
 
@@ -129,7 +129,7 @@ def test_package_relative_rejects_absolute() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Frontmatter parsing (T015)
+# Frontmatter parsing
 # ---------------------------------------------------------------------------
 
 
@@ -174,7 +174,7 @@ def test_parse_command_frontmatter_rejects_non_mapping(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Typed empty defaults & handoffs normalization (T016)
+# Typed empty defaults & handoffs normalization
 # ---------------------------------------------------------------------------
 
 
@@ -211,7 +211,7 @@ def test_build_command_rejects_non_boolean_optional(tmp_path: Path, override_lay
 
 
 # ---------------------------------------------------------------------------
-# Scripts: partial runtimes, ordering (T016)
+# Scripts: partial runtimes, ordering
 # ---------------------------------------------------------------------------
 
 
@@ -266,7 +266,7 @@ def test_python_script_name_hyphenated(tmp_path: Path, override_layout) -> None:
 def test_build_core_inventory_deterministic_ordering() -> None:
     a = build_core_inventory()
     b = build_core_inventory()
-    # Byte-identical serialization is the SC-002 gate.
+    # Byte-identical serialization gate.
     assert json.dumps(a, sort_keys=False) == json.dumps(b, sort_keys=False)
 
 
@@ -283,14 +283,14 @@ def test_top_level_keys_have_fixed_order() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Stable-id grammar (US2 T028)
+# Stable-id grammar
 # ---------------------------------------------------------------------------
 
 
 _STABLE_ID = re.compile(r"^core:_:(command|template|script):[A-Za-z0-9._-]+$")
 
 
-def test_all_ids_match_4210_grammar() -> None:
+def test_all_ids_match_stable_grammar() -> None:
     inv = build_core_inventory()
     seen: list[str] = []
     for section, kind in [("commands", "command"), ("templates", "template"), ("scripts", "script")]:
@@ -304,7 +304,7 @@ def test_all_ids_match_4210_grammar() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Fail-fast behavior on packaging errors (SC-004, FR-012)
+# Fail-fast behavior on packaging errors
 # ---------------------------------------------------------------------------
 
 
@@ -383,7 +383,7 @@ def test_template_without_any_description_fails_fast(tmp_path: Path, override_la
 
 
 # ---------------------------------------------------------------------------
-# Path-shape invariant (T022)
+# Path-shape invariant
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_core_inventory.py
+++ b/tests/test_core_inventory.py
@@ -136,7 +136,9 @@ def test_package_relative_rejects_absolute() -> None:
 def test_parse_command_frontmatter_success(tmp_path: Path) -> None:
     md = tmp_path / "cmd.md"
     md.write_text("---\ndescription: hi\nartifact: foo\n---\nbody\n", encoding="utf-8")
-    parsed = core_pkg._read_leading_frontmatter(md, kind="command", name="cmd")
+    parsed = core_pkg._read_leading_frontmatter(
+        md, kind="command", name="cmd", source_path="commands/cmd.md"
+    )
     assert parsed == {"description": "hi", "artifact": "foo"}
 
 
@@ -144,7 +146,9 @@ def test_parse_command_frontmatter_raises_on_unclosed_fence(tmp_path: Path) -> N
     md = tmp_path / "cmd.md"
     md.write_text("---\ndescription: hi\n\nbody with no close\n", encoding="utf-8")
     with pytest.raises(CoreInventoryError) as excinfo:
-        core_pkg._read_leading_frontmatter(md, kind="command", name="cmd")
+        core_pkg._read_leading_frontmatter(
+            md, kind="command", name="cmd", source_path="commands/cmd.md"
+        )
     assert excinfo.value.error == "core_inventory.frontmatter_parse"
     assert excinfo.value.kind == "command"
 
@@ -152,14 +156,21 @@ def test_parse_command_frontmatter_raises_on_unclosed_fence(tmp_path: Path) -> N
 def test_parse_command_frontmatter_returns_empty_when_absent(tmp_path: Path) -> None:
     md = tmp_path / "cmd.md"
     md.write_text("# just markdown, no frontmatter\n", encoding="utf-8")
-    assert core_pkg._read_leading_frontmatter(md, kind="command", name="cmd") == {}
+    assert (
+        core_pkg._read_leading_frontmatter(
+            md, kind="command", name="cmd", source_path="commands/cmd.md"
+        )
+        == {}
+    )
 
 
 def test_parse_command_frontmatter_rejects_non_mapping(tmp_path: Path) -> None:
     md = tmp_path / "cmd.md"
     md.write_text("---\n- one\n- two\n---\nbody\n", encoding="utf-8")
     with pytest.raises(CoreInventoryError):
-        core_pkg._read_leading_frontmatter(md, kind="command", name="cmd")
+        core_pkg._read_leading_frontmatter(
+            md, kind="command", name="cmd", source_path="commands/cmd.md"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_core_inventory.py
+++ b/tests/test_core_inventory.py
@@ -1,0 +1,386 @@
+"""Unit and behavioral tests for ``specify_cli.core.build_core_inventory``.
+
+Test targets:
+
+- Path resolution across wheel and source layouts
+- Frontmatter parsing with typed empty defaults (Clarifications Q2)
+- Alphabetical ordering & determinism (research §R6, SC-002)
+- Stable id grammar per companion #4210 (US2 T028)
+- Fail-fast failure modes (FR-012, SC-004)
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from specify_cli import core as core_pkg
+from specify_cli.core import CoreInventoryError, build_core_inventory
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — build a minimal in-tmp layout that mirrors the source-checkout
+# shape so we can exercise every branch without touching the real repo.
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture
+def well_formed_layout(tmp_path: Path) -> Path:
+    """A minimal source-shaped layout: 2 commands, 1 template, 1 script × 3 runtimes."""
+    _write(
+        tmp_path / "templates" / "commands" / "alpha.md",
+        "---\ndescription: The alpha command.\n---\n\nbody",
+    )
+    _write(
+        tmp_path / "templates" / "commands" / "beta.md",
+        "---\ndescription: The beta command.\nhandoffs:\n  - agent: alpha\n  - agent: alpha\n---\n\nbody",
+    )
+    _write(
+        tmp_path / "templates" / "spec-template.md",
+        "---\ndescription: A test template.\n---\n\n# Spec Template\n",
+    )
+    _write(
+        tmp_path / "scripts" / "bash" / "helper.sh",
+        "#!/usr/bin/env bash\n# Helper script.\n# Second header line.\n\necho hi\n",
+    )
+    _write(tmp_path / "scripts" / "powershell" / "helper.ps1", "# ps helper\n")
+    _write(tmp_path / "scripts" / "python" / "helper.py", "# py helper\n")
+    return tmp_path
+
+
+@pytest.fixture
+def override_layout(monkeypatch: pytest.MonkeyPatch):
+    """Patch ``_resolve_core_root`` to point at any given tmp source-layout root.
+
+    Returns a callable ``use(root: Path)``.
+    """
+
+    def use(root: Path) -> None:
+        layout = core_pkg._CoreLayout(
+            commands_dir=root / "templates" / "commands",
+            templates_dir=root / "templates",
+            scripts_dir=root / "scripts",
+        )
+        monkeypatch.setattr(core_pkg, "_resolve_core_root", lambda: layout)
+
+        # Discovery of the command name set must also point at the fixture,
+        # else _build_command_entry looks for names the fixture doesn't have.
+        names = frozenset(
+            p.stem
+            for p in (root / "templates" / "commands").glob("*.md")
+            if p.is_file()
+        )
+        monkeypatch.setattr(
+            "specify_cli.extensions._load_core_command_names", lambda: names
+        )
+
+    return use
+
+
+# ---------------------------------------------------------------------------
+# Path resolution (T015)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_core_root_prefers_wheel_pack(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fake_pack = tmp_path / "core_pack"
+    (fake_pack / "commands").mkdir(parents=True)
+    (fake_pack / "templates").mkdir()
+    (fake_pack / "scripts").mkdir()
+    monkeypatch.setattr(core_pkg, "_locate_core_pack", lambda: fake_pack)
+    layout = core_pkg._resolve_core_root()
+    assert layout.commands_dir == fake_pack / "commands"
+
+
+def test_resolve_core_root_falls_back_to_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(core_pkg, "_locate_core_pack", lambda: None)
+    fake_repo = tmp_path / "repo"
+    (fake_repo / "templates" / "commands").mkdir(parents=True)
+    (fake_repo / "scripts").mkdir()
+    monkeypatch.setattr(core_pkg, "_repo_root", lambda: fake_repo)
+    layout = core_pkg._resolve_core_root()
+    assert layout.commands_dir == fake_repo / "templates" / "commands"
+
+
+def test_resolve_core_root_raises_when_nothing_shipped(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(core_pkg, "_locate_core_pack", lambda: None)
+    monkeypatch.setattr(core_pkg, "_repo_root", lambda: tmp_path)
+    with pytest.raises(CoreInventoryError) as excinfo:
+        core_pkg._resolve_core_root()
+    assert excinfo.value.error == "core_inventory.assets_missing"
+
+
+def test_package_relative_rejects_backslash() -> None:
+    with pytest.raises(CoreInventoryError) as excinfo:
+        core_pkg._package_relative("templates\\commands\\foo.md")
+    assert excinfo.value.error == "core_inventory.invalid_source_path"
+
+
+def test_package_relative_rejects_absolute() -> None:
+    with pytest.raises(CoreInventoryError):
+        core_pkg._package_relative("/etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing (T015)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_command_frontmatter_success(tmp_path: Path) -> None:
+    md = tmp_path / "cmd.md"
+    md.write_text("---\ndescription: hi\nartifact: foo\n---\nbody\n", encoding="utf-8")
+    parsed = core_pkg._read_leading_frontmatter(md, kind="command", name="cmd")
+    assert parsed == {"description": "hi", "artifact": "foo"}
+
+
+def test_parse_command_frontmatter_raises_on_unclosed_fence(tmp_path: Path) -> None:
+    md = tmp_path / "cmd.md"
+    md.write_text("---\ndescription: hi\n\nbody with no close\n", encoding="utf-8")
+    with pytest.raises(CoreInventoryError) as excinfo:
+        core_pkg._read_leading_frontmatter(md, kind="command", name="cmd")
+    assert excinfo.value.error == "core_inventory.frontmatter_parse"
+    assert excinfo.value.kind == "command"
+
+
+def test_parse_command_frontmatter_returns_empty_when_absent(tmp_path: Path) -> None:
+    md = tmp_path / "cmd.md"
+    md.write_text("# just markdown, no frontmatter\n", encoding="utf-8")
+    assert core_pkg._read_leading_frontmatter(md, kind="command", name="cmd") == {}
+
+
+def test_parse_command_frontmatter_rejects_non_mapping(tmp_path: Path) -> None:
+    md = tmp_path / "cmd.md"
+    md.write_text("---\n- one\n- two\n---\nbody\n", encoding="utf-8")
+    with pytest.raises(CoreInventoryError):
+        core_pkg._read_leading_frontmatter(md, kind="command", name="cmd")
+
+
+# ---------------------------------------------------------------------------
+# Typed empty defaults & handoffs normalization (T016)
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_entries_uses_typed_empty_defaults(well_formed_layout: Path, override_layout) -> None:
+    override_layout(well_formed_layout)
+    inv = build_core_inventory()
+    alpha = next(c for c in inv["commands"] if c["name"] == "alpha")
+    # alpha.md declares only `description:` — everything else must default.
+    assert alpha["artifact"] is None
+    assert alpha["optional"] is False
+    assert alpha["handoffs"] == []
+
+
+def test_build_command_handoffs_flatten_agent_field(well_formed_layout: Path, override_layout) -> None:
+    override_layout(well_formed_layout)
+    inv = build_core_inventory()
+    beta = next(c for c in inv["commands"] if c["name"] == "beta")
+    # beta.md's handoffs are mappings with `agent:` — we surface only agent ids.
+    assert beta["handoffs"] == ["alpha", "alpha"]
+
+
+def test_build_command_rejects_non_boolean_optional(tmp_path: Path, override_layout) -> None:
+    _write(
+        tmp_path / "templates" / "commands" / "gamma.md",
+        "---\ndescription: hi\noptional: yes\n---\n",
+    )
+    (tmp_path / "templates" / "spec-template.md").parent.mkdir(exist_ok=True)
+    _write(tmp_path / "templates" / "spec-template.md", "# Spec Template\n")
+    _write(tmp_path / "scripts" / "bash" / "helper.sh", "#!/usr/bin/env bash\n# hi\n")
+    override_layout(tmp_path)
+    with pytest.raises(CoreInventoryError) as excinfo:
+        build_core_inventory()
+    assert excinfo.value.kind == "command"
+
+
+# ---------------------------------------------------------------------------
+# Scripts: partial runtimes, ordering (T016)
+# ---------------------------------------------------------------------------
+
+
+def test_build_script_entries_reports_partial_runtimes(tmp_path: Path, override_layout) -> None:
+    _write(
+        tmp_path / "templates" / "commands" / "alpha.md",
+        "---\ndescription: hi\n---\n",
+    )
+    _write(tmp_path / "templates" / "spec-template.md", "# Spec\n")
+    _write(tmp_path / "scripts" / "bash" / "solo.sh", "#!/usr/bin/env bash\n# solo\n")
+    # No powershell variant. Only python.
+    _write(tmp_path / "scripts" / "python" / "solo.py", "# py\n")
+    override_layout(tmp_path)
+    inv = build_core_inventory()
+    solo = next(s for s in inv["scripts"] if s["name"] == "solo")
+    assert solo["runtimes"] == ["bash", "python"]
+
+
+def test_script_without_bash_fails_fast(tmp_path: Path, override_layout) -> None:
+    _write(
+        tmp_path / "templates" / "commands" / "alpha.md",
+        "---\ndescription: hi\n---\n",
+    )
+    _write(tmp_path / "templates" / "spec-template.md", "# Spec\n")
+    # Only powershell — no bash canonical.
+    _write(tmp_path / "scripts" / "powershell" / "nobash.ps1", "# ps\n")
+    override_layout(tmp_path)
+    with pytest.raises(CoreInventoryError) as excinfo:
+        build_core_inventory()
+    assert excinfo.value.error == "core_inventory.missing_canonical"
+
+
+def test_python_script_name_hyphenated(tmp_path: Path, override_layout) -> None:
+    _write(
+        tmp_path / "templates" / "commands" / "alpha.md",
+        "---\ndescription: hi\n---\n",
+    )
+    _write(tmp_path / "templates" / "spec-template.md", "# Spec\n")
+    _write(tmp_path / "scripts" / "bash" / "setup-plan.sh", "#!/usr/bin/env bash\n# setup\n")
+    _write(tmp_path / "scripts" / "python" / "setup_plan.py", "# py\n")
+    override_layout(tmp_path)
+    inv = build_core_inventory()
+    names = [s["name"] for s in inv["scripts"]]
+    assert names == ["setup-plan"]  # underscore → hyphen normalization
+
+
+# ---------------------------------------------------------------------------
+# Determinism, ordering, and integration against the real shipped baseline
+# ---------------------------------------------------------------------------
+
+
+def test_build_core_inventory_deterministic_ordering() -> None:
+    a = build_core_inventory()
+    b = build_core_inventory()
+    # Byte-identical serialization is the SC-002 gate.
+    assert json.dumps(a, sort_keys=False) == json.dumps(b, sort_keys=False)
+
+
+def test_names_are_alphabetically_sorted() -> None:
+    inv = build_core_inventory()
+    for section in ("commands", "templates", "scripts"):
+        names = [entry["name"] for entry in inv[section]]
+        assert names == sorted(names), f"{section} not sorted"
+
+
+def test_top_level_keys_have_fixed_order() -> None:
+    inv = build_core_inventory()
+    assert list(inv.keys()) == ["commands", "templates", "scripts"]
+
+
+# ---------------------------------------------------------------------------
+# Stable-id grammar (US2 T028)
+# ---------------------------------------------------------------------------
+
+
+_STABLE_ID = re.compile(r"^core:_:(command|template|script):[A-Za-z0-9._-]+$")
+
+
+def test_all_ids_match_4210_grammar() -> None:
+    inv = build_core_inventory()
+    seen: list[str] = []
+    for section, kind in [("commands", "command"), ("templates", "template"), ("scripts", "script")]:
+        for entry in inv[section]:
+            eid: str = entry["id"]
+            assert _STABLE_ID.match(eid), f"bad id: {eid}"
+            assert eid == f"core:_:{kind}:{entry['name']}"
+            seen.append(eid)
+    # No dupes across sections.
+    assert len(seen) == len(set(seen))
+
+
+# ---------------------------------------------------------------------------
+# Fail-fast behavior on packaging errors (SC-004, FR-012)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_command_file_exits_with_envelope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Layout exists but the requested command file is missing.
+    _write(tmp_path / "templates" / "spec-template.md", "# Spec\n")
+    _write(tmp_path / "scripts" / "bash" / "helper.sh", "#!/usr/bin/env bash\n# hi\n")
+    (tmp_path / "templates" / "commands").mkdir(parents=True, exist_ok=True)
+    layout = core_pkg._CoreLayout(
+        commands_dir=tmp_path / "templates" / "commands",
+        templates_dir=tmp_path / "templates",
+        scripts_dir=tmp_path / "scripts",
+    )
+    monkeypatch.setattr(core_pkg, "_resolve_core_root", lambda: layout)
+    monkeypatch.setattr(
+        "specify_cli.extensions._load_core_command_names",
+        lambda: frozenset({"ghost"}),
+    )
+    with pytest.raises(CoreInventoryError) as excinfo:
+        build_core_inventory()
+    envelope = excinfo.value.to_envelope()
+    assert envelope["error"] == "core_inventory.missing_file"
+    assert envelope["artifact"]["kind"] == "command"
+    assert envelope["artifact"]["name"] == "ghost"
+
+
+def test_unparseable_command_frontmatter_produces_envelope(tmp_path: Path, override_layout) -> None:
+    _write(
+        tmp_path / "templates" / "commands" / "broken.md",
+        "---\ndescription: hi\n[unclosed brace\n\nbody with no close\n",
+    )
+    _write(tmp_path / "templates" / "spec-template.md", "# Spec\n")
+    _write(tmp_path / "scripts" / "bash" / "helper.sh", "#!/usr/bin/env bash\n# hi\n")
+    override_layout(tmp_path)
+    with pytest.raises(CoreInventoryError) as excinfo:
+        build_core_inventory()
+    envelope = excinfo.value.to_envelope()
+    assert envelope["error"] == "core_inventory.frontmatter_parse"
+
+
+# ---------------------------------------------------------------------------
+# Template description fallback path (H1 heading when no frontmatter)
+# ---------------------------------------------------------------------------
+
+
+def test_template_description_falls_back_to_h1(tmp_path: Path, override_layout) -> None:
+    _write(
+        tmp_path / "templates" / "commands" / "alpha.md",
+        "---\ndescription: hi\n---\n",
+    )
+    _write(
+        tmp_path / "templates" / "noframe-template.md",
+        "# The Fallback Heading\n\nBody.\n",
+    )
+    _write(tmp_path / "scripts" / "bash" / "helper.sh", "#!/usr/bin/env bash\n# helper\n")
+    override_layout(tmp_path)
+    inv = build_core_inventory()
+    tmpl = next(t for t in inv["templates"] if t["name"] == "noframe-template")
+    assert tmpl["description"] == "The Fallback Heading"
+
+
+def test_template_without_any_description_fails_fast(tmp_path: Path, override_layout) -> None:
+    _write(
+        tmp_path / "templates" / "commands" / "alpha.md",
+        "---\ndescription: hi\n---\n",
+    )
+    _write(
+        tmp_path / "templates" / "nada-template.md",
+        "just body, no heading, no frontmatter\n",
+    )
+    _write(tmp_path / "scripts" / "bash" / "helper.sh", "#!/usr/bin/env bash\n# helper\n")
+    override_layout(tmp_path)
+    with pytest.raises(CoreInventoryError) as excinfo:
+        build_core_inventory()
+    assert excinfo.value.kind == "template"
+
+
+# ---------------------------------------------------------------------------
+# Path-shape invariant (T022)
+# ---------------------------------------------------------------------------
+
+
+def test_all_source_paths_are_package_relative_posix() -> None:
+    inv = build_core_inventory()
+    for section in ("commands", "templates", "scripts"):
+        for entry in inv[section]:
+            sp = entry["sourcePath"]
+            assert not sp.startswith("/"), sp
+            assert "\\" not in sp, sp


### PR DESCRIPTION
Closes #4215

Introduces `specify core info --json` — a read-only command that emits Spec Kit's baked-in inventory (commands, templates, scripts) as a deterministic JSON document. Downstream tools (starting with `speckit-wizard-canvas`) can now consume the baseline programmatically instead of maintaining a hand-copied duplicate.

## What ships

- **New package** `src/specify_cli/core/` with `build_core_inventory()` + `CoreInventoryError`, wired to the existing `_locate_core_pack()` / `_repo_root()` helpers so wheel-installed and source-checkout layouts both work.
- **New Typer group** `specify core` with one leaf command, `info --json`. `--json` is required by design (the surface is programmatic); invoking without it exits 2 with a pointer at the flag.
- **Deterministic output**: alphabetically sorted by `name` within each section; fixed top-level key order (`commands`, `templates`, `scripts`); forward-slash source paths on every platform; byte-identical across runs.
- **Stable ids** follow the [#4210](https://github.com/github/spec-kit/issues/4210) grammar `core:_:<kind>:<name>`, so the output is join-ready against the future `specify artifact info` surface tracked in [#4212](https://github.com/github/spec-kit/issues/4212).
- **Fail-fast on packaging errors**: JSON envelope on stderr and exit 1 on missing files, unparseable frontmatter, wheel/source mismatches, or type mismatches — no partial output ever escapes.
- **Docs** at `docs/reference/core-info.md`, wired into `docs/toc.yml`; `CHANGELOG.md` entry added.

## Tests

- `tests/test_core_inventory.py` — unit tests for path resolution, frontmatter parsing, typed empty defaults, handoffs normalization, partial script runtimes, template-description fallback, determinism, sorting, stable-id grammar, and every fail-fast branch.
- `tests/test_core_info_command.py` — CLI-level tests via `CliRunner`: exit codes, help surface, schema-conformance, determinism, path shape, project-isolation (runs outside a Spec Kit project and ignores installed presets), and fail-fast envelopes.
- `tests/contract/test_core_inventory_wheel.py` — count/name parity between the source-checkout resolution and a simulated wheel-`core_pack/` layout.

> ⚠️ **Local test run was blocked** by a TLS handshake failure preventing `uv sync --extra test` (or `pip install pytest`) from installing pytest into the venv. All logic was validated with inline `python -c` scripts against the live repo, but pytest itself did not run in this environment — I'm relying on CI to execute the test suites.

## Two documented deviations

Both are called out in `docs/reference/core-info.md`:

1. Four of six shipped helper scripts (`create-new-feature`, `setup-plan`, `setup-tasks`, `resolve-template`) currently have no header comment. The command emits a filename-derived fallback description (`"Baseline helper script: <name>."`) rather than fail hard. Adding real headers to those scripts is left as a follow-up.
2. Real-world frontmatter for `handoffs:` in `templates/commands/*.md` is a list of mappings with `agent`, `label`, and `prompt` keys — not a bare list of strings. The inventory surfaces only the `agent` values (`list[str]`) to match the schema; consumers that need labels/prompts should read the frontmatter directly.

## Companion issues

- Uses the id grammar from [#4210](https://github.com/github/spec-kit/issues/4210).
- Complements the `preset info` / `extension info` JSON surfaces from [#4213](https://github.com/github/spec-kit/issues/4213).
- The forward-looking join against project-scoped artifacts is deferred to [#4212](https://github.com/github/spec-kit/issues/4212); a `TODO(#4212)` marker is left at the top of `tests/test_core_info_command.py`.

---

*Assisted-by: GitHub Copilot (model: claude-opus-4.7, supervised) — every commit on this branch carries the same trailer.*