### PR TITLE
fix(catalog): repoint speckit-inventory and inventory-alignment at live release artifacts

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -4790,9 +4790,9 @@
       "id": "speckit-inventory",
       "description": "Read-only inventory of live requirement and task IDs, with focused per-task context packs instead of whole-file dumps.",
       "author": "Yash Chindam",
-      "version": "0.1.0",
-      "download_url": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment/releases/download/v0.1.0/speckit-inventory.zip",
-      "sha256": "9ebf004ef6494323f6dccfab2554a04898c9e92bc7f25e0638b5aee916566e7f",
+      "version": "0.1.1",
+      "download_url": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment/releases/download/v0.1.1/speckit-inventory.zip",
+      "sha256": "df735fe7c7ca7afe1ac279ffe5768061a29710a9d61956f90ee2cf2d66da04be",
       "repository": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment",
       "homepage": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment",
       "documentation": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment/blob/main/speckit-inventory/README.md",
@@ -4818,7 +4818,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-08-20T00:00:00Z",
-      "updated_at": "2026-08-20T00:00:00Z"
+      "updated_at": "2026-09-05T00:00:00Z"
     },
     "speckit-superpowers-bridge": {
       "name": "Superpowers Implementation Bridge",

--- a/presets/catalog.community.json
+++ b/presets/catalog.community.json
@@ -488,17 +488,17 @@
     "inventory-alignment": {
       "name": "Inventory Alignment",
       "id": "inventory-alignment",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Classifies each requirement against a read-only inventory of live IDs before writing, so reworded requirements are updated instead of duplicated.",
       "author": "Yash Chindam",
       "repository": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment",
-      "download_url": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment/releases/download/v0.1.0/inventory-alignment.zip",
-      "sha256": "8ea62813aeb88d85001f54d91d8eceb011f5fb872bc764d5ea83e8e7ab92a2c1",
+      "download_url": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment/releases/download/v0.1.1/inventory-alignment.zip",
+      "sha256": "227db99a4c0626e8310f0116153929923a3f832b1b2d849231caeaff958b65a6",
       "homepage": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment",
       "documentation": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment/blob/main/inventory-alignment/README.md",
       "license": "MIT",
       "requires": {
-        "speckit_version": ">=0.9.0",
+        "speckit_version": ">=1.0.4",
         "extensions": [
           "speckit-inventory"
         ]
@@ -515,7 +515,7 @@
         "workflow"
       ],
       "created_at": "2026-08-20T00:00:00Z",
-      "updated_at": "2026-08-20T00:00:00Z"
+      "updated_at": "2026-09-05T00:00:00Z"
     },
     "isaqb-architecture-governance": {
       "name": "iSAQB Architecture Governance",


### PR DESCRIPTION
## Problem

Both community entries I submitted in #4226 and #4227 point at release assets under a repository that no longer exists:

```json
"download_url": "https://github.com/Yash-Chindam/spec-kit-inventory-alignment/releases/download/v0.1.0/speckit-inventory.zip"
```

`repository`, `homepage`, `documentation`, `changelog`, and `download_url` all 404. Installation fails at the download, before `verify_archive_sha256` is ever reached:

```
specify extension add speckit-inventory
specify preset add inventory-alignment
```

This is my fault, and I'm sorry it reached the catalog in that state.

## Fix

I've restored the source in a standalone repository and cut [v0.1.1](https://github.com/Yash-Chindam/spec-kit-inventory-alignment/releases/tag/v0.1.1). The v0.1.0 archives are **unrecoverable** — nothing reproduces their pinned digests — so v0.1.1 supersedes them and the pinned SHA-256 values change with it.

| Entry | Was | Now |
|---|---|---|
| `speckit-inventory` | `v0.1.0`, `9ebf004e…` | `v0.1.1`, `df735fe7…` |
| `inventory-alignment` | `v0.1.0`, `8ea62813…` | `v0.1.1`, `227db99a…` |

Release artifacts are built with sorted members, a fixed timestamp, and two canonical permission modes — mirroring `bundler/services/packager.py` — and `.gitattributes` pins `eol=lf` so a Windows checkout cannot yield a different digest. A clean clone reproduces both digests byte for byte.

## One correctness fix beyond the URLs

The preset entry declares `requires.extensions`, but claimed `speckit_version: ">=0.9.0"`. That floor is wrong: `requires.extensions` first shipped in **v1.0.4** (#4250) — `v1.0.3` has no `_validate_requires_extensions`, `v1.0.4` does. A v0.9 CLI would install the preset and ignore the dependency it declares, which is the exact silent-no-op failure #4250 set out to prevent. Raised to `>=1.0.4`.

## Verification

- Both `download_url`s return **HTTP 200**, and the downloaded bytes hash to the pinned `sha256` (checked against the live URLs, not local files).
- `CatalogEntry.from_dict()` parses both entries.
- `tests/contract/test_catalog_schema.py` — **45 passed**.
- Both bundle manifests validate against `PresetManifest` / `ExtensionManifest`, and the extension's own suite passes (9 tests).

Diff is 9 lines across the two catalogs; no other entry is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)