### PR TITLE
add --require-spec to check-prerequisites

### DIFF
--- a/scripts/bash/check-prerequisites.sh
+++ b/scripts/bash/check-prerequisites.sh
@@ -9,6 +9,7 @@
 #
 # OPTIONS:
 #   --json              Output in JSON format
+#   --require-spec      Require spec.md to exist (for analysis phase)
 #   --require-tasks     Require tasks.md to exist (for implementation phase)
 #   --include-tasks     Include tasks.md in AVAILABLE_DOCS list
 #   --paths-only        Only output path variables (no validation)
@@ -24,6 +25,7 @@ set -e
 
 # Parse command line arguments
 JSON_MODE=false
+REQUIRE_SPEC=false
 REQUIRE_TASKS=false
 INCLUDE_TASKS=false
 PATHS_ONLY=false
@@ -33,6 +35,9 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --json)
             JSON_MODE=true
+            ;;
+        --require-spec)
+            REQUIRE_SPEC=true
             ;;
         --require-tasks)
             REQUIRE_TASKS=true
@@ -59,6 +64,7 @@ Consolidated prerequisite checking for Spec-Driven Development workflow.
 
 OPTIONS:
   --json              Output in JSON format
+  --require-spec      Require spec.md to exist (for analysis phase)
   --require-tasks     Require tasks.md to exist (for implementation phase)
   --include-tasks     Include tasks.md in AVAILABLE_DOCS list
   --paths-only        Only output path variables (no prerequisite validation)
@@ -139,6 +145,13 @@ fi
 if [[ ! -f "$IMPL_PLAN" ]]; then
     echo "ERROR: plan.md not found in $FEATURE_DIR" >&2
     echo "Run $(format_speckit_command plan "$REPO_ROOT") first to create the implementation plan." >&2
+    exit 1
+fi
+
+# Check for spec.md if required
+if $REQUIRE_SPEC && [[ ! -f "$FEATURE_SPEC" ]]; then
+    echo "ERROR: spec.md not found in $FEATURE_DIR" >&2
+    echo "Run $(format_speckit_command specify "$REPO_ROOT") first to create the feature specification." >&2
     exit 1
 fi
 

--- a/scripts/powershell/check-prerequisites.ps1
+++ b/scripts/powershell/check-prerequisites.ps1
@@ -10,8 +10,7 @@
 # OPTIONS:
 #   -Json               Output in JSON format
 #   -RequireSpec        Require spec.md to exist (for analysis phase)
-#   -RequireSpec        Require spec.md to exist (for analysis phase)
-  -RequireTasks       Require tasks.md to exist (for implementation phase)
+#   -RequireTasks       Require tasks.md to exist (for implementation phase)
 #   -IncludeTasks       Include tasks.md in AVAILABLE_DOCS list
 #   -PathsOnly          Only output path variables (no validation)
 #   -Template NAME      Include composed template content in JSON output

--- a/scripts/powershell/check-prerequisites.ps1
+++ b/scripts/powershell/check-prerequisites.ps1
@@ -9,7 +9,9 @@
 #
 # OPTIONS:
 #   -Json               Output in JSON format
-#   -RequireTasks       Require tasks.md to exist (for implementation phase)
+#   -RequireSpec        Require spec.md to exist (for analysis phase)
+#   -RequireSpec        Require spec.md to exist (for analysis phase)
+  -RequireTasks       Require tasks.md to exist (for implementation phase)
 #   -IncludeTasks       Include tasks.md in AVAILABLE_DOCS list
 #   -PathsOnly          Only output path variables (no validation)
 #   -Template NAME      Include composed template content in JSON output
