### PR TITLE
fix: scaffold extension config when installing via bundler

### DIFF
--- a/src/specify_cli/bundler/services/primitives.py
+++ b/src/specify_cli/bundler/services/primitives.py
@@ -263,9 +263,10 @@ class _ExtensionKindManager:
                 component.version,
                 _bundled_manifest_version(bundled / "extension.yml", "extension"),
             )
-            self._manager.install_from_directory(
+            manifest = self._manager.install_from_directory(
                 bundled, speckit_version, priority=priority, force=force
             )
+            self._manager.scaffold_config(manifest.id)
             return
 
         if not self._allow_network:
@@ -293,9 +294,10 @@ class _ExtensionKindManager:
         )
         zip_path = catalog.download_extension(component.id)
         try:
-            self._manager.install_from_zip(
+            manifest = self._manager.install_from_zip(
                 zip_path, speckit_version, priority=priority, force=force
             )
+            self._manager.scaffold_config(manifest.id)
         finally:
             with contextlib.suppress(Exception):
                 if zip_path.exists():

--- a/tests/unit/test_bundler_primitives.py
+++ b/tests/unit/test_bundler_primitives.py
@@ -7,6 +7,7 @@ offline-first).
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -169,16 +170,66 @@ def test_bundled_extension_pin_match_installs(tmp_path: Path, monkeypatch):
     bundled = _write_manifest(tmp_path / "ext", "extension", "1.0.0")
     monkeypatch.setattr(assets, "_locate_bundled_extension", lambda cid: bundled)
     called: list = []
-    monkeypatch.setattr(
-        ExtensionManager, "install_from_directory",
-        lambda self, *a, **k: called.append(a),
-    )
+
+    def _fake_install(self, *a, **k):
+        called.append(a)
+        return SimpleNamespace(id="my-ext")
+
+    monkeypatch.setattr(ExtensionManager, "install_from_directory", _fake_install)
 
     manager = primitive_manager("extensions", tmp_path, allow_network=False)
     # matching pin, and unpinned, both install cleanly
     manager.install(ComponentRef(kind="extensions", id="my-ext", version="1.0.0"))
     manager.install(ComponentRef(kind="extensions", id="my-ext", version=None))
     assert len(called) == 2
+
+
+def _write_extension_with_config(ext_dir: Path) -> None:
+    """A minimal, real (unmocked) extension source with a provides.config entry."""
+    import yaml
+
+    ext_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": "1.0",
+        "extension": {
+            "id": "my-ext",
+            "name": "My Extension",
+            "version": "1.0.0",
+            "description": "Test extension",
+        },
+        "requires": {"speckit_version": ">=0.1.0"},
+        "provides": {
+            "commands": [
+                {"name": "speckit.my-ext.hello", "file": "commands/hello.md"},
+            ],
+            "config": [
+                {"name": "my-ext-config.yml", "template": "config-template.yml"},
+            ],
+        },
+    }
+    (ext_dir / "extension.yml").write_text(yaml.dump(manifest), encoding="utf-8")
+    (ext_dir / "config-template.yml").write_text("setting: default\n", encoding="utf-8")
+    (ext_dir / "commands").mkdir(exist_ok=True)
+    (ext_dir / "commands" / "hello.md").write_text("---\ndescription: Test\n---\n\nhi\n", encoding="utf-8")
+
+
+def test_bundled_extension_install_scaffolds_config(tmp_path: Path, monkeypatch):
+    """A bundle-installed extension must have its provides.config templates
+    scaffolded, exactly like `specify extension add` does (issue: bundle
+    install skipped ExtensionManager.scaffold_config)."""
+    import specify_cli._assets as assets
+
+    project = tmp_path / "project"
+    ext_source = tmp_path / "ext-source"
+    _write_extension_with_config(ext_source)
+    monkeypatch.setattr(assets, "_locate_bundled_extension", lambda cid: ext_source)
+
+    manager = primitive_manager("extensions", project, allow_network=False)
+    manager.install(ComponentRef(kind="extensions", id="my-ext"))
+
+    scaffolded = project / ".specify" / "extensions" / "my-ext" / "my-ext-config.yml"
+    assert scaffolded.exists()
+    assert scaffolded.read_text(encoding="utf-8") == "setting: default\n"
 
 
 def test_bundled_preset_pin_mismatch_refuses(tmp_path: Path, monkeypatch):
