### PR TITLE
fix(bundler): pass explicit workflow_add options from bundle install

### DIFF
--- a/src/specify_cli/bundler/services/primitives.py
+++ b/src/specify_cli/bundler/services/primitives.py
@@ -337,7 +337,7 @@ class _WorkflowKindManager:
         with _chdir(self._root):
             _delegate_command(
                 "install", f"workflow '{component.id}'",
-                lambda: workflow_add(component.id),
+                lambda: workflow_add(component.id, dev=False, from_url=None),
             )
 
     def refresh(self, component: ComponentRef) -> None:

--- a/tests/unit/test_bundler_primitives.py
+++ b/tests/unit/test_bundler_primitives.py
@@ -77,13 +77,17 @@ def test_offline_workflow_allows_bundled(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
         assets, "_locate_bundled_workflow", lambda wid: tmp_path / "wf"
     )
-    calls: list[str] = []
-    monkeypatch.setattr(specify_cli, "workflow_add", lambda wid: calls.append(wid))
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        specify_cli,
+        "workflow_add",
+        lambda wid, dev=object(), from_url=object(): calls.append((wid, dev, from_url)),
+    )
 
     manager = primitive_manager("workflows", tmp_path, allow_network=False)
     manager.install(_component("workflows", "bundled-wf"))
 
-    assert calls == ["bundled-wf"]
+    assert calls == [("bundled-wf", False, None)]
 
 
 def test_assert_pinned_version_matches_passes():


### PR DESCRIPTION
## Description

Fixes #4282

`specify bundle install` failed to install any workflow from a catalog. The
root cause is in `_WorkflowKindManager.install` (`src/specify_cli/bundler/services/primitives.py`):
it calls the Typer command `workflow_add` directly as a plain Python function,
`workflow_add(component.id)`. Typer only binds `dev`/`from_url` to their
declared defaults (`False` / `None`) when it invokes the command itself —
calling the function directly leaves `dev` bound to the raw (truthy)
`typer.OptionInfo` object. That makes the local-path branch trigger, so the
workflow's catalog ID is treated as a filesystem path and installation fails
with:

```
Error: --dev source must be a workflow YAML file, supported archive, or
directory containing workflow.yml: lifecycle-greenfield-bootstrap
```

This passes `dev=False, from_url=None` explicitly at the call site, matching
the fix suggested in the issue.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync --extra test && uv run pytest -q` — 7308 passed, 10 skipped
- [x] `uvx ruff@0.15.0 check src tests` — all checks passed
- [x] Added a regression assertion to `tests/unit/test_bundler_primitives.py::test_offline_workflow_allows_bundled` that captures the `dev`/`from_url` values `workflow_add` is actually called with

Verified the added assertion fails without the fix:

```
$ git checkout HEAD~1 -- src/specify_cli/bundler/services/primitives.py
$ uv run pytest tests/unit/test_bundler_primitives.py -k test_offline_workflow_allows_bundled -v
...
FAILED tests/unit/test_bundler_primitives.py::test_offline_workflow_allows_bundled
AssertionError: assert [('bundled-wf', <object object at 0x...>, <object object at 0x...>)] == [('bundled-wf', False, None)]
$ git checkout HEAD -- src/specify_cli/bundler/services/primitives.py
$ uv run pytest tests/unit/test_bundler_primitives.py -v
...
20 passed in 0.21s
```

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Implemented autonomously by Claude Code (Sonnet 5) under automated direction. The regression test was written and confirmed to fail before the fix, then the full test suite and lint were run locally as shown above.
