### PR TITLE
fix(auth): reject malformed URL ports before credential matching

### DIFF
--- a/src/specify_cli/authentication/config.py
+++ b/src/specify_cli/authentication/config.py
@@ -221,12 +221,14 @@ def find_entries_for_url(
 ) -> list[AuthConfigEntry]:
     """Return entries whose ``hosts`` match the hostname of *url*."""
     # A malformed authority (e.g. an unterminated IPv6 bracket "https://[::1")
-    # makes urlparse/hostname raise ValueError. Treat that the same as a
+    # makes urlparse, hostname, or port raise ValueError. Treat that the same as a
     # host-less URL: no entry can match, so return no matches rather than
     # leaking a raw ValueError out of the shared HTTP client (build_request /
     # open_url call this before any URL validation).
     try:
-        hostname = (urlparse(url).hostname or "").lower()
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").lower()
+        _ = parsed.port
     except ValueError:
         return []
     if not hostname:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -345,7 +345,7 @@ class TestLoadAuthConfig:
 class TestFindEntriesForUrl:
     def test_exact_match(self):
         entry = _github_entry()
-        result = find_entries_for_url("https://github.com/org/repo", [entry])
+        result = find_entries_for_url("https://github.com:443/org/repo", [entry])
         assert result == [entry]
 
     def test_wildcard_match(self):
@@ -409,10 +409,12 @@ class TestFindEntriesForUrl:
         [
             "https://[::1",                 # unterminated ipv6 bracket
             "https://[not-an-ip]/file",     # bracketed non-ip host
+            "https://github.com:notaport/x", # non-numeric port
+            "https://github.com:99999/x",   # out-of-range port
         ],
     )
     def test_malformed_url_returns_empty(self, url):
-        # A malformed authority makes urlparse/hostname raise ValueError.
+        # A malformed authority makes urlparse, hostname, or port raise ValueError.
         # Since no entry can match such a URL, this must return no matches
         # (like a host-less URL) rather than leaking a raw ValueError out of
         # the shared HTTP client.


### PR DESCRIPTION
## Description

Prevent malformed explicit ports from matching `auth.json` entries before URL validation. Valid explicit ports continue matching by hostname.

## Testing

- `.venv/bin/python -m pytest tests/test_authentication.py -q`
- `uvx ruff@0.15.0 check src tests`
- `git diff --check`