### PR TITLE
fix(workflows): reject a non-integer or out-of-range current_step_index in RunState resume

### DIFF
--- a/src/specify_cli/workflows/engine.py
+++ b/src/specify_cli/workflows/engine.py
@@ -851,7 +851,32 @@ class RunState:
             installed_origin_tracked=has_installed_workflow_id,
         )
         state.status = RunStatus(state_data["status"])
-        state.current_step_index = state_data.get("current_step_index", 0)
+
+        # ``resume()`` slices ``definition.steps[state.current_step_index :]``
+        # with no guard of its own -- unlike ``workflow_id`` /
+        # ``installed_workflow_id`` / ``installed_registry_root`` / ``inputs``
+        # above, this field was never shape-checked here. A non-int value (a
+        # hand-edited or externally-written state.json, e.g. a string or
+        # float) reaches that slice and raises a raw, unhelpful
+        # ``TypeError: slice indices must be integers or None or have an
+        # __index__ method`` from deep inside ``resume()`` instead of the
+        # clean "Invalid run state: ..." this loader already gives every
+        # other malformed field. A negative value slices from the end instead
+        # of failing, silently resuming from the wrong step. Reject both here,
+        # consistent with the sibling checks. ``bool`` is an ``int`` subclass,
+        # so it is excluded explicitly (mirrors the ``max_iterations`` /
+        # ``continue_on_error`` bool guards elsewhere in this module).
+        current_step_index = state_data.get("current_step_index", 0)
+        if (
+            isinstance(current_step_index, bool)
+            or not isinstance(current_step_index, int)
+            or current_step_index < 0
+        ):
+            raise ValueError(
+                "Invalid run state: 'current_step_index' must be a "
+                f"non-negative integer, got {current_step_index!r}"
+            )
+        state.current_step_index = current_step_index
         state.current_step_id = state_data.get("current_step_id")
         state.step_results = state_data.get("step_results", {})
         state.workflow_dir = state_data.get("workflow_dir")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -7377,6 +7377,49 @@ class TestRunState:
             RunState.load("requested-run", project_dir)
 
     @pytest.mark.parametrize(
+        "bad_current_step_index",
+        ["not-a-number", 1.5, -1, [0], {"index": 0}, True],
+    )
+    def test_load_rejects_invalid_current_step_index(
+        self, project_dir, bad_current_step_index
+    ):
+        """A malformed ``current_step_index`` must fail at load(), not resume().
+
+        ``resume()`` slices ``definition.steps[state.current_step_index :]``
+        with no guard of its own. Every other field this loader restores
+        (``workflow_id``, ``installed_workflow_id``, ``installed_registry_root``,
+        ``inputs``) is shape-checked here and raises the same clean "Invalid
+        run state: ..." ``ValueError`` on a malformed value; ``current_step_index``
+        was the one field silently passed through. A non-int value reaches the
+        slice and raises a raw, unhelpful ``TypeError`` from deep inside
+        ``resume()`` instead. ``True`` is included because ``bool`` is an
+        ``int`` subclass and would otherwise slip past a bare ``isinstance(...,
+        int)`` check.
+        """
+        from specify_cli.workflows.engine import RunState
+
+        run_dir = (
+            project_dir / ".specify" / "workflows" / "runs" / "bad-index-run"
+        )
+        run_dir.mkdir(parents=True)
+        (run_dir / "state.json").write_text(
+            json.dumps(
+                {
+                    "run_id": "bad-index-run",
+                    "workflow_id": "test-workflow",
+                    "status": "paused",
+                    "current_step_index": bad_current_step_index,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(
+            ValueError, match="'current_step_index' must be a non-negative integer"
+        ):
+            RunState.load("bad-index-run", project_dir)
+
+    @pytest.mark.parametrize(
         ("installed_workflow_id", "installed_registry_root"),
         [
             ("", None),

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -7383,18 +7383,9 @@ class TestRunState:
     def test_load_rejects_invalid_current_step_index(
         self, project_dir, bad_current_step_index
     ):
-        """A malformed ``current_step_index`` must fail at load(), not resume().
+        """Reject non-integer and negative resume indices at load time.
 
-        ``resume()`` slices ``definition.steps[state.current_step_index :]``
-        with no guard of its own. Every other field this loader restores
-        (``workflow_id``, ``installed_workflow_id``, ``installed_registry_root``,
-        ``inputs``) is shape-checked here and raises the same clean "Invalid
-        run state: ..." ``ValueError`` on a malformed value; ``current_step_index``
-        was the one field silently passed through. A non-int value reaches the
-        slice and raises a raw, unhelpful ``TypeError`` from deep inside
-        ``resume()`` instead. ``True`` is included because ``bool`` is an
-        ``int`` subclass and would otherwise slip past a bare ``isinstance(...,
-        int)`` check.
+        ``bool`` is covered explicitly because it subclasses ``int``.
         """
         from specify_cli.workflows.engine import RunState
 


### PR DESCRIPTION
## Summary
- `RunState.load()` restores `current_step_index` via `state_data.get("current_step_index", 0)` with no shape check, unlike a few of the other fields it restores — `workflow_id`, `installed_workflow_id`, `installed_registry_root`, and `inputs` — which are validated and raise a clean `Invalid run state: ...` `ValueError` on a malformed value. (This loader does not shape-check *every* restored field: `step_results`, `workflow_dir`, `current_step_id`, `created_at`/`updated_at`, and `error` are still assigned directly with no `isinstance` check. This PR only addresses `current_step_index`, since it's the one `resume()` depends on for a safe list slice — it is not a loader-wide validation audit.)
- `resume()` later slices `definition.steps[state.current_step_index :]` with no guard of its own, so a non-int `current_step_index` (e.g. a hand-edited or externally-written `state.json`) reaches that slice and raises a raw `TypeError: slice indices must be integers or None or have an __index__ method`, instead of the same clean domain error the other validated fields already get. A negative value slices from the end of the step list instead of failing, silently resuming from the wrong step.
- A follow-up commit in this PR also rejects an **out-of-range positive** index in `resume()` itself (`RunState.load()` can reject non-int/negative values but can't check the upper bound — the step count isn't known until the workflow definition loads, later, in `resume()`). Without this, an out-of-range index would silently slice to an empty list and complete the run without executing any step.
- This is the same "validate cleanly vs. crash at runtime on the same bad value" shape already fixed repeatedly for step configs in this codebase (e.g. #4144 for switch's `cases`, #3899 for run-state IDs) — here it shows up in `RunState.load()`'s field validation instead of a step's `validate()`/`execute()` pair.

## Test plan
- [x] Added `test_load_rejects_invalid_current_step_index` (parametrized over a string, float, negative int, list, dict, and bool) to `tests/test_workflows.py::TestRunState`
- [x] Added `test_resume_rejects_out_of_range_current_step_index` covering the upper-bound case caught in `resume()`
- [x] Verified both new tests fail without their respective fix and pass with it (stashed only `src/specify_cli/workflows/engine.py`, confirmed the failure, then restored it and confirmed the pass)
- [x] Ran `tests/test_workflows.py::TestRunState` — passing, no regressions
- [x] Ran the full `tests/test_workflows.py` — pre-existing Windows-only symlink-guard/tmp-dir failures reproduced identically on `main`, unrelated to this change

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

This PR was authored with [Claude Code](https://claude.com/claude-code) (model: Claude Sonnet 5), used in its interactive, agentic CLI mode with full local tool access (file read/edit, running `pytest`, `git`). It identified the bug, wrote the source fix, the out-of-range follow-up fix, and the regression tests, and ran the verification described above, under my direction. I reviewed the diff and test output myself before opening this PR and understand the change being made.

Separately, **GitHub Copilot** reviewed this PR and left two inline findings pointing out that the new comment/docstring overclaimed loader-wide field validation (the same issue raised in review here). Its automated **Copilot Autofix** commit (`bf9de58b`, "Potential fix for pull request finding") addressed one of the two — trimming the inaccurate claim out of the test docstring in `tests/test_workflows.py`, no logic change — which I reviewed before it stayed on the branch. The matching finding on the `engine.py` source comment was not auto-fixed; that one is what this update (commit `e61c1561`) resolves.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
