### PR TITLE
fix(scripts): name setup-plan's feature directory key FEATURE_DIR

### DIFF
--- a/scripts/bash/setup-plan.sh
+++ b/scripts/bash/setup-plan.sh
@@ -70,16 +70,16 @@ if $JSON_MODE; then
         jq -cn \
             --arg feature_spec "$FEATURE_SPEC" \
             --arg impl_plan "$IMPL_PLAN" \
-            --arg specs_dir "$FEATURE_DIR" \
+            --arg feature_dir "$FEATURE_DIR" \
             --arg branch "$CURRENT_BRANCH" \
-            '{FEATURE_SPEC:$feature_spec,IMPL_PLAN:$impl_plan,SPECS_DIR:$specs_dir,BRANCH:$branch}'
+            '{FEATURE_SPEC:$feature_spec,IMPL_PLAN:$impl_plan,FEATURE_DIR:$feature_dir,BRANCH:$branch}'
     else
-        printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s"}\n' \
+        printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","FEATURE_DIR":"%s","BRANCH":"%s"}\n' \
             "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$IMPL_PLAN")" "$(json_escape "$FEATURE_DIR")" "$(json_escape "$CURRENT_BRANCH")"
     fi
 else
     echo "FEATURE_SPEC: $FEATURE_SPEC"
     echo "IMPL_PLAN: $IMPL_PLAN"
-    echo "SPECS_DIR: $FEATURE_DIR"
+    echo "FEATURE_DIR: $FEATURE_DIR"
     echo "BRANCH: $CURRENT_BRANCH"
 fi

--- a/scripts/powershell/setup-plan.ps1
+++ b/scripts/powershell/setup-plan.ps1
@@ -76,13 +76,13 @@ if ($Json) {
     $result = [PSCustomObject]@{
         FEATURE_SPEC = $paths.FEATURE_SPEC
         IMPL_PLAN = $paths.IMPL_PLAN
-        SPECS_DIR = $paths.FEATURE_DIR
+        FEATURE_DIR = $paths.FEATURE_DIR
         BRANCH = $paths.CURRENT_BRANCH
     }
     $result | ConvertTo-Json -Compress
 } else {
     Write-Output "FEATURE_SPEC: $($paths.FEATURE_SPEC)"
     Write-Output "IMPL_PLAN: $($paths.IMPL_PLAN)"
-    Write-Output "SPECS_DIR: $($paths.FEATURE_DIR)"
+    Write-Output "FEATURE_DIR: $($paths.FEATURE_DIR)"
     Write-Output "BRANCH: $($paths.CURRENT_BRANCH)"
 }

--- a/scripts/python/setup_plan.py
+++ b/scripts/python/setup_plan.py
@@ -82,7 +82,7 @@ def main(argv: list[str] | None = None) -> int:
                 {
                     "FEATURE_SPEC": str(paths.feature_spec),
                     "IMPL_PLAN": str(paths.impl_plan),
-                    "SPECS_DIR": str(paths.feature_dir),
+                    "FEATURE_DIR": str(paths.feature_dir),
                     "BRANCH": paths.current_branch,
                 }
             )
@@ -90,7 +90,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(f"FEATURE_SPEC: {paths.feature_spec}")
         print(f"IMPL_PLAN: {paths.impl_plan}")
-        print(f"SPECS_DIR: {paths.feature_dir}")
+        print(f"FEATURE_DIR: {paths.feature_dir}")
         print(f"BRANCH: {paths.current_branch}")
     return 0
 

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -59,7 +59,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Outline
 
-1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. **Setup**: Run `{SCRIPT}` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, FEATURE_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load context**: Read FEATURE_SPEC and `/memory/constitution.md`. Load IMPL_PLAN template (already copied).
 

--- a/tests/test_setup_plan_python_parity.py
+++ b/tests/test_setup_plan_python_parity.py
@@ -374,3 +374,57 @@ def test_python_json_output_matches_powershell(repo: Path) -> None:
 
     assert py.returncode == ps.returncode == 0
     assert json_stdout(py) == json_stdout(ps)
