### PR TITLE
feat(presets): let a preset declare a required extension

### DIFF
--- a/presets/PUBLISHING.md
+++ b/presets/PUBLISHING.md
@@ -101,9 +101,9 @@ If your preset overrides commands that call into an extension, declare it in
 `requires.extensions`. Without the extension the preset still installs and the
 overrides fall through to the core workflow, so nothing errors — the feature
 just silently does less than the user expects. Declaring the dependency makes
-`specify preset add` say so, and name the command that fixes it.
+`specify preset add` say so, and spell out how to resolve it.
 
-Use a bare id, or a mapping when you need a version floor or an optional
+Use a bare id, or a mapping when you need a version constraint or an optional
 dependency:
 
 ```yaml
@@ -112,14 +112,19 @@ requires:
   extensions:
     - "companion-extension"              # required, any version
     - id: "other-extension"
-      version: ">=1.2.0"                 # optional PEP 440 specifier
+      version: ">=1.2.0,<2"              # optional PEP 440 specifier
       required: false                    # optional, defaults to true
 ```
+
+`version` accepts any PEP 440 specifier, not just a lower bound — upper bounds
+(`<2`), exact pins (`==1.2.0`), and exclusions (`!=1.3.0`) all work.
 
 Notes:
 
 - The field is optional. A preset that declares nothing behaves exactly as before.
-- A missing or version-unsatisfied dependency produces a **warning, not a failure** — the install still succeeds.
+- A dependency that is missing, disabled, or version-unsatisfied produces a **warning, not a failure** — the install still succeeds.
+- A disabled extension counts as unmet. Resolution skips disabled extensions, so the preset is just as inert as if it were absent.
+- The warning names an exact command for the missing and disabled cases. For a version mismatch it states the constraint to satisfy rather than naming a command, because `specify extension update` only moves forward to the catalog release and cannot satisfy an upper bound, a pin, or a downgrade.
 - `required: false` documents an enhancing-but-optional extension and is never warned about.
 - Declare it in `preset.yml`, not only in your catalog entry. The catalog is not consulted for `--dev` and `--from <url>` installs, so the manifest is the only copy present on every install path.
 

--- a/presets/PUBLISHING.md
+++ b/presets/PUBLISHING.md
@@ -122,9 +122,10 @@ requires:
 Notes:
 
 - The field is optional. A preset that declares nothing behaves exactly as before.
-- A dependency that is missing, disabled, or version-unsatisfied produces a **warning, not a failure** — the install still succeeds.
-- A disabled extension counts as unmet. Resolution skips disabled extensions, so the preset is just as inert as if it were absent.
-- The warning names an exact command for the missing and disabled cases. For a version mismatch it states the constraint to satisfy rather than naming a command, because `specify extension update` only moves forward to the catalog release and cannot satisfy an upper bound, a pin, or a downgrade.
+- A dependency that is missing, stale, disabled, or version-unsatisfied produces a **warning, not a failure** — the install still succeeds.
+- A disabled extension counts as unmet, and so does one whose registry entry survives after its files were removed. Resolution skips both, so the preset is just as inert as if the extension were absent.
+- The warning names an exact command for the missing, stale, and disabled cases. For a version mismatch it states the constraint to satisfy rather than naming a command, because `specify extension update` only moves forward to the catalog release and cannot satisfy an upper bound, a pin, or a downgrade.
+- A recorded version that cannot be parsed is treated as uncomparable rather than as a mismatch, so an extension whose registry version reads `unknown` is not reported as failing a constraint it was never evaluated against.
 - `required: false` documents an enhancing-but-optional extension and is never warned about.
 - Declare it in `preset.yml`, not only in your catalog entry. The catalog is not consulted for `--dev` and `--from <url>` installs, so the manifest is the only copy present on every install path.
 

--- a/presets/PUBLISHING.md
+++ b/presets/PUBLISHING.md
@@ -126,6 +126,7 @@ Notes:
 - A disabled extension counts as unmet, and so does one whose registry entry survives after its files were removed. Resolution skips both, so the preset is just as inert as if the extension were absent.
 - The warning names an exact command for the missing, stale, and disabled cases. For a version mismatch it states the constraint to satisfy rather than naming a command, because `specify extension update` only moves forward to the catalog release and cannot satisfy an upper bound, a pin, or a downgrade.
 - A recorded version that cannot be parsed is treated as uncomparable rather than as a mismatch, so an extension whose registry version reads `unknown` is not reported as failing a constraint it was never evaluated against.
+- An extension present on disk but absent from the registry counts as satisfied. Resolution admits unregistered directories, so the preset works and warning about it would be a false alarm — though with no recorded version, a `version` constraint cannot be checked against it.
 - `required: false` documents an enhancing-but-optional extension and is never warned about.
 - Declare it in `preset.yml`, not only in your catalog entry. The catalog is not consulted for `--dev` and `--from <url>` installs, so the manifest is the only copy present on every install path.
 

--- a/presets/PUBLISHING.md
+++ b/presets/PUBLISHING.md
@@ -68,6 +68,8 @@ preset:
 
 requires:
   speckit_version: ">=0.1.0"      # Required spec-kit version
+  extensions:                      # Optional: extensions this preset needs
+    - "companion-extension"
 
 provides:
   templates:
@@ -92,6 +94,34 @@ tags:                              # 2-5 relevant tags
 - ✅ Template names are lowercase with hyphens only
 - ✅ Command names use dot notation (e.g. `speckit.specify`)
 - ✅ Tags are lowercase and descriptive
+
+#### Declaring extension dependencies
+
+If your preset overrides commands that call into an extension, declare it in
+`requires.extensions`. Without the extension the preset still installs and the
+overrides fall through to the core workflow, so nothing errors — the feature
+just silently does less than the user expects. Declaring the dependency makes
+`specify preset add` say so, and name the command that fixes it.
+
+Use a bare id, or a mapping when you need a version floor or an optional
+dependency:
+
+```yaml
+requires:
+  speckit_version: ">=0.9.0"
+  extensions:
+    - "companion-extension"              # required, any version
+    - id: "other-extension"
+      version: ">=1.2.0"                 # optional PEP 440 specifier
+      required: false                    # optional, defaults to true
+```
+
+Notes:
+
+- The field is optional. A preset that declares nothing behaves exactly as before.
+- A missing or version-unsatisfied dependency produces a **warning, not a failure** — the install still succeeds.
+- `required: false` documents an enhancing-but-optional extension and is never warned about.
+- Declare it in `preset.yml`, not only in your catalog entry. The catalog is not consulted for `--dev` and `--from <url>` installs, so the manifest is the only copy present on every install path.
 
 ### 3. Test Locally
 

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -381,6 +381,14 @@ class PresetManifest:
                 f"got {type(requires['speckit_version']).__name__}"
             )
 
+        # Validate the optional extension dependency list. A preset that
+        # overrides commands calling into an extension is inert without it, and
+        # until now the only place that could be said was the README -- see
+        # issue #4231. Absent means "no dependencies", so every existing preset
+        # stays valid.
+        if "extensions" in requires:
+            self._validate_requires_extensions(requires["extensions"])
+
         # Validate provides section
         provides = self.data["provides"]
         if "templates" not in provides:
@@ -524,10 +532,115 @@ class PresetManifest:
         """Get preset author."""
         return self.data["preset"].get("author", "")
 
+    @staticmethod
+    def _validate_requires_extensions(declared: Any) -> None:
+        """Validate the optional ``requires.extensions`` list.
+
+        Accepts either a bare extension id or a mapping carrying an optional
+        version specifier and an optional ``required`` flag:
+
+        .. code-block:: yaml
+
+            requires:
+              extensions:
+                - speckit-inventory
+                - id: other-ext
+                  version: ">=1.2.0"
+                  required: false
+
+        Raises:
+            PresetValidationError: If the list or any entry is malformed.
+        """
+        if not isinstance(declared, list):
+            raise PresetValidationError(
+                "Invalid requires.extensions: expected a list, "
+                f"got {type(declared).__name__}"
+            )
+
+        for index, entry in enumerate(declared):
+            label = f"requires.extensions[{index}]"
+
+            if isinstance(entry, str):
+                entry = {"id": entry}
+            elif not isinstance(entry, dict):
+                raise PresetValidationError(
+                    f"Invalid {label}: expected a string or a mapping, "
+                    f"got {type(entry).__name__}"
+                )
+
+            if "id" not in entry:
+                raise PresetValidationError(f"Missing {label}.id")
+            extension_id = entry["id"]
+            if not isinstance(extension_id, str):
+                raise PresetValidationError(
+                    f"Invalid {label}.id: expected a string, "
+                    f"got {type(extension_id).__name__}"
+                )
+            # Same id shape the extension loader enforces, so a dependency can
+            # never name something that could not be installed in the first place.
+            if not re.match(r'^[a-z0-9-]+$', extension_id):
+                raise PresetValidationError(
+                    f"Invalid {label}.id '{extension_id}': "
+                    "must be lowercase alphanumeric with hyphens only"
+                )
+
+            if "version" in entry:
+                constraint = entry["version"]
+                # Mirrors the requires.speckit_version reasoning: a non-string
+                # escapes InvalidSpecifier two ways -- scalars raise TypeError
+                # from the constructor, and a list/dict is iterable so it
+                # constructs and only fails later inside .contains().
+                if not isinstance(constraint, str) or not constraint.strip():
+                    raise PresetValidationError(
+                        f"Invalid {label}.version: expected a non-empty string, "
+                        f"got {type(constraint).__name__}"
+                    )
+                try:
+                    SpecifierSet(constraint)
+                except InvalidSpecifier:
+                    raise PresetValidationError(
+                        f"Invalid {label}.version '{constraint}': "
+                        "not a valid version specifier"
+                    )
+
+            if "required" in entry and not isinstance(entry["required"], bool):
+                raise PresetValidationError(
+                    f"Invalid {label}.required: expected a boolean, "
+                    f"got {type(entry['required']).__name__}"
+                )
+
     @property
     def requires_speckit_version(self) -> str:
         """Get required spec-kit version range."""
         return self.data["requires"]["speckit_version"]
+
+    @property
+    def requires_extensions(self) -> List[Dict[str, Any]]:
+        """Get declared extension dependencies, normalized to mappings.
+
+        Returns:
+            One entry per dependency with ``id``, ``version`` (``None`` when
+            unconstrained), and ``required`` (defaulting to ``True``). Empty
+            when the manifest declares no dependencies.
+        """
+        declared = self.data["requires"].get("extensions")
+        if not isinstance(declared, list):
+            return []
+
+        normalized: List[Dict[str, Any]] = []
+        for entry in declared:
+            if isinstance(entry, str):
+                entry = {"id": entry}
+            if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
+                continue
+            normalized.append(
+                {
+                    "id": entry["id"],
+                    "version": entry.get("version"),
+                    "required": entry.get("required", True),
+                }
+            )
+        return normalized
 
     @property
     def templates(self) -> List[Dict[str, Any]]:
@@ -840,6 +953,65 @@ class PresetManager:
             )
 
         return True
