### PR TITLE
docs(workflows): sync the reference copy with the shipped workflow

### DIFF
--- a/docs/reference/workflows.md
+++ b/docs/reference/workflows.md
@@ -431,14 +431,19 @@ schema_version: "1.0"
 workflow:
   id: "speckit"
   name: "Full SDD Cycle"
-  version: "1.0.0"
+  version: "1.0.1"
   author: "GitHub"
   description: "Runs specify → plan → tasks → implement with review gates"
 
 requires:
-  speckit_version: ">=0.7.2"
+  speckit_version: ">=0.8.5"
   integrations:
-    any: ["copilot", "claude", "gemini"]
+    any:
+      - "alquimia"
+      - "claude"
+      - "copilot"
+      - "gemini"
+      - "opencode"
 
 inputs:
   spec:
@@ -447,8 +452,8 @@ inputs:
     prompt: "Describe what you want to build"
   integration:
     type: string
-    default: "copilot"
-    prompt: "Integration to use (e.g. claude, copilot, gemini)"
+    default: "auto"
+    prompt: "Integration to use (e.g. claude, copilot, gemini; 'auto' uses the project's initialized integration)"
 
 steps:
   - id: specify

--- a/tests/workflows/test_bundled_speckit_workflow.py
+++ b/tests/workflows/test_bundled_speckit_workflow.py
@@ -8,9 +8,19 @@ import yaml
 
 from specify_cli.workflows.engine import WorkflowDefinition, validate_workflow
 
-BUNDLED = (
-    Path(__file__).resolve().parents[2] / "workflows" / "speckit" / "workflow.yml"
-)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUNDLED = REPO_ROOT / "workflows" / "speckit" / "workflow.yml"
+REFERENCE_DOC = REPO_ROOT / "docs" / "reference" / "workflows.md"
+DOC_INTRO = "Here is the built-in **Full SDD Cycle** workflow that ships with Spec Kit:"
+
+
+def _documented_workflow() -> object:
+    """Return the workflow YAML the reference guide claims is the shipped one."""
+    text = REFERENCE_DOC.read_text(encoding="utf-8")
+    intro = text.index(DOC_INTRO)
+    start = text.index("```yaml", intro) + len("```yaml")
+    end = text.index("```", start)
+    return yaml.safe_load(text[start:end])
 
 
 def test_bundled_speckit_workflow_has_no_unused_scope_input() -> None:
@@ -30,3 +40,19 @@ def test_bundled_speckit_workflow_has_no_unused_scope_input() -> None:
         if args is None:
             continue
         assert "inputs.scope" not in str(args)
+
+
+def test_reference_doc_matches_the_shipped_workflow() -> None:
+    """The reference guide reproduces this workflow, so it must not drift from it.
+
+    ``docs/reference/workflows.md`` introduces its YAML block as the workflow
+    that ships with Spec Kit, so a reader is entitled to treat it as the real
+    definition. It had drifted on four points -- a stale ``version`` and
+    ``speckit_version``, a short ``integrations.any`` list, and an
+    ``integration`` default of ``copilot`` where the shipped default is
+    ``auto`` -- which is exactly the sort of thing nothing else would catch.
+
+    The comparison is on parsed YAML, not text, so the guide stays free to
+    format lists however reads best; only the content has to agree.
+    """
+    assert _documented_workflow() == yaml.safe_load(BUNDLED.read_text(encoding="utf-8"))


### PR DESCRIPTION
Follow-up to #4384 / #4398 — @mnriem asked me to open this in [#4398](https://github.com/github/spec-kit/pull/4398#issuecomment-5526283124).

## Problem

`docs/reference/workflows.md` introduces its YAML block with:

> Here is the built-in **Full SDD Cycle** workflow that ships with Spec Kit:

A reader is entitled to treat that as the real definition. Diffing the block against `workflows/speckit/workflow.yml` shows it had drifted on four points:

| | reference guide | shipped workflow |
|---|---|---|
| `workflow.version` | `"1.0.0"` | `"1.0.1"` |
| `requires.speckit_version` | `">=0.7.2"` | `">=0.8.5"` |
| `requires.integrations.any` | `copilot`, `claude`, `gemini` | also `alquimia`, `opencode` |
| `inputs.integration.default` | `"copilot"` | `"auto"` |

The last is the most user-visible. The guide stated the default integration is `copilot`, when it is actually `auto`, resolved from the project's initialized integration — so someone reading the guide to learn what they get by default was told the wrong thing. The `prompt:` text is updated to match for the same reason.

The `steps:` section was already accurate and is untouched.

## Guard

`test_reference_doc_matches_the_shipped_workflow` extends the file added in #4401 and pins the two together, so this cannot drift again silently.

It compares **parsed YAML rather than text**, so the guide stays free to format lists however reads best — only the content has to agree.

Verified in both directions:

- against the pre-sync copy it **fails**, and names all four differences:
  ```
  {'requires': {'speckit_version': '>=0.7.2', 'integrations': {'any': ['copilot', 'claude', 'gemini']}}}
    != {'requires': {'speckit_version': '>=0.8.5', 'integrations': {'any': ['alquimia', 'claude', 'copilot', 'gemini', 'opencode']}}}
  {'workflow': {... 'version': '1.0.0' ...}} != {'workflow': {... 'version': '1.0.1' ...}}
  ```
- after the sync it **passes**

## Notes

Only the reference guide's copy is touched. The other `scope`/`enum` examples elsewhere are generic authoring illustrations rather than reproductions of the bundled workflow, so they are correctly left alone:

- `workflows/README.md` — the input type-coercion section
- `workflows/PUBLISHING.md` — a skeleton for authoring your own workflow
- `workflows/ARCHITECTURE.md` — the schema table row documenting `enum`

`pytest tests/workflows/` — 200 passed. The 10 failures are all `WinError 1314: A required privilege is not held by the client` from symlink creation on my Windows machine; zero non-symlink failures, and the identical set fails on unmodified `main`.

---

*Disclosure: this change was developed with AI assistance (Claude). The AI helped diff the two definitions, write the guard, and draft this description. The four differences and both directions of the guard were verified by running the tests; I reviewed the change before submitting.*
