### PR TITLE
fix(toml): add standard \b and \f escape sequences to escape_toml_basic

### DIFF
--- a/src/specify_cli/_toml_string.py
+++ b/src/specify_cli/_toml_string.py
@@ -53,6 +53,10 @@ def escape_toml_basic(value: str) -> str:
             out.append("\\r")
         elif ch == "\t":
             out.append("\\t")
+        elif ch == "\b":
+            out.append("\\b")
+        elif ch == "\f":
+            out.append("\\f")
         elif code < 0x20 or code == 0x7F:
             out.append(f"\\u{code:04x}")
         else:


### PR DESCRIPTION
In `src/specify_cli/_toml_string.py`:
- In the TOML v1.0 specification, `\b` (backspace) and `\f` (form feed) are standard short escape sequences.
- Emits `\b` and `\f` explicitly instead of falling back to 4-digit unicode escapes.