### PR TITLE
docs: add workflow quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Spec-Driven Development **flips the script** on traditional software development
 
 ### SDD Quickstart
 
+Replace `vX.Y.Z` with the [latest release tag](https://github.com/github/spec-kit/releases), keeping the leading `v`.
+
 ```bash
 uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
 specify init my-project --integration copilot
@@ -73,6 +75,8 @@ Bug fixes are risky when an agent jumps straight from a report to a patch withou
 
 ### Bug Fix Quickstart
 
+Replace `vX.Y.Z` with the [latest release tag](https://github.com/github/spec-kit/releases), keeping the leading `v`.
+
 ```bash
 uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
 specify init my-project --integration copilot
@@ -91,6 +95,8 @@ Launch your coding agent in the project directory, then:
 Good ideas deserve evidence before commitment, whether or not they become software. The bundled, opt-in assess extension turns a raw idea into a documented **go / needs-clarification / kill** decision through an independent **intake → research → define → shape → decide** workflow.
 
 ### Idea Assessment Quickstart
+
+Replace `vX.Y.Z` with the [latest release tag](https://github.com/github/spec-kit/releases), keeping the leading `v`.
 
 ```bash
 uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 ## Table of Contents
 
 - [🤔 What is Spec-Driven Development?](#-what-is-spec-driven-development)
+- [🐞 Bug Fixing with Spec Kit](#-bug-fixing-with-spec-kit)
+- [💡 Assessing Ideas with Spec Kit](#-assessing-ideas-with-spec-kit)
 - [⚡ Get Started](#-get-started)
 - [📽️ Video Overview](#️-video-overview)
 - [🌍 Community](#-community)
@@ -44,6 +46,69 @@
 ## 🤔 What is Spec-Driven Development?
 
 Spec-Driven Development **flips the script** on traditional software development. For decades, code has been king — specifications were just scaffolding we built and discarded once the "real work" of coding began. Spec-Driven Development changes this: **specifications become executable**, directly generating working implementations rather than just guiding them.
+
+### SDD Quickstart
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
+specify init my-project --integration copilot
+cd my-project
+```
+
+Launch your coding agent in the project directory, then:
+
+0. **Establish** your project principles once (`/speckit-constitution`). This is a one-time step per project.
+1. **Specify** what you want to build (`/speckit-specify`).
+2. **Plan** how you will build it (`/speckit-plan`).
+3. **Break down** the plan into actionable tasks (`/speckit-tasks`).
+4. **Implement** the tasks (`/speckit-implement`).
+5. **Converge** the implementation against the spec, plan, and tasks (`/speckit-converge`).
+
+> [!NOTE]
+> Repeat steps 4 and 5 until `/speckit-converge` reports **Converged**.
+
+## 🐞 Bug Fixing with Spec Kit
+
+Bug fixes are risky when an agent jumps straight from a report to a patch without validating the diagnosis or confirming that the fix resolves the original symptom. The bundled, opt-in bug extension provides a repeatable **assess → fix → test** workflow that keeps each fix scoped, evidence-based, and documented from root cause through verification.
+
+### Bug Fix Quickstart
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
+specify init my-project --integration copilot
+cd my-project
+specify extension add bug
+```
+
+Launch your coding agent in the project directory, then:
+
+1. **Assess** the bug (`/speckit-bug-assess "<bug report>" slug=login-crash`).
+2. **Fix** the assessed cause (`/speckit-bug-fix slug=login-crash`).
+3. **Test** the fix (`/speckit-bug-test slug=login-crash`).
+
+## 💡 Assessing Ideas with Spec Kit
+
+Good ideas deserve evidence before commitment, whether or not they become software. The bundled, opt-in assess extension turns a raw idea into a documented **go / needs-clarification / kill** decision through an independent **intake → research → define → shape → decide** workflow.
+
+### Idea Assessment Quickstart
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
+specify init my-project --integration copilot
+cd my-project
+specify extension add assess
+```
+
+Launch your coding agent in the project directory, then:
+
+1. **Intake** the idea (`/speckit-assess-intake "<idea>" slug=offline-mode`).
+2. **Research** supporting and opposing evidence (`/speckit-assess-research slug=offline-mode`).
+3. **Define** the problem, goals, and success metrics (`/speckit-assess-define slug=offline-mode`).
+4. **Shape** possible solutions and their trade-offs (`/speckit-assess-shape slug=offline-mode`).
+5. **Decide** whether to proceed, clarify, or stop (`/speckit-assess-decide slug=offline-mode`).
+
+> [!NOTE]
+> Idea assessment is standalone. If you choose to build an idea with a **go** decision, you can hand it off to `/speckit-specify`.
 
 ## ⚡ Get Started
 


### PR DESCRIPTION
## Description

Adds concise README quickstarts that show how to install Spec Kit and use its three primary workflows:

- run the core SDD lifecycle through convergence
- assess, fix, and verify bugs with the bundled bug extension
- evaluate ideas independently with the bundled assess extension

This gives new users a scannable path from installation to useful outcomes while retaining the detailed walkthrough below.

## Testing

Documentation-only change. Rendered the README locally with GitHub-style Markdown and checked the final diff for formatting errors.

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

README content was authored and refined by GitHub Copilot (model: GPT-5.6 Sol) on behalf of @mnriem through iterative human direction.