### PR TITLE
docs: flatten project history navigation

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -2,11 +2,9 @@
 - name: Home
   href: index.md
 
-# About
-- name: About
-  items:
-    - name: History
-      href: history.md
+# Project history
+- name: Project History
+  href: history.md
 
 # Getting started section
 - name: Getting Started


### PR DESCRIPTION
## Description

Makes Project History a direct top-level documentation destination and removes the single-item About hierarchy.

## Testing

Documentation-only navigation change; reviewed the rendered TOC structure and checked the diff for whitespace errors.

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot (model: GPT-5.6 Sol) assessed the documentation information architecture and authored the navigation change under user direction.