### PR TITLE
fix(workflows): reject a condition that is spliced into text, not evaluated

### DIFF
--- a/src/specify_cli/workflows/expressions.py
+++ b/src/specify_cli/workflows/expressions.py
@@ -785,6 +785,42 @@ def condition_is_never_evaluated(condition: Any) -> bool:
     return _first_unclosable_block(stripped) == "verbatim"
 
 
+def condition_is_interpolated_to_text(condition: Any) -> bool:
+    """True when *condition* holds ``{{ }}`` blocks but is spliced into text, not evaluated.
+
+    ``evaluate_expression`` takes its typed fast path only when the whole string is
+    exactly one ``{{ ... }}`` block (``_is_single_expression``). Anything else — two
+    blocks, or one block with any text around it — goes to ``_interpolate_expressions``,
+    which substitutes each block into the surrounding string and returns a *string*.
+    ``evaluate_condition`` then coerces that with ``bool()``, so the result is true for
+    every rendering except ``""``, ``"true"`` and ``"false"``::
+
+        {{ inputs.ready }} and {{ inputs.count > 100 }}   ->  "False and False"  ->  True
+        not {{ inputs.ready }}                            ->  "not False"        ->  True
+        {{ inputs.count }} > 100                          ->  "0 > 100"          ->  True
+
+    Each of those reads as a real expression and is always true, which is the same
+    silent-truthiness fault ``condition_is_never_evaluated`` reports one layer out: there
+    the braces are missing, here they are present but do not cover the whole condition.
+    The operators belong *inside* one block, and the validators already tell authors the
+    condition must be "a single complete '{{ }}' block" -- this is the check behind that
+    sentence.
+
+    Deliberately derived from ``_is_single_expression`` rather than restated, so this
+    cannot drift from the fast path it is predicting.
+    """
+    if not isinstance(condition, str):
+        return False
+    stripped = condition.strip()
+    if not stripped or "{{" not in stripped:
+        return False
+    # Leave both of the faults that already have their own message and advice: a block
+    # the substituter cannot close is not an interpolation problem.
+    if condition_is_never_evaluated(condition) or condition_has_malformed_expression_block(condition):
+        return False
+    return not _is_single_expression(stripped)
+
+
 def condition_has_malformed_expression_block(condition: Any) -> bool:
     """True when *condition* holds a ``{{`` block the quote-aware scan cannot close,
     but which ``_interpolate_expressions`` still evaluates through its raw-close

--- a/src/specify_cli/workflows/steps/do_while/__init__.py
+++ b/src/specify_cli/workflows/steps/do_while/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from specify_cli.workflows.base import StepBase, StepContext, StepResult, StepStatus
 from specify_cli.workflows.expressions import (
     condition_has_malformed_expression_block,
+    condition_is_interpolated_to_text,
     condition_is_never_evaluated,
     format_condition_remediation,
 )
@@ -120,6 +121,21 @@ class DoWhileStep(StepBase):
                 "close, so it falls back to the first raw '}}' and evaluates a "
                 "truncated expression instead of the one written. Balance the "
                 "delimiters and quotes."
+            )
+        elif condition_is_interpolated_to_text(config["condition"]):
+            # Third fault, third message. The braces are here and they close, but they
+            # do not cover the whole condition, so evaluate_expression takes its text
+            # path rather than the typed one: each block is substituted into the
+            # surrounding string and the result is coerced by bool(). Two blocks joined
+            # by `and` render "False and False", which is true. No paste-ready
+            # correction is offered: there is no single right rewrite, because only the
+            # author knows which grouping the operators were meant to have.
+            errors.append(
+                f"Do-while step {config.get('id', '?')!r}: 'condition' "
+                f"{config['condition']!r} holds more than one '{{{{ }}}}' block, or "
+                "text around one, so it is substituted into a string and coerced by "
+                "bool() instead of being evaluated. Put the whole expression inside a "
+                "single '{{ }}' block."
             )
         max_iter = config.get("max_iterations")
         if max_iter is not None:

--- a/src/specify_cli/workflows/steps/if_then/__init__.py
+++ b/src/specify_cli/workflows/steps/if_then/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from specify_cli.workflows.base import StepBase, StepContext, StepResult, StepStatus
 from specify_cli.workflows.expressions import (
     condition_has_malformed_expression_block,
+    condition_is_interpolated_to_text,
     condition_is_never_evaluated,
     format_condition_remediation,
     evaluate_condition,
@@ -111,6 +112,21 @@ class IfThenStep(StepBase):
                 "close, so it falls back to the first raw '}}' and evaluates a "
                 "truncated expression instead of the one written. Balance the "
                 "delimiters and quotes."
+            )
+        elif condition_is_interpolated_to_text(config["condition"]):
+            # Third fault, third message. The braces are here and they close, but they
+            # do not cover the whole condition, so evaluate_expression takes its text
+            # path rather than the typed one: each block is substituted into the
+            # surrounding string and the result is coerced by bool(). Two blocks joined
+            # by `and` render "False and False", which is true. No paste-ready
+            # correction is offered: there is no single right rewrite, because only the
+            # author knows which grouping the operators were meant to have.
+            errors.append(
+                f"If step {config.get('id', '?')!r}: 'condition' "
+                f"{config['condition']!r} holds more than one '{{{{ }}}}' block, or "
+                "text around one, so it is substituted into a string and coerced by "
+                "bool() instead of being evaluated. Put the whole expression inside a "
+                "single '{{ }}' block."
             )
         if "then" not in config:
             errors.append(

--- a/src/specify_cli/workflows/steps/while_loop/__init__.py
+++ b/src/specify_cli/workflows/steps/while_loop/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from specify_cli.workflows.base import StepBase, StepContext, StepResult, StepStatus
 from specify_cli.workflows.expressions import (
     condition_has_malformed_expression_block,
+    condition_is_interpolated_to_text,
     condition_is_never_evaluated,
     format_condition_remediation,
     evaluate_condition,
@@ -129,6 +130,21 @@ class WhileStep(StepBase):
                 "close, so it falls back to the first raw '}}' and evaluates a "
                 "truncated expression instead of the one written. Balance the "
                 "delimiters and quotes."
+            )
+        elif condition_is_interpolated_to_text(config["condition"]):
+            # Third fault, third message. The braces are here and they close, but they
+            # do not cover the whole condition, so evaluate_expression takes its text
+            # path rather than the typed one: each block is substituted into the
+            # surrounding string and the result is coerced by bool(). Two blocks joined
+            # by `and` render "False and False", which is true. No paste-ready
+            # correction is offered: there is no single right rewrite, because only the
+            # author knows which grouping the operators were meant to have.
+            errors.append(
+                f"While step {config.get('id', '?')!r}: 'condition' "
+                f"{config['condition']!r} holds more than one '{{{{ }}}}' block, or "
+                "text around one, so it is substituted into a string and coerced by "
+                "bool() instead of being evaluated. Put the whole expression inside a "
+                "single '{{ }}' block."
             )
         max_iter = config.get("max_iterations")
         if max_iter is not None:

--- a/tests/unit/test_condition_expression_block.py
+++ b/tests/unit/test_condition_expression_block.py
@@ -6,8 +6,10 @@ import yaml
 from specify_cli.workflows.base import StepContext
 from specify_cli.workflows.expressions import (
     condition_has_malformed_expression_block,
+    condition_is_interpolated_to_text,
     condition_is_never_evaluated,
     evaluate_condition,
+    evaluate_expression,
     format_condition_correction,
     _has_unbalanced_quote,
     _has_unbalanced_bracket,
@@ -139,6 +141,75 @@ def test_a_malformed_block_can_raise_rather_than_be_true():
     ctx = StepContext(inputs={"count": 5})
     with pytest.raises(ValueError):
         evaluate_condition("{{ inputs.missing | default('oops }}", ctx)
+
+
+# A third fault. The braces are present and they close, but they do not cover the
+# whole condition, so `evaluate_expression` leaves its typed fast path: each block is
+# substituted into the surrounding text and the result is a *string*, which
+# `evaluate_condition` then coerces. Every one of these reads as a real expression and
+# is always true. The validators already told authors the condition must be "a single
+# complete '{{ }}' block" -- nothing checked it.
+INTERPOLATED_TO_TEXT = [
+    "{{ inputs.ready }} and {{ inputs.count > 100 }}",   # two blocks joined by an operator
+    "{{ inputs.ready }} or {{ inputs.ready }}",
+    "not {{ inputs.ready }}",                            # operator outside the block
+    "{{ inputs.count }} > 100",                          # comparison outside the block
+    "ready: {{ inputs.ready }}",                         # prose around one block
+    "{{ inputs.ready }}x",                               # a single trailing character
+]
+
+
+@pytest.mark.parametrize("condition", INTERPOLATED_TO_TEXT)
+def test_a_condition_spliced_into_text_is_silently_true_and_is_flagged(condition):
+    # Ground truth first: the interpolated form really is a string, and really is true
+    # for a set of inputs where the expression the author wrote would be false.
+    ctx = StepContext(inputs={"ready": False, "count": 0})
+    rendered = evaluate_expression(condition, ctx)
+    assert isinstance(rendered, str)
+    assert evaluate_condition(condition, ctx) is True
+
+    assert condition_is_interpolated_to_text(condition) is True
+
+
+@pytest.mark.parametrize("condition", INTERPOLATED_TO_TEXT)
+@pytest.mark.parametrize("step_cls", STEP_CLASSES)
+def test_every_condition_step_rejects_a_spliced_condition(step_cls, condition):
+    config = {"id": "s1", "condition": condition, "then": [], "steps": []}
+    errors = [e for e in step_cls().validate(config) if "'condition'" in e]
+
+    assert len(errors) == 1
+    assert "single '{{ }}' block" in errors[0]
+    # No paste-ready correction: there is no single right rewrite of `{{ a }} and {{ b }}`.
+    assert "Wrap the expression" not in errors[0]
+
+
+VALID_SINGLE_BLOCKS = [
+    "{{ inputs.ready }}",
+    "{{ inputs.ready and inputs.count > 100 }}",
+    "{{ not inputs.ready }}",
+    "{{ inputs.tags | join(', ') == 'a, b' }}",
+    # A '}}' inside a quoted argument does not end the block, so this is still one
+    # expression and must stay on the fast path.
+    "{{ inputs.text | contains('}}') }}",
+    # `evaluate_expression` strips before testing the fast path, so surrounding
+    # whitespace is not "text around the block" and must stay accepted.
+    "  {{ inputs.ready }}  ",
+]
+
+
+@pytest.mark.parametrize("condition", VALID_SINGLE_BLOCKS)
+@pytest.mark.parametrize("step_cls", STEP_CLASSES)
+def test_a_single_complete_block_is_still_accepted(step_cls, condition):
+    """The narrowing must not widen: one block, however complex, is the supported form."""
+    assert condition_is_interpolated_to_text(condition) is False
+    config = {"id": "s1", "condition": condition, "then": [], "steps": []}
+    assert [e for e in step_cls().validate(config) if "'condition'" in e] == []
+
+
+@pytest.mark.parametrize("condition", NEVER_EVALUATED + MALFORMED_BLOCKS)
+def test_the_older_two_faults_keep_their_own_message(condition):
+    """The new check yields to both, so each fault keeps the advice written for it."""
+    assert condition_is_interpolated_to_text(condition) is False
 
 
 @pytest.mark.parametrize("condition", NEVER_EVALUATED + MALFORMED_BLOCKS)


### PR DESCRIPTION
Follow-up to #4182 and #4230, one layer out from both.

## The defect

`evaluate_expression` takes its typed fast path only when the whole string is exactly one `{{ ... }}` block (`_is_single_expression`). Anything else goes to `_interpolate_expressions`, which substitutes each block into the surrounding text and returns a **string** — and `evaluate_condition` then coerces it with `bool()`.

So a condition whose braces do not cover the whole expression is always true. Measured on `main` (`27f50f7`) with `inputs.ready: false`, `inputs.count: 0`:

| condition | `evaluate_expression` | `evaluate_condition` | validator errors |
| --- | --- | ---: | ---: |
| `{{ inputs.ready }} and {{ inputs.count > 100 }}` | `'False and False'` | **True** | 0 |
| `not {{ inputs.ready }}` | `'not False'` | **True** | 0 |
| `{{ inputs.count }} > 100` | `'0 > 100'` | **True** | 0 |
| `ready: {{ inputs.ready }}` | `'ready: False'` | **True** | 0 |
| `{{ inputs.ready }}` *(control)* | `False` | False | 0 |

Every one of those reads as a real comparison, validates clean, and takes `then` on every run. A `while`/`do-while` written that way spins to `max_iterations`.

The first form is the one I would expect authors to reach for most, because it is the habit both Jinja and GitHub Actions teach.

## Why it slipped through

The three validators already assert the property — verbatim, in all of `if_then`, `while_loop` and `do_while`:

```python
f"{config['condition']!r} is not a single complete '{{{{ }}}}' block, so "
"it is never evaluated as an expression and is always true. "
```

Nothing checked it. `condition_is_never_evaluated` asks only whether *some* `{{` exists and whether every block closes:

```python
    if "{{" not in stripped:
        return True
    ...
    return _first_unclosable_block(stripped) == "verbatim"
```

That is the same shape as #4182 — a rule the runtime has that the gate does not derive — with the braces present instead of missing.

## The fix

`condition_is_interpolated_to_text` derives the answer from `_is_single_expression`, the very predicate the fast path branches on, rather than restating it. Given #4274, restating it was the one thing I did not want to do.

It yields to both existing faults, so each keeps the message and advice written for it, and the three validators gain it as a third `elif`. **No paste-ready correction is offered** — there is no single right rewrite of `{{ a }} and {{ b }}`, since only the author knows which grouping was meant, and that is the refusal policy #4230 established rather than a new one.

## Verification

Windows, Python 3.11.

```
tests/unit/test_condition_expression_block.py            335 passed   (286 before)
tests/unit/test_condition_expression_block.py
  + tests/test_workflows.py + tests/test_extensions.py   22 failed, 1777 passed
  main, same three files                                 22 failed, 1728 passed
```

Identical 22 failures on both sides, `diff` clean — the pre-existing symlink and bash-parity classes on unelevated Windows. 1728 → 1777 is exactly the 49 cases added. `ruff`: **0 net new findings** across all five changed files (13 before, 13 after, same rules, same files).

**Mutation-checked**, after confirming each edit actually applied:

```
predicate never flags                    -> 24 failed
predicate does not yield to the two
  existing faults                        ->  5 failed
predicate tests the unstripped string    ->  3 failed
```

The third mutation is there because `evaluate_expression` strips before testing the fast path — I measured that rather than assuming it, so `"  {{ inputs.ready }}  "` stays accepted and is pinned as such.

## One thing I could not measure

Whether a multi-block condition is ever legitimate. I could not construct one — a mixed string is truthy unless it renders exactly `""`, `"true"` or `"false"` — but that is an argument, not a measurement. If you know of a shape that should stay accepted, say so and I will narrow the check to exclude it.
