### PR TITLE
fix(integrations): atomically record generated skill files

### DIFF
--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -563,17 +563,14 @@ class IntegrationBase(ABC):
     ) -> Path:
         """Write *content* to *dest*, hash it, and record in *manifest*.
 
-        Creates parent directories as needed.  Writes bytes directly to
-        avoid platform newline translation (CRLF on Windows).  Any
-        ``\r\n`` sequences in *content* are normalised to ``\n`` before
-        writing.  Returns *dest*.
+        Uses the manifest as the single write-and-record entry point, so a
+        generated file cannot be written without its hash being recorded.
+        Any ``\r\n`` sequences in *content* are normalised to ``\n`` before
+        writing. Returns the path written by the manifest.
         """
-        dest.parent.mkdir(parents=True, exist_ok=True)
         normalized = content.replace("\r\n", "\n")
-        dest.write_bytes(normalized.encode("utf-8"))
         rel = dest.resolve().relative_to(project_root.resolve())
-        manifest.record_existing(rel)
-        return dest
+        return manifest.record_file(rel, normalized)
 
     def integration_scripts_dir(self) -> Path | None:
         """Return path to this integration's bundled ``scripts/`` directory.

--- a/tests/integrations/test_integration_claude.py
+++ b/tests/integrations/test_integration_claude.py
@@ -41,6 +41,15 @@ class TestClaudeIntegration:
         skill_files = [path for path in created if path.name == "SKILL.md"]
         assert skill_files
 
+        manifest.save()
+        manifest_data = json.loads(manifest.manifest_path.read_text(encoding="utf-8"))
+        recorded_paths = set(manifest_data["files"])
+        expected_paths = {
+            path.relative_to(tmp_path).as_posix() for path in skill_files
+        }
+        assert expected_paths <= recorded_paths
+        assert ".claude/skills/speckit-converge/SKILL.md" in recorded_paths
+
         skills_dir = tmp_path / ".claude" / "skills"
         assert skills_dir.is_dir()
 


### PR DESCRIPTION
## Summary
- route generated integration files through IntegrationManifest.record_file so writing and manifest tracking happen together
- add Claude integration coverage ensuring every generated SKILL.md, including speckit-converge, persists in claude.manifest.json

Fixes #4273

## Validation
- python -m compileall -q completed for both modified Python files

The full repository test suite is not available in the local environment, so CI should run the integration test.