+
+    def find_unmet_extension_dependencies(
+        self,
+        manifest: PresetManifest
+    ) -> List[Dict[str, Any]]:
+        """Find declared extension dependencies that are not satisfied.
+
+        Reports rather than raises. A preset whose overrides call into an
+        extension is written to degrade safely -- without the extension the
+        core workflow still runs -- so a missing dependency is a warning, not
+        an install failure. See issue #4231.
+
+        Args:
+            manifest: Preset manifest to inspect
+
+        Returns:
+            One entry per unsatisfied dependency, each with ``id``, the
+            requested ``version`` specifier (``None`` when unconstrained), the
+            ``installed`` version (``None`` when absent), and a ``reason`` of
+            either ``"missing"`` or ``"version"``. Optional dependencies
+            (``required: false``) are never reported.
+        """
+        # Defense in depth, mirroring check_compatibility(): this method is
+        # public and also reachable with a hand-built manifest object that
+        # predates this field. A manifest without it declares nothing.
+        candidates = getattr(manifest, "requires_extensions", None)
+        if not isinstance(candidates, list):
+            return []
+
+        declared = [
+            dep for dep in candidates
+            if isinstance(dep, dict) and dep.get("required", True)
+        ]
+        if not declared:
+            return []
+
+        registry = ExtensionRegistry(self.project_root / ".specify" / "extensions")
+        unmet: List[Dict[str, Any]] = []
+
+        for dep in declared:
+            metadata = registry.get(dep["id"])
+            if metadata is None:
+                unmet.append({**dep, "installed": None, "reason": "missing"})
+                continue
+
+            constraint = dep["version"]
+            if not constraint:
+                continue
+
+            installed = metadata.get("version")
+            if not isinstance(installed, str):
+                # A registry entry without a usable version cannot be compared.
+                # Treat it as satisfied rather than inventing a failure, since
+                # the extension is demonstrably installed.
+                continue
+            if not version_satisfies(installed, constraint):
+                unmet.append({**dep, "installed": installed, "reason": "version"})
+
+        return unmet
 
     def _register_commands(
         self,

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -591,10 +591,15 @@ class PresetManifest:
                     f"got {type(extension_id).__name__}"
                 )
             # Same id shape the extension loader enforces, so a dependency can
-            # never name something that could not be installed in the first place.
-            if not re.match(r'^[a-z0-9-]+$', extension_id):
+            # never name something that could not be installed in the first
+            # place. fullmatch rather than match with an anchored pattern: `$`
+            # also matches before a trailing newline, so "demo-ext\n" would
+            # otherwise validate here while PresetResolver._is_safe_registry_id
+            # (which uses fullmatch) rejects it, and the newline would land in
+            # a suggested command.
+            if not re.fullmatch(r'[a-z0-9-]+', extension_id):
                 raise PresetValidationError(
-                    f"Invalid {label}.id '{extension_id}': "
+                    f"Invalid {label}.id {extension_id!r}: "
                     "must be lowercase alphanumeric with hyphens only"
                 )
 
@@ -986,9 +991,12 @@ class PresetManager:
             One entry per unsatisfied dependency, each with ``id``, the
             requested ``version`` specifier (``None`` when unconstrained), the
             ``installed`` version (``None`` when absent or unusable), and a
-            ``reason`` of ``"missing"``, ``"stale"``, ``"disabled"``, or
-            ``"version"``. Optional dependencies (``required: false``) are
-            never reported.
+            ``reason`` of ``"missing"``, ``"corrupt"``, ``"stale"``,
+            ``"disabled"``, or ``"version"``. Optional dependencies
+            (``required: false``) are never reported.
+
+            An unreadable registry yields no results rather than raising, since
+            this runs after the install has already succeeded.
 
             A registry version that cannot be parsed is treated as
             uncomparable, not as a mismatch: the extension is installed and
@@ -1003,15 +1011,36 @@ class PresetManager:
         if not isinstance(candidates, list):
             return []
 
-        declared = [
-            dep for dep in candidates
-            if isinstance(dep, dict) and dep.get("required", True)
-        ]
+        # Collapse exact repeats so a manifest naming the same dependency twice
+        # warns once. Two entries for one id with *different* constraints are
+        # kept, since both genuinely have to hold.
+        declared: List[Dict[str, Any]] = []
+        seen: Set[tuple] = set()
+        for dep in candidates:
+            if not isinstance(dep, dict) or not dep.get("required", True):
+                continue
+            key = (dep.get("id"), dep.get("version"))
+            if key in seen:
+                continue
+            seen.add(key)
+            declared.append(dep)
         if not declared:
             return []
 
         extensions_dir = self.project_root / ".specify" / "extensions"
-        registry = ExtensionRegistry(extensions_dir)
+        try:
+            registry = ExtensionRegistry(extensions_dir)
+            registered_ids = registry.keys()
+            registry_corrupt = registry.is_corrupt()
+        except OSError:
+            # Both reads can raise: _load() recovers from malformed content but
+            # deliberately lets OSError through, and is_corrupt() re-reads the
+            # file. This check runs *after* the install has completed, and
+            # preset_add only handles preset-domain errors, so letting that
+            # escape would turn a finished install into a traceback over a
+            # warning. An unreadable registry simply cannot be inspected.
+            return []
+
         unmet: List[Dict[str, Any]] = []
 
         for dep in declared:
@@ -1025,15 +1054,19 @@ class PresetManager:
                 # path fail closed and contribute nothing.
                 #
                 # get() returns None for a corrupted (non-dict) entry as well as
-                # an absent one, and keys() deliberately retains corrupted ids so
-                # resolution does *not* re-admit their directories as
-                # unregistered. Requiring absence from keys() keeps this fallback
-                # from reviving exactly what resolution excludes.
+                # an absent one, but keys() retains corrupted ids -- both so
+                # resolution does not re-admit their directories as
+                # unregistered, and because is_installed() still counts them, so
+                # a plain `extension add` would be refused as already installed.
+                # That is a different state from absent, and needs a different
+                # remedy.
+                if dep["id"] in registered_ids:
+                    unmet.append({**dep, "installed": None, "reason": "corrupt"})
+                    continue
                 if (
-                    dep["id"] not in registry.keys()
-                    and (extensions_dir / dep["id"]).is_dir()
+                    (extensions_dir / dep["id"]).is_dir()
                     and PresetResolver._is_safe_registry_id(dep["id"])
-                    and not registry.is_corrupt()
+                    and not registry_corrupt
                 ):
                     # Unregistered means no recorded version, so a constraint
                     # cannot be evaluated -- uncomparable, not unsatisfied.

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -972,8 +972,8 @@ class PresetManager:
             One entry per unsatisfied dependency, each with ``id``, the
             requested ``version`` specifier (``None`` when unconstrained), the
             ``installed`` version (``None`` when absent), and a ``reason`` of
-            either ``"missing"`` or ``"version"``. Optional dependencies
-            (``required: false``) are never reported.
+            ``"missing"``, ``"disabled"``, or ``"version"``. Optional
+            dependencies (``required: false``) are never reported.
         """
         # Defense in depth, mirroring check_compatibility(): this method is
         # public and also reachable with a hand-built manifest object that
@@ -998,18 +998,35 @@ class PresetManager:
                 unmet.append({**dep, "installed": None, "reason": "missing"})
                 continue
 
+            installed_version = metadata.get("version")
+            installed_version = (
+                installed_version if isinstance(installed_version, str) else None
+            )
+
+            # A disabled extension is registered but contributes nothing:
+            # resolution skips it (see _collect_extension_layers), so the
+            # preset is just as inert as if it were absent. Report it before
+            # any version check -- enabling it is the prerequisite, and the
+            # version may well be fine once it is.
+            if not metadata.get("enabled", True):
+                unmet.append(
+                    {**dep, "installed": installed_version, "reason": "disabled"}
+                )
+                continue
+
             constraint = dep["version"]
             if not constraint:
                 continue
 
-            installed = metadata.get("version")
-            if not isinstance(installed, str):
+            if installed_version is None:
                 # A registry entry without a usable version cannot be compared.
                 # Treat it as satisfied rather than inventing a failure, since
-                # the extension is demonstrably installed.
+                # the extension is demonstrably installed and enabled.
                 continue
-            if not version_satisfies(installed, constraint):
-                unmet.append({**dep, "installed": installed, "reason": "version"})
+            if not version_satisfies(installed_version, constraint):
+                unmet.append(
+                    {**dep, "installed": installed_version, "reason": "version"}
+                )
 
         return unmet
 

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -992,7 +992,9 @@ class PresetManager:
 
             A registry version that cannot be parsed is treated as
             uncomparable, not as a mismatch: the extension is installed and
-            usable, and only its recorded version is unreadable.
+            usable, and only its recorded version is unreadable. An extension
+            present on disk but absent from the registry is likewise treated as
+            satisfied, because resolution admits unregistered directories.
         """
         # Defense in depth, mirroring check_compatibility(): this method is
         # public and also reachable with a hand-built manifest object that
@@ -1015,6 +1017,20 @@ class PresetManager:
         for dep in declared:
             metadata = registry.get(dep["id"])
             if metadata is None:
+                # An absent registry entry does not mean the extension is
+                # unusable. _get_all_extensions_by_priority() admits a safe
+                # on-disk directory as an unregistered extension at implicit
+                # priority 10, so it resolves and the preset works -- but only
+                # when the registry is readable, since a corrupt one makes that
+                # path fail closed and contribute nothing.
+                if (
+                    (extensions_dir / dep["id"]).is_dir()
+                    and PresetResolver._is_safe_registry_id(dep["id"])
+                    and not registry.is_corrupt()
+                ):
+                    # Unregistered means no recorded version, so a constraint
+                    # cannot be evaluated -- uncomparable, not unsatisfied.
+                    continue
                 unmet.append({**dep, "installed": None, "reason": "missing"})
                 continue
 

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -381,6 +381,14 @@ class PresetManifest:
                 f"got {type(requires['speckit_version']).__name__}"
             )
 
+        # Validate the optional extension dependency list. A preset that
+        # overrides commands calling into an extension is inert without it, and
+        # until now the only place that could be said was the README -- see
+        # issue #4231. Absent means "no dependencies", so every existing preset
+        # stays valid.
+        if "extensions" in requires:
+            self._validate_requires_extensions(requires["extensions"])
+
         # Validate provides section
         provides = self.data["provides"]
         if "templates" not in provides:
@@ -524,10 +532,115 @@ class PresetManifest:
         """Get preset author."""
         return self.data["preset"].get("author", "")
 