+
+
+@requires_bash
+@pytest.mark.parametrize("args", [("--json",), ()], ids=["json", "text"])
+def test_all_variants_emit_feature_dir_not_specs_dir(
+    repo: Path, args: tuple[str, ...]
+) -> None:
+    r"""Pin the output key name, not just cross-port agreement.
+
+    The other tests here compare the ports against each other, so all three
+    could regress to ``SPECS_DIR`` together and still pass. This asserts the
+    contract absolutely: the key is ``FEATURE_DIR``, it carries the feature
+    directory rather than the specs root, and the old name is gone.
+    ``SPECS_DIR`` means the specs root in ``create-new-feature.sh``, so
+    re-emitting it here would reintroduce one name for two paths.
+
+    The value is matched by suffix because the ports legitimately differ in
+    path flavour -- under MSYS bash reports ``/tmp/...`` where the Python and
+    PowerShell ports report ``C:\...``. The suffix still separates
+    ``specs/001-my-feature`` from a bare ``specs``, which is the regression
+    this guards.
+    """
+    json_mode = args == ("--json",)
+    suffix = ("specs", "001-my-feature")
+
+    commands = [bash_cmd(repo, SCRIPT, *args), py_cmd(repo, SCRIPT, *args)]
+    if HAS_POWERSHELL:
+        commands.append(ps_cmd(repo, SCRIPT, *(("-Json",) if json_mode else ())))
+
+    for cmd in commands:
+        result = run(cmd, repo)
+        assert result.returncode == 0, result.stderr
+        assert "SPECS_DIR" not in result.stdout
+
+        if json_mode:
+            payload = json_stdout(result)
+            assert isinstance(payload, dict)
+            assert sorted(payload) == [
+                "BRANCH",
+                "FEATURE_DIR",
+                "FEATURE_SPEC",
+                "IMPL_PLAN",
+            ]
+            value = payload["FEATURE_DIR"]
+        else:
+            lines = dict(
+                line.split(": ", 1)
+                for line in result.stdout.splitlines()
+                if ": " in line
+            )
+            assert "FEATURE_DIR" in lines
+            value = lines["FEATURE_DIR"]
+
+        assert tuple(value.replace("\\", "/").rstrip("/").split("/")[-2:]) == suffix


### PR DESCRIPTION
Fixes #4017

## Problem

`setup-plan` emitted a JSON key named `SPECS_DIR` holding `$FEATURE_DIR` — the per-feature subdirectory, not the specs root.

The name is already in use elsewhere with the other meaning. In `scripts/bash/create-new-feature.sh`:

```bash
SPECS_DIR="$REPO_ROOT/specs"           # the specs root
FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"  # one feature inside it
```

So `SPECS_DIR` meant `specs/` in one script and `specs/001-my-feature/` in another.

## Why `FEATURE_DIR` is the right name

`setup-plan` was the only script in the suite using `SPECS_DIR`. Every sibling already emits `FEATURE_DIR` for exactly this value:

```
scripts/bash/setup-tasks.sh:75           FEATURE_DIR:$feature_dir
scripts/bash/check-prerequisites.sh:122  FEATURE_DIR:$feature_dir
scripts/bash/check-prerequisites.sh:208  FEATURE_DIR:$feature_dir
```

This brings `setup-plan` in line rather than inventing a convention.

## Scope

The issue lists four bash locations. The same key is emitted by all three ports, and there is a consumer that parses it by name — fixing only bash would leave the ports disagreeing, which is worse than the current state. Full surface:

```
scripts/bash/setup-plan.sh         73, 75, 77, 83
scripts/powershell/setup-plan.ps1  79, 86
scripts/python/setup_plan.py       85, 93
templates/commands/plan.md         62   <- parses the key by name
```

`plan.md` ships alongside the scripts, so it stays in sync automatically.

## On the compatibility question

I raised rename-vs-deprecated-alias on the issue. Going with the straight rename here, since `plan.md` is the only in-repo consumer and the value was never the specs root — anything relying on `SPECS_DIR` to mean the specs root was already reading the wrong path. Happy to switch to emitting `FEATURE_DIR` while keeping `SPECS_DIR` as a deprecated alias for a release or two if you would rather not break external parsers.

## Verification

Ran all three variants against a scratch project and compared the emitted keys:

```
bash    rc=0 keys=['BRANCH', 'FEATURE_DIR', 'FEATURE_SPEC', 'IMPL_PLAN']
python  rc=0 keys=['BRANCH', 'FEATURE_DIR', 'FEATURE_SPEC', 'IMPL_PLAN']
pwsh    rc=0 keys=['BRANCH', 'FEATURE_DIR', 'FEATURE_SPEC', 'IMPL_PLAN']
```

Also confirmed no other reference to the old key remains outside `create-new-feature.sh`, where `SPECS_DIR` correctly means the specs root and is untouched.

`pytest tests/ -k "plan or command_template or preset"` — 852 passed. The 8 failures are all `WinError 1314: A required privilege is not held by the client` from symlink creation; the identical set fails on unmodified `upstream/main`, so they are environmental and unrelated.

---

*Disclosure: this change was developed with AI assistance (Claude). The AI helped map the affected call sites across the three ports, apply the rename, and draft this description. The three-port key comparison above was produced by running the scripts; I reviewed the change before submitting.*
