### PR TITLE
fix(workflows): drop the bundled speckit workflow's inert scope input

### DIFF
--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -415,10 +415,6 @@ inputs:
     type: string
     default: "copilot"
     prompt: "Integration to use (e.g. claude, copilot, gemini)"
-  scope:
-    type: string
-    default: "full"
-    enum: ["full", "backend-only", "frontend-only"]
 
 steps:
   - id: specify

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -73,7 +73,7 @@ specify workflow run ./my-workflow.yml --input spec="Build a user authentication
 ```bash
 specify workflow run speckit \
   --input spec="Build a user authentication system with OAuth support" \
-  --input scope="backend-only"
+  --input integration="claude"
 ```
 
 ## Step Types

--- a/workflows/speckit/workflow.yml
+++ b/workflows/speckit/workflow.yml
@@ -35,10 +35,6 @@ inputs:
     type: string
     default: "auto"
     prompt: "Integration to use (e.g. claude, copilot, gemini; 'auto' uses the project's initialized integration)"
-  scope:
-    type: string
-    default: "full"
-    enum: ["full", "backend-only", "frontend-only"]
 
 steps:
   - id: specify


### PR DESCRIPTION
Fixes #4384

## Problem

The bundled `workflows/speckit/workflow.yml` declared a required-choice `scope` input that no step referenced. All four steps pass `{{ inputs.spec }}`, so every choice behaved identically.

## What actually happens

Two corrections to the report's framing, both checked against `main`:

**Workflow inputs are never prompted for.** The report says users "are prompted to choose among three values", but nothing in the engine reads an input's `prompt:` field to ask anything — `_resolve_inputs` only merges provided values with defaults, and the sole interactive `input()` call in `workflows/` belongs to the gate step. The `prompt:` key is documentation-only metadata today, which is also why `scope` being the one input without one went unnoticed.

**The value is validated, then discarded.** Calling `_coerce_input` with the declared definition:

```
-i scope=full           -> ACCEPTED as 'full'
-i scope=backend-only   -> ACCEPTED as 'backend-only'
-i scope=frontend-only  -> ACCEPTED as 'frontend-only'
-i scope=bogus          -> REJECTED: Input 'scope' value 'bogus' not in allowed values: [...]
```

That is worse than being ignored outright: a bogus value errors, so the acceptance of `backend-only` reads to the user as confirmation the flag does something.

## Why removal rather than propagation

The issue offered both. Propagating scope has no contract to hang it on — the four steps take a single `args` string, so a scope could only be smuggled in by appending prose to `{{ inputs.spec }}`, putting a scoping instruction into the same free-text field the user's own description occupies and leaving its interpretation to the agent. That is a feature with a design question attached, not a bug fix.

Removing the selector restores the invariant that every declared input affects the run, and leaves a real scope feature free to land later on its own terms.

## Also updated

`workflows/README.md` demonstrated "Multiple Inputs" using this exact input against the bundled workflow:

```bash
specify workflow run speckit \
  --input spec="..." \
  --input scope="backend-only"
```

That documented the inert input as if it worked, so the example now uses a declared one (`integration`). The `inputs.scope` reference further down in the If/Then/Else section is a generic authoring illustration with its own hypothetical workflow, not the bundled one, so it stays.

## Verification

```
declared  : ['integration', 'spec']
referenced: ['integration', 'spec']
referenced-but-undeclared: none
declared-but-unused      : none
```

`pytest tests/test_workflows.py` — 941 passed. The 20 failures are all `WinError 1314: A required privilege is not held by the client` from symlink creation; I confirmed the identical set fails on unmodified `upstream/main`, so they are environmental and unrelated.

## Follow-up worth considering separately

`validate_workflow` already rejects malformed `enum` shapes and out-of-enum defaults, but has no check for a declared input that no step references. A warning there would have caught this at authoring time. Left out of this PR to keep it to the fix.

---

*Disclosure: this change was developed with AI assistance (Claude). The AI helped trace the input-resolution path, establish the accept-and-discard behaviour, and draft this description. The coercion results and the declared/referenced comparison above were produced by running the code; I reviewed the change before submitting.*