+    @staticmethod
+    def _validate_requires_extensions(declared: Any) -> None:
+        """Validate the optional ``requires.extensions`` list.
+
+        Accepts either a bare extension id or a mapping carrying an optional
+        version specifier and an optional ``required`` flag:
+
+        .. code-block:: yaml
+
+            requires:
+              extensions:
+                - speckit-inventory
+                - id: other-ext
+                  version: ">=1.2.0"
+                  required: false
+
+        Raises:
+            PresetValidationError: If the list or any entry is malformed.
+        """
+        if not isinstance(declared, list):
+            raise PresetValidationError(
+                "Invalid requires.extensions: expected a list, "
+                f"got {type(declared).__name__}"
+            )
+
+        for index, entry in enumerate(declared):
+            label = f"requires.extensions[{index}]"
+
+            if isinstance(entry, str):
+                entry = {"id": entry}
+            elif not isinstance(entry, dict):
+                raise PresetValidationError(
+                    f"Invalid {label}: expected a string or a mapping, "
+                    f"got {type(entry).__name__}"
+                )
+
+            if "id" not in entry:
+                raise PresetValidationError(f"Missing {label}.id")
+            extension_id = entry["id"]
+            if not isinstance(extension_id, str):
+                raise PresetValidationError(
+                    f"Invalid {label}.id: expected a string, "
+                    f"got {type(extension_id).__name__}"
+                )
+            # Same id shape the extension loader enforces, so a dependency can
+            # never name something that could not be installed in the first place.
+            if not re.match(r'^[a-z0-9-]+$', extension_id):
+                raise PresetValidationError(
+                    f"Invalid {label}.id '{extension_id}': "
+                    "must be lowercase alphanumeric with hyphens only"
+                )
+
+            if "version" in entry:
+                constraint = entry["version"]
+                # Mirrors the requires.speckit_version reasoning: a non-string
+                # escapes InvalidSpecifier two ways -- scalars raise TypeError
+                # from the constructor, and a list/dict is iterable so it
+                # constructs and only fails later inside .contains().
+                if not isinstance(constraint, str) or not constraint.strip():
+                    raise PresetValidationError(
+                        f"Invalid {label}.version: expected a non-empty string, "
+                        f"got {type(constraint).__name__}"
+                    )
+                try:
+                    SpecifierSet(constraint)
+                except InvalidSpecifier:
+                    raise PresetValidationError(
+                        f"Invalid {label}.version '{constraint}': "
+                        "not a valid version specifier"
+                    )
+
+            if "required" in entry and not isinstance(entry["required"], bool):
+                raise PresetValidationError(
+                    f"Invalid {label}.required: expected a boolean, "
+                    f"got {type(entry['required']).__name__}"
+                )
+
     @property
     def requires_speckit_version(self) -> str:
         """Get required spec-kit version range."""
         return self.data["requires"]["speckit_version"]
+
+    @property
+    def requires_extensions(self) -> List[Dict[str, Any]]:
+        """Get declared extension dependencies, normalized to mappings.
+
+        Returns:
+            One entry per dependency with ``id``, ``version`` (``None`` when
+            unconstrained), and ``required`` (defaulting to ``True``). Empty
+            when the manifest declares no dependencies.
+        """
+        declared = self.data["requires"].get("extensions")
+        if not isinstance(declared, list):
+            return []
+
+        normalized: List[Dict[str, Any]] = []
+        for entry in declared:
+            if isinstance(entry, str):
+                entry = {"id": entry}
+            if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
+                continue
+            normalized.append(
+                {
+                    "id": entry["id"],
+                    "version": entry.get("version"),
+                    "required": entry.get("required", True),
+                }
+            )
+        return normalized
 
     @property
     def templates(self) -> List[Dict[str, Any]]:
@@ -837,6 +950,65 @@ class PresetManager:
             )
 
         return True
