### PR TITLE
fix(scripts): honor SPECKIT_PYTHON override for preset manifest parsing

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -400,7 +400,8 @@ check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" |
 
 _python3_command() {
     if [[ -n "${SPECKIT_PYTHON:-}" ]] && command -v "$SPECKIT_PYTHON" >/dev/null 2>&1 &&
-        "$SPECKIT_PYTHON" -c 'import sys; raise SystemExit(sys.version_info.major != 3)' >/dev/null 2>&1; then
+        "$SPECKIT_PYTHON" -c 'import sys; raise SystemExit(sys.version_info.major != 3)' >/dev/null 2>&1 &&
+        "$SPECKIT_PYTHON" -c 'import yaml' >/dev/null 2>&1; then
         printf '%s\n' "$SPECKIT_PYTHON"
     elif command -v python3 >/dev/null 2>&1 &&
         python3 -c 'import sys; raise SystemExit(sys.version_info.major != 3)' >/dev/null 2>&1; then

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -399,7 +399,10 @@ check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 
 _python3_command() {
-    if command -v python3 >/dev/null 2>&1 &&
+    if [[ -n "${SPECKIT_PYTHON:-}" ]] && command -v "$SPECKIT_PYTHON" >/dev/null 2>&1 &&
+        "$SPECKIT_PYTHON" -c 'import sys; raise SystemExit(sys.version_info.major != 3)' >/dev/null 2>&1; then
+        printf '%s\n' "$SPECKIT_PYTHON"
+    elif command -v python3 >/dev/null 2>&1 &&
         python3 -c 'import sys; raise SystemExit(sys.version_info.major != 3)' >/dev/null 2>&1; then
         printf '%s\n' "python3"
     elif command -v python >/dev/null 2>&1 &&

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -411,7 +411,7 @@ _python3_command() {
         printf '%s\n' "python"
     elif command -v py >/dev/null 2>&1 &&
         py -3 -c 'import sys' >/dev/null 2>&1; then
-        printf '%s\n' "py -3"
+        printf '%s\n' "py" "-3"
     else
         return 1
     fi
@@ -419,10 +419,9 @@ _python3_command() {
 
 _sorted_extension_ids() {
     local ext_dir="$1"
-    local python_spec
-    if python_spec=$(_python3_command); then
-        local -a python_cmd
-        read -r -a python_cmd <<< "$python_spec"
+    local -a python_cmd=()
+    mapfile -t python_cmd < <(_python3_command)
+    if [ "${#python_cmd[@]}" -gt 0 ]; then
         local py_stderr sorted_ids
         py_stderr=$(mktemp)
         if sorted_ids=$(SPECKIT_EXTENSIONS="$ext_dir" "${python_cmd[@]}" -c "
@@ -517,11 +516,8 @@ resolve_template() {
     local presets_dir="$repo_root/.specify/presets"
     if [ -d "$presets_dir" ]; then
         local registry_file="$presets_dir/.registry"
-        local python_spec=""
         local -a python_cmd=()
-        if python_spec=$(_python3_command); then
-            read -r -a python_cmd <<< "$python_spec"
-        fi
+        mapfile -t python_cmd < <(_python3_command)
         if [ -f "$registry_file" ] && [ "${#python_cmd[@]}" -gt 0 ]; then
             # Read preset IDs sorted by priority (lower number = higher precedence).
             # The python3 call is wrapped in an if-condition so that set -e does not
@@ -640,11 +636,8 @@ resolve_template_content() {
         local registry_file="$presets_dir/.registry"
         local sorted_presets=""
         local registry_parsed=false
-        local python_spec=""
         local -a python_cmd=()
-        if python_spec=$(_python3_command); then
-            read -r -a python_cmd <<< "$python_spec"
-        fi
+        mapfile -t python_cmd < <(_python3_command)
         if [ -f "$registry_file" ] && [ "${#python_cmd[@]}" -gt 0 ]; then
             if sorted_presets=$(SPECKIT_REGISTRY="$registry_file" "${python_cmd[@]}" -c "
 import json, re, sys, os

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -420,7 +420,10 @@ _python3_command() {
 _sorted_extension_ids() {
     local ext_dir="$1"
     local -a python_cmd=()
-    mapfile -t python_cmd < <(_python3_command)
+    local _python_cmd_line
+    while IFS= read -r _python_cmd_line; do
+        python_cmd+=("$_python_cmd_line")
+    done < <(_python3_command)
     if [ "${#python_cmd[@]}" -gt 0 ]; then
         local py_stderr sorted_ids
         py_stderr=$(mktemp)
@@ -517,7 +520,10 @@ resolve_template() {
     if [ -d "$presets_dir" ]; then
         local registry_file="$presets_dir/.registry"
         local -a python_cmd=()
-        mapfile -t python_cmd < <(_python3_command)
+        local _python_cmd_line
+        while IFS= read -r _python_cmd_line; do
+            python_cmd+=("$_python_cmd_line")
+        done < <(_python3_command)
         if [ -f "$registry_file" ] && [ "${#python_cmd[@]}" -gt 0 ]; then
             # Read preset IDs sorted by priority (lower number = higher precedence).
             # The python3 call is wrapped in an if-condition so that set -e does not
@@ -637,7 +643,10 @@ resolve_template_content() {
         local sorted_presets=""
         local registry_parsed=false
         local -a python_cmd=()
-        mapfile -t python_cmd < <(_python3_command)
+        local _python_cmd_line
+        while IFS= read -r _python_cmd_line; do
+            python_cmd+=("$_python_cmd_line")
+        done < <(_python3_command)
         if [ -f "$registry_file" ] && [ "${#python_cmd[@]}" -gt 0 ]; then
             if sorted_presets=$(SPECKIT_REGISTRY="$registry_file" "${python_cmd[@]}" -c "
 import json, re, sys, os

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -320,6 +320,10 @@ function Format-SpecKitCommand {
 # Find a usable Python 3 executable (python3, python, or py -3).
 # Returns the command/arguments as an array, or $null if none found.
 function Get-Python3Command {
+    if ($env:SPECKIT_PYTHON -and (Get-Command $env:SPECKIT_PYTHON -ErrorAction SilentlyContinue)) {
+        $ver = & $env:SPECKIT_PYTHON --version 2>&1
+        if ($ver -match 'Python 3') { return @($env:SPECKIT_PYTHON) }
+    }
     if (Get-Command python3 -ErrorAction SilentlyContinue) { return @('python3') }
     if (Get-Command python -ErrorAction SilentlyContinue) {
         $ver = & python --version 2>&1

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -322,7 +322,10 @@ function Format-SpecKitCommand {
 function Get-Python3Command {
     if ($env:SPECKIT_PYTHON -and (Get-Command $env:SPECKIT_PYTHON -ErrorAction SilentlyContinue)) {
         $ver = & $env:SPECKIT_PYTHON --version 2>&1
-        if ($ver -match 'Python 3') { return @($env:SPECKIT_PYTHON) }
+        if ($ver -match 'Python 3') {
+            & $env:SPECKIT_PYTHON -c 'import yaml' *> $null
+            if ($LASTEXITCODE -eq 0) { return @($env:SPECKIT_PYTHON) }
+        }
     }
     if (Get-Command python3 -ErrorAction SilentlyContinue) { return @('python3') }
     if (Get-Command python -ErrorAction SilentlyContinue) {

--- a/scripts/python/common.py
+++ b/scripts/python/common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -380,6 +381,76 @@ def _validate_manifest_template_entry(entry: object) -> None:
         )
 
 
+class _DelegatedYAMLError(Exception):
+    """Raised when a SPECKIT_PYTHON-delegated manifest parse fails."""
+
+
+class _DelegatedYAML:
+    """``yaml.safe_load`` proxy that shells out to SPECKIT_PYTHON.
+
+    Used when this interpreter lacks PyYAML but SPECKIT_PYTHON names one
+    that has it (e.g. a `uv tool install` / `pipx` venv invisible to the
+    bare `python3` a script is launched with). See #4443.
+    """
+
+    YAMLError = _DelegatedYAMLError
+
+    def __init__(self, python_exe: str) -> None:
+        self._python_exe = python_exe
+
+    def safe_load(self, text: str) -> object:
+        try:
+            proc = subprocess.run(
+                [
+                    self._python_exe,
+                    "-c",
+                    "import sys, json, yaml; "
+                    "json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout)",
+                ],
+                input=text,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise _DelegatedYAMLError(
+                f"SPECKIT_PYTHON could not parse the manifest: {exc}"
+            ) from exc
+        if proc.returncode != 0:
+            raise _DelegatedYAMLError(
+                proc.stderr.strip() or "SPECKIT_PYTHON could not parse the manifest"
+            )
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise _DelegatedYAMLError(
+                f"SPECKIT_PYTHON returned invalid JSON: {exc}"
+            ) from exc
+
+
+def _import_yaml() -> object | None:
+    """Import PyYAML, delegating to SPECKIT_PYTHON if this interpreter lacks it."""
+    try:
+        import yaml
+
+        return yaml
+    except ImportError:
+        pass
+
+    python_override = os.environ.get("SPECKIT_PYTHON")
+    if not python_override:
+        return None
+    try:
+        probe = subprocess.run(
+            [python_override, "-c", "import yaml"], capture_output=True, timeout=10
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if probe.returncode != 0:
+        return None
+    return _DelegatedYAML(python_override)
+
+
 def _preset_template_layer(
     preset_dir: Path, template_name: str
 ) -> tuple[Path, str] | None:
@@ -387,13 +458,12 @@ def _preset_template_layer(
     manifest_path = preset_dir / "preset.yml"
     conventional = _conventional_template(preset_dir, template_name)
 
-    try:
-        import yaml
-    except ImportError as exc:
+    yaml = _import_yaml()
+    if yaml is None:
         if manifest_path.is_file():
             raise TemplateResolutionError(
                 "PyYAML is required to resolve preset template composition"
-            ) from exc
+            )
         return (conventional, "replace") if conventional is not None else None
 
     if manifest_path.is_file():

--- a/scripts/python/common.py
+++ b/scripts/python/common.py
@@ -430,7 +430,21 @@ class _DelegatedYAML:
                     "import sys, json, yaml\n"
                     "def _default(value):\n"
                     f"    return {{'{_NON_NATIVE_MARKER_KEY}': True}}\n"
-                    "json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout, default=_default)",
+                    "def _stringify_keys(obj):\n"
+                    "    if isinstance(obj, dict):\n"
+                    "        return {\n"
+                    "            (k if isinstance(k, (str, int, float, bool)) or k is None else str(k)): _stringify_keys(v)\n"
+                    "            for k, v in obj.items()\n"
+                    "        }\n"
+                    "    if isinstance(obj, list):\n"
+                    "        return [_stringify_keys(v) for v in obj]\n"
+                    "    return obj\n"
+                    "try:\n"
+                    "    data = yaml.safe_load(sys.stdin.read())\n"
+                    "except yaml.YAMLError as exc:\n"
+                    "    print(str(exc), file=sys.stderr)\n"
+                    "    sys.exit(1)\n"
+                    "json.dump(_stringify_keys(data), sys.stdout, default=_default)",
                 ],
                 input=text,
                 capture_output=True,

--- a/scripts/python/common.py
+++ b/scripts/python/common.py
@@ -385,6 +385,28 @@ class _DelegatedYAMLError(Exception):
     """Raised when a SPECKIT_PYTHON-delegated manifest parse fails."""
 
 
+class _NonNativeYAMLValue:
+    """Marker for a YAML value with no native JSON equivalent (e.g. a date).
+
+    Preserves the fact that native ``yaml.safe_load`` would not have produced
+    a string/int/etc. here, so callers validating field types (e.g. that
+    ``file`` is a string) reject it the same way the in-process parser would,
+    instead of silently accepting a stringified value.
+    """
+
+    def __repr__(self) -> str:
+        return "<non-native YAML value>"
+
+
+_NON_NATIVE_MARKER_KEY = "$speckit_non_native"
+
+
+def _delegated_yaml_object_hook(obj: dict) -> object:
+    if len(obj) == 1 and obj.get(_NON_NATIVE_MARKER_KEY) is True:
+        return _NonNativeYAMLValue()
+    return obj
+
+
 class _DelegatedYAML:
     """``yaml.safe_load`` proxy that shells out to SPECKIT_PYTHON.
 
@@ -399,17 +421,21 @@ class _DelegatedYAML:
         self._python_exe = python_exe
 
     def safe_load(self, text: str) -> object:
+        child_env = dict(os.environ, PYTHONIOENCODING="utf-8")
         try:
             proc = subprocess.run(
                 [
                     self._python_exe,
                     "-c",
-                    "import sys, json, yaml; "
-                    "json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout, default=str)",
+                    "import sys, json, yaml\n"
+                    "def _default(value):\n"
+                    f"    return {{'{_NON_NATIVE_MARKER_KEY}': True}}\n"
+                    "json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout, default=_default)",
                 ],
                 input=text,
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
+                env=child_env,
                 timeout=10,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
@@ -421,7 +447,7 @@ class _DelegatedYAML:
                 proc.stderr.strip() or "SPECKIT_PYTHON could not parse the manifest"
             )
         try:
-            return json.loads(proc.stdout)
+            return json.loads(proc.stdout, object_hook=_delegated_yaml_object_hook)
         except json.JSONDecodeError as exc:
             raise _DelegatedYAMLError(
                 f"SPECKIT_PYTHON returned invalid JSON: {exc}"

--- a/scripts/python/common.py
+++ b/scripts/python/common.py
@@ -405,7 +405,7 @@ class _DelegatedYAML:
                     self._python_exe,
                     "-c",
                     "import sys, json, yaml; "
-                    "json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout)",
+                    "json.dump(yaml.safe_load(sys.stdin.read()), sys.stdout, default=str)",
                 ],
                 input=text,
                 capture_output=True,

--- a/scripts/python/common.py
+++ b/scripts/python/common.py
@@ -430,14 +430,20 @@ class _DelegatedYAML:
                     "import sys, json, yaml\n"
                     "def _default(value):\n"
                     f"    return {{'{_NON_NATIVE_MARKER_KEY}': True}}\n"
-                    "def _stringify_keys(obj):\n"
+                    "def _stringify_keys(obj, seen=None):\n"
+                    "    if seen is None:\n"
+                    "        seen = set()\n"
+                    "    if isinstance(obj, (dict, list)):\n"
+                    "        if id(obj) in seen:\n"
+                    f"            return {{'{_NON_NATIVE_MARKER_KEY}': True}}\n"
+                    "        seen.add(id(obj))\n"
                     "    if isinstance(obj, dict):\n"
                     "        return {\n"
-                    "            (k if isinstance(k, (str, int, float, bool)) or k is None else str(k)): _stringify_keys(v)\n"
+                    "            (k if isinstance(k, (str, int, float, bool)) or k is None else str(k)): _stringify_keys(v, seen)\n"
                     "            for k, v in obj.items()\n"
                     "        }\n"
                     "    if isinstance(obj, list):\n"
-                    "        return [_stringify_keys(v) for v in obj]\n"
+                    "        return [_stringify_keys(v, seen) for v in obj]\n"
                     "    return obj\n"
                     "try:\n"
                     "    data = yaml.safe_load(sys.stdin.read())\n"
@@ -482,7 +488,13 @@ def _import_yaml() -> object | None:
         return None
     try:
         probe = subprocess.run(
-            [python_override, "-c", "import yaml"], capture_output=True, timeout=10
+            [
+                python_override,
+                "-c",
+                "import sys, yaml\nraise SystemExit(sys.version_info.major != 3)",
+            ],
+            capture_output=True,
+            timeout=10,
         )
     except (OSError, subprocess.TimeoutExpired):
         return None

--- a/tests/parity_helpers.py
+++ b/tests/parity_helpers.py
@@ -82,6 +82,13 @@ def clean_env() -> dict[str, str]:
     return env
 
 
+def venv_python3_exe(venv_dir: Path) -> Path:
+    """Path to the python3 executable of a venv created with ``--without-pip``."""
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python3"
+
+
 def collation_range_locale() -> str | None:
     """A locale whose ``[a-z]`` bracket range is collation-ordered, or ``None``.
 

--- a/tests/test_resolve_template_python_parity.py
+++ b/tests/test_resolve_template_python_parity.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -646,6 +648,58 @@ def test_all_variants_fail_when_yaml_parser_is_unavailable(
 
     assert all(result.returncode != 0 for result in results)
     assert all(result.stdout == "" for result in results)
+
+
+@requires_bash
+def test_all_variants_honor_speckit_python_override_when_yaml_missing(
+    tmp_path: Path,
+) -> None:
+    """SPECKIT_PYTHON can name an interpreter with PyYAML when the default
+    one lacks it, e.g. a `uv tool install` venv invisible to bare `python3`
+    on PATH (#4443)."""
+    repo, expected = _setup_repo(tmp_path)
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
+        check=True,
+        capture_output=True,
+    )
+    no_yaml_bin = no_yaml_python / "bin"
+    no_yaml_exe = no_yaml_bin / "python3"
+    assert no_yaml_exe.is_file()
+
+    py_script = repo / ".specify" / "scripts" / "python" / "resolve_template.py"
+
+    baseline_env = clean_env()
+    baseline_env["PATH"] = f"{no_yaml_bin}{os.pathsep}{baseline_env.get('PATH', '')}"
+    baseline_results = [
+        run(bash_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo, baseline_env),
+        run([str(no_yaml_exe), str(py_script), TEMPLATE, "--json"], repo, baseline_env),
+    ]
+    if HAS_POWERSHELL:
+        baseline_results.append(
+            run(ps_cmd(repo, SCRIPT, TEMPLATE, "-Json"), repo, baseline_env)
+        )
+    assert all(result.returncode != 0 for result in baseline_results)
+
+    override_env = dict(baseline_env)
+    override_env["SPECKIT_PYTHON"] = sys.executable
+    override_results = [
+        run(bash_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo, override_env),
+        run([str(no_yaml_exe), str(py_script), TEMPLATE, "--json"], repo, override_env),
+    ]
+    if HAS_POWERSHELL:
+        override_results.append(
+            run(ps_cmd(repo, SCRIPT, TEMPLATE, "-Json"), repo, override_env)
+        )
+
+    assert all(result.returncode == 0 for result in override_results)
+    assert all(
+        json_stdout(result)
+        == {"TEMPLATE_NAME": TEMPLATE, "TEMPLATE_CONTENT": expected}
+        for result in override_results
+    )
 
 
 @requires_bash

--- a/tests/test_resolve_template_python_parity.py
+++ b/tests/test_resolve_template_python_parity.py
@@ -703,6 +703,46 @@ def test_all_variants_honor_speckit_python_override_when_yaml_missing(
 
 
 @requires_bash
+def test_all_variants_fall_back_when_speckit_python_lacks_pyyaml(
+    tmp_path: Path,
+) -> None:
+    """SPECKIT_PYTHON naming a Python-3 interpreter without PyYAML must not
+    break composition that a PATH interpreter can already serve.
+
+    SPECKIT_PYTHON is an override for *expanding* what's available (#4443),
+    not a way to narrow it: falling through to a working PATH interpreter
+    when the override lacks PyYAML must behave the same as if SPECKIT_PYTHON
+    had never been set.
+    """
+    repo, expected = _setup_repo(tmp_path)
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
+        check=True,
+        capture_output=True,
+    )
+    no_yaml_exe = no_yaml_python / "bin" / "python3"
+    assert no_yaml_exe.is_file()
+
+    env = clean_env()
+    env["SPECKIT_PYTHON"] = str(no_yaml_exe)
+
+    results = [
+        run(bash_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo, env),
+    ]
+    if HAS_POWERSHELL:
+        results.append(run(ps_cmd(repo, SCRIPT, TEMPLATE, "-Json"), repo, env))
+
+    assert all(result.returncode == 0 for result in results)
+    assert all(
+        json_stdout(result)
+        == {"TEMPLATE_NAME": TEMPLATE, "TEMPLATE_CONTENT": expected}
+        for result in results
+    )
+
+
+@requires_bash
 def test_bash_fails_when_override_read_fails(tmp_path: Path) -> None:
     repo = make_repo(tmp_path)
     install_scripts(repo, SCRIPT)

--- a/tests/test_resolve_template_python_parity.py
+++ b/tests/test_resolve_template_python_parity.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts.python import common as python_common
 from tests.conftest import requires_bash
 from tests.parity_helpers import (
     HAS_POWERSHELL,
@@ -750,9 +751,13 @@ def test_bash_honors_speckit_python_path_containing_spaces(tmp_path: Path) -> No
     named "tool env"); callers must treat it as one argv element rather than
     splitting it on whitespace (#4445).
 
-    A symlink to `sys.executable` guarantees the spaced path actually has
-    PyYAML (rather than relying on `--system-site-packages` inheritance,
-    which does not reach a calling venv's own site-packages). PATH's
+    A shim script that execs `sys.executable` guarantees the spaced path
+    actually has PyYAML: a symlink would not do, since `sys.executable` may
+    itself be a venv-relative symlink (e.g. under `uv run`), and invoking it
+    through a second symlink placed outside that venv's directory tree
+    breaks Python's `pyvenv.cfg` discovery, silently hiding the venv's
+    site-packages (and PyYAML with it). Exec'ing the real path from a shim
+    keeps `argv[0]` at its original, correctly-resolvable location. PATH's
     `python3` is a PyYAML-less venv, so success is only possible if
     `_python3_command` selects the spaced override intact.
     """
@@ -761,7 +766,8 @@ def test_bash_honors_speckit_python_path_containing_spaces(tmp_path: Path) -> No
     spaced_dir = tmp_path / "tool env"
     spaced_dir.mkdir()
     spaced_exe = spaced_dir / Path(sys.executable).name
-    spaced_exe.symlink_to(sys.executable)
+    spaced_exe.write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n')
+    spaced_exe.chmod(0o755)
 
     no_yaml_python = tmp_path / "no-yaml-venv"
     subprocess.run(
@@ -940,6 +946,66 @@ def test_python_variant_delegates_manifest_with_non_json_native_mapping_key(
         "TEMPLATE_NAME": TEMPLATE,
         "TEMPLATE_CONTENT": expected,
     }
+
+
+@requires_bash
+def test_python_variant_delegates_manifest_with_recursive_yaml_alias(
+    tmp_path: Path,
+) -> None:
+    """An ignored `metadata` mapping containing a self-referential YAML alias
+    (`&m {self: *m}`) must not break delegation: `yaml.safe_load` supports
+    this via a shared reference, so naive recursive serialization of the
+    same object forever revisits it and raises `RecursionError` instead of
+    ignoring the unused field the way the in-process parser does (#4445)."""
+    repo, expected = _setup_repo(tmp_path)
+
+    manifest = repo / ".specify" / "presets" / "wrap-pack" / "preset.yml"
+    manifest.write_text(
+        "metadata: &m\n  self: *m\n" + manifest.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
+        check=True,
+        capture_output=True,
+    )
+    no_yaml_exe = venv_python3_exe(no_yaml_python)
+    assert no_yaml_exe.is_file()
+
+    py_script = repo / ".specify" / "scripts" / "python" / "resolve_template.py"
+    env = clean_env()
+    env["SPECKIT_PYTHON"] = sys.executable
+
+    result = run([str(no_yaml_exe), str(py_script), TEMPLATE, "--json"], repo, env)
+
+    assert result.returncode == 0, result.stderr
+    assert json_stdout(result) == {
+        "TEMPLATE_NAME": TEMPLATE,
+        "TEMPLATE_CONTENT": expected,
+    }
+
+
+def test_python_variant_rejects_speckit_python_override_without_python_3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A `SPECKIT_PYTHON` override that can `import yaml` but is not a
+    Python 3 interpreter (e.g. Python 2 with PyYAML installed) must not be
+    accepted: probing only `import yaml` lets it through, and the later
+    delegated subprocess then fails with syntax/runtime errors instead of
+    falling back to a working interpreter (#4445)."""
+    monkeypatch.setitem(sys.modules, "yaml", None)
+    monkeypatch.setenv("SPECKIT_PYTHON", "/fake/python2")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        code = cmd[2]
+        returncode = 1 if "version_info" in code else 0
+        return subprocess.CompletedProcess(cmd, returncode)
+
+    monkeypatch.setattr(python_common.subprocess, "run", fake_run)
+
+    assert python_common._import_yaml() is None
 
 
 @requires_bash

--- a/tests/test_resolve_template_python_parity.py
+++ b/tests/test_resolve_template_python_parity.py
@@ -748,20 +748,32 @@ def test_all_variants_fall_back_when_speckit_python_lacks_pyyaml(
 def test_bash_honors_speckit_python_path_containing_spaces(tmp_path: Path) -> None:
     """SPECKIT_PYTHON may be an absolute path containing spaces (e.g. a venv
     named "tool env"); callers must treat it as one argv element rather than
-    splitting it on whitespace (#4445)."""
+    splitting it on whitespace (#4445).
+
+    A symlink to `sys.executable` guarantees the spaced path actually has
+    PyYAML (rather than relying on `--system-site-packages` inheritance,
+    which does not reach a calling venv's own site-packages). PATH's
+    `python3` is a PyYAML-less venv, so success is only possible if
+    `_python3_command` selects the spaced override intact.
+    """
     repo, expected = _setup_repo(tmp_path)
 
-    spaced_venv = tmp_path / "tool env"
+    spaced_dir = tmp_path / "tool env"
+    spaced_dir.mkdir()
+    spaced_exe = spaced_dir / Path(sys.executable).name
+    spaced_exe.symlink_to(sys.executable)
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
     subprocess.run(
-        [sys.executable, "-m", "venv", "--system-site-packages", str(spaced_venv)],
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
         check=True,
         capture_output=True,
     )
-    spaced_exe = venv_python3_exe(spaced_venv)
-    assert spaced_exe.is_file()
+    no_yaml_bin = venv_python3_exe(no_yaml_python).parent
 
     env = clean_env()
     env["SPECKIT_PYTHON"] = str(spaced_exe)
+    env["PATH"] = f"{no_yaml_bin}{os.pathsep}{env.get('PATH', '')}"
 
     result = run(bash_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo, env)
 
@@ -889,6 +901,78 @@ def test_python_variant_delegates_manifest_with_non_ascii_metadata_under_ascii_l
         "TEMPLATE_NAME": TEMPLATE,
         "TEMPLATE_CONTENT": expected,
     }
+
+
+@requires_bash
+def test_python_variant_delegates_manifest_with_non_json_native_mapping_key(
+    tmp_path: Path,
+) -> None:
+    """An otherwise-ignored mapping whose key PyYAML parses into a
+    non-JSON-native type (e.g. an unquoted date) must not break delegation:
+    `json.dump`'s `default` hook only applies to values, never to keys, so
+    such a key must be stringified before serialization instead of raising
+    `TypeError` (#4445)."""
+    repo, expected = _setup_repo(tmp_path)
+
+    manifest = repo / ".specify" / "presets" / "wrap-pack" / "preset.yml"
+    manifest.write_text(
+        "metadata:\n  2026-09-08: value\n" + manifest.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
+        check=True,
+        capture_output=True,
+    )
+    no_yaml_exe = venv_python3_exe(no_yaml_python)
+    assert no_yaml_exe.is_file()
+
+    py_script = repo / ".specify" / "scripts" / "python" / "resolve_template.py"
+    env = clean_env()
+    env["SPECKIT_PYTHON"] = sys.executable
+
+    result = run([str(no_yaml_exe), str(py_script), TEMPLATE, "--json"], repo, env)
+
+    assert result.returncode == 0, result.stderr
+    assert json_stdout(result) == {
+        "TEMPLATE_NAME": TEMPLATE,
+        "TEMPLATE_CONTENT": expected,
+    }
+
+
+@requires_bash
+def test_python_variant_reports_concise_error_for_malformed_delegated_manifest(
+    tmp_path: Path,
+) -> None:
+    """A syntactically invalid manifest parsed via delegation must fail with
+    a concise message, matching the in-process parser, instead of leaking
+    the child interpreter's raw Python traceback into the user-facing
+    error (#4445)."""
+    repo, _ = _setup_repo(tmp_path)
+
+    manifest = repo / ".specify" / "presets" / "wrap-pack" / "preset.yml"
+    manifest.write_text("provides: [\n", encoding="utf-8")
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
+        check=True,
+        capture_output=True,
+    )
+    no_yaml_exe = venv_python3_exe(no_yaml_python)
+    assert no_yaml_exe.is_file()
+
+    py_script = repo / ".specify" / "scripts" / "python" / "resolve_template.py"
+    env = clean_env()
+    env["SPECKIT_PYTHON"] = sys.executable
+
+    result = run([str(no_yaml_exe), str(py_script), TEMPLATE, "--json"], repo, env)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "Traceback" not in result.stderr
 
 
 @requires_bash

--- a/tests/test_resolve_template_python_parity.py
+++ b/tests/test_resolve_template_python_parity.py
@@ -810,6 +810,111 @@ def test_python_variant_delegates_manifest_with_non_json_native_yaml_value(
 
 
 @requires_bash
+def test_python_variant_rejects_delegated_manifest_with_non_string_validated_field(
+    tmp_path: Path,
+) -> None:
+    """A validated field (``file``) holding a value PyYAML parses into a
+    non-JSON-native type (e.g. an unquoted date) must be rejected via
+    delegation exactly as the in-process parser rejects it, not silently
+    coerced to a string that passes the ``isinstance(str)`` check (#4445)."""
+    repo, _ = _setup_repo(tmp_path)
+
+    manifest = repo / ".specify" / "presets" / "wrap-pack" / "preset.yml"
+    manifest.write_text(
+        "provides:\n"
+        "  templates:\n"
+        "    - type: template\n"
+        f"      name: {TEMPLATE}\n"
+        "      file: 2026-09-08\n"
+        "      strategy: wrap\n",
+        encoding="utf-8",
+    )
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
+        check=True,
+        capture_output=True,
+    )
+    no_yaml_exe = venv_python3_exe(no_yaml_python)
+    assert no_yaml_exe.is_file()
+
+    py_script = repo / ".specify" / "scripts" / "python" / "resolve_template.py"
+    env = clean_env()
+    env["SPECKIT_PYTHON"] = sys.executable
+
+    result = run([str(no_yaml_exe), str(py_script), TEMPLATE, "--json"], repo, env)
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+@requires_bash
+def test_python_variant_delegates_manifest_with_non_ascii_metadata_under_ascii_locale(
+    tmp_path: Path,
+) -> None:
+    """Delegated manifest parsing must force UTF-8 on the subprocess pipe and
+    the child's own stdio, not the process locale, so non-ASCII metadata in a
+    manifest still resolves when this interpreter lacks PyYAML and the
+    process is running under a forced ASCII locale (#4445)."""
+    repo, expected = _setup_repo(tmp_path)
+
+    manifest = repo / ".specify" / "presets" / "wrap-pack" / "preset.yml"
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8") + '      description: "Café ✓"\n',
+        encoding="utf-8",
+    )
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
+        check=True,
+        capture_output=True,
+    )
+    no_yaml_exe = venv_python3_exe(no_yaml_python)
+    assert no_yaml_exe.is_file()
+
+    py_script = repo / ".specify" / "scripts" / "python" / "resolve_template.py"
+    env = clean_env()
+    env["SPECKIT_PYTHON"] = sys.executable
+    env["PYTHONUTF8"] = "0"
+    env["PYTHONCOERCECLOCALE"] = "0"
+    env["LC_ALL"] = "C"
+    env["LANG"] = "C"
+
+    result = run([str(no_yaml_exe), str(py_script), TEMPLATE, "--json"], repo, env)
+
+    assert result.returncode == 0, result.stderr
+    assert json_stdout(result) == {
+        "TEMPLATE_NAME": TEMPLATE,
+        "TEMPLATE_CONTENT": expected,
+    }
+
+
+@requires_bash
+def test_bash_resolves_composed_template_without_bash4_mapfile_builtin(
+    tmp_path: Path,
+) -> None:
+    """`resolve_template_content` must not rely on `mapfile`, a Bash 4+
+    builtin unavailable on macOS's system Bash 3.2 (#4445). Disabling the
+    builtin for this process reproduces that environment without requiring
+    an actual Bash 3.2 install."""
+    repo, expected = _setup_repo(tmp_path)
+
+    script = repo / ".specify" / "scripts" / "bash" / f"{SCRIPT}.sh"
+    result = run(
+        ["bash", "-c", 'enable -n mapfile; source "$0" "$@"', str(script), TEMPLATE, "--json"],
+        repo,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json_stdout(result) == {
+        "TEMPLATE_NAME": TEMPLATE,
+        "TEMPLATE_CONTENT": expected,
+    }
+
+
+@requires_bash
 def test_bash_fails_when_override_read_fails(tmp_path: Path) -> None:
     repo = make_repo(tmp_path)
     install_scripts(repo, SCRIPT)

--- a/tests/test_resolve_template_python_parity.py
+++ b/tests/test_resolve_template_python_parity.py
@@ -22,6 +22,7 @@ from tests.parity_helpers import (
     ps_cmd,
     py_cmd,
     run,
+    venv_python3_exe,
 )
 
 SCRIPT = "resolve-template"
@@ -665,13 +666,14 @@ def test_all_variants_honor_speckit_python_override_when_yaml_missing(
         check=True,
         capture_output=True,
     )
-    no_yaml_bin = no_yaml_python / "bin"
-    no_yaml_exe = no_yaml_bin / "python3"
+    no_yaml_exe = venv_python3_exe(no_yaml_python)
+    no_yaml_bin = no_yaml_exe.parent
     assert no_yaml_exe.is_file()
 
     py_script = repo / ".specify" / "scripts" / "python" / "resolve_template.py"
 
     baseline_env = clean_env()
+    baseline_env.pop("SPECKIT_PYTHON", None)
     baseline_env["PATH"] = f"{no_yaml_bin}{os.pathsep}{baseline_env.get('PATH', '')}"
     baseline_results = [
         run(bash_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo, baseline_env),
@@ -722,7 +724,7 @@ def test_all_variants_fall_back_when_speckit_python_lacks_pyyaml(
         check=True,
         capture_output=True,
     )
-    no_yaml_exe = no_yaml_python / "bin" / "python3"
+    no_yaml_exe = venv_python3_exe(no_yaml_python)
     assert no_yaml_exe.is_file()
 
     env = clean_env()
@@ -740,6 +742,71 @@ def test_all_variants_fall_back_when_speckit_python_lacks_pyyaml(
         == {"TEMPLATE_NAME": TEMPLATE, "TEMPLATE_CONTENT": expected}
         for result in results
     )
+
+
+@requires_bash
+def test_bash_honors_speckit_python_path_containing_spaces(tmp_path: Path) -> None:
+    """SPECKIT_PYTHON may be an absolute path containing spaces (e.g. a venv
+    named "tool env"); callers must treat it as one argv element rather than
+    splitting it on whitespace (#4445)."""
+    repo, expected = _setup_repo(tmp_path)
+
+    spaced_venv = tmp_path / "tool env"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--system-site-packages", str(spaced_venv)],
+        check=True,
+        capture_output=True,
+    )
+    spaced_exe = venv_python3_exe(spaced_venv)
+    assert spaced_exe.is_file()
+
+    env = clean_env()
+    env["SPECKIT_PYTHON"] = str(spaced_exe)
+
+    result = run(bash_cmd(repo, SCRIPT, TEMPLATE, "--json"), repo, env)
+
+    assert result.returncode == 0, result.stderr
+    assert json_stdout(result) == {
+        "TEMPLATE_NAME": TEMPLATE,
+        "TEMPLATE_CONTENT": expected,
+    }
+
+
+@requires_bash
+def test_python_variant_delegates_manifest_with_non_json_native_yaml_value(
+    tmp_path: Path,
+) -> None:
+    """A manifest holding a value PyYAML parses into a non-JSON-native type
+    (e.g. an unquoted date) must still resolve when the Python twin delegates
+    parsing to SPECKIT_PYTHON because its own interpreter lacks PyYAML."""
+    repo, expected = _setup_repo(tmp_path)
+
+    manifest = repo / ".specify" / "presets" / "wrap-pack" / "preset.yml"
+    manifest.write_text(
+        "created_at: 2026-09-08\n" + manifest.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    no_yaml_python = tmp_path / "no-yaml-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(no_yaml_python)],
+        check=True,
+        capture_output=True,
+    )
+    no_yaml_exe = venv_python3_exe(no_yaml_python)
+    assert no_yaml_exe.is_file()
+
+    py_script = repo / ".specify" / "scripts" / "python" / "resolve_template.py"
+    env = clean_env()
+    env["SPECKIT_PYTHON"] = sys.executable
+
+    result = run([str(no_yaml_exe), str(py_script), TEMPLATE, "--json"], repo, env)
+
+    assert result.returncode == 0, result.stderr
+    assert json_stdout(result) == {
+        "TEMPLATE_NAME": TEMPLATE,
+        "TEMPLATE_CONTENT": expected,
+    }
 
 
 @requires_bash


### PR DESCRIPTION
## Summary

Fixes #4443.

Preset composition raises `PyYAML is required to resolve preset template
composition` whenever the resolve/setup scripts are invoked under a bare
`python3` that lacks PyYAML, while a `uv tool install` / `pipx`-isolated
CLI venv (which *does* have PyYAML, per `pyproject.toml`) is invisible to
that bare interpreter. This happens both when the bash/PowerShell twins
shell out to Python to parse a `preset.yml` manifest, and when the Python
twin (`resolve_template.py` / `setup_plan.py` / etc., via `common.py`)
tries to `import yaml` directly in its own process.

`SPECKIT_PYTHON` is already the established override for exactly this class
of problem elsewhere in the codebase (see
`extensions/agent-context/scripts/bash/update-agent-context.sh` and its
tests). This PR extends that same override to the three
template-resolution twins:

- `scripts/bash/common.sh`: `_python3_command()` now prefers `SPECKIT_PYTHON`
  (verified to be a working Python 3 interpreter *that also has PyYAML*)
  before falling back to `python3` / `python` / `py -3` on PATH.
- `scripts/powershell/common.ps1`: `Get-Python3Command` does the same.
- `scripts/python/common.py`: since this twin runs *in-process* rather than
  shelling out, `_preset_template_layer` now tries `import yaml` first and,
  if that fails, delegates manifest parsing to `SPECKIT_PYTHON` via a small
  subprocess-based `safe_load`/`YAMLError` shim (`_import_yaml` /
  `_DelegatedYAML`) so the rest of the function's logic is unchanged.

No dependencies, lockfiles, or CI config were touched — `pyyaml` was already
a declared dependency; this only fixes which interpreter picks it up.

**Update:** an earlier revision of this PR let the bash/PowerShell twins
adopt `SPECKIT_PYTHON` as soon as it resolved to *any* Python 3 interpreter,
without checking it actually had PyYAML — unlike the precedent this PR
cites, which validates both. That meant a `SPECKIT_PYTHON` set to a valid
but PyYAML-less interpreter (e.g. pinned for an unrelated reason) would
shadow a working `python3` on PATH and turn previously-succeeding preset
composition into a `PyYAML is required` failure. Both `_python3_command()`
and `Get-Python3Command` now also probe `import yaml` before accepting
`SPECKIT_PYTHON`, matching `update-agent-context.sh`'s candidate-validation
loop; if the probe fails they fall through to the existing `python3`/
`python`/`py -3` chain exactly as if `SPECKIT_PYTHON` were unset.

## Test plan

Added `test_all_variants_honor_speckit_python_override_when_yaml_missing` to
`tests/test_resolve_template_python_parity.py`. It creates a real
PyYAML-less interpreter (`python -m venv --without-pip`) and:
1. runs the bash and Python twins with that interpreter as the default
   `python3` and no `SPECKIT_PYTHON` set — asserts both fail (reproduces
   #4443), then
2. sets `SPECKIT_PYTHON` to the interpreter that has PyYAML — asserts both
   succeed and produce the correct composed template content.
(PowerShell is included in the same assertions when `pwsh` is available.)

Also added `test_all_variants_fall_back_when_speckit_python_lacks_pyyaml`,
covering the regression an earlier revision introduced: it sets
`SPECKIT_PYTHON` to a real Python-3 interpreter *without* PyYAML while
leaving PATH's own `python3` (which has PyYAML) untouched, and asserts
composition still succeeds via that PATH fallback across the bash and
PowerShell twins.

Confirmed both tests fail without their respective fixes:
- `test_all_variants_honor_speckit_python_override_when_yaml_missing`: with
  `git checkout HEAD~2 -- scripts/bash/common.sh
  scripts/powershell/common.ps1 scripts/python/common.py`, fails with
  `assert False` on the override-succeeds assertion.
- `test_all_variants_fall_back_when_speckit_python_lacks_pyyaml`: with only
  the latest commit's two files reverted (`git checkout HEAD~1 --
  scripts/bash/common.sh scripts/powershell/common.ps1`, i.e. the state the
  independent reviewer blocked), fails the same way — reproducing the
  reviewer's exact regression scenario.
Restored the fix in both cases and reran; both pass.

```
$ .venv/bin/python -m pytest tests/test_resolve_template_python_parity.py -q
============================= 42 passed in 39.14s ==============================

$ .venv/bin/python -m pytest tests/extensions/test_extension_agent_context.py -q
======================== 39 passed, 1 skipped in 10.62s ========================

$ .venv/bin/python -m pytest tests/ -q
========== 7706 passed, 12 skipped, 48 warnings in 416.00s (0:06:56) ===========

$ shellcheck --severity=error scripts/bash/common.sh
(no output, exit 0)

$ uvx ruff@0.15.0 check tests/test_resolve_template_python_parity.py src
All checks passed!
```

## AI disclosure

This PR was written by Claude Code, Anthropic's agentic coding CLI, based on
the issue's description and existing `SPECKIT_PYTHON` precedent in the
codebase. An independent reviewer agent blocked the first revision for
letting the bash/PowerShell twins honor `SPECKIT_PYTHON` without checking
it actually had PyYAML (a regression relative to the cited precedent); that
revision and subsequent review-response revisions fixed that gap and the
issues raised in later rounds, each adding a regression test reproducing
the specific issue and rerunning the full test suite, shellcheck, and ruff
before pushing.

The most recent revision (preserving non-recursive shared YAML aliases in
`_stringify_keys` while still catching true cycles) was generated by Claude
Code running Claude Sonnet 5 (model ID `claude-sonnet-5`). Earlier revisions
in this thread were also produced with Claude Code; the specific underlying
Claude model used for each of those earlier revisions was not recorded at
the time.