@@ -18,6 +20,7 @@
 [CmdletBinding()]
 param(
     [switch]$Json,
+    [switch]$RequireSpec,
     [switch]$RequireTasks,
     [switch]$IncludeTasks,
     [switch]$PathsOnly,
@@ -36,6 +39,7 @@ Consolidated prerequisite checking for Spec-Driven Development workflow.
 
 OPTIONS:
   -Json               Output in JSON format
+  -RequireSpec        Require spec.md to exist (for analysis phase)
   -RequireTasks       Require tasks.md to exist (for implementation phase)
   -IncludeTasks       Include tasks.md in AVAILABLE_DOCS list
   -PathsOnly          Only output path variables (no prerequisite validation)
@@ -102,6 +106,14 @@ if (-not (Test-Path $paths.IMPL_PLAN -PathType Leaf)) {
     [Console]::Error.WriteLine("ERROR: plan.md not found in $($paths.FEATURE_DIR)")
     $planCommand = Format-SpecKitCommand -CommandName 'plan' -RepoRoot $paths.REPO_ROOT
     [Console]::Error.WriteLine("Run $planCommand first to create the implementation plan.")
+    exit 1
+}
+
+# Check for spec.md if required
+if ($RequireSpec -and -not (Test-Path $paths.FEATURE_SPEC -PathType Leaf)) {
+    [Console]::Error.WriteLine("ERROR: spec.md not found in $($paths.FEATURE_DIR)")
+    $specifyCommand = Format-SpecKitCommand -CommandName 'specify' -RepoRoot $paths.REPO_ROOT
+    [Console]::Error.WriteLine("Run $specifyCommand first to create the feature specification.")
     exit 1
 }
 

--- a/scripts/python/check_prerequisites.py
+++ b/scripts/python/check_prerequisites.py
@@ -37,6 +37,7 @@ Consolidated prerequisite checking for Spec-Driven Development workflow.
 
 OPTIONS:
   --json              Output in JSON format
+  --require-spec      Require spec.md to exist (for analysis phase)
   --require-tasks     Require tasks.md to exist (for implementation phase)
   --include-tasks     Include tasks.md in AVAILABLE_DOCS list
   --paths-only        Only output path variables (no prerequisite validation)
@@ -59,6 +60,7 @@ EXAMPLES:
 @dataclass(frozen=True)
 class Args:
     json_mode: bool = False
+    require_spec: bool = False
     require_tasks: bool = False
     include_tasks: bool = False
     paths_only: bool = False
@@ -67,6 +69,7 @@ class Args:
 
 def _parse_args(argv: list[str]) -> Args:
     json_mode = False
+    require_spec = False
     require_tasks = False
     include_tasks = False
     paths_only = False
@@ -77,6 +80,8 @@ def _parse_args(argv: list[str]) -> Args:
         arg = argv[index]
         if arg == "--json":
             json_mode = True
+        elif arg == "--require-spec":
+            require_spec = True
         elif arg == "--require-tasks":
             require_tasks = True
         elif arg == "--include-tasks":
@@ -105,6 +110,7 @@ def _parse_args(argv: list[str]) -> Args:
 
     return Args(
         json_mode=json_mode,
+        require_spec=require_spec,
         require_tasks=require_tasks,
         include_tasks=include_tasks,
         paths_only=paths_only,
@@ -226,6 +232,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: plan.md not found in {paths.feature_dir}", file=sys.stderr)
         print(
             f"Run {format_speckit_command('plan', paths.repo_root)} first to create the implementation plan.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.require_spec and not paths.feature_spec.is_file():
+        print(f"ERROR: spec.md not found in {paths.feature_dir}", file=sys.stderr)
+        print(
+            f"Run {format_speckit_command('specify', paths.repo_root)} first to create the feature specification.",
             file=sys.stderr,
         )
         return 1

--- a/templates/commands/analyze.md
+++ b/templates/commands/analyze.md
@@ -1,8 +1,8 @@
 ---
 description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
 scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
+  sh: scripts/bash/check-prerequisites.sh --json --require-spec --require-tasks --include-tasks
+  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireSpec -RequireTasks -IncludeTasks
   py: scripts/python/check_prerequisites.py --json --require-tasks --include-tasks
 ---
 

--- a/templates/commands/analyze.md
+++ b/templates/commands/analyze.md
@@ -3,7 +3,7 @@ description: Perform a non-destructive cross-artifact consistency and quality an
 scripts:
   sh: scripts/bash/check-prerequisites.sh --json --require-spec --require-tasks --include-tasks
   ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireSpec -RequireTasks -IncludeTasks
-  py: scripts/python/check_prerequisites.py --json --require-tasks --include-tasks
+  py: scripts/python/check_prerequisites.py --json --require-spec --require-tasks --include-tasks
 ---
 
 ## User Input

--- a/templates/commands/converge.md
+++ b/templates/commands/converge.md
@@ -1,8 +1,8 @@
 ---
 description: Assess the current codebase against the feature's spec, plan, and tasks, then append any remaining unbuilt work as new tasks to tasks.md so implement can complete it.
 scripts:
-  sh: scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
-  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
+  sh: scripts/bash/check-prerequisites.sh --json --require-spec --require-tasks --include-tasks
+  ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireSpec -RequireTasks -IncludeTasks
   py: scripts/python/check_prerequisites.py --json --require-tasks --include-tasks
 ---
 

--- a/templates/commands/converge.md
+++ b/templates/commands/converge.md
@@ -3,7 +3,7 @@ description: Assess the current codebase against the feature's spec, plan, and t
 scripts:
   sh: scripts/bash/check-prerequisites.sh --json --require-spec --require-tasks --include-tasks
   ps: scripts/powershell/check-prerequisites.ps1 -Json -RequireSpec -RequireTasks -IncludeTasks
-  py: scripts/python/check_prerequisites.py --json --require-tasks --include-tasks
+  py: scripts/python/check_prerequisites.py --json --require-spec --require-tasks --include-tasks
 ---
 
 ## User Input

--- a/tests/test_check_prerequisites_python_parity.py
+++ b/tests/test_check_prerequisites_python_parity.py
@@ -283,6 +283,42 @@ def test_python_require_spec_matches_bash(prereq_repo: Path) -> None:
     assert _json_stdout(py_present) == _json_stdout(bash_present)
 
 
+@pytest.mark.skipif(not (HAS_PWSH or _WINDOWS_POWERSHELL), reason="no PowerShell available")
+def test_powershell_require_spec_matches_python(prereq_repo: Path) -> None:
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True)
+    (feat / "plan.md").write_text("# plan\n", encoding="utf-8")
+    (feat / "tasks.md").write_text("# tasks\n", encoding="utf-8")
+    _write_feature_json(prereq_repo)
+
+    # spec.md is missing, and without the flag that stays the caller's problem
+    ps_without = _run(_ps_cmd(prereq_repo, "-Json", "-RequireTasks"), prereq_repo)
+    py_without = _run(_py_cmd(prereq_repo, "--json", "--require-tasks"), prereq_repo)
+    assert ps_without.returncode == py_without.returncode == 0
+
+    # with the flag both variants fail the same way and name the same file
+    ps_missing = _run(
+        _ps_cmd(prereq_repo, "-Json", "-RequireSpec", "-RequireTasks"), prereq_repo
+    )
+    py_missing = _run(
+        _py_cmd(prereq_repo, "--json", "--require-spec", "--require-tasks"), prereq_repo
+    )
+    assert ps_missing.returncode == py_missing.returncode == 1
+    assert "spec.md not found" in ps_missing.stderr
+    assert "spec.md not found" in py_missing.stderr
+
+    # and once the spec exists the flag is satisfied and the payloads agree
+    (feat / "spec.md").write_text("# spec\n", encoding="utf-8")
+    ps_present = _run(
+        _ps_cmd(prereq_repo, "-Json", "-RequireSpec", "-RequireTasks"), prereq_repo
+    )
+    py_present = _run(
+        _py_cmd(prereq_repo, "--json", "--require-spec", "--require-tasks"), prereq_repo
+    )
+    assert ps_present.returncode == py_present.returncode == 0
+    assert _json_stdout(ps_present) == _json_stdout(py_present)
+
+
 @requires_bash
 def test_python_text_output_matches_bash(prereq_repo: Path) -> None:
     feat = prereq_repo / "specs" / "001-my-feature"

--- a/tests/test_check_prerequisites_python_parity.py
+++ b/tests/test_check_prerequisites_python_parity.py
@@ -248,6 +248,42 @@ def test_python_json_output_matches_bash(prereq_repo: Path, args: tuple[str, ...
 
 
 @requires_bash
+def test_python_require_spec_matches_bash(prereq_repo: Path) -> None:
+    feat = prereq_repo / "specs" / "001-my-feature"
+    feat.mkdir(parents=True)
+    (feat / "plan.md").write_text("# plan\n", encoding="utf-8")
+    (feat / "tasks.md").write_text("# tasks\n", encoding="utf-8")
+    _write_feature_json(prereq_repo)
+
+    # spec.md is missing, and without the flag that stays the caller's problem
+    bash_without = _run(_bash_cmd(prereq_repo, "--json", "--require-tasks"), prereq_repo)
+    py_without = _run(_py_cmd(prereq_repo, "--json", "--require-tasks"), prereq_repo)
+    assert py_without.returncode == bash_without.returncode == 0
+
+    # with the flag both variants fail the same way and name the same command
+    bash_missing = _run(
+        _bash_cmd(prereq_repo, "--json", "--require-spec", "--require-tasks"), prereq_repo
+    )
+    py_missing = _run(
+        _py_cmd(prereq_repo, "--json", "--require-spec", "--require-tasks"), prereq_repo
+    )
+    assert py_missing.returncode == bash_missing.returncode == 1
+    assert py_missing.stderr == bash_missing.stderr
+    assert "spec.md not found" in bash_missing.stderr
+
+    # and once the spec exists the flag is satisfied
+    (feat / "spec.md").write_text("# spec\n", encoding="utf-8")
+    bash_present = _run(
+        _bash_cmd(prereq_repo, "--json", "--require-spec", "--require-tasks"), prereq_repo
+    )
+    py_present = _run(
+        _py_cmd(prereq_repo, "--json", "--require-spec", "--require-tasks"), prereq_repo
+    )
+    assert py_present.returncode == bash_present.returncode == 0
+    assert _json_stdout(py_present) == _json_stdout(bash_present)
+
+
+@requires_bash
 def test_python_text_output_matches_bash(prereq_repo: Path) -> None:
     feat = prereq_repo / "specs" / "001-my-feature"
     feat.mkdir(parents=True)


### PR DESCRIPTION
Closes #4364

## problem

`check-prerequisites` validates `FEATURE_DIR`, `plan.md`, and `tasks.md` under `--require-tasks`, each with an error naming the command to run. it resolves `FEATURE_SPEC`, exports it in the json payload and prints it in text mode, but never checks that the file exists.

`analyze` and `converge` both call it and then read `spec.md` directly. with the spec missing the prerequisite check exits 0, and the failure surfaces later without the "run specify first" guidance the script gives for everything else, which is the thing this script exists to prevent.

## fix

a `--require-spec` flag, shaped exactly like `--require-tasks`:

```
ERROR: spec.md not found in specs/001-my-feature
Run /speckit.specify first to create the feature specification.
```

it is opt in, as suggested in the issue, so nothing changes for callers that do not read the spec. `analyze` and `converge` pass it because they do.

## all three variants

the flag is in bash, powershell and python. that is not gold plating, the parity tests compare help text, json output and error shapes across the three, so adding it to one would have broken them.

| file | change |
|---|---|
| `scripts/bash/check-prerequisites.sh` | `--require-spec` |
| `scripts/powershell/check-prerequisites.ps1` | `-RequireSpec` |
| `scripts/python/check_prerequisites.py` | `--require-spec` |
| `templates/commands/analyze.md` | passes the flag in sh ps and py |
| `templates/commands/converge.md` | passes the flag in sh ps and py |

## tests

`test_python_require_spec_matches_bash` covers three states across bash and python:

- spec missing and no flag, both exit 0, so the opt in stays opt in
- spec missing with the flag, both exit 1 with byte identical stderr
- spec present with the flag, both exit 0 with identical json

it fails on `main` with `ERROR: Unknown option '--require-spec'`.

## verification

| check | result |
|---|---|
| new test on `main` | fails |
| new test with the change | passes |
| full suite before | 10 failed, 7135 passed |
| full suite after | 10 failed, 7137 passed |
| new failures introduced | none, i diffed the two failure lists |
| `ruff check scripts tests` | all checks passed |

the 10 pre existing failures are the composed template parity tests and are unrelated to this.

---

disclaimer: this contribution was prepared with the assistance of an ai agent. i reproduced the gap first, checked which callers actually read the spec, and ran the parity suite locally before opening this.

