### PR TITLE
fix: reject unknown setup-plan arguments

### DIFF
--- a/scripts/bash/setup-plan.sh
+++ b/scripts/bash/setup-plan.sh
@@ -4,7 +4,6 @@ set -e
 
 # Parse command line arguments
 JSON_MODE=false
-ARGS=()
 
 for arg in "$@"; do
     case "$arg" in
@@ -18,7 +17,8 @@ for arg in "$@"; do
             exit 0
             ;;
         *)
-            ARGS+=("$arg")
+            echo "ERROR: Unknown option '$arg'" >&2
+            exit 1
             ;;
     esac
 done

--- a/scripts/powershell/setup-plan.ps1
+++ b/scripts/powershell/setup-plan.ps1
@@ -20,6 +20,11 @@ if ($Help) {
     exit 0
 }
 
+if ($RemainingArgs.Count -gt 0) {
+    [Console]::Error.WriteLine("ERROR: Unknown option '$($RemainingArgs[0])'")
+    exit 1
+}
+
 # Load common functions
 . "$PSScriptRoot/common.ps1"
 

--- a/scripts/python/setup_plan.py
+++ b/scripts/python/setup_plan.py
@@ -42,7 +42,9 @@ def main(argv: list[str] | None = None) -> int:
         elif arg in {"--help", "-h"}:
             sys.stdout.write(_help_text(sys.argv[0]))
             return 0
-        # Other arguments are accepted and silently ignored, matching setup-plan.sh.
+        else:
+            print(f"ERROR: Unknown option '{arg}'", file=sys.stderr)
+            return 1
 
     try:
         paths = get_feature_paths(script_file=Path(__file__))

--- a/tests/test_setup_plan_python_parity.py
+++ b/tests/test_setup_plan_python_parity.py
@@ -132,7 +132,7 @@ def test_python_existing_plan_matches_bash(repo: Path, args: tuple[str, ...]) ->
 
 @requires_bash
 @pytest.mark.skipif(not HAS_POWERSHELL, reason="no PowerShell available")
-def test_all_variants_ignore_extra_arguments(tmp_path: Path) -> None:
+def test_all_variants_reject_unknown_options(tmp_path: Path) -> None:
     repos = [
         _setup_repo(tmp_path, "bash"),
         _setup_repo(tmp_path, "powershell"),
@@ -143,13 +143,15 @@ def test_all_variants_ignore_extra_arguments(tmp_path: Path) -> None:
     ps = run(ps_cmd(repos[1], SCRIPT, "-Json", "--bogus"), repos[1])
     py = run(py_cmd(repos[2], SCRIPT, "--json", "--bogus"), repos[2])
 
-    assert bash.returncode == ps.returncode == py.returncode == 0
-    assert normalize_repo_paths(bash.stdout, repos[0]) == normalize_repo_paths(
-        ps.stdout, repos[1]
-    ) == normalize_repo_paths(py.stdout, repos[2])
-    assert normalize_repo_paths(bash.stderr, repos[0]) == normalize_repo_paths(
-        ps.stderr, repos[1]
-    ) == normalize_repo_paths(py.stderr, repos[2])
+    assert bash.returncode == ps.returncode == py.returncode == 1
+    assert bash.stdout == ps.stdout == py.stdout == ""
+    assert bash.stderr == ps.stderr == py.stderr == (
+        "ERROR: Unknown option '--bogus'\n"
+    )
+    assert all(
+        not (current / "specs" / "001-my-feature" / "plan.md").exists()
+        for current in repos
+    )
 
 
 @requires_bash


### PR DESCRIPTION
## Description

Fixes #4363.

`setup-plan` accepted unknown arguments because the Bash variant collected them without reading them, while the PowerShell and Python variants intentionally ignored them for parity. This change rejects the first unknown option before resolving feature paths in all three variants, matching the existing `setup-tasks` behavior.

The regression test verifies the shared exit code, stdout, stderr, and absence of `plan.md` side effects across Bash, PowerShell, and Python.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [x] Tested with a sample project (if applicable)

- `python -m pytest tests/test_setup_plan_python_parity.py::test_all_variants_reject_unknown_options -q` — 1 passed with PortableGit Bash, PowerShell 7.6.4, and Python 3.14.3
- Inverse mutation (Bash ignores the option again) — the regression failed as expected; restoring the fix returned it to passing
- `uvx ruff@0.15.0 check scripts tests` — passed
- `shellcheck --severity=error` on every tracked shell script — passed
- `bash -n scripts/bash/setup-plan.sh` — passed
- `python -m pytest tests -q` — 6,778 passed, 467 skipped, 85 local environment failures outside the changed paths (primarily unavailable Windows symlink privileges, GBK default decoding, and unrelated PowerShell fixture capture)

The normal `/speckit.plan` invocation is unchanged; the sample-project parity fixture covers the new invalid direct-invocation path.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

This contribution was implemented autonomously with OpenAI Codex (GPT-5) on behalf of @pttydou. The agent inspected the three script variants, authored the code and regression test, reviewed the diff, and ran the checks reported above.
