### PR TITLE
docs(extensions): fix private catalog FAQ command

### DIFF
--- a/extensions/EXTENSION-PUBLISHING-GUIDE.md
+++ b/extensions/EXTENSION-PUBLISHING-GUIDE.md
@@ -274,8 +274,7 @@ When releasing a new version:
 A: The main catalog is for public extensions only. For private extensions:
 
 - Host your own catalog.json file
-- Users add your catalog: `specify extension add-catalog https://your-domain.com/catalog.json`
-- Not yet implemented - coming in Phase 4
+- In a Spec Kit project, users add your catalog: `specify extension catalog add https://your-domain.com/catalog.json --name private-catalog`
 
 ### Q: How long does review take?
 


### PR DESCRIPTION
## Summary

- Replace the obsolete private-catalog FAQ command with `specify extension catalog add`.
- Document the required project context and catalog name.
- Remove the stale Phase 4 implementation note while retaining the safe discovery-only default.

## Validation

- `.venv/bin/specify extension catalog add --help`
- `git diff --check origin/main`
- Verified command and default-policy parity against the current implementation and extension references.