### PR TITLE
fix(github-http): reject malformed explicit URL ports

### DIFF
--- a/src/specify_cli/_github_http.py
+++ b/src/specify_cli/_github_http.py
@@ -39,6 +39,7 @@ def build_github_request(url: str) -> urllib.request.Request:
         ValueError: If ``url`` is empty or whitespace-only.
         ValueError: If ``url`` does not use the ``http`` or ``https`` scheme.
         ValueError: If ``url`` does not include a hostname.
+        ValueError: If ``url`` includes a malformed explicit port.
     """
     headers: Dict[str, str] = {}
     url = url.strip()
@@ -49,6 +50,8 @@ def build_github_request(url: str) -> urllib.request.Request:
         raise ValueError(f"url must start with http:// or https://, got: {url!r}")
     if not parsed.hostname:
         raise ValueError(f"url must include a hostname, got: {url!r}")
+    # Accessing ``port`` validates any explicit port before request construction.
+    parsed.port
     github_token = (os.environ.get("GITHUB_TOKEN") or "").strip()
     gh_token = (os.environ.get("GH_TOKEN") or "").strip()
     token = github_token or gh_token or None

--- a/tests/test_github_http.py
+++ b/tests/test_github_http.py
@@ -42,6 +42,16 @@ class TestBuildGitHubRequest:
         with pytest.raises(ValueError, match="url must start with http"):
             build_github_request("ftp://github.com/file.zip")
 
+    @pytest.mark.parametrize(
+        "url", ["https://github.com:notaport/file", "https://github.com:65536/file"]
+    )
+    def test_malformed_explicit_port_raises_before_request_construction(self, url):
+        """Malformed explicit ports are rejected before creating a Request."""
+        with patch("specify_cli._github_http.urllib.request.Request") as request:
+            with pytest.raises(ValueError):
+                build_github_request(url)
+        request.assert_not_called()
+
     # --- Valid URL Tests ---
 
     def test_valid_https_url_returns_request(self):
@@ -53,6 +63,14 @@ class TestBuildGitHubRequest:
         """build_github_request() must accept http:// URLs."""
         req = build_github_request("http://example.com/file")
         assert req.full_url == "http://example.com/file"
+
+    def test_valid_explicit_port_retains_url_method_and_github_auth(self):
+        """A valid explicit port retains normal GitHub request behavior."""
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "test-token", "GH_TOKEN": ""}):
+            req = build_github_request("https://github.com:8443/github/spec-kit")
+        assert req.full_url == "https://github.com:8443/github/spec-kit"
+        assert req.get_method() == "GET"
+        assert req.get_header("Authorization") == "Bearer test-token"
 
     # --- Auth Header Tests ---
 


### PR DESCRIPTION
## Summary

- Validate explicit HTTP(S) ports before GitHub token lookup or urllib request construction.
- Preserve valid request URLs, methods, and exact-host bearer authentication behavior.
- Add regression coverage for malformed and valid explicit ports.

## Validation

- `.venv/bin/python -m pytest tests/test_github_http.py tests/test_authentication.py -q`
- `uvx ruff@0.15.0 check src tests`
- `git diff --check`