### PR TITLE
fix(tasks): require field constraints from data-model.md in generated tasks

### DIFF
--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -197,6 +197,7 @@ Every task MUST strictly follow this format:
    - Map each entity to the user story(ies) that need it
    - If entity serves multiple stories: Put in earliest story or Setup phase
    - Relationships → service layer tasks in appropriate story phase
+   - For each field with constraints in data-model.md (max length, nullable/required, enum values, validation rules), quote the constraint verbatim in the task description so it is not left to implementation-time discretion
 
 4. **From Setup/Infrastructure**:
    - Shared infrastructure → Setup phase (Phase 1)

--- a/tests/test_tasks_template_constraints.py
+++ b/tests/test_tasks_template_constraints.py
@@ -21,8 +21,9 @@ def test_data_model_section_requires_verbatim_field_constraints():
     next_section_start = content.index("**From Setup/Infrastructure**")
     section = content[from_data_model_start:next_section_start]
 
-    assert "constraint" in section.lower(), (
+    assert "quote the constraint verbatim in the task description" in section.lower(), (
         "The 'From Data Model' task-organization rules must instruct the "
-        "agent to carry field constraints (max length, nullable, enum, "
-        "validation rules) from data-model.md into task descriptions."
+        "agent to quote field constraints (max length, nullable, enum, "
+        "validation rules) from data-model.md verbatim in task descriptions, "
+        "not merely mention that constraints exist."
     )

--- a/tests/test_tasks_template_constraints.py
+++ b/tests/test_tasks_template_constraints.py
@@ -1,0 +1,28 @@
+"""Regression test for #4383: tasks.md loses data-model field constraints.
+
+The /speckit.tasks command template maps data-model.md entities to task
+descriptions but did not require that field-level constraints (max length,
+nullable/required, enum values, validation rules) be carried into the
+generated task text verbatim. Without an explicit instruction, the
+implementing agent falls back to its own defaults instead of the value
+recorded in data-model.md.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+TASKS_TEMPLATE = REPO_ROOT / "templates" / "commands" / "tasks.md"
+
+
+def test_data_model_section_requires_verbatim_field_constraints():
+    content = TASKS_TEMPLATE.read_text(encoding="utf-8")
+
+    from_data_model_start = content.index("**From Data Model**")
+    next_section_start = content.index("**From Setup/Infrastructure**")
+    section = content[from_data_model_start:next_section_start]
+
+    assert "constraint" in section.lower(), (
+        "The 'From Data Model' task-organization rules must instruct the "
+        "agent to carry field constraints (max length, nullable, enum, "
+        "validation rules) from data-model.md into task descriptions."
+    )


### PR DESCRIPTION
Fixes #4383

## Problem

`/speckit.tasks` maps `data-model.md` entities to user stories (`templates/commands/tasks.md`, "From Data Model" section) but never instructed the agent to carry field-level constraints (max length, nullable/required, enum values, validation rules) into the generated task text. Left to the agent's discretion, a constraint present in `data-model.md` can be silently dropped from `tasks.md`, and the implementing agent then invents its own value (e.g. the reporter's `data-model.md` said `SuspendReason nvarchar(200)` but the generated code used `SuspendReasonMaxLength = 500` because `tasks.md` never repeated the `200` constraint for that field).

## Fix

Added one bullet to the "From Data Model" task-organization rule in `templates/commands/tasks.md` requiring that field constraints from `data-model.md` be quoted verbatim in the corresponding task description, so the value isn't left to implementation-time discretion.

This is a prompt-only change — no Python code, no breaking changes.

## Testing

Added `tests/test_tasks_template_constraints.py`, which asserts the "From Data Model" section of `templates/commands/tasks.md` mentions carrying constraints forward.

Verified the test fails without the fix and passes with it:

```
$ git checkout HEAD~1 -- templates/commands/tasks.md   # (unfixed content)
$ python -m pytest tests/test_tasks_template_constraints.py -v
FAILED tests/test_tasks_template_constraints.py::test_data_model_section_requires_verbatim_field_constraints
AssertionError: The 'From Data Model' task-organization rules must instruct the agent to carry
field constraints (max length, nullable, enum, validation rules) from data-model.md into task
descriptions.
1 failed in 0.49s

$ git checkout HEAD -- templates/commands/tasks.md      # (fixed content)
$ python -m pytest tests/test_tasks_template_constraints.py -v
tests/test_tasks_template_constraints.py::test_data_model_section_requires_verbatim_field_constraints PASSED
1 passed in 0.17s
```

Full suite:

```
$ python -m pytest tests -q --ignore=tests/hooks
10 failed, 7691 passed, 12 skipped, 48 warnings in 473.70s
```

The 10 failures are pre-existing and unrelated to this change — they are all `*_python_parity` tests exercising the "composed" preset variant (`test_check_prerequisites_python_parity.py`, `test_create_new_feature_python_parity.py`, `test_resolve_template_python_parity.py`, `test_setup_plan_python_parity.py`, `test_setup_tasks_python_parity.py`). I confirmed the identical 10 tests fail on a clean checkout of `upstream/main` with no changes applied, in this sandbox (likely missing an environment prerequisite for the composed-preset fixtures, e.g. PowerShell). All tests in the affected files pass individually in isolation.

## AI Disclosure

I **did** use AI assistance (Claude, via Claude Code) to investigate the issue, write the template change, and write/verify the regression test.
