### PR TITLE
fix: decode feature.json as UTF-8 in Windows PowerShell

### DIFF
--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -135,7 +135,7 @@ function Save-FeatureJson {
     # Read current value and skip write when unchanged
     if (Test-Path -LiteralPath $fjPath -PathType Leaf) {
         try {
-            $raw = Get-Content -LiteralPath $fjPath -Raw
+            $raw = [System.IO.File]::ReadAllText($fjPath, [System.Text.Encoding]::UTF8)
             $cfg = $raw | ConvertFrom-Json
             if ($cfg.feature_directory -eq $FeatureDirectory) {
                 return
@@ -187,7 +187,7 @@ function Get-FeaturePathsEnv {
             Save-FeatureJson -RepoRoot $repoRoot -FeatureDirectory $env:SPECIFY_FEATURE_DIRECTORY
         }
     } elseif (Test-Path $featureJson) {
-        $featureJsonRaw = Get-Content -LiteralPath $featureJson -Raw
+        $featureJsonRaw = [System.IO.File]::ReadAllText($featureJson, [System.Text.Encoding]::UTF8)
         try {
             $featureConfig = $featureJsonRaw | ConvertFrom-Json
         } catch {

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -38,7 +38,7 @@ def _write_feature_json(
     repo: Path, feature_directory: str = "specs/001-my-feature"
 ) -> None:
     (repo / ".specify" / "feature.json").write_text(
-        json.dumps({"feature_directory": feature_directory}),
+        json.dumps({"feature_directory": feature_directory}, ensure_ascii=False),
         encoding="utf-8",
     )
 

--- a/tests/test_check_prerequisites_paths_only.py
+++ b/tests/test_check_prerequisites_paths_only.py
@@ -288,6 +288,40 @@ def test_ps_paths_only_succeeds_on_non_spec_branch(prereq_repo: Path) -> None:
     assert "FEATURE_DIR" in data
 
 
+@pytest.mark.skipif(
+    not _WINDOWS_POWERSHELL, reason="Windows PowerShell 5.1 not available"
+)
+def test_windows_powershell_reads_bomless_utf8_feature_json(
+    prereq_repo: Path,
+) -> None:
+    """Windows PowerShell must decode non-ASCII feature paths as UTF-8 (#4333)."""
+    feature_directory = "specs/001-后台信息架构"
+    feature_path = prereq_repo / feature_directory
+    feature_path.mkdir(parents=True)
+    _write_feature_json(prereq_repo, feature_directory)
+
+    resolved_path = prereq_repo / "resolved-feature-path.txt"
+    common_ps = prereq_repo / ".specify" / "scripts" / "powershell" / "common.ps1"
+    ps_command = (
+        f". '{common_ps}'; "
+        "$resolved = Get-FeaturePathsEnv -NoPersist; "
+        "$utf8NoBom = New-Object System.Text.UTF8Encoding($false); "
+        f"[System.IO.File]::WriteAllText('{resolved_path}', "
+        "[string]$resolved.FEATURE_DIR, $utf8NoBom)"
+    )
+    result = subprocess.run(
+        [_WINDOWS_POWERSHELL, "-NoProfile", "-Command", ps_command],
+        cwd=prereq_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_clean_env(),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert resolved_path.read_text(encoding="utf-8") == str(feature_path)
+
+
 @pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
 @pytest.mark.parametrize(
     ("use_env_var", "specify_feature", "expected_branch"),


### PR DESCRIPTION
## Description

Fixes #4333.

Windows PowerShell 5.1 decodes `Get-Content -Raw` with the active ANSI code page, so a BOM-less UTF-8 `feature.json` can corrupt non-ASCII feature paths before JSON parsing. Read both existing `feature.json` paths with `System.IO.File.ReadAllText(..., Encoding.UTF8)` instead.

The regression writes a BOM-less UTF-8 feature directory containing Chinese characters, invokes `Get-FeaturePathsEnv` under Windows PowerShell 5.1, and verifies the exact resolved path.

## Testing

- [ ] Tested locally with `uv run specify --help`
- [ ] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Additional checks:

- `python3 -m py_compile tests/test_check_prerequisites_paths_only.py`
- `git diff --check`
- The Windows-only regression is skipped on macOS. `uv sync` could not complete because the configured package registry was unreachable, so CI still needs to execute the test on Windows PowerShell 5.1.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Codex (GPT-5, autonomous) assisted with issue investigation, implementation, test design, and review. The resulting diff and repository requirements were manually reviewed before submission.