+
+    def find_unmet_extension_dependencies(
+        self,
+        manifest: PresetManifest
+    ) -> List[Dict[str, Any]]:
+        """Find declared extension dependencies that are not satisfied.
+
+        Reports rather than raises. A preset whose overrides call into an
+        extension is written to degrade safely -- without the extension the
+        core workflow still runs -- so a missing dependency is a warning, not
+        an install failure. See issue #4231.
+
+        Args:
+            manifest: Preset manifest to inspect
+
+        Returns:
+            One entry per unsatisfied dependency, each with ``id``, the
+            requested ``version`` specifier (``None`` when unconstrained), the
+            ``installed`` version (``None`` when absent), and a ``reason`` of
+            either ``"missing"`` or ``"version"``. Optional dependencies
+            (``required: false``) are never reported.
+        """
+        # Defense in depth, mirroring check_compatibility(): this method is
+        # public and also reachable with a hand-built manifest object that
+        # predates this field. A manifest without it declares nothing.
+        candidates = getattr(manifest, "requires_extensions", None)
+        if not isinstance(candidates, list):
+            return []
+
+        declared = [
+            dep for dep in candidates
+            if isinstance(dep, dict) and dep.get("required", True)
+        ]
+        if not declared:
+            return []
+
+        registry = ExtensionRegistry(self.project_root / ".specify" / "extensions")
+        unmet: List[Dict[str, Any]] = []
+
+        for dep in declared:
+            metadata = registry.get(dep["id"])
+            if metadata is None:
+                unmet.append({**dep, "installed": None, "reason": "missing"})
+                continue
+
+            constraint = dep["version"]
+            if not constraint:
+                continue
+
+            installed = metadata.get("version")
+            if not isinstance(installed, str):
+                # A registry entry without a usable version cannot be compared.
+                # Treat it as satisfied rather than inventing a failure, since
+                # the extension is demonstrably installed.
+                continue
+            if not version_satisfies(installed, constraint):
+                unmet.append({**dep, "installed": installed, "reason": "version"})
+
+        return unmet
 
     def _register_commands(
         self,

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -1023,8 +1023,15 @@ class PresetManager:
                 # priority 10, so it resolves and the preset works -- but only
                 # when the registry is readable, since a corrupt one makes that
                 # path fail closed and contribute nothing.
+                #
+                # get() returns None for a corrupted (non-dict) entry as well as
+                # an absent one, and keys() deliberately retains corrupted ids so
+                # resolution does *not* re-admit their directories as
+                # unregistered. Requiring absence from keys() keeps this fallback
+                # from reviving exactly what resolution excludes.
                 if (
-                    (extensions_dir / dep["id"]).is_dir()
+                    dep["id"] not in registry.keys()
+                    and (extensions_dir / dep["id"]).is_dir()
                     and PresetResolver._is_safe_registry_id(dep["id"])
                     and not registry.is_corrupt()
                 ):

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -969,8 +969,8 @@ class PresetManager:
             One entry per unsatisfied dependency, each with ``id``, the
             requested ``version`` specifier (``None`` when unconstrained), the
             ``installed`` version (``None`` when absent), and a ``reason`` of
-            either ``"missing"`` or ``"version"``. Optional dependencies
-            (``required: false``) are never reported.
+            ``"missing"``, ``"disabled"``, or ``"version"``. Optional
+            dependencies (``required: false``) are never reported.
         """
         # Defense in depth, mirroring check_compatibility(): this method is
         # public and also reachable with a hand-built manifest object that
@@ -995,18 +995,35 @@ class PresetManager:
                 unmet.append({**dep, "installed": None, "reason": "missing"})
                 continue
 
+            installed_version = metadata.get("version")
+            installed_version = (
+                installed_version if isinstance(installed_version, str) else None
+            )
+
+            # A disabled extension is registered but contributes nothing:
+            # resolution skips it (see _collect_extension_layers), so the
+            # preset is just as inert as if it were absent. Report it before
+            # any version check -- enabling it is the prerequisite, and the
+            # version may well be fine once it is.
+            if not metadata.get("enabled", True):
+                unmet.append(
+                    {**dep, "installed": installed_version, "reason": "disabled"}
+                )
+                continue
+
             constraint = dep["version"]
             if not constraint:
                 continue
 
-            installed = metadata.get("version")
-            if not isinstance(installed, str):
+            if installed_version is None:
                 # A registry entry without a usable version cannot be compared.
                 # Treat it as satisfied rather than inventing a failure, since
-                # the extension is demonstrably installed.
+                # the extension is demonstrably installed and enabled.
                 continue
-            if not version_satisfies(installed, constraint):
-                unmet.append({**dep, "installed": installed, "reason": "version"})
+            if not version_satisfies(installed_version, constraint):
+                unmet.append(
+                    {**dep, "installed": installed_version, "reason": "version"}
+                )
 
         return unmet
 

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -63,6 +63,20 @@ def _content_sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+def _is_comparable_version(value: str) -> bool:
+    """Return whether a recorded version can be evaluated against a specifier.
+
+    ``version_satisfies()`` answers "does not satisfy" for an unparseable
+    version, which is indistinguishable from a genuine mismatch. Callers that
+    need to tell those apart check here first.
+    """
+    try:
+        pkg_version.Version(value)
+    except pkg_version.InvalidVersion:
+        return False
+    return True
+
+
 def _constitution_is_generated(
     project_root: Path,
     memory_constitution: Path,
@@ -971,9 +985,14 @@ class PresetManager:
         Returns:
             One entry per unsatisfied dependency, each with ``id``, the
             requested ``version`` specifier (``None`` when unconstrained), the
-            ``installed`` version (``None`` when absent), and a ``reason`` of
-            ``"missing"``, ``"disabled"``, or ``"version"``. Optional
-            dependencies (``required: false``) are never reported.
+            ``installed`` version (``None`` when absent or unusable), and a
+            ``reason`` of ``"missing"``, ``"stale"``, ``"disabled"``, or
+            ``"version"``. Optional dependencies (``required: false``) are
+            never reported.
+
+            A registry version that cannot be parsed is treated as
+            uncomparable, not as a mismatch: the extension is installed and
+            usable, and only its recorded version is unreadable.
         """
         # Defense in depth, mirroring check_compatibility(): this method is
         # public and also reachable with a hand-built manifest object that
@@ -989,7 +1008,8 @@ class PresetManager:
         if not declared:
             return []
 
-        registry = ExtensionRegistry(self.project_root / ".specify" / "extensions")
+        extensions_dir = self.project_root / ".specify" / "extensions"
+        registry = ExtensionRegistry(extensions_dir)
         unmet: List[Dict[str, Any]] = []
 
         for dep in declared:
@@ -1002,6 +1022,17 @@ class PresetManager:
             installed_version = (
                 installed_version if isinstance(installed_version, str) else None
             )
+
+            # A registry entry is not proof the extension can contribute. If
+            # its directory is gone, PresetResolver skips it outright (both
+            # template lookup and layer collection guard on ``is_dir()``), so
+            # the preset is as inert as if it were never installed -- but the
+            # surviving entry would otherwise read as satisfied.
+            if not (extensions_dir / dep["id"]).is_dir():
+                unmet.append(
+                    {**dep, "installed": installed_version, "reason": "stale"}
+                )
+                continue
 
             # A disabled extension is registered but contributes nothing:
             # resolution skips it (see _collect_extension_layers), so the
@@ -1018,10 +1049,13 @@ class PresetManager:
             if not constraint:
                 continue
 
-            if installed_version is None:
-                # A registry entry without a usable version cannot be compared.
-                # Treat it as satisfied rather than inventing a failure, since
-                # the extension is demonstrably installed and enabled.
+            # A version that cannot be compared is not a mismatch. Absent or
+            # non-string is one way to be unusable; an unparseable string such
+            # as "unknown" is another, and version_satisfies() cannot tell them
+            # apart -- it catches InvalidVersion and returns False, which would
+            # report a mismatch against a version nobody can evaluate. Check
+            # parseability up front so only real comparisons reach the warning.
+            if installed_version is None or not _is_comparable_version(installed_version):
                 continue
             if not version_satisfies(installed_version, constraint):
                 unmet.append(

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -66,6 +66,12 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
         if reason == "missing":
             console.print(f"    [yellow]{extension_id}[/yellow] is not installed")
             remedy = f"specify extension add {extension_id}"
+        elif reason == "stale":
+            console.print(
+                f"    [yellow]{extension_id}[/yellow] is registered but its "
+                "files are missing"
+            )
+            remedy = f"specify extension add {extension_id} --force"
         elif reason == "disabled":
             console.print(f"    [yellow]{extension_id}[/yellow] is installed but disabled")
             remedy = f"specify extension enable {extension_id}"

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -49,6 +49,8 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
     missing extension and the command that installs it turns that silence into
     something actionable. See issue #4231.
     """
+    from ..extensions._commands import _command_safe_id
+
     unmet = manager.find_unmet_extension_dependencies(manifest)
     if not unmet:
         return
@@ -57,6 +59,12 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
     console.print("[yellow]![/yellow]  This preset depends on extensions that are not satisfied:")
     for dep in unmet:
         extension_id = _escape_markup(dep["id"])
+        # The displayed id only needs Rich escaping, but a suggested command
+        # has to survive Typer's parser: `^[a-z0-9-]+$` admits a leading
+        # hyphen, so an id like `--force` would render as an option rather
+        # than the positional argument. _command_safe_id substitutes a
+        # placeholder in that case, the same way extension commands do.
+        command_id = _command_safe_id(dep["id"])
         reason = dep["reason"]
         # The remediation has to match the reason. `extension add` refuses an
         # already-installed extension without --force, and `extension update`
@@ -65,16 +73,16 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
         # downgrade, so do not promise that update will satisfy it.
         if reason == "missing":
             console.print(f"    [yellow]{extension_id}[/yellow] is not installed")
-            remedy = f"specify extension add {extension_id}"
+            remedy = f"specify extension add {command_id}"
         elif reason == "stale":
             console.print(
                 f"    [yellow]{extension_id}[/yellow] is registered but its "
                 "files are missing"
             )
-            remedy = f"specify extension add {extension_id} --force"
+            remedy = f"specify extension add {command_id} --force"
         elif reason == "disabled":
             console.print(f"    [yellow]{extension_id}[/yellow] is installed but disabled")
-            remedy = f"specify extension enable {extension_id}"
+            remedy = f"specify extension enable {command_id}"
         else:
             console.print(
                 f"    [yellow]{extension_id}[/yellow] "
@@ -83,7 +91,7 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
             )
             remedy = (
                 "install a release of "
-                f"{extension_id} satisfying {_escape_markup(dep['version'])}"
+                f"{command_id} satisfying {_escape_markup(dep['version'])}"
             )
         console.print(f"      Fix with: {remedy}")
     console.print()

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -74,6 +74,13 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
         if reason == "missing":
             console.print(f"    [yellow]{extension_id}[/yellow] is not installed")
             remedy = f"specify extension add {command_id}"
+        elif reason == "corrupt":
+            console.print(
+                f"    [yellow]{extension_id}[/yellow] has an unreadable "
+                "registry entry"
+            )
+            # is_installed() still counts the key, so a plain add is refused.
+            remedy = f"specify extension add {command_id} --force"
         elif reason == "stale":
             console.print(
                 f"    [yellow]{extension_id}[/yellow] is registered but its "
@@ -95,11 +102,26 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
             )
         console.print(f"      Fix with: {remedy}")
     console.print()
-    console.print(
-        "[dim]The preset is installed and safe to use; the parts that rely on "
-        "these extensions will do nothing until this is resolved.[/dim]"
-    )
-    if any(dep["reason"] in ("missing", "stale") for dep in unmet):
+    # The consequence differs by reason and must not be overstated. An
+    # unavailable extension contributes nothing, so those features are simply
+    # inert. A version mismatch is the opposite: the extension is installed and
+    # enabled, so the preset does invoke it -- the combination is just untested
+    # against the declared constraint, which is not the same as "safe".
+    console.print("[dim]The preset is installed.[/dim]")
+    if any(
+        dep["reason"] in ("missing", "corrupt", "stale", "disabled")
+        for dep in unmet
+    ):
+        console.print(
+            "[dim]Anything relying on an unavailable extension does nothing "
+            "until that is resolved.[/dim]"
+        )
+    if any(dep["reason"] == "version" for dep in unmet):
+        console.print(
+            "[dim]Where only a version constraint is unmet the extension is "
+            "still used, so it may not behave as the preset expects.[/dim]"
+        )
+    if any(dep["reason"] in ("missing", "corrupt", "stale") for dep in unmet):
         # `extension add <id>` resolves through the catalogs, and the default
         # community catalog is discovery-only, so installing by id alone is
         # rejected for anything listed only there. Say so once rather than

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -91,6 +91,15 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
         "[dim]The preset is installed and safe to use; the parts that rely on "
         "these extensions will do nothing until this is resolved.[/dim]"
     )
+    if any(dep["reason"] in ("missing", "stale") for dep in unmet):
+        # `extension add <id>` resolves through the catalogs, and the default
+        # community catalog is discovery-only, so installing by id alone is
+        # rejected for anything listed only there. Say so once rather than
+        # per dependency, since determining it would mean a catalog fetch.
+        console.print(
+            "[dim]An extension listed only in a discovery-only catalog cannot be "
+            "installed by id; pass --from <archive-url> with its release archive.[/dim]"
+        )
 
 
 # ===== Preset Commands =====

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -40,6 +40,39 @@ preset_catalog_app = typer.Typer(
 preset_app.add_typer(preset_catalog_app, name="catalog")
 
 
+def _warn_unmet_extension_dependencies(manager, manifest) -> None:
+    """Warn when a preset's declared extension dependencies are unsatisfied.
+
+    A preset whose command overrides call into an extension is inert without
+    it, but the overrides still fall through to the core workflow, so nothing
+    breaks -- it just silently does less than the user expects. Naming the
+    missing extension and the command that installs it turns that silence into
+    something actionable. See issue #4231.
+    """
+    unmet = manager.find_unmet_extension_dependencies(manifest)
+    if not unmet:
+        return
+
+    console.print()
+    console.print("[yellow]![/yellow]  This preset depends on extensions that are not satisfied:")
+    for dep in unmet:
+        extension_id = _escape_markup(dep["id"])
+        if dep["reason"] == "missing":
+            console.print(f"    [yellow]{extension_id}[/yellow] is not installed")
+        else:
+            console.print(
+                f"    [yellow]{extension_id}[/yellow] "
+                f"{_escape_markup(dep['installed'])} does not satisfy "
+                f"{_escape_markup(dep['version'])}"
+            )
+        console.print(f"      Install with: specify extension add {extension_id}")
+    console.print()
+    console.print(
+        "[dim]The preset is installed and safe to use; the parts that rely on "
+        "these extensions will do nothing until they are present.[/dim]"
+    )
+
+
 # ===== Preset Commands =====
 
 
@@ -282,6 +315,12 @@ def preset_add(
         else:
             console.print("[red]Error:[/red] Specify a preset ID, --from URL, or --dev path")
             raise typer.Exit(1)
+
+        # Every install path above binds `manifest` and the no-source branch
+        # exits, so one call here covers --dev, --from, and catalog installs
+        # alike. Warns rather than fails: the preset is installed and its
+        # overrides fall through to the core workflow without the extension.
+        _warn_unmet_extension_dependencies(manager, manifest)
 
     except PresetCompatibilityError as e:
         console.print(f"[red]Compatibility Error:[/red] {_escape_markup(str(e))}")

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -59,8 +59,10 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
         extension_id = _escape_markup(dep["id"])
         reason = dep["reason"]
         # The remediation has to match the reason. `extension add` refuses an
-        # already-installed extension without --force, so suggesting it for a
-        # disabled or out-of-date one would hand the user a command that fails.
+        # already-installed extension without --force, and `extension update`
+        # only moves forward to the catalog release. A general PEP 440
+        # constraint may require an exact version, an upper bound, or a
+        # downgrade, so do not promise that update will satisfy it.
         if reason == "missing":
             console.print(f"    [yellow]{extension_id}[/yellow] is not installed")
             remedy = f"specify extension add {extension_id}"
@@ -73,7 +75,10 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
                 f"{_escape_markup(dep['installed'])} does not satisfy "
                 f"{_escape_markup(dep['version'])}"
             )
-            remedy = f"specify extension update {extension_id}"
+            remedy = (
+                "install a release of "
+                f"{extension_id} satisfying {_escape_markup(dep['version'])}"
+            )
         console.print(f"      Fix with: {remedy}")
     console.print()
     console.print(

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -57,7 +57,9 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
 
     console.print()
     console.print("[yellow]![/yellow]  This preset depends on extensions that are not satisfied:")
+    needs_catalog = False
     for dep in unmet:
+        uses_catalog = False
         extension_id = _escape_markup(dep["id"])
         # The displayed id only needs Rich escaping, but a suggested command
         # has to survive Typer's parser: `^[a-z0-9-]+$` admits a leading
@@ -73,34 +75,41 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
         # downgrade, so do not promise that update will satisfy it.
         if reason == "missing":
             console.print(f"    [yellow]{extension_id}[/yellow] is not installed")
-            remedy = f"specify extension add {command_id}"
+            label, remedy = "Install with", f"specify extension add {command_id}"
+            uses_catalog = True
         elif reason == "corrupt":
             console.print(
                 f"    [yellow]{extension_id}[/yellow] has an unreadable "
                 "registry entry"
             )
             # is_installed() still counts the key, so a plain add is refused.
+            label = "Reinstall with"
             remedy = f"specify extension add {command_id} --force"
+            uses_catalog = True
         elif reason == "stale":
             console.print(
                 f"    [yellow]{extension_id}[/yellow] is registered but its "
                 "files are missing"
             )
+            label = "Reinstall with"
             remedy = f"specify extension add {command_id} --force"
+            uses_catalog = True
         elif reason == "disabled":
             console.print(f"    [yellow]{extension_id}[/yellow] is installed but disabled")
-            remedy = f"specify extension enable {command_id}"
+            label, remedy = "Enable with", f"specify extension enable {command_id}"
         else:
             console.print(
                 f"    [yellow]{extension_id}[/yellow] "
                 f"{_escape_markup(dep['installed'])} does not satisfy "
                 f"{_escape_markup(dep['version'])}"
             )
+            label = "Needs"
             remedy = (
-                "install a release of "
-                f"{command_id} satisfying {_escape_markup(dep['version'])}"
+                f"a release of {command_id} satisfying "
+                f"{_escape_markup(dep['version'])}"
             )
-        console.print(f"      Fix with: {remedy}")
+        console.print(f"      {label}: {remedy}")
+        needs_catalog = needs_catalog or uses_catalog
     console.print()
     # The consequence differs by reason and must not be overstated. An
     # unavailable extension contributes nothing, so those features are simply
@@ -121,14 +130,19 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
             "[dim]Where only a version constraint is unmet the extension is "
             "still used, so it may not behave as the preset expects.[/dim]"
         )
-    if any(dep["reason"] in ("missing", "corrupt", "stale") for dep in unmet):
+    if needs_catalog:
         # `extension add <id>` resolves through the catalogs, and the default
-        # community catalog is discovery-only, so installing by id alone is
-        # rejected for anything listed only there. Say so once rather than
-        # per dependency, since determining it would mean a catalog fetch.
+        # community catalog is discovery-only, so installing by id is refused
+        # for anything listed only there -- true of every extension motivating
+        # this feature. Knowing which applies would mean a catalog fetch, and
+        # this runs on an install path that touches no network, so describe
+        # the outcome instead of asserting the command succeeds. The rejection
+        # itself prints the exact --from form, so this is a signpost rather
+        # than a dead end.
         console.print(
-            "[dim]An extension listed only in a discovery-only catalog cannot be "
-            "installed by id; pass --from <archive-url> with its release archive.[/dim]"
+            "[dim]If an extension is listed only in a discovery-only catalog, "
+            "that command is refused and prints the "
+            "--from <archive-url> form to use instead.[/dim]"
         )
 
 

--- a/src/specify_cli/presets/_commands.py
+++ b/src/specify_cli/presets/_commands.py
@@ -57,19 +57,28 @@ def _warn_unmet_extension_dependencies(manager, manifest) -> None:
     console.print("[yellow]![/yellow]  This preset depends on extensions that are not satisfied:")
     for dep in unmet:
         extension_id = _escape_markup(dep["id"])
-        if dep["reason"] == "missing":
+        reason = dep["reason"]
+        # The remediation has to match the reason. `extension add` refuses an
+        # already-installed extension without --force, so suggesting it for a
+        # disabled or out-of-date one would hand the user a command that fails.
+        if reason == "missing":
             console.print(f"    [yellow]{extension_id}[/yellow] is not installed")
+            remedy = f"specify extension add {extension_id}"
+        elif reason == "disabled":
+            console.print(f"    [yellow]{extension_id}[/yellow] is installed but disabled")
+            remedy = f"specify extension enable {extension_id}"
         else:
             console.print(
                 f"    [yellow]{extension_id}[/yellow] "
                 f"{_escape_markup(dep['installed'])} does not satisfy "
                 f"{_escape_markup(dep['version'])}"
             )
-        console.print(f"      Install with: specify extension add {extension_id}")
+            remedy = f"specify extension update {extension_id}"
+        console.print(f"      Fix with: {remedy}")
     console.print()
     console.print(
         "[dim]The preset is installed and safe to use; the parts that rely on "
-        "these extensions will do nothing until they are present.[/dim]"
+        "these extensions will do nothing until this is resolved.[/dim]"
     )
 
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1187,10 +1187,19 @@ class TestPresetExtensionDependencies:
     """Test find_unmet_extension_dependencies (issue #4231)."""
 
     @staticmethod
-    def _install_extension(project_dir, extension_id, version, enabled=True):
-        """Register an installed extension the way the extension installer does."""
+    def _install_extension(
+        project_dir, extension_id, version, enabled=True, with_files=True
+    ):
+        """Register an installed extension the way the extension installer does.
+
+        ``with_files=False`` leaves the registry entry without its directory,
+        reproducing the stale state left behind when the files are deleted out
+        from under the registry.
+        """
         extensions_dir = project_dir / ".specify" / "extensions"
         extensions_dir.mkdir(parents=True, exist_ok=True)
+        if with_files:
+            (extensions_dir / extension_id).mkdir(parents=True, exist_ok=True)
         registry_path = extensions_dir / ".registry"
         data = {"schema_version": "1.0", "extensions": {}}
         if registry_path.exists():
@@ -1306,15 +1315,21 @@ class TestPresetExtensionDependencies:
             manifest
         ) == []
 
-    def test_registry_entry_without_version_is_not_a_failure(
-        self, project_dir, temp_dir, valid_pack_data
+    @pytest.mark.parametrize("bad_version", [None, 5, "unknown", "", "latest"])
+    def test_uncomparable_registry_version_is_not_a_mismatch(
+        self, project_dir, temp_dir, valid_pack_data, bad_version
     ):
-        """An unusable registry version cannot be compared, so it is not invented
-        into a mismatch -- the extension is demonstrably installed."""
+        """A version that cannot be evaluated must not be reported as a mismatch.
+
+        ``version_satisfies()`` returns False for an unparseable version, which
+        is indistinguishable from a genuine mismatch -- so a string like
+        "unknown" would otherwise be reported as failing a constraint nobody
+        can actually evaluate it against.
+        """
         self._install_extension(project_dir, "speckit-inventory", "0.1.0")
         registry_path = project_dir / ".specify" / "extensions" / ".registry"
         data = json.loads(registry_path.read_text(encoding="utf-8"))
-        data["extensions"]["speckit-inventory"]["version"] = None
+        data["extensions"]["speckit-inventory"]["version"] = bad_version
         registry_path.write_text(json.dumps(data), encoding="utf-8")
 
         manifest = self._manifest(
@@ -1325,6 +1340,62 @@ class TestPresetExtensionDependencies:
         assert PresetManager(project_dir).find_unmet_extension_dependencies(
             manifest
         ) == []
+
+    def test_stale_registry_entry_is_reported(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A registry entry whose extension directory is gone counts as unmet.
+
+        PresetResolver guards on ``ext_dir.is_dir()`` in both template lookup
+        and layer collection, so a stale entry contributes nothing -- but the
+        surviving registry entry would otherwise read as satisfied.
+        """
+        self._install_extension(
+            project_dir, "speckit-inventory", "0.1.0", with_files=False
+        )
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert len(unmet) == 1
+        assert unmet[0]["reason"] == "stale"
+        assert unmet[0]["installed"] == "0.1.0"
+
+    def test_stale_is_reported_ahead_of_disabled_and_version(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """Restoring the files is the prerequisite, so it is reported first."""
+        self._install_extension(
+            project_dir, "speckit-inventory", "0.1.0",
+            enabled=False, with_files=False,
+        )
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=9.0.0"}],
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["reason"] for dep in unmet] == ["stale"]
+
+    def test_stale_warning_suggests_a_forced_reinstall(self):
+        """The stale remedy must restore the files, not re-add a registered id."""
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {
+                "id": "speckit-inventory",
+                "reason": "stale",
+                "installed": "0.1.0",
+                "version": None,
+            }
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        output = strip_ansi(capture.get())
+        assert "its files are missing" in output
+        assert "specify extension add speckit-inventory --force" in output
 
     def test_disabled_dependency_is_reported(
         self, project_dir, temp_dir, valid_pack_data

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1341,6 +1341,53 @@ class TestPresetExtensionDependencies:
             manifest
         ) == []
 
+    def test_unregistered_extension_on_disk_is_satisfied(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A directory with no registry entry still resolves, so it is not missing.
+
+        ``_get_all_extensions_by_priority`` admits safe unregistered
+        directories at implicit priority 10, so the preset works -- warning
+        that the dependency is absent would be a false alarm.
+        """
+        (project_dir / ".specify" / "extensions" / "speckit-inventory").mkdir(
+            parents=True
+        )
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_unregistered_extension_cannot_be_version_checked(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """No registry entry means no recorded version, so nothing to compare."""
+        (project_dir / ".specify" / "extensions" / "speckit-inventory").mkdir(
+            parents=True
+        )
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=9.0.0"}],
+        )
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_unregistered_extension_with_corrupt_registry_is_missing(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A corrupt registry makes resolution fail closed, so it is not usable."""
+        extensions_dir = project_dir / ".specify" / "extensions"
+        (extensions_dir / "speckit-inventory").mkdir(parents=True)
+        (extensions_dir / ".registry").write_text("{not valid json", encoding="utf-8")
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["reason"] for dep in unmet] == ["missing"]
+
     def test_stale_registry_entry_is_reported(
         self, project_dir, temp_dir, valid_pack_data
     ):

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -40,6 +40,8 @@ from specify_cli.presets import (
     VALID_PRESET_TEMPLATE_TYPES,
 )
 from specify_cli.extensions import ExtensionRegistry
+from specify_cli._console import console
+from specify_cli.presets._commands import _warn_unmet_extension_dependencies
 
 
 # ===== Fixtures =====
@@ -1244,6 +1246,25 @@ class TestPresetExtensionDependencies:
         assert unmet[0]["reason"] == "version"
         assert unmet[0]["installed"] == "0.1.0"
         assert unmet[0]["version"] == ">=9.0.0"
+
+    def test_version_warning_does_not_promise_update_satisfies_constraint(self):
+        """Version remediation must handle constraints update cannot guarantee."""
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {
+                "id": "speckit-inventory",
+                "reason": "version",
+                "installed": "3.0.0",
+                "version": "<2",
+            }
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        output = strip_ansi(capture.get())
+        assert "install a release of speckit-inventory satisfying <2" in output
+        assert "specify extension update" not in output
 
     def test_optional_dependency_is_never_reported(
         self, project_dir, temp_dir, valid_pack_data

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1158,7 +1158,7 @@ class TestPresetExtensionDependencies:
     """Test find_unmet_extension_dependencies (issue #4231)."""
 
     @staticmethod
-    def _install_extension(project_dir, extension_id, version):
+    def _install_extension(project_dir, extension_id, version, enabled=True):
         """Register an installed extension the way the extension installer does."""
         extensions_dir = project_dir / ".specify" / "extensions"
         extensions_dir.mkdir(parents=True, exist_ok=True)
@@ -1166,7 +1166,7 @@ class TestPresetExtensionDependencies:
         data = {"schema_version": "1.0", "extensions": {}}
         if registry_path.exists():
             data = json.loads(registry_path.read_text(encoding="utf-8"))
-        data["extensions"][extension_id] = {"version": version, "enabled": True}
+        data["extensions"][extension_id] = {"version": version, "enabled": enabled}
         registry_path.write_text(json.dumps(data), encoding="utf-8")
 
     @staticmethod
@@ -1278,19 +1278,60 @@ class TestPresetExtensionDependencies:
             manifest
         ) == []
 
+    def test_disabled_dependency_is_reported(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A disabled extension contributes nothing, so it counts as unmet.
+
+        Resolution skips disabled extensions, leaving the preset just as inert
+        as if the extension were absent -- but the registry entry exists, so a
+        presence-only check would call it satisfied and stay silent.
+        """
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0", enabled=False)
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert len(unmet) == 1
+        assert unmet[0]["reason"] == "disabled"
+        assert unmet[0]["installed"] == "0.1.0"
+
+    def test_disabled_is_reported_ahead_of_version_mismatch(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """Enabling is the prerequisite, so it is reported before the version."""
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0", enabled=False)
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=9.0.0"}],
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["reason"] for dep in unmet] == ["disabled"]
+
     def test_multiple_dependencies_report_independently(
         self, project_dir, temp_dir, valid_pack_data
     ):
         """Each declared dependency is evaluated on its own."""
         self._install_extension(project_dir, "present-ext", "1.0.0")
+        self._install_extension(project_dir, "off-ext", "1.0.0", enabled=False)
         manifest = self._manifest(
             temp_dir, valid_pack_data,
-            ["present-ext", "absent-ext", {"id": "opt-ext", "required": False}],
+            [
+                "present-ext",
+                "absent-ext",
+                "off-ext",
+                {"id": "opt-ext", "required": False},
+            ],
         )
 
         unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
 
-        assert [dep["id"] for dep in unmet] == ["absent-ext"]
+        assert [(dep["id"], dep["reason"]) for dep in unmet] == [
+            ("absent-ext", "missing"),
+            ("off-ext", "disabled"),
+        ]
 
 
 class TestRegistryPriority:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -535,6 +535,61 @@ provides:
         manifest = PresetManifest(manifest_path)
         assert len(manifest.templates) == 2
 
+    def test_requires_extensions_absent_is_valid(self, temp_dir, valid_pack_data):
+        """A preset with no declared dependencies stays valid and reports none."""
+        manifest_path = temp_dir / "preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+        assert PresetManifest(manifest_path).requires_extensions == []
+
+    def test_requires_extensions_accepts_both_forms(self, temp_dir, valid_pack_data):
+        """Bare ids and mappings normalize to the same shape."""
+        valid_pack_data["requires"]["extensions"] = [
+            "speckit-inventory",
+            {"id": "other-ext", "version": ">=1.2.0", "required": False},
+        ]
+        manifest_path = temp_dir / "preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+
+        assert PresetManifest(manifest_path).requires_extensions == [
+            {"id": "speckit-inventory", "version": None, "required": True},
+            {"id": "other-ext", "version": ">=1.2.0", "required": False},
+        ]
+
+    @pytest.mark.parametrize(
+        "bad, expected",
+        [
+            ("speckit-inventory", "Invalid requires.extensions"),      # str, not list
+            ({"id": "x"}, "Invalid requires.extensions"),              # mapping, not list
+            ([123], r"Invalid requires\.extensions\[0\]"),             # member not str/mapping
+            ([None], r"Invalid requires\.extensions\[0\]"),
+            ([{"version": ">=1"}], r"Missing requires\.extensions\[0\]\.id"),
+            ([{"id": 5}], r"Invalid requires\.extensions\[0\]\.id"),
+            ([{"id": "Bad_ID"}], r"Invalid requires\.extensions\[0\]\.id"),
+            (["Bad_ID"], r"Invalid requires\.extensions\[0\]\.id"),
+            ([{"id": "x", "version": 1.0}], r"Invalid requires\.extensions\[0\]\.version"),
+            ([{"id": "x", "version": "  "}], r"Invalid requires\.extensions\[0\]\.version"),
+            ([{"id": "x", "version": "nonsense"}], r"Invalid requires\.extensions\[0\]\.version"),
+            ([{"id": "x", "required": "yes"}], r"Invalid requires\.extensions\[0\]\.required"),
+        ],
+    )
+    def test_requires_extensions_rejects_malformed(
+        self, temp_dir, valid_pack_data, bad, expected
+    ):
+        """Malformed dependency declarations fail as PresetValidationError.
+
+        Same reasoning as requires.speckit_version: an unvalidated value reaches
+        ``SpecifierSet`` or ``re.match`` later and surfaces as a bare TypeError
+        that no caller handles as a malformed manifest.
+        """
+        valid_pack_data["requires"]["extensions"] = bad
+        manifest_path = temp_dir / "preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+        with pytest.raises(PresetValidationError, match=expected):
+            PresetManifest(manifest_path)
+
 
 # ===== PresetRegistry Tests =====
 
@@ -1097,6 +1152,145 @@ class TestPresetManager:
         installed = manager.list_installed()
         assert len(installed) == 1
         assert installed[0]["priority"] == 3
+
+
+class TestPresetExtensionDependencies:
+    """Test find_unmet_extension_dependencies (issue #4231)."""
+
+    @staticmethod
+    def _install_extension(project_dir, extension_id, version):
+        """Register an installed extension the way the extension installer does."""
+        extensions_dir = project_dir / ".specify" / "extensions"
+        extensions_dir.mkdir(parents=True, exist_ok=True)
+        registry_path = extensions_dir / ".registry"
+        data = {"schema_version": "1.0", "extensions": {}}
+        if registry_path.exists():
+            data = json.loads(registry_path.read_text(encoding="utf-8"))
+        data["extensions"][extension_id] = {"version": version, "enabled": True}
+        registry_path.write_text(json.dumps(data), encoding="utf-8")
+
+    @staticmethod
+    def _manifest(temp_dir, valid_pack_data, declared):
+        valid_pack_data["requires"]["extensions"] = declared
+        manifest_path = temp_dir / "dep-preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+        return PresetManifest(manifest_path)
+
+    def test_no_declared_dependencies_is_satisfied(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A preset declaring nothing never reports an unmet dependency."""
+        manifest_path = temp_dir / "plain-preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+
+        manager = PresetManager(project_dir)
+        assert manager.find_unmet_extension_dependencies(
+            PresetManifest(manifest_path)
+        ) == []
+
+    def test_missing_dependency_is_reported(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """An uninstalled required extension is reported as missing."""
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert len(unmet) == 1
+        assert unmet[0]["id"] == "speckit-inventory"
+        assert unmet[0]["reason"] == "missing"
+        assert unmet[0]["installed"] is None
+
+    def test_installed_dependency_is_satisfied(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """An installed extension with no version constraint is satisfied."""
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0")
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_satisfied_version_constraint(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A satisfied version constraint reports nothing."""
+        self._install_extension(project_dir, "speckit-inventory", "1.5.0")
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=1.2.0"}],
+        )
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_unsatisfied_version_constraint_reports_both_versions(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A version mismatch reports the installed version alongside the constraint."""
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0")
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=9.0.0"}],
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert len(unmet) == 1
+        assert unmet[0]["reason"] == "version"
+        assert unmet[0]["installed"] == "0.1.0"
+        assert unmet[0]["version"] == ">=9.0.0"
+
+    def test_optional_dependency_is_never_reported(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """`required: false` opts out of the warning even when absent."""
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "required": False}],
+        )
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_registry_entry_without_version_is_not_a_failure(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """An unusable registry version cannot be compared, so it is not invented
+        into a mismatch -- the extension is demonstrably installed."""
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0")
+        registry_path = project_dir / ".specify" / "extensions" / ".registry"
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+        data["extensions"]["speckit-inventory"]["version"] = None
+        registry_path.write_text(json.dumps(data), encoding="utf-8")
+
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=9.0.0"}],
+        )
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_multiple_dependencies_report_independently(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """Each declared dependency is evaluated on its own."""
+        self._install_extension(project_dir, "present-ext", "1.0.0")
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            ["present-ext", "absent-ext", {"id": "opt-ext", "required": False}],
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["id"] for dep in unmet] == ["absent-ext"]
 
 
 class TestRegistryPriority:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1185,7 +1185,7 @@ class TestPresetExtensionDependencies:
     """Test find_unmet_extension_dependencies (issue #4231)."""
 
     @staticmethod
-    def _install_extension(project_dir, extension_id, version):
+    def _install_extension(project_dir, extension_id, version, enabled=True):
         """Register an installed extension the way the extension installer does."""
         extensions_dir = project_dir / ".specify" / "extensions"
         extensions_dir.mkdir(parents=True, exist_ok=True)
@@ -1193,7 +1193,7 @@ class TestPresetExtensionDependencies:
         data = {"schema_version": "1.0", "extensions": {}}
         if registry_path.exists():
             data = json.loads(registry_path.read_text(encoding="utf-8"))
-        data["extensions"][extension_id] = {"version": version, "enabled": True}
+        data["extensions"][extension_id] = {"version": version, "enabled": enabled}
         registry_path.write_text(json.dumps(data), encoding="utf-8")
 
     @staticmethod
@@ -1305,19 +1305,60 @@ class TestPresetExtensionDependencies:
             manifest
         ) == []
 
+    def test_disabled_dependency_is_reported(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A disabled extension contributes nothing, so it counts as unmet.
+
+        Resolution skips disabled extensions, leaving the preset just as inert
+        as if the extension were absent -- but the registry entry exists, so a
+        presence-only check would call it satisfied and stay silent.
+        """
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0", enabled=False)
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert len(unmet) == 1
+        assert unmet[0]["reason"] == "disabled"
+        assert unmet[0]["installed"] == "0.1.0"
+
+    def test_disabled_is_reported_ahead_of_version_mismatch(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """Enabling is the prerequisite, so it is reported before the version."""
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0", enabled=False)
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=9.0.0"}],
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["reason"] for dep in unmet] == ["disabled"]
+
     def test_multiple_dependencies_report_independently(
         self, project_dir, temp_dir, valid_pack_data
     ):
         """Each declared dependency is evaluated on its own."""
         self._install_extension(project_dir, "present-ext", "1.0.0")
+        self._install_extension(project_dir, "off-ext", "1.0.0", enabled=False)
         manifest = self._manifest(
             temp_dir, valid_pack_data,
-            ["present-ext", "absent-ext", {"id": "opt-ext", "required": False}],
+            [
+                "present-ext",
+                "absent-ext",
+                "off-ext",
+                {"id": "opt-ext", "required": False},
+            ],
         )
 
         unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
 
-        assert [dep["id"] for dep in unmet] == ["absent-ext"]
+        assert [(dep["id"], dep["reason"]) for dep in unmet] == [
+            ("absent-ext", "missing"),
+            ("off-ext", "disabled"),
+        ]
 
 
 class TestRegistryPriority:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -40,6 +40,8 @@ from specify_cli.presets import (
     VALID_PRESET_TEMPLATE_TYPES,
 )
 from specify_cli.extensions import ExtensionRegistry
+from specify_cli._console import console
+from specify_cli.presets._commands import _warn_unmet_extension_dependencies
 
 
 # ===== Fixtures =====
@@ -1271,6 +1273,25 @@ class TestPresetExtensionDependencies:
         assert unmet[0]["reason"] == "version"
         assert unmet[0]["installed"] == "0.1.0"
         assert unmet[0]["version"] == ">=9.0.0"
+
+    def test_version_warning_does_not_promise_update_satisfies_constraint(self):
+        """Version remediation must handle constraints update cannot guarantee."""
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {
+                "id": "speckit-inventory",
+                "reason": "version",
+                "installed": "3.0.0",
+                "version": "<2",
+            }
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        output = strip_ansi(capture.get())
+        assert "install a release of speckit-inventory satisfying <2" in output
+        assert "specify extension update" not in output
 
     def test_optional_dependency_is_never_reported(
         self, project_dir, temp_dir, valid_pack_data

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -577,6 +577,12 @@ provides:
             ([{"id": "x", "version": "  "}], r"Invalid requires\.extensions\[0\]\.version"),
             ([{"id": "x", "version": "nonsense"}], r"Invalid requires\.extensions\[0\]\.version"),
             ([{"id": "x", "required": "yes"}], r"Invalid requires\.extensions\[0\]\.required"),
+            # `$` also matches before a trailing newline, so an anchored
+            # re.match would admit these while the resolver's fullmatch-based
+            # safe-id check rejects them.
+            (["demo-ext\n"], r"Invalid requires\.extensions\[0\]\.id"),
+            ([{"id": "demo-ext\n"}], r"Invalid requires\.extensions\[0\]\.id"),
+            (["demo\next"], r"Invalid requires\.extensions\[0\]\.id"),
         ],
     )
     def test_requires_extensions_rejects_malformed(
@@ -1397,7 +1403,9 @@ class TestPresetExtensionDependencies:
 
         unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
 
-        assert [dep["reason"] for dep in unmet] == ["missing"]
+        # Reported as corrupt rather than missing: the id is still registered,
+        # so a plain `extension add` would be refused as already installed.
+        assert [dep["reason"] for dep in unmet] == ["corrupt"]
 
     def test_missing_and_stale_warnings_mention_discovery_only_catalogs(self):
         """`extension add <id>` is rejected for discovery-only entries, so say so."""
@@ -1472,6 +1480,125 @@ class TestPresetExtensionDependencies:
         unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
 
         assert [dep["reason"] for dep in unmet] == ["missing"]
+
+    def test_corrupted_entry_gets_a_forced_reinstall_remedy(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A corrupted entry is not simply absent: `add <id>` would be refused.
+
+        ``get()`` returns None for it, but ``is_installed()`` still counts the
+        key, so a plain add reports "already installed". It needs --force.
+        """
+        extensions_dir = project_dir / ".specify" / "extensions"
+        extensions_dir.mkdir(parents=True)
+        (extensions_dir / ".registry").write_text(
+            json.dumps(
+                {"schema_version": "1.0", "extensions": {"speckit-inventory": "bad"}}
+            ),
+            encoding="utf-8",
+        )
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["reason"] for dep in unmet] == ["corrupt"]
+
+    def test_corrupt_warning_suggests_forced_reinstall(self):
+        """The corrupt remedy must use --force, since the id is still registered."""
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {"id": "speckit-inventory", "reason": "corrupt",
+             "installed": None, "version": None}
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        output = strip_ansi(capture.get())
+        assert "unreadable registry entry" in output
+        assert "specify extension add speckit-inventory --force" in output
+
+    def test_unreadable_registry_does_not_raise(
+        self, project_dir, temp_dir, valid_pack_data, monkeypatch
+    ):
+        """An OSError from the registry must not crash an already-completed install.
+
+        ``_load()`` lets OSError through, and ``preset_add`` only handles
+        preset-domain errors, so raising here would turn a finished install
+        into a traceback over what is only a warning.
+        """
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        import specify_cli.presets as presets_mod
+
+        def _boom(*args, **kwargs):
+            raise PermissionError("registry unreadable")
+
+        monkeypatch.setattr(presets_mod, "ExtensionRegistry", _boom)
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_version_only_footer_does_not_claim_the_feature_is_inert(self):
+        """A version mismatch still invokes the extension, so wording differs."""
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {"id": "speckit-inventory", "reason": "version",
+             "installed": "0.1.0", "version": ">=9.0.0"}
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        output = " ".join(strip_ansi(capture.get()).split())
+        assert "may not behave as the preset expects" in output
+        assert "does nothing" not in output
+        assert "safe to use" not in output
+
+    def test_unavailable_footer_states_the_feature_is_inert(self):
+        """An unavailable extension genuinely contributes nothing."""
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {"id": "speckit-inventory", "reason": "missing",
+             "installed": None, "version": None}
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        output = " ".join(strip_ansi(capture.get()).split())
+        assert "does nothing" in output
+        assert "may not behave as the preset expects" not in output
+
+    def test_exact_duplicate_declarations_warn_once(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """Naming the same dependency twice must not print the warning twice."""
+        manifest = self._manifest(
+            temp_dir, valid_pack_data, ["speckit-inventory", "speckit-inventory"]
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["id"] for dep in unmet] == ["speckit-inventory"]
+
+    def test_same_id_with_different_constraints_is_checked_twice(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """Distinct constraints on one id both have to hold, so both are checked."""
+        self._install_extension(project_dir, "speckit-inventory", "1.0.0")
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [
+                {"id": "speckit-inventory", "version": ">=9.0.0"},
+                {"id": "speckit-inventory", "version": "<0.5"},
+            ],
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["version"] for dep in unmet] == [">=9.0.0", "<0.5"]
 
     def test_stale_registry_entry_is_reported(
         self, project_dir, temp_dir, valid_pack_data

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -538,6 +538,61 @@ provides:
         manifest = PresetManifest(manifest_path)
         assert len(manifest.templates) == 2
 
+    def test_requires_extensions_absent_is_valid(self, temp_dir, valid_pack_data):
+        """A preset with no declared dependencies stays valid and reports none."""
+        manifest_path = temp_dir / "preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+        assert PresetManifest(manifest_path).requires_extensions == []
+
+    def test_requires_extensions_accepts_both_forms(self, temp_dir, valid_pack_data):
+        """Bare ids and mappings normalize to the same shape."""
+        valid_pack_data["requires"]["extensions"] = [
+            "speckit-inventory",
+            {"id": "other-ext", "version": ">=1.2.0", "required": False},
+        ]
+        manifest_path = temp_dir / "preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+
+        assert PresetManifest(manifest_path).requires_extensions == [
+            {"id": "speckit-inventory", "version": None, "required": True},
+            {"id": "other-ext", "version": ">=1.2.0", "required": False},
+        ]
+
+    @pytest.mark.parametrize(
+        "bad, expected",
+        [
+            ("speckit-inventory", "Invalid requires.extensions"),      # str, not list
+            ({"id": "x"}, "Invalid requires.extensions"),              # mapping, not list
+            ([123], r"Invalid requires\.extensions\[0\]"),             # member not str/mapping
+            ([None], r"Invalid requires\.extensions\[0\]"),
+            ([{"version": ">=1"}], r"Missing requires\.extensions\[0\]\.id"),
+            ([{"id": 5}], r"Invalid requires\.extensions\[0\]\.id"),
+            ([{"id": "Bad_ID"}], r"Invalid requires\.extensions\[0\]\.id"),
+            (["Bad_ID"], r"Invalid requires\.extensions\[0\]\.id"),
+            ([{"id": "x", "version": 1.0}], r"Invalid requires\.extensions\[0\]\.version"),
+            ([{"id": "x", "version": "  "}], r"Invalid requires\.extensions\[0\]\.version"),
+            ([{"id": "x", "version": "nonsense"}], r"Invalid requires\.extensions\[0\]\.version"),
+            ([{"id": "x", "required": "yes"}], r"Invalid requires\.extensions\[0\]\.required"),
+        ],
+    )
+    def test_requires_extensions_rejects_malformed(
+        self, temp_dir, valid_pack_data, bad, expected
+    ):
+        """Malformed dependency declarations fail as PresetValidationError.
+
+        Same reasoning as requires.speckit_version: an unvalidated value reaches
+        ``SpecifierSet`` or ``re.match`` later and surfaces as a bare TypeError
+        that no caller handles as a malformed manifest.
+        """
+        valid_pack_data["requires"]["extensions"] = bad
+        manifest_path = temp_dir / "preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+        with pytest.raises(PresetValidationError, match=expected):
+            PresetManifest(manifest_path)
+
 
 # ===== PresetRegistry Tests =====
 
@@ -1124,6 +1179,145 @@ class TestPresetManager:
         installed = manager.list_installed()
         assert len(installed) == 1
         assert installed[0]["priority"] == 3
+
+
+class TestPresetExtensionDependencies:
+    """Test find_unmet_extension_dependencies (issue #4231)."""
+
+    @staticmethod
+    def _install_extension(project_dir, extension_id, version):
+        """Register an installed extension the way the extension installer does."""
+        extensions_dir = project_dir / ".specify" / "extensions"
+        extensions_dir.mkdir(parents=True, exist_ok=True)
+        registry_path = extensions_dir / ".registry"
+        data = {"schema_version": "1.0", "extensions": {}}
+        if registry_path.exists():
+            data = json.loads(registry_path.read_text(encoding="utf-8"))
+        data["extensions"][extension_id] = {"version": version, "enabled": True}
+        registry_path.write_text(json.dumps(data), encoding="utf-8")
+
+    @staticmethod
+    def _manifest(temp_dir, valid_pack_data, declared):
+        valid_pack_data["requires"]["extensions"] = declared
+        manifest_path = temp_dir / "dep-preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+        return PresetManifest(manifest_path)
+
+    def test_no_declared_dependencies_is_satisfied(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A preset declaring nothing never reports an unmet dependency."""
+        manifest_path = temp_dir / "plain-preset.yml"
+        with open(manifest_path, 'w') as f:
+            yaml.dump(valid_pack_data, f)
+
+        manager = PresetManager(project_dir)
+        assert manager.find_unmet_extension_dependencies(
+            PresetManifest(manifest_path)
+        ) == []
+
+    def test_missing_dependency_is_reported(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """An uninstalled required extension is reported as missing."""
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert len(unmet) == 1
+        assert unmet[0]["id"] == "speckit-inventory"
+        assert unmet[0]["reason"] == "missing"
+        assert unmet[0]["installed"] is None
+
+    def test_installed_dependency_is_satisfied(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """An installed extension with no version constraint is satisfied."""
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0")
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_satisfied_version_constraint(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A satisfied version constraint reports nothing."""
+        self._install_extension(project_dir, "speckit-inventory", "1.5.0")
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=1.2.0"}],
+        )
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_unsatisfied_version_constraint_reports_both_versions(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A version mismatch reports the installed version alongside the constraint."""
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0")
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=9.0.0"}],
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert len(unmet) == 1
+        assert unmet[0]["reason"] == "version"
+        assert unmet[0]["installed"] == "0.1.0"
+        assert unmet[0]["version"] == ">=9.0.0"
+
+    def test_optional_dependency_is_never_reported(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """`required: false` opts out of the warning even when absent."""
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "required": False}],
+        )
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_registry_entry_without_version_is_not_a_failure(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """An unusable registry version cannot be compared, so it is not invented
+        into a mismatch -- the extension is demonstrably installed."""
+        self._install_extension(project_dir, "speckit-inventory", "0.1.0")
+        registry_path = project_dir / ".specify" / "extensions" / ".registry"
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+        data["extensions"]["speckit-inventory"]["version"] = None
+        registry_path.write_text(json.dumps(data), encoding="utf-8")
+
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            [{"id": "speckit-inventory", "version": ">=9.0.0"}],
+        )
+
+        assert PresetManager(project_dir).find_unmet_extension_dependencies(
+            manifest
+        ) == []
+
+    def test_multiple_dependencies_report_independently(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """Each declared dependency is evaluated on its own."""
+        self._install_extension(project_dir, "present-ext", "1.0.0")
+        manifest = self._manifest(
+            temp_dir, valid_pack_data,
+            ["present-ext", "absent-ext", {"id": "opt-ext", "required": False}],
+        )
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["id"] for dep in unmet] == ["absent-ext"]
 
 
 class TestRegistryPriority:

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1414,6 +1414,39 @@ class TestPresetExtensionDependencies:
         assert "discovery-only catalog" in output
         assert "--from <archive-url>" in output
 
+    @pytest.mark.parametrize(
+        "reason, extra",
+        [
+            ("missing", {"installed": None, "version": None}),
+            ("stale", {"installed": "0.1.0", "version": None}),
+            ("disabled", {"installed": "0.1.0", "version": None}),
+            ("version", {"installed": "0.1.0", "version": ">=9.0.0"}),
+        ],
+    )
+    def test_leading_hyphen_id_is_not_emitted_into_a_command(self, reason, extra):
+        """A leading-hyphen id satisfies `^[a-z0-9-]+$` but breaks the command.
+
+        Typer would read it as an option rather than the positional extension
+        argument, so the advertised fix would fail. Every remedy substitutes
+        the placeholder `_command_safe_id` returns. The id here is deliberately
+        not a real flag, so a match cannot be confused with `--force` appearing
+        legitimately in the stale remedy.
+        """
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {"id": "--not-a-real-flag", "reason": reason, **extra}
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        output = strip_ansi(capture.get())
+        remedy = next(
+            line for line in output.splitlines() if "Fix with:" in line
+        )
+        assert "--not-a-real-flag" not in remedy
+        assert "<extension-id>" in remedy
+
     def test_version_only_warning_omits_the_discovery_only_note(self):
         """The note is about installing by id, which a version mismatch does not do."""
         manager = MagicMock()

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1375,6 +1375,58 @@ class TestPresetExtensionDependencies:
             manifest
         ) == []
 
+    def test_corrupted_registry_entry_with_directory_is_not_satisfied(
+        self, project_dir, temp_dir, valid_pack_data
+    ):
+        """A corrupted entry keeps its id registered, so its directory is excluded.
+
+        ``get()`` returns None for a non-dict entry just as it does for an
+        absent one, but ``keys()`` retains the id specifically so resolution
+        does not re-admit the directory as an unregistered extension. The
+        fallback must not revive what resolution excludes.
+        """
+        extensions_dir = project_dir / ".specify" / "extensions"
+        (extensions_dir / "speckit-inventory").mkdir(parents=True)
+        (extensions_dir / ".registry").write_text(
+            json.dumps(
+                {"schema_version": "1.0", "extensions": {"speckit-inventory": "corrupt"}}
+            ),
+            encoding="utf-8",
+        )
+        manifest = self._manifest(temp_dir, valid_pack_data, ["speckit-inventory"])
+
+        unmet = PresetManager(project_dir).find_unmet_extension_dependencies(manifest)
+
+        assert [dep["reason"] for dep in unmet] == ["missing"]
+
+    def test_missing_and_stale_warnings_mention_discovery_only_catalogs(self):
+        """`extension add <id>` is rejected for discovery-only entries, so say so."""
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {"id": "speckit-inventory", "reason": "missing",
+             "installed": None, "version": None}
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        output = strip_ansi(capture.get())
+        assert "discovery-only catalog" in output
+        assert "--from <archive-url>" in output
+
+    def test_version_only_warning_omits_the_discovery_only_note(self):
+        """The note is about installing by id, which a version mismatch does not do."""
+        manager = MagicMock()
+        manager.find_unmet_extension_dependencies.return_value = [
+            {"id": "speckit-inventory", "reason": "version",
+             "installed": "0.1.0", "version": ">=9.0.0"}
+        ]
+
+        with console.capture() as capture:
+            _warn_unmet_extension_dependencies(manager, MagicMock())
+
+        assert "discovery-only" not in strip_ansi(capture.get())
+
     def test_unregistered_extension_with_corrupt_registry_is_missing(
         self, project_dir, temp_dir, valid_pack_data
     ):

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1304,8 +1304,8 @@ class TestPresetExtensionDependencies:
         with console.capture() as capture:
             _warn_unmet_extension_dependencies(manager, MagicMock())
 
-        output = strip_ansi(capture.get())
-        assert "install a release of speckit-inventory satisfying <2" in output
+        output = " ".join(strip_ansi(capture.get()).split())
+        assert "Needs: a release of speckit-inventory satisfying <2" in output
         assert "specify extension update" not in output
 
     def test_optional_dependency_is_never_reported(
@@ -1421,6 +1421,7 @@ class TestPresetExtensionDependencies:
         output = strip_ansi(capture.get())
         assert "discovery-only catalog" in output
         assert "--from <archive-url>" in output
+        assert "Install with: specify extension add speckit-inventory" in output
 
     @pytest.mark.parametrize(
         "reason, extra",
@@ -1448,10 +1449,14 @@ class TestPresetExtensionDependencies:
         with console.capture() as capture:
             _warn_unmet_extension_dependencies(manager, MagicMock())
 
-        output = strip_ansi(capture.get())
-        remedy = next(
-            line for line in output.splitlines() if "Fix with:" in line
+        output = " ".join(strip_ansi(capture.get()).split())
+        # Isolate the remedy: the description line legitimately shows the raw
+        # id, escaped for display; only the copyable command must not carry it.
+        label = next(
+            lbl for lbl in ("Install with:", "Reinstall with:", "Enable with:", "Needs:")
+            if lbl in output
         )
+        remedy = output.split(label, 1)[1].split("The preset is installed.")[0]
         assert "--not-a-real-flag" not in remedy
         assert "<extension-id>" in remedy
 
@@ -1516,7 +1521,7 @@ class TestPresetExtensionDependencies:
 
         output = strip_ansi(capture.get())
         assert "unreadable registry entry" in output
-        assert "specify extension add speckit-inventory --force" in output
+        assert "Reinstall with: specify extension add speckit-inventory --force" in output
 
     def test_unreadable_registry_does_not_raise(
         self, project_dir, temp_dir, valid_pack_data, monkeypatch


### PR DESCRIPTION
## Description

Closes #4231.

A preset whose command overrides call into an extension is inert without it — but the overrides fall through to the core workflow, so nothing errors. The feature just silently does less than the user expects, with nothing in the install output pointing at the cause. Until now the only place that dependency could be stated was the README, which fails exactly the user who did not read it.

Three community presets already declare `requires.extensions` in `catalog.community.json` (`aide-in-place`, `inventory-alignment`, `mde`), and the preset submission template already collects the field — but `preset.yml` had no supported key for it and nothing read it. This adds the manifest field and the install-time check.

### What changed

**Schema.** `preset.yml` accepts an optional `requires.extensions`, taking either a bare id or a mapping:

```yaml
requires:
  speckit_version: ">=0.9.0"
  extensions:
    - "companion-extension"        # required, any version
    - id: "other-extension"
      version: ">=1.2.0"           # optional PEP 440 specifier
      required: false              # optional, defaults to true
```

**Validation.** Follows the `requires.speckit_version` strictness established by #3980, for the same reason: an unvalidated value reaches `re.match` or `SpecifierSet` later and surfaces as a bare `TypeError` that no caller handles as a malformed manifest. A non-list, a member that is neither string nor mapping, a missing or non-string or badly-shaped `id`, a non-string/blank/unparseable `version`, and a non-boolean `required` each raise `PresetValidationError` naming the offending index.

**Install-time check.** `PresetManager.find_unmet_extension_dependencies()` reports rather than raises. `specify preset add` warns once per unsatisfied dependency:

```
!  This preset depends on extensions that are not satisfied:
    speckit-inventory 0.1.0 does not satisfy >=9.0.0
      Install with: specify extension add speckit-inventory

The preset is installed and safe to use; the parts that rely on these
extensions will do nothing until they are present.
```

The check sits at the single point where the `--dev`, `--from`, and catalog paths converge, so all three behave identically rather than drifting.

### Design decisions

These follow the positions I set out in [the issue](https://github.com/github/spec-kit/issues/4231#issuecomment-5364742294) against the assessment's carried-forward questions. Each is easy to change if you'd rather go the other way.

- **Warn, not fail.** These presets are written to degrade safely, and three catalog entries already declare the dependency — hard-failing would break installs that work today. The `required` flag leaves the door open for an opt-in hard-fail later.
- **Version constraints included in v1.** The mapping form has to be parsed and validated anyway to accept `version`, so the incremental cost is the comparison itself. Deferring it would ship a field that validates but is silently ignored — the same shape as the problem this issue is about.
- **Preset side only; `extension.yml` left alone.** It has the identical limitation, but no extension in the catalog declares a dependency on another extension, so there's no demonstrated need. Happy to mirror it here or in a follow-up.
- **Manifest authoritative, catalog a mirror.** The catalog isn't consulted for `--dev` or `--from <url>` installs, so the manifest is the only copy present on every path. Documented in `PUBLISHING.md` rather than mechanically reconciled; validating the catalog field against the packaged manifest seems better as its own change against the `add-community-preset` workflow.

The field is optional, so every existing preset stays valid and silent.

### Worth flagging

The warning will fire for nobody on day one. The three presets carrying `requires.extensions` do so only in their catalog entries, not in their packaged `preset.yml`. I maintain `inventory-alignment` and will add it there; the other two need their authors. Not a blocker, but the feature starts with no live coverage.

## Testing

### Automated

`tests/test_presets.py`: **624 passed**, 8 failed. All 8 failures are `WinError 1314` symlink-privilege failures from my Windows environment and reproduce identically on `main` with this branch stashed. `tests/test_extensions.py` + `tests/test_extension_registration.py`: **540 passed**, 2 failed, same symlink cause.

22 new tests:

- `requires.extensions` absent stays valid and reports no dependencies
- both declaration forms normalize to the same shape
- 12 parametrized malformed-input cases (not-a-list, bad member type, missing/non-string/bad-pattern `id`, non-string/blank/unparseable `version`, non-boolean `required`)
- dependency missing / installed / version satisfied / version unsatisfied
- `required: false` never reported
- registry entry with an unusable version is not invented into a mismatch
- multiple dependencies evaluated independently

### Manual

Per the mapping rules, `src/specify_cli/*.py` → test the affected CLI command. This changes `specify preset add`; it is not an init/scaffolding change, so no slash command is affected.

**Agent**: n/a (CLI change) | **OS/Shell**: Windows 11 / Git Bash, Python 3.11.14

| Command tested | Notes |
|----------------|-------|
| `specify preset add --dev` | Dependency missing → warning naming the extension and install command. Preset still installs. |
| `specify preset add --dev` | Extension installed, no constraint → no warning. |
| `specify preset add --dev` | `>=0.1.0` against installed `0.1.0` → no warning. |
| `specify preset add --dev` | `>=9.0.0` against installed `0.1.0` → warning showing both versions. |
| `specify preset add --dev` | Preset declaring nothing → unchanged output. |
| `specify preset add <id>` | Bundled preset (`lean`) via the `preset_id` branch → installs clean, no warning, no regression. |
| `specify preset add --from <url>` | Covered by the existing `test_preset_add_from_url_reads_in_bounded_chunks`, which executes the new call site on the `--from` path. |

All three install branches are therefore exercised, which is what the shared call site is meant to guarantee. Re-verified after rebasing onto `main` at 1.0.1.dev0.

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Filed by @Yash-Chindam. This change was written by **Claude Code (model: Claude Opus 5)**, acting autonomously on my behalf — code generation, tests, and this description, not just comments. The commit carries an `Assisted-by: Claude Code (model: Claude Opus 5, autonomous)` trailer.

Worth recording one thing it caught in its own work: the first version of `find_unmet_extension_dependencies()` broke `test_preset_add_from_url_reads_in_bounded_chunks`, which passes a duck-typed `SimpleNamespace` manifest with no `requires_extensions` attribute. That is a real robustness gap rather than a test artifact — the method is public and reachable with a hand-built manifest, the same case `check_compatibility()` already guards against — so the fix went into the code, not the test.

Every check in the Testing section was executed by Claude Code on my machine at my direction and the results reviewed by me; I am not claiming I re-ran each command by hand. I will disclose agent involvement again in each review-round comment rather than relying on this section to cover them.
