### PR TITLE
fix(events): stop falling back to a fake "pwsh" argv when no launcher exists

### DIFF
--- a/src/specify_cli/events.py
+++ b/src/specify_cli/events.py
@@ -677,7 +677,16 @@ def _resolve_event_command_argv(
         # subprocess.run(shell=False); invoke via `pwsh -File` (PowerShell 7+),
         # falling back to `powershell -File` (Windows PowerShell) when pwsh is
         # absent (S6). The default Windows script type would otherwise fail.
-        launcher = shutil.which("pwsh") or shutil.which("powershell") or "pwsh"
+        # When NEITHER is on PATH, degrade to "no argv" like every other
+        # failure branch in this resolver (and its documented stdlib mirror,
+        # the generated dispatcher's `_resolve_argv`) — a bare "pwsh" here
+        # would make subprocess.run() raise FileNotFoundError, surfacing as a
+        # confusing "[Errno 2] No such file or directory: 'pwsh'" instead of
+        # the clean "No script found for event command" the caller reports
+        # for a genuinely missing script.
+        launcher = shutil.which("pwsh") or shutil.which("powershell")
+        if not launcher:
+            return None
         return [launcher, "-File", str(script_abs), *rest_args]
 
     # sh: the script is chmod'd executable during install on POSIX. On Windows

--- a/tests/integrations/test_events.py
+++ b/tests/integrations/test_events.py
@@ -1340,6 +1340,37 @@ class TestCommandRunner:
         assert argv[1] == "-File"
         assert PurePath(argv[2]).as_posix().endswith(".specify/scripts/powershell/boot.ps1")
 
+    def test_ps_variant_returns_none_when_no_launcher_available(self, tmp_path, monkeypatch):
+        """When NEITHER pwsh nor powershell is on PATH, the resolver must
+        degrade to "no argv" like every other failure branch in this
+        function — not fall back to a bare "pwsh" string, which would make
+        subprocess.run() raise FileNotFoundError instead of the caller's
+        clean "No script found for event command" warning.
+
+        The generated dispatcher's documented stdlib mirror, `_resolve_argv`,
+        already does this correctly (`if not launcher: return None`).
+        """
+        from specify_cli.events import _resolve_event_command_argv
+        import shutil as _shutil
+
+        cmd_dir = tmp_path / ".specify" / "templates" / "commands"
+        cmd_dir.mkdir(parents=True)
+        (cmd_dir / "boot.md").write_text(
+            "---\n"
+            "description: \"Boot\"\n"
+            "scripts:\n"
+            "  ps: scripts/powershell/boot.ps1\n"
+            "---\nBody\n",
+            encoding="utf-8",
+        )
+        ps_dir = tmp_path / ".specify" / "scripts" / "powershell"
+        ps_dir.mkdir(parents=True)
+        (ps_dir / "boot.ps1").write_text("exit 0\n", encoding="utf-8")
+
+        monkeypatch.setattr(_shutil, "which", lambda name: None)
+        argv = _resolve_event_command_argv(cmd_dir / "boot.md", tmp_path, None)
+        assert argv is None
+
     def test_run_command_executes_with_project_root_cwd(self, tmp_path):
         """R1: the event command runs with cwd set to the project root, not the
         caller's arbitrary working directory, so project-relative script logic


### PR DESCRIPTION
## Summary
- `_resolve_event_command_argv`'s `ps` branch did:
  ```python
  launcher = shutil.which("pwsh") or shutil.which("powershell") or "pwsh"
  ```
  When neither `pwsh` nor `powershell` is on PATH, this silently returns `["pwsh", "-File", <script>, ...]` instead of degrading to "no runnable script" (`None`) like every other failure branch in this same function (unparseable frontmatter, non-mapping scripts, unresolvable script path, etc.).
- `subprocess.run()` then raises `FileNotFoundError` trying to exec a binary that was just proven absent, which `resolve_and_run_event_command`'s generic exception handler reports as a confusing `Event command X error: [Errno 2] No such file or directory: 'pwsh'` (exit code 2) instead of the clean `No script found for event command` warning (exit code 0) every other missing-script case gets.
- This function is explicitly documented as mirroring the generated dispatcher's own stdlib-only `_resolve_argv` (same file), which already gets this right: `if not launcher: return None`. The two had drifted apart.
- Fix: mirror that behavior — return `None` when neither launcher is found, instead of fabricating an argv naming a binary that doesn't exist.

## Test plan
- [x] Added `test_ps_variant_returns_none_when_no_launcher_available` to `tests/integrations/test_events.py::TestCommandRunner`: with `shutil.which` mocked to return `None` for every name, the resolver must return `None` rather than an argv naming a nonexistent `pwsh`.
- [x] Verified the test fails without the fix (test-the-test): it asserted `argv is None` but got `['pwsh', '-File', '.../boot.ps1']` — reproducing the exact bug.
- [x] Ran the full `tests/integrations/test_events.py` suite: 118 passed, 4 pre-existing Windows symlink-elevation failures (need admin rights, unrelated to this change), 1 skipped.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01PJHJ2dHP2RVCNncHqN8Qm9