### PR TITLE
fix(scripts): stop wrap composition looping on a token in core content

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -902,12 +902,20 @@ except Exception as exc:
                     *'{CORE_TEMPLATE}'*) ;;
                     *) echo "Error: wrap strategy missing {CORE_TEMPLATE} placeholder" >&2; return 2 ;;
                 esac
-                while [[ "$layer_content" == *'{CORE_TEMPLATE}'* ]]; do
-                    local before="${layer_content%%\{CORE_TEMPLATE\}*}"
-                    local after="${layer_content#*\{CORE_TEMPLATE\}}"
-                    layer_content="${before}${content}${after}"
+                # Consume the wrapper left to right instead of rewriting it in
+                # place. Rewriting re-scanned the string just modified, so base
+                # content holding a literal {CORE_TEMPLATE} reintroduced the
+                # token every pass and the loop never terminated. Advancing over
+                # ``rest`` bounds the work by the tokens in the original wrapper
+                # and leaves inserted content untouched, matching the single-pass
+                # semantics of .Replace()/.replace() in the PowerShell and Python
+                # ports.
+                local wrapped="" rest="$layer_content"
+                while [[ "$rest" == *'{CORE_TEMPLATE}'* ]]; do
+                    wrapped="${wrapped}${rest%%\{CORE_TEMPLATE\}*}${content}"
+                    rest="${rest#*\{CORE_TEMPLATE\}}"
                 done
-                content="$layer_content"
+                content="${wrapped}${rest}"
                 ;;
             *) echo "Error: unknown strategy '$strat'" >&2; return 2 ;;
         esac

--- a/tests/parity_helpers.py
+++ b/tests/parity_helpers.py
@@ -83,8 +83,17 @@ def clean_env() -> dict[str, str]:
 
 
 def run(
-    cmd: list[str], repo: Path, env: dict[str, str] | None = None
+    cmd: list[str],
+    repo: Path,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    """Run a script variant.
+
+    ``timeout`` guards cases whose regression mode is a hang rather than a bad
+    value; without it such a failure would stall the suite instead of failing
+    it. ``subprocess.TimeoutExpired`` propagates so the test reports the hang.
+    """
     return subprocess.run(
         cmd,
         cwd=repo,
@@ -92,6 +101,7 @@ def run(
         text=True,
         check=False,
         env=env if env is not None else clean_env(),
+        timeout=timeout,
     )
 
 

--- a/tests/test_resolve_template_python_parity.py
+++ b/tests/test_resolve_template_python_parity.py
@@ -92,6 +92,40 @@ def test_all_variants_preserve_composition_parity(
 
 
 @requires_bash
+def test_all_variants_treat_core_token_in_core_content_as_literal(
+    tmp_path: Path,
+) -> None:
+    """Core content holding a literal ``{CORE_TEMPLATE}`` must not be re-expanded.
+
+    The wrap strategy fills the placeholders present in the *wrapper*. A token
+    that arrives as part of the composed core content is data, not a slot, so it
+    survives into the output untouched. Rescanning the substituted string instead
+    reintroduces a token on every pass and never terminates, so the regression
+    mode here is a hang rather than a wrong value -- hence the timeout, without
+    which a reintroduced bug would stall the suite instead of failing it.
+    """
+    repo = make_repo(tmp_path)
+    install_scripts(repo, SCRIPT)
+    expected = install_composition_stack(repo, TEMPLATE, "# Core {CORE_TEMPLATE}\n")
+
+    results = [
+        run(bash_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo, timeout=30),
+        run(py_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo, timeout=30),
+    ]
+    if HAS_POWERSHELL:
+        results.append(run(ps_cmd(repo, SCRIPT, TEMPLATE, "-Json"), repo, timeout=30))
+
+    assert all(result.returncode == 0 for result in results)
+    assert all(result.stderr == "" for result in results)
+    # The wrapper contributes exactly one placeholder, so exactly one literal
+    # token -- the one carried in by the core content -- remains in the output.
+    assert expected.count("{CORE_TEMPLATE}") == 1
+    assert all(
+        json_stdout(result)["TEMPLATE_CONTENT"] == expected for result in results
+    )
+
+
+@requires_bash
 def test_all_variants_read_utf8_registry_under_ascii_locale(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Fixes #4385

## Problem

`scripts/bash/common.sh` rewrote `layer_content` in place and then re-tested the string it had just modified:

```bash
while [[ "$layer_content" == *'{CORE_TEMPLATE}'* ]]; do
    local before="${layer_content%%\{CORE_TEMPLATE\}*}"
    local after="${layer_content#*\{CORE_TEMPLATE\}}"
    layer_content="${before}${content}${after}"
done
```

When the resolved core content holds a literal `{CORE_TEMPLATE}`, every pass reinserts it and the condition is true forever.

## Why this shape of fix

The PowerShell and Python ports were already correct, so the intended semantics did not need inventing — only matching:

```powershell
# scripts/powershell/common.ps1:789
$content = $layerContent.Replace('{CORE_TEMPLATE}', $content)
```

```python
# scripts/python/common.py:466
content = layer_content.replace(placeholder, content)
```

`String.Replace` and `str.replace` scan the original subject once and never revisit inserted text. The new loop consumes the wrapper left to right into an accumulator, so work is bounded by the placeholders in the original wrapper and inserted content is never re-examined. This aligns bash with the other two ports rather than introducing a third behaviour.

`tests/parity_helpers.py` already treats `.replace()` as the oracle for expected wrap output (`install_composition_stack`), so the three ports now agree with the harness by construction.

## Verification

I extracted the wrap block verbatim from `upstream/main` and from this branch and ran both under Git Bash:

| case | wrapper | core content | before | after |
|---|---|---|---|---|
| A — normal | `BEFORE\n{CORE_TEMPLATE}\nAFTER` | `BASE` | `BEFORE\nBASE\nAFTER` | identical |
| B — this bug | `BEFORE\n{CORE_TEMPLATE}\nAFTER` | `BASE {CORE_TEMPLATE}` | **hangs (rc=124)** | `BEFORE\nBASE {CORE_TEMPLATE}\nAFTER` |
| C — two tokens | `A{CORE_TEMPLATE}B{CORE_TEMPLATE}C` | `X` | `AXBXC` | identical |

A and C confirm no behaviour change on the paths that already worked, including multiple placeholders in the wrapper — the fix is not "replace the first occurrence". B matches `str.replace` byte for byte.

## Test

`test_all_variants_treat_core_token_in_core_content_as_literal` runs all three variants through the existing parity harness with core content carrying a literal token.

The regression mode here is a **hang, not a wrong value**, so a plain assertion would never fail — it would just never finish. `run()` therefore grows an optional `timeout` parameter (default `None`, so every existing call is unchanged) and the new test passes `timeout=30`. Without it, a reintroduced bug would stall the suite instead of failing it.

## Notes on local test runs

The bash parity tests skip on my machine: Windows resolves `bash` to the WSL launcher, which `tests/conftest.py::_has_working_bash` correctly rejects. I verified the bash behaviour by driving Git Bash directly, as in the table above; CI will exercise the new test through the normal harness.

`pytest tests/` shows 20 pre-existing failures locally, all `WinError 1314: A required privilege is not held by the client` from symlink creation. I confirmed the identical set fails on unmodified `upstream/main`, so they are environmental and unrelated.

---

*Disclosure: this change was developed with AI assistance (Claude). The AI helped locate the defect, compare the three ports, draft the fix and test, and write this description. All reasoning and results above were verified by running the code; I reviewed the change before submitting.*
