### PR TITLE
fix(ci): harden PyPI release tag handling

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,8 +19,9 @@ jobs:
       actions: write
     steps:
       - name: Verify tag format
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: '$TAG' is not a valid release tag (expected vX.Y.Z)"
             exit 1
@@ -40,9 +41,10 @@ jobs:
           python-version: "3.13"
 
       - name: Verify tag matches package version
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          TAG_VERSION="${{ inputs.tag }}"
-          TAG_VERSION="${TAG_VERSION#v}"
+          TAG_VERSION="${TAG#v}"
           PROJECT_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
           if [[ "$TAG_VERSION" != "$PROJECT_VERSION" ]]; then
             echo "Error: Tag version ($TAG_VERSION) does not match pyproject.toml version ($PROJECT_VERSION)"

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
+import sys
 from pathlib import Path
+
+import yaml
+
+from tests.conftest import requires_bash
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -12,6 +19,11 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 # inline shorthand (`      - uses: x@sha`) used in catalog-assign.yml.
 USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)", re.MULTILINE)
 PINNED_SHA_RE = re.compile(r"@[0-9a-f]{40}$", re.IGNORECASE)
+PUBLISH_WORKFLOW = WORKFLOWS_DIR / "publish-pypi.yml"
+PUBLISH_VALIDATION_STEPS = (
+    "Verify tag format",
+    "Verify tag matches package version",
+)
 COMMUNITY_SUBMISSION_WORKFLOWS = (
     (
         "bundle",
@@ -35,6 +47,34 @@ COMMUNITY_SUBMISSION_WORKFLOWS = (
         "Do not modify any other files",
     ),
 )
+
+
+def _publish_workflow_steps() -> dict[str, dict[str, object]]:
+    workflow = yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+    return {step["name"]: step for step in workflow["jobs"]["build"]["steps"]}
+
+
+def _run_publish_validation_step(
+    step_name: str, tag: str, working_directory: Path
+) -> subprocess.CompletedProcess[str]:
+    step = _publish_workflow_steps()[step_name]
+    env = os.environ.copy()
+    env["TAG"] = tag
+    env["PATH"] = f"{Path(sys.executable).parent}{os.pathsep}{env['PATH']}"
+    return subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", step["run"]],
+        cwd=working_directory,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_project_version(working_directory: Path, version: str) -> None:
+    (working_directory / "pyproject.toml").write_text(
+        f'[project]\nversion = "{version}"\n', encoding="utf-8"
+    )
 
 
 def _create_pull_request_allowed_files(source_text: str) -> list[str]:
@@ -76,6 +116,52 @@ def test_github_actions_are_pinned_to_full_commit_shas():
             unpinned_refs.append(f"{workflow.relative_to(REPO_ROOT)}: {uses_ref}")
 
     assert unpinned_refs == []
+
+
+def test_publish_tag_validation_uses_environment_variable():
+    steps = _publish_workflow_steps()
+
+    for step_name in PUBLISH_VALIDATION_STEPS:
+        step = steps[step_name]
+        assert step["env"]["TAG"] == "${{ inputs.tag }}"
+        assert "${{ inputs.tag }}" not in step["run"]
+
+
+@requires_bash
+def test_publish_tag_validation_accepts_valid_tag(tmp_path):
+    _write_project_version(tmp_path, "1.2.3")
+
+    for step_name in PUBLISH_VALIDATION_STEPS:
+        result = _run_publish_validation_step(step_name, "v1.2.3", tmp_path)
+        assert result.returncode == 0, result.stderr
+
+
+@requires_bash
+def test_publish_tag_validation_rejects_invalid_tag(tmp_path):
+    for invalid_tag in ("1.2.3", "v1.2", "v1.2.3-rc1"):
+        result = _run_publish_validation_step(
+            "Verify tag format", invalid_tag, tmp_path
+        )
+        assert result.returncode != 0
+        assert "is not a valid release tag" in result.stdout
+
+    injected_file = tmp_path / "interpolated"
+    injected_tag = f'v1.2.3"; touch "{injected_file}"; #'
+    result = _run_publish_validation_step("Verify tag format", injected_tag, tmp_path)
+    assert result.returncode != 0
+    assert not injected_file.exists()
+
+
+@requires_bash
+def test_publish_tag_validation_rejects_version_mismatch(tmp_path):
+    _write_project_version(tmp_path, "1.2.3")
+
+    result = _run_publish_validation_step(
+        "Verify tag matches package version", "v1.2.4", tmp_path
+    )
+
+    assert result.returncode != 0
+    assert "does not match pyproject.toml version" in result.stdout
 
 
 def test_pinned_action_ref_accepts_uppercase_hex_sha():


### PR DESCRIPTION
## Description

Pass the manually supplied PyPI release tag through step-level `TAG` environment variables before either validation script consumes it. This prevents GitHub Actions expression expansion from injecting untrusted input into shell source while preserving the existing strict `vX.Y.Z` and package-version checks.

Add workflow regression tests that execute the embedded validation scripts for valid tags, ordinary malformed tags, a shell-injection-shaped tag, and a package-version mismatch.

Fixes #4380.

## Testing

- [ ] Tested locally with `uv run specify --help` (not applicable; no CLI behavior changed)
- [x] Ran existing tests with an isolated worktree environment: focused workflow suites passed (`24 passed`)
- [ ] Tested with a sample project (not applicable; workflow-only change)
- [x] `actionlint 1.7.12 .github/workflows/publish-pypi.yml`
- [x] `uvx ruff@0.15.0 check src tests`
- [x] `uvx pre-commit run --files .github/workflows/publish-pypi.yml tests/test_github_workflows.py`
- [x] `git diff --check`

The full suite completed with `7155 passed, 156 skipped, 27 failed`; all failures are existing PowerShell interoperability tests that cannot access this WSL UNC worktree (`UnauthorizedAccess`). The focused GitHub workflow and security suites pass in full.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

This PR was implemented, tested, and prepared autonomously by Devmate (OpenAI GPT-5.6) on behalf of @srpatcha. The commit includes the repository-required `Assisted-by` trailer.
