### PR TITLE
fix(bundler): reject non-string catalog entry tag members

### DIFF
--- a/src/specify_cli/bundler/models/catalog.py
+++ b/src/specify_cli/bundler/models/catalog.py
@@ -106,10 +106,11 @@ class CatalogSource:
 
 
 def _parse_tags(value: Any, entry_id: str) -> tuple[str, ...]:
-    """Coerce a catalog entry's ``tags`` into a tuple of strings.
+    """Parse a catalog entry's ``tags`` into a tuple of strings.
 
     Catalogs are untrusted input: a bare string would otherwise be iterated
-    character-by-character, so reject anything that is not a list/tuple.
+    character-by-character, so reject anything that is not a list/tuple, and
+    reject any non-string member instead of silently coercing it.
     """
     if value is None:
         return ()
@@ -117,7 +118,11 @@ def _parse_tags(value: Any, entry_id: str) -> tuple[str, ...]:
         raise BundlerError(
             f"Catalog entry '{entry_id}': 'tags' must be a list of strings."
         )
-    return tuple(str(t) for t in value)
+    if any(not isinstance(item, str) for item in value):
+        raise BundlerError(
+            f"Catalog entry '{entry_id}': 'tags' must be a list of strings."
+        )
+    return tuple(value)
 
 
 def _parse_verified(value: Any, entry_id: str) -> bool:

--- a/tests/contract/test_catalog_schema.py
+++ b/tests/contract/test_catalog_schema.py
@@ -238,6 +238,15 @@ def test_catalog_entry_rejects_string_tags():
         CatalogEntry.from_dict(data)
 
 
+def test_catalog_entry_rejects_non_string_tag_members():
+    from specify_cli.bundler.models.catalog import CatalogEntry
+
+    data = catalog_entry_dict("demo")
+    data["tags"] = ["valid", 1]
+    with pytest.raises(BundlerError, match="'tags' must be a list of strings"):
+        CatalogEntry.from_dict(data)
+
+
 def test_catalog_entry_rejects_non_boolean_verified():
     from specify_cli.bundler.models.catalog import CatalogEntry
 


### PR DESCRIPTION
## Summary
- `_parse_tags` in `src/specify_cli/bundler/models/catalog.py` validates that a catalog entry's `tags` field is a list/tuple, but then silently coerces each member with `str(t) for t in value` — so `tags: [1, true, {}]` becomes `("1", "True", "{}")` instead of being rejected.
- This is the same bug class just fixed in #4091 for the manifest's `_parse_str_list` (`src/specify_cli/bundler/models/manifest.py`), which rejects non-string list members with `'{field}' must be a list of strings`. The catalog's `_parse_tags` sibling wasn't updated in that PR, even though catalogs are explicitly untrusted input (per its own docstring).
- Fix: reject any non-string member the same way the manifest fix does, instead of silently coercing it.

## Test plan
- [x] Added `test_catalog_entry_rejects_non_string_tag_members` to `tests/contract/test_catalog_schema.py`, mirroring the existing `test_catalog_entry_rejects_string_tags`.
- [x] Verified the new test fails without the fix (`DID NOT RAISE BundlerError`) and passes with it.
- [x] Ran `tests/contract/test_catalog_schema.py` — 21 passed; the remaining 22 errors are pre-existing Windows `tmp_path`/`PermissionError: WinError 5` environment failures unrelated to this change (reproduced on an unmodified checkout).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FW9fAYsCBCAgdKWovtSyqt