### PR TITLE
docs: clarify autonomous PR handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,7 +506,7 @@ Disclosure is **continuous**, not a one-time event. A single AI-disclosure parag
 ### Opening pull requests
 
 - Before opening a pull request, check whether the account that will file it already has three open pull requests in this repository.
-- If so, alert the user that additional submissions may receive lower review priority and ask for explicit permission to proceed. Do not assume consent.
+- If so, alert the user that additional submissions may receive lower review priority and ask for explicit permission to proceed. Do not assume consent. If the user is unavailable to provide that permission, including during autonomous or non-interactive operation, do not open the pull request. Preserve the work on a branch and report that confirmation is required.
 
 ### Commits
 


### PR DESCRIPTION
Assisted-by: GitHub Copilot (model: GPT-5.6 Sol, supervised)

## Description

Clarifies the existing pull request guidance for autonomous or non-interactive agents. When the filing account already has three open pull requests and the user is unavailable to provide permission, the agent should preserve the work on a branch rather than assume consent and open another pull request.

The existing threshold and policy remain unchanged.

## Testing

Documentation-only change; no tests were required.

## AI Disclosure

<!-- Per our Contributing guidelines, AI assistance must be disclosed. -->
<!-- See: https://github.com/github/spec-kit/blob/main/CONTRIBUTING.md#ai-contributions-in-spec-kit -->

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot helped workshop and review the wording, edit `AGENTS.md`, and prepare this pull request under direct human supervision.
