### PR TITLE
test(bundle): join across wrap points in the build output-path assertion

### DIFF
--- a/tests/contract/test_bundle_cli.py
+++ b/tests/contract/test_bundle_cli.py
@@ -340,7 +340,10 @@ def test_build_escapes_markup_in_output_path(project: Path):
 
     assert result.exit_code == 0, repr(result.exception)
     assert list(out_dir.glob("*.zip")), "the artifact should still be built"
-    assert "dist[bold]out" in strip_ansi(result.output), (
+    # Join across Rich's wrap points: the success line prints an absolute path,
+    # so the console folds it mid-token whenever the temp directory is long
+    # enough, which is a property of the runner's path, not of the escaping.
+    assert "dist[bold]out" in "".join(strip_ansi(result.output).split()), (
         "the reported path must match the directory actually written"
     )
 


### PR DESCRIPTION
## Description

`tests/contract/test_bundle_cli.py::test_build_escapes_markup_in_output_path`
fails or passes depending on how long the runner's temp directory path is.

The `bundle build` success line prints an absolute path. Rich folds it at the
console width, and when the fold lands inside the asserted token the substring
check misses:

```
E   AssertionError: the reported path must match the directory actually written
E   assert 'dist[bold]out' in '✓ Built demo-bundle-1.2.0.zip (2 files) →
E   /tmp/pytest-of-runner/pytest-1/test_build_escapes_markup_in_o0/dist[bo
E   ld]out/demo-bundle-1.2.0.zip\n'
```

Reproduced on a clean checkout of `main` (27f50f7): fails under the default
`--basetemp`, passes under a `--basetemp` 60 characters longer, because the
wrap point moves. Nothing about the escaping under test changes — only where
the line breaks.

## Fix

Join across the wrap points before the substring check, the same normalization
#4166 applied to the analogous `presets` assertion:

```python
assert "dist[bold]out" in "".join(strip_ansi(result.output).split())
```

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Full suite on this branch: `7137 passed, 181 skipped` on Linux / Python 3.14.
On `main` the same run is `7136 passed, 1 failed` -- the failure being this test.

`tests/contract/test_bundle_cli.py` on its own: 44 passed, under both the
default `--basetemp` (which fails on `main`) and a deliberately long one.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Code generated with Claude Code. I reviewed the change, confirmed it fails on
`main` under the default `--basetemp`, and understand what it does.
