### PR TITLE
[community] Update SpecAssay to v0.4.13 (extension, preset, bundle)

### DIFF
--- a/bundles/catalog.community.json
+++ b/bundles/catalog.community.json
@@ -34,12 +34,12 @@
     "specassay": {
       "name": "SpecAssay",
       "id": "specassay",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "role": "developer",
       "description": "Durable-ID promotion for stock Spec Kit: templates, Gate 2 refusal, and trace-manifest emission.",
       "author": "Rik Dryfoos",
       "license": "MIT",
-      "download_url": "https://github.com/rdryfoos/specassay/releases/download/v0.4.12/specassay-0.4.12.zip",
+      "download_url": "https://github.com/rdryfoos/specassay/releases/download/v0.4.13/specassay-0.4.13.zip",
       "repository": "https://github.com/rdryfoos/specassay",
       "requires": {
         "speckit_version": ">=0.14.0"

--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -4705,8 +4705,8 @@
       "id": "specassay-check",
       "description": "Gate 2 refuses silent gaps and emits a trace-manifest (`trace-manifest.json`).",
       "author": "Rik Dryfoos",
-      "version": "0.4.12",
-      "download_url": "https://github.com/rdryfoos/specassay/releases/download/v0.4.12/specassay-check-0.4.12.zip",
+      "version": "0.4.13",
+      "download_url": "https://github.com/rdryfoos/specassay/releases/download/v0.4.13/specassay-check-0.4.13.zip",
       "repository": "https://github.com/rdryfoos/specassay",
       "homepage": "https://www.specassay.com",
       "documentation": "https://github.com/rdryfoos/specassay/blob/main/extensions/specassay-check/README.md",
@@ -4729,7 +4729,7 @@
         ]
       },
       "provides": {
-        "commands": 2,
+        "commands": 5,
         "hooks": 1
       },
       "tags": [
@@ -4743,7 +4743,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-08-13T00:00:00Z",
-      "updated_at": "2026-08-21T00:00:00Z"
+      "updated_at": "2026-09-04T00:00:00Z"
     },
     "specjudge": {
       "name": "SpecJudge — right-size the model before you implement",

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -836,11 +836,11 @@
     "specassay": {
       "name": "SpecAssay",
       "id": "specassay",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "description": "Appends durable-ID, Carries, and SpecAssay vocabulary onto Spec Kit spec, tasks, and constitution templates.",
       "author": "Rik Dryfoos",
       "repository": "https://github.com/rdryfoos/specassay",
-      "download_url": "https://github.com/rdryfoos/specassay/releases/download/v0.4.12/specassay-preset-0.4.12.zip",
+      "download_url": "https://github.com/rdryfoos/specassay/releases/download/v0.4.13/specassay-preset-0.4.13.zip",
       "homepage": "https://github.com/rdryfoos/specassay",
       "documentation": "https://github.com/rdryfoos/specassay/blob/main/presets/specassay/README.md",
       "license": "MIT",
@@ -858,7 +858,7 @@
         "sdd"
       ],
       "created_at": "2026-08-14T00:00:00Z",
-      "updated_at": "2026-08-21T00:00:00Z"
+      "updated_at": "2026-09-04T00:00:00Z"
     },
     "test-first-governance": {
       "name": "Test-First Governance",


### PR DESCRIPTION
## Description

Version-bump for the three SpecAssay community catalog entries, from v0.4.12 to v0.4.13: `specassay-check` (extension), `specassay` (preset), and `specassay` (bundle). Same fields the previous update PRs changed (#4254, #4256, #4257): `version`, `download_url`, `updated_at`, plus the extension's `provides.commands` (2 to 5; the extension has shipped five commands since dig, matrix, and portfolio landed). All three move together in one PR because the bundle pins its component versions; bumping one entry alone would make `specify bundle install specassay` fail resolution.

Release: https://github.com/rdryfoos/specassay/releases/tag/v0.4.13 (tag `105c4845f8ae88f1af361d56c0de458089b50fad`, built and published by the repo's Release workflow). Asset digests, as reported by GitHub's release API and re-verified by download:

- `specassay-check-0.4.13.zip`: `sha256:d7ac14c271b99aff0b649def9c3444b6e03090649df43ea2b9c3949ded91ed9f`
- `specassay-preset-0.4.13.zip`: `sha256:ed4298d72b80f083400c0ac7bcbf9a3eb5d5950eb50abd542e8fc4b5b77d8a58`
- `specassay-0.4.13.zip`: `sha256:8529e8b7542a712542321856368b4f3d7f2f820f98350f7c7f7115670005f18d`

What v0.4.13 changes for a first-time installer, briefly: the Gate detects `python3` or `python` (Windows Git Bash works), reports its config state on startup, and explains what to do when the registry is empty instead of printing a bare OK. Full notes: https://github.com/rdryfoos/specassay/blob/main/CHANGELOG.md. The submission-form issues with the complete test evidence for this version will follow per the publishing guides; this PR is only the catalog pointer, so people installing from the community catalog stop landing on the version whose cold-install dead end v0.4.13 fixes.

## Testing

- [x] Clean `specify init` project, catalogs added install-allowed, `specify bundle install specassay` at 0.4.13: 2 components installed, `specify extension list` reports v0.4.13 with `Commands: 5 | Hooks: 1`.
- [x] Upgrade from a real v0.4.12 catalog install: `specify bundle update specassay` moves both components to v0.4.13 with the user's edited config preserved.
- [x] Full transcript with digests: https://github.com/rdryfoos/specassay/blob/main/docs/submission/test-evidence.md
- [ ] Tested locally with `uv run specify --help` (not applicable: JSON catalog data only)
- [ ] Ran existing tests with `uv sync && uv run pytest` (not applicable: JSON catalog data only)

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

Claude Code (Anthropic) prepared the JSON edits and this PR text under the maintainer's direction; the release, digests, and install tests were run and verified by the same session against the real CLI.
