### PR TITLE
docs: explain how Spec Kit dogfoods itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,10 +334,12 @@ follows the generated assessment skills against feature requests. The other
 agentic workflows currently operate independently of the Specify CLI.
 
 This does not mean every change goes through the full workflow. Small fixes can
-use the normal issue, pull request, review, and test process. Most generated
-dogfooding scaffolding and feature artifacts (`.specify/`, `specs/`, and agent
-command files) are also intentionally gitignored, so they usually do not appear
-in the repository history. See the [contributor development
+use the normal issue, pull request, review, and test process. Dogfooding
+scaffolding and artifacts under `.github/agents/`, `.github/prompts/`,
+`.github/copilot-instructions.md`, `.grok/`, `.specify/`, and `specs/` are
+intentionally gitignored. The automated assessment workflow is ephemeral and
+neither commits nor pushes its generated Copilot skills, so its output does not
+enter repository history. See the [contributor development
 workflow](./CONTRIBUTING.md#development-workflow) for the validation expectations.
 
 ## 🌟 Development Phases

--- a/README.md
+++ b/README.md
@@ -326,10 +326,12 @@ Spec-Driven Development is a structured process that emphasizes:
 
 Yes — we dogfood Spec Kit while developing Spec Kit, especially for substantial
 features and changes to the development workflow. Contributors are asked to test
-relevant changes through the Spec-Driven Development commands, and the
-[feature assessment workflow](./.github/workflows/feature-assess.md) installs the
-CLI from the current checkout and runs Spec Kit's `assess` extension against
-feature requests.
+relevant changes through the Spec-Driven Development commands. The
+[feature assessment workflow](./.github/workflows/feature-assess.md) is currently
+the automated dogfooding path: its setup uses the CLI from the current checkout
+to initialize Copilot and install the `assess` extension, after which Copilot
+follows the generated assessment skills against feature requests. The other
+agentic workflows currently operate independently of the Specify CLI.
 
 This does not mean every change goes through the full workflow. Small fixes can
 use the normal issue, pull request, review, and test process. Most generated

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [🧩 Making Spec Kit Your Own: Extensions & Presets](#-making-spec-kit-your-own-extensions--presets)
 - [📦 Bundles: Role-Based Setups](#-bundles-role-based-setups)
 - [📚 Core Philosophy](#-core-philosophy)
+- [🪞 Does Spec Kit Use Spec Kit?](#-does-spec-kit-use-spec-kit)
 - [🌟 Development Phases](#-development-phases)
 - [🎯 Experimental Goals](#-experimental-goals)
 - [🔧 Prerequisites](#-prerequisites)
@@ -320,6 +321,22 @@ Spec-Driven Development is a structured process that emphasizes:
 - **Rich specification creation** using guardrails and organizational principles
 - **Multi-step refinement** rather than one-shot code generation from prompts
 - **Heavy reliance** on advanced AI model capabilities for specification interpretation
+
+## 🪞 Does Spec Kit Use Spec Kit?
+
+Yes — we dogfood Spec Kit while developing Spec Kit, especially for substantial
+features and changes to the development workflow. Contributors are asked to test
+relevant changes through the Spec-Driven Development commands, and the
+[feature assessment workflow](./.github/workflows/feature-assess.md) installs the
+CLI from the current checkout and runs Spec Kit's `assess` extension against
+feature requests.
+
+This does not mean every change goes through the full workflow. Small fixes can
+use the normal issue, pull request, review, and test process. Most generated
+dogfooding scaffolding and feature artifacts (`.specify/`, `specs/`, and agent
+command files) are also intentionally gitignored, so they usually do not appear
+in the repository history. See the [contributor development
+workflow](./CONTRIBUTING.md#development-workflow) for the validation expectations.
 
 ## 🌟 Development Phases
 


### PR DESCRIPTION
## Summary

- answer whether Spec Kit uses its own workflow
- distinguish substantial-feature dogfooding from the normal path for small changes
- explain why generated dogfooding artifacts usually do not appear in repository history
- link the contributor workflow and automated feature-assessment workflow

Addresses https://github.com/github/spec-kit/discussions/4353.

## AI disclosure

This documentation update was authored autonomously by GitHub Copilot (GPT-5.6 Sol) on behalf of @mnriem.