### PR TITLE
Add Vurnix Honest Gate extension to community catalog

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -5885,6 +5885,47 @@
       "stars": 0,
       "created_at": "2026-04-13T00:00:00Z",
       "updated_at": "2026-04-13T00:00:00Z"
+    },
+    "vurnix": {
+      "name": "Vurnix Honest Gate",
+      "id": "vurnix",
+      "description": "Deterministic three-state honest gate for AI-written code: compile + phantom-import + honest test count in one verdict, executed as code — not as agent self-review. PASS (exit 0) / BLOCK (exit 1) / UNPROVEN (exit 3): a check that cannot run is not a check that passed.",
+      "author": "shiersa",
+      "version": "0.1.1",
+      "download_url": "https://github.com/shiersa/vurnix-spec-kit/releases/download/v0.1.1/vurnix-0.1.1.zip",
+      "repository": "https://github.com/shiersa/vurnix-spec-kit",
+      "homepage": "https://vurnix.dev",
+      "documentation": "https://github.com/shiersa/vurnix-spec-kit#readme",
+      "license": "MIT",
+      "category": "process",
+      "effect": "read-only",
+      "requires": {
+        "speckit_version": ">=0.16.2"
+      },
+      "provides": {
+        "commands": 1,
+        "hooks": 1
+      },
+      "tags": [
+        "anti-weakening",
+        "deterministic",
+        "exit-code",
+        "fail-closed",
+        "honest-gate",
+        "mutation-testing",
+        "phantom-imports",
+        "quality",
+        "spec-kit",
+        "spec-kit-extension",
+        "test-integrity",
+        "three-state",
+        "unproven"
+      ],
+      "verified": false,
+      "downloads": 0,
+      "stars": 0,
+      "created_at": "2026-08-26T00:00:00Z",
+      "updated_at": "2026-08-26T00:00:00Z"
     }
   }
 }


### PR DESCRIPTION
## What

Adds **Vurnix Honest Gate** (`vurnix`) to the community extension catalog — a deterministic three-state honest gate for AI-written code.

Unlike rubric-driven review extensions, the judgment here is executable code, not agent self-review: the extension ships a `provides.scripts` bash wrapper around [`vurnix`](https://github.com/shiersa/vurnix) (zero-dependency PyPI checkers: compile + phantom-import + honest test count), and the verdict is its exit code — PASS (0) / BLOCK (1) / **UNPROVEN (3)**. A missing toolchain, an empty test suite, or a missing `vurnix` install all exit 3, never 0: *a check that cannot run is not a check that passed*. The agent-facing command instructs the agent to relay the verdict verbatim and never soften it.

- Repository: https://github.com/shiersa/vurnix-spec-kit
- Release: https://github.com/shiersa/vurnix-spec-kit/releases/tag/v0.1.1
- Effect: read-only (the gate reads and verdicts; it never edits the project)

## Verification

- `extension.yml` validates against the manifest rules from #4012 (script name pattern, relative paths, runtimes)
- End-to-end tested on spec-kit main: `specify init` → `specify extension add vurnix --from <release zip>` → extension Enabled (1 command, 1 hook) → installed script run against PASS/BLOCK/UNPROVEN fixtures returns exit 0/1/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)