### PR TITLE
docs: update landing page stats for 1.0.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Define what to build before building it. Rich templates, quality checklists, and
 
 ### Use any coding agent
 
-<span class="pillar-stat">35 integrations</span> — Copilot, Gemini, Codex, Kilo Code, Zed, Claude, Forge, Kiro, and more. Switch freely between agents with a single command. No lock-in.
+<span class="pillar-stat">38 integrations</span> — Copilot, Gemini, Codex, Kilo Code, Zed, Claude, Forge, Kiro, and more. Switch freely between agents with a single command. No lock-in.
 
 Run `specify init` with your agent of choice and Spec Kit sets up the right command files and directory structures automatically. If your agent isn't listed, the `generic` integration is an escape hatch for any tool.
 
@@ -43,7 +43,7 @@ Run `specify init` with your agent of choice and Spec Kit sets up the right comm
 
 ### Make it your own
 
-<span class="pillar-stat">138 community extensions</span> (70+ authors), <span class="pillar-stat">25 presets</span>, and growing. Tune the core process with presets, extend it with extensions, orchestrate it with workflows, and package it all up as bundles you can share — or replace the process entirely. The process itself lives in these building blocks, so you're never locked to SDD, or even to software.
+<span class="pillar-stat">157 community extensions</span> (90+ authors), <span class="pillar-stat">33 presets</span>, and growing. Tune the core process with presets, extend it with extensions, orchestrate it with workflows, and package it all up as bundles you can share — or replace the process entirely. The process itself lives in these building blocks, so you're never locked to SDD, or even to software.
 
 Including entirely different processes:
 
@@ -82,31 +82,31 @@ Community extensions like CI Guard and Architecture Guard add compliance gates a
 
 ## Built by the community
 
-**240+ contributors** power the Spec Kit ecosystem — from core integrations to entirely new processes. Anyone can create and publish an extension, preset, or workflow.
+**270+ contributors** power the Spec Kit ecosystem — from core integrations to entirely new processes. Anyone can create and publish an extension, preset, or workflow.
 
 <div class="stats-grid">
   <div class="stat-item">
-    <span class="stat-number">121K+</span>
+    <span class="stat-number">130K+</span>
     <span class="stat-label">GitHub stars</span>
   </div>
   <div class="stat-item">
-    <span class="stat-number">240+</span>
+    <span class="stat-number">270+</span>
     <span class="stat-label">Contributors</span>
   </div>
   <div class="stat-item">
-    <span class="stat-number">35</span>
+    <span class="stat-number">38</span>
     <span class="stat-label">Integrations</span>
   </div>
   <div class="stat-item">
-    <span class="stat-number">138</span>
+    <span class="stat-number">157</span>
     <span class="stat-label">Extensions</span>
   </div>
   <div class="stat-item">
-    <span class="stat-number">25</span>
+    <span class="stat-number">33</span>
     <span class="stat-label">Presets</span>
   </div>
   <div class="stat-item">
-    <span class="stat-number">6</span>
+    <span class="stat-number">7</span>
     <span class="stat-label">Friends projects</span>
   </div>
 </div>
@@ -155,4 +155,4 @@ Ready to start? Follow the [Quick Start Guide](quickstart.md).
 
 </div>
 
-<p class="text-end small text-body-secondary">Last updated: July 16, 2026</p>
+<p class="text-end small text-body-secondary">Last updated: August 21, 2026</p>


### PR DESCRIPTION
## Description

Updates the documentation landing page with the Spec Kit 1.0.0 launch metrics: 130K+ stars, 270+ contributors, 38 integrations, 157 community extensions from 90+ authors, 33 presets, and 7 friends projects. Also updates the page timestamp to August 21, 2026.

## Testing

Documentation-only change. Confirmed catalog counts against the v1.0.0 tag, checked GitHub repository metrics, and verified the diff has no whitespace errors.

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot (GPT-5.6 Sol) updated and validated the metrics, authored the commit, and opened this PR autonomously on behalf of @mnriem.