@@ -227,10 +278,12 @@ def test_extension_refresh_calls_install_with_force(tmp_path: Path, monkeypatch)
     bundled = _write_manifest(tmp_path / "ext", "extension", "1.0.0")
     monkeypatch.setattr(assets, "_locate_bundled_extension", lambda cid: bundled)
     force_values: list = []
-    monkeypatch.setattr(
-        ExtensionManager, "install_from_directory",
-        lambda self, *a, **k: force_values.append(k.get("force", False)),
-    )
+
+    def _fake_install(self, *a, **k):
+        force_values.append(k.get("force", False))
+        return SimpleNamespace(id="my-ext")
+
+    monkeypatch.setattr(ExtensionManager, "install_from_directory", _fake_install)
 
     manager = primitive_manager("extensions", tmp_path, allow_network=False)
     manager.refresh(ComponentRef(kind="extensions", id="my-ext"))
@@ -265,10 +318,12 @@ def test_default_installer_refresh_dispatches_to_kind_manager(tmp_path: Path, mo
     bundled = _write_manifest(tmp_path / "ext", "extension", "1.0.0")
     monkeypatch.setattr(assets, "_locate_bundled_extension", lambda cid: bundled)
     force_values: list = []
-    monkeypatch.setattr(
-        ExtensionManager, "install_from_directory",
-        lambda self, *a, **k: force_values.append(k.get("force", False)),
-    )
+
+    def _fake_install(self, *a, **k):
+        force_values.append(k.get("force", False))
+        return SimpleNamespace(id="my-ext")
+
+    monkeypatch.setattr(ExtensionManager, "install_from_directory", _fake_install)
 
     installer = DefaultPrimitiveInstaller(allow_network=False)
     installer.refresh(tmp_path, _component("extensions", "my-ext"))
@@ -290,6 +345,7 @@ def test_refresh_succeeds_and_passes_force_true(tmp_path: Path, monkeypatch):
     def _fake_install_from_directory(self, *a, **k):
         force_seen.append(k.get("force", False))
         self.registry.add("my-ext", {"version": "1.0.0"})
+        return SimpleNamespace(id="my-ext")
 
     monkeypatch.setattr(
         ExtensionManager, "install_from_directory", _fake_install_from_directory

--- a/tests/unit/test_bundler_primitives.py
+++ b/tests/unit/test_bundler_primitives.py
@@ -232,6 +232,45 @@ def test_bundled_extension_install_scaffolds_config(tmp_path: Path, monkeypatch)
     assert scaffolded.read_text(encoding="utf-8") == "setting: default\n"
 
 
+def test_catalog_extension_install_scaffolds_config(tmp_path: Path, monkeypatch):
+    """A catalog-resolved (downloaded ZIP) extension install must also
+    scaffold its provides.config templates, matching the bundled-directory
+    coverage above. Exercises the reported reproduction, which installed an
+    extension resolved from the catalog rather than one shipped with Spec Kit."""
+    import zipfile
+
+    import specify_cli._assets as assets
+    from specify_cli.extensions import ExtensionCatalog
+
+    project = tmp_path / "project"
+    ext_source = tmp_path / "ext-source"
+    _write_extension_with_config(ext_source)
+
+    zip_path = tmp_path / "my-ext.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for f in ext_source.rglob("*"):
+            if f.is_file():
+                zf.write(f, f.relative_to(ext_source))
+
+    # No bundled asset located: forces the catalog/ZIP branch (install_from_zip).
+    monkeypatch.setattr(assets, "_locate_bundled_extension", lambda cid: None)
+    monkeypatch.setattr(
+        ExtensionCatalog,
+        "get_extension_info",
+        lambda self, eid: {"id": eid, "_install_allowed": True},
+    )
+    monkeypatch.setattr(
+        ExtensionCatalog, "download_extension", lambda self, eid: zip_path
+    )
+
+    manager = primitive_manager("extensions", project, allow_network=True)
+    manager.install(ComponentRef(kind="extensions", id="my-ext"))
+
+    scaffolded = project / ".specify" / "extensions" / "my-ext" / "my-ext-config.yml"
+    assert scaffolded.exists()
+    assert scaffolded.read_text(encoding="utf-8") == "setting: default\n"
+
+
 def test_bundled_preset_pin_mismatch_refuses(tmp_path: Path, monkeypatch):
     import specify_cli._assets as assets
     from specify_cli.presets import PresetManager


### PR DESCRIPTION
## Summary

Fixes #4283.

`specify bundle install` installs an extension by calling
`ExtensionManager.install_from_directory` / `install_from_zip` directly
from `_ExtensionKindManager._do_install` in
`src/specify_cli/bundler/services/primitives.py`, but never called
`ExtensionManager.scaffold_config` afterwards. The `specify extension add`
command flow (`src/specify_cli/extensions/_commands.py`) does call it, so
an extension installed as part of a bundle ended up with its
`provides.config` templates present on disk but never deployed — the
extension silently had no configuration, while installing the same
extension directly worked correctly.

## Change

- `src/specify_cli/bundler/services/primitives.py`: call
  `self._manager.scaffold_config(manifest.id)` right after a successful
  `install_from_directory`/`install_from_zip` call in
  `_ExtensionKindManager._do_install`, using the id from the manifest
  returned by the install call (matching what the `extension add` command
  flow does).
- `tests/unit/test_bundler_primitives.py`: added
  `test_bundled_extension_install_scaffolds_config`, which installs a real
  (unmocked) extension source with a `provides.config` entry through
  `primitive_manager("extensions", ...)` and asserts the config file lands
  at `.specify/extensions/<id>/<name>`. Also updated the existing
  `install_from_directory` mocks in this file to return an object with an
  `.id` attribute (as the real method does), since the new call site reads
  `manifest.id` off the return value.

Out of scope: the issue's related documentation nit about
`_target_follows_preserved_convention` naming conventions not being
documented in `EXTENSION-API-REFERENCE.md`, and surfacing per-file
deployed/skipped/failed console reporting through the bundler's CLI
summary (the bundler currently reports install results only as install
counts, not per-component detail — plumbing that through is a larger,
separate change).

## Test plan

Confirmed the new test fails without the fix (temporarily reverted just
the production file):

```
$ git stash push -- src/specify_cli/bundler/services/primitives.py
$ python3 -m uv run pytest tests/unit/test_bundler_primitives.py -q
...
FAILED tests/unit/test_bundler_primitives.py::test_bundled_extension_install_scaffolds_config - AssertionError: assert False
 +  where False = exists()
 +    where exists = PosixPath('.../project/.specify/extensions/my-ext/my-ext-config.yml').exists
1 failed, 20 passed in 0.28s
$ git stash pop
```

With the fix:

```
$ python3 -m uv run pytest tests/unit/test_bundler_primitives.py -q
21 passed in 0.27s
```

Full suite (unmodified elsewhere):

```
$ python3 -m uv run pytest -q
7309 passed, 10 skipped, 48 warnings in 467.66s
```

`ruff check` on the touched files reports 4 pre-existing issues (unused
`noqa` on lines untouched by this change, import-order in two unrelated
test functions) that are also present on unmodified `upstream/main` —
confirmed by stashing this change and re-running the same `ruff check`
invocation, which reported the identical 4 findings at the same
locations.

## AI disclosure

This change was implemented with AI assistance (Claude Code), including
the fix, the regression test, and this PR description. All commands
listed above were run and their output verified directly.
