### PR TITLE
fix: stop wrap composition looping when core text contains {CORE_TEMPLATE}

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -902,12 +902,18 @@ except Exception as exc:
                     *'{CORE_TEMPLATE}'*) ;;
                     *) echo "Error: wrap strategy missing {CORE_TEMPLATE} placeholder" >&2; return 2 ;;
                 esac
-                while [[ "$layer_content" == *'{CORE_TEMPLATE}'* ]]; do
-                    local before="${layer_content%%\{CORE_TEMPLATE\}*}"
-                    local after="${layer_content#*\{CORE_TEMPLATE\}}"
-                    layer_content="${before}${content}${after}"
+                # Walk the original wrapper only. Inserted core content must not
+                # be rescanned: if it contains a literal {CORE_TEMPLATE}, a
+                # while-loop over the growing string never finishes (and would
+                # disagree with the Python/PowerShell one-shot Replace).
+                local result="" rest="$layer_content"
+                while [[ "$rest" == *'{CORE_TEMPLATE}'* ]]; do
+                    local before="${rest%%\{CORE_TEMPLATE\}*}"
+                    local after="${rest#*\{CORE_TEMPLATE\}}"
+                    result="${result}${before}${content}"
+                    rest="$after"
                 done
-                content="$layer_content"
+                content="${result}${rest}"
                 ;;
             *) echo "Error: unknown strategy '$strat'" >&2; return 2 ;;
         esac

--- a/tests/test_resolve_template_python_parity.py
+++ b/tests/test_resolve_template_python_parity.py
@@ -588,6 +588,78 @@ def test_all_variants_fail_when_wrap_placeholder_is_missing(
 
 
 @requires_bash
+def test_wrap_preserves_literal_core_template_in_base_content(
+    tmp_path: Path,
+) -> None:
+    """Base text that contains {CORE_TEMPLATE} must not re-enter the wrap scan.
+
+    Reproduces github/spec-kit#4385: the Bash resolver used to rewrite
+    ``layer_content`` in place, so inserted tokens kept the loop alive.
+    """
+    repo = make_repo(tmp_path)
+    install_scripts(repo, SCRIPT)
+
+    presets = repo / ".specify" / "presets"
+    wrap = presets / "a-wrap"
+    base = presets / "b-base"
+    (wrap / "templates").mkdir(parents=True)
+    (base / "templates").mkdir(parents=True)
+
+    (wrap / "templates" / f"{TEMPLATE}.md").write_text(
+        "BEFORE\n{CORE_TEMPLATE}\nAFTER\n",
+        encoding="utf-8",
+    )
+    (wrap / "preset.yml").write_text(
+        "provides:\n"
+        "  templates:\n"
+        "    - type: template\n"
+        f"      name: {TEMPLATE}\n"
+        f"      file: templates/{TEMPLATE}.md\n"
+        "      strategy: wrap\n",
+        encoding="utf-8",
+    )
+    (base / "templates" / f"{TEMPLATE}.md").write_text(
+        "BASE {CORE_TEMPLATE}\n",
+        encoding="utf-8",
+    )
+    (base / "preset.yml").write_text(
+        "provides:\n"
+        "  templates:\n"
+        "    - type: template\n"
+        f"      name: {TEMPLATE}\n"
+        f"      file: templates/{TEMPLATE}.md\n"
+        "      strategy: replace\n",
+        encoding="utf-8",
+    )
+    (presets / ".registry").write_text(
+        json.dumps(
+            {
+                "presets": {
+                    "a-wrap": {"enabled": True, "priority": 1},
+                    "b-base": {"enabled": True, "priority": 2},
+                }
+            },
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    expected = "BEFORE\nBASE {CORE_TEMPLATE}\n\nAFTER\n"
+    results = [
+        run(bash_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo),
+        run(py_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo),
+    ]
+    if HAS_POWERSHELL:
+        results.append(run(ps_cmd(repo, SCRIPT, TEMPLATE, "-Json"), repo))
+
+    assert all(result.returncode == 0 for result in results)
+    assert all(
+        json_stdout(result)["TEMPLATE_CONTENT"] == expected for result in results
+    )
+
+
+@requires_bash
 def test_all_variants_fail_when_yaml_parser_is_unavailable(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Bash wrap composition no longer rescans inserted core content for `{CORE_TEMPLATE}`
- Matches the existing Python / PowerShell one-shot replace behavior
- Adds a parity regression for the infinite-loop case in #4385

## Context

`scripts/bash/common.sh` used a `while` loop that wrote the substituted string back into `layer_content`. If the base layer literally contained `{CORE_TEMPLATE}`, every iteration reintroduced a match and `resolve-template.sh` hung until killed.

## Test plan

- [x] `uv run pytest tests/test_resolve_template_python_parity.py::test_wrap_preserves_literal_core_template_in_base_content`
- [x] Nearby wrap parity tests still pass
- [ ] CI green on this PR

Fixes #4385
