### PR TITLE
fix(workflows): reject falsy non-mapping step.yml in step add

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -3364,12 +3364,18 @@ def workflow_step_add(
         try:
             import yaml as _yaml
 
-            meta = _yaml.safe_load(step_yml_content.decode("utf-8")) or {}
+            meta = _yaml.safe_load(step_yml_content.decode("utf-8"))
         except Exception as exc:
             console.print(f"[red]Error:[/red] Invalid step.yml: {exc}")
             raise typer.Exit(1)
 
-        if not isinstance(meta, dict):
+        # Do NOT coerce with ``or {}`` here: that also turns a FALSY non-mapping
+        # (top-level ``[]``, ``false``, ``0``, ``''``) into ``{}`` and silently
+        # bypasses this shape check, surfacing the unrelated "missing
+        # 'step.type_key'" error below instead of the real problem.
+        if meta is None:
+            meta = {}
+        elif not isinstance(meta, dict):
             console.print("[red]Error:[/red] step.yml must be a YAML mapping")
             raise typer.Exit(1)
 

--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -3369,8 +3369,14 @@ def workflow_step_add(
             # explicit null scalar (``null``, ``~``, ``NULL``), so it cannot
             # tell them apart on its own. ``compose`` yields no node only for
             # a genuinely empty document.
-            is_empty_document = _yaml.compose(step_yml_text) is None
+            node = _yaml.compose(step_yml_text)
             meta = _yaml.safe_load(step_yml_text)
+            is_empty_document = node is None or (
+                meta is None
+                and isinstance(node, _yaml.nodes.ScalarNode)
+                and node.value == ""
+                and node.start_mark.index == node.end_mark.index
+            )
         except Exception as exc:
             console.print(f"[red]Error:[/red] Invalid step.yml: {exc}")
             raise typer.Exit(1)

--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -3364,16 +3364,23 @@ def workflow_step_add(
         try:
             import yaml as _yaml
 
-            meta = _yaml.safe_load(step_yml_content.decode("utf-8"))
+            step_yml_text = step_yml_content.decode("utf-8")
+            # ``safe_load`` returns None for BOTH an empty document and an
+            # explicit null scalar (``null``, ``~``, ``NULL``), so it cannot
+            # tell them apart on its own. ``compose`` yields no node only for
+            # a genuinely empty document.
+            is_empty_document = _yaml.compose(step_yml_text) is None
+            meta = _yaml.safe_load(step_yml_text)
         except Exception as exc:
             console.print(f"[red]Error:[/red] Invalid step.yml: {exc}")
             raise typer.Exit(1)
 
         # Do NOT coerce with ``or {}`` here: that also turns a FALSY non-mapping
-        # (top-level ``[]``, ``false``, ``0``, ``''``) into ``{}`` and silently
-        # bypasses this shape check, surfacing the unrelated "missing
-        # 'step.type_key'" error below instead of the real problem.
-        if meta is None:
+        # (top-level ``[]``, ``false``, ``0``, ``''``, or an explicit ``null``)
+        # into ``{}`` and silently bypasses this shape check, surfacing the
+        # unrelated "missing 'step.type_key'" error below instead of the real
+        # problem. Only a genuinely empty document defaults to ``{}``.
+        if meta is None and is_empty_document:
             meta = {}
         elif not isinstance(meta, dict):
             console.print("[red]Error:[/red] step.yml must be a YAML mapping")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -10451,6 +10451,74 @@ class TestWorkflowStepAddCLI:
             project_dir / ".specify" / "workflows" / "steps" / "my-step"
         ).exists()
 
+    @pytest.mark.parametrize("step_yml_body", [b"[]", b"false", b"0", b"''"])
+    def test_add_rejects_falsy_non_mapping_step_yml(
+        self, project_dir, monkeypatch, step_yml_body
+    ):
+        """A FALSY non-mapping step.yml document ([], false, 0, '') must be
+        reported as "step.yml must be a YAML mapping", not silently coerced by
+        ``or {}`` into {} and then misreported as the unrelated "missing
+        'step.type_key'" error — matching how a TRUTHY non-mapping document
+        (e.g. a bare string) already reports the mapping-shape error."""
+        from typer.testing import CliRunner
+        from specify_cli import app
+        from specify_cli.workflows.catalog import StepCatalog
+        from specify_cli.authentication import http as auth_http
+
+        monkeypatch.chdir(project_dir)
+        monkeypatch.setattr(
+            StepCatalog,
+            "get_step_info",
+            lambda self, step_id: {
+                "id": step_id,
+                "name": "Test Step",
+                "url": "https://example.com/step.yml",
+                "init_url": "https://example.com/__init__.py",
+                "_install_allowed": True,
+            },
+        )
+
+        class _FakeResponse:
+            def __init__(self, url):
+                self.url = url
+                self.body = step_yml_body if url.endswith("step.yml") else b""
+                self.offset = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def getheader(self, name):
+                return None
+
+            def geturl(self):
+                return self.url
+
+            def read(self, size=-1):
+                if size < 0:
+                    size = len(self.body) - self.offset
+                chunk = self.body[self.offset : self.offset + size]
+                self.offset += len(chunk)
+                return chunk
+
+        monkeypatch.setattr(
+            auth_http,
+            "open_url",
+            lambda url, timeout=30, redirect_validator=None: _FakeResponse(url),
+        )
+
+        result = CliRunner().invoke(
+            app, ["workflow", "step", "add", "my-step"]
+        )
+
+        assert result.exit_code != 0
+        assert "step.yml must be a YAML mapping" in result.output
+        assert not (
+            project_dir / ".specify" / "workflows" / "steps" / "my-step"
+        ).exists()
+
     @pytest.mark.parametrize(
         ("catalog_fields", "expected"),
         [

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -10451,7 +10451,9 @@ class TestWorkflowStepAddCLI:
             project_dir / ".specify" / "workflows" / "steps" / "my-step"
         ).exists()
 
-    @pytest.mark.parametrize("step_yml_body", [b"[]", b"false", b"0", b"''"])
+    @pytest.mark.parametrize(
+        "step_yml_body", [b"[]", b"false", b"0", b"''", b"null", b"~", b"NULL"]
+    )
     def test_add_rejects_falsy_non_mapping_step_yml(
         self, project_dir, monkeypatch, step_yml_body
     ):
@@ -10459,7 +10461,10 @@ class TestWorkflowStepAddCLI:
         reported as "step.yml must be a YAML mapping", not silently coerced by
         ``or {}`` into {} and then misreported as the unrelated "missing
         'step.type_key'" error — matching how a TRUTHY non-mapping document
-        (e.g. a bare string) already reports the mapping-shape error."""
+        (e.g. a bare string) already reports the mapping-shape error. An
+        explicit null scalar (null/~/NULL) parses to the same ``None`` as a
+        genuinely empty document, so it must be distinguished (via
+        ``yaml.compose``) and rejected too, rather than defaulting to {}."""
         from typer.testing import CliRunner
         from specify_cli import app
         from specify_cli.workflows.catalog import StepCatalog


### PR DESCRIPTION
## Summary
- `workflow_step_add` (`src/specify_cli/workflows/_commands.py`) parses a fetched `step.yml` with `_yaml.safe_load(step_yml_content.decode("utf-8")) or {}`.
- That `or {}` coerces a **falsy non-mapping** top-level document (`[]`, `false`, `0`, `''`) to `{}` *before* the `if not isinstance(meta, dict): ...` shape check runs. The command then proceeds with `meta = {}`, derives `step_meta = meta.get("step", {})` → `{}` and `type_key = ""`, and reports the unrelated `"step.yml missing 'step.type_key' field"` instead of the real problem: `"step.yml must be a YAML mapping"`.
- A **truthy** non-mapping document (e.g. a bare string) already hits the correct `isinstance` check and reports the right error — this was an inconsistency between falsy and truthy malformed inputs.
- Same falsy-or-coerce shape as the catalog-config bugs already fixed this cycle in `workflows/catalog.py` (`WorkflowCatalog`/`StepCatalog`), `presets/__init__.py` (`PresetCatalog._load_catalog_config`), and `integrations` (#4187).

## Test plan
- [x] Added `test_add_rejects_falsy_non_mapping_step_yml` to `TestWorkflowStepAddCLI`, parametrized over `[]`, `false`, `0`, `''`, mocking the HTTP fetch so `step.yml`'s body is the falsy document.
- [x] Verified all 4 new parametrized cases fail without the fix (stashed only the source change, confirmed the misleading `"missing 'step.type_key'"` message) and pass with it.
- [x] Ran `TestWorkflowStepAddCLI` in full — 24 passed; the 1 remaining failure (`test_add_rejects_symlinked_steps_base_dir`) is a pre-existing Windows symlink-elevation failure unrelated to this change (reproduces on an unmodified checkout).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FW9fAYsCBCAgdKWovtSyqt