### PR TITLE
fix: preserve extension authors in generated skills

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -402,7 +402,7 @@ class CommandRegistrar:
         source_file: str,
         project_root: Path,
         extension_id: Optional[str] = None,
-        author: str = "github-spec-kit",
+        author: object = "github-spec-kit",
     ) -> str:
         """Render a command override as a SKILL.md file.
 
@@ -443,15 +443,18 @@ class CommandRegistrar:
         skill_name: str,
         description: str,
         source: str,
-        author: str = "github-spec-kit",
+        author: object = "github-spec-kit",
     ) -> dict:
         """Build consistent SKILL.md frontmatter across all skill generators."""
+        normalized_author = (
+            "github-spec-kit" if author is None or author == "" else str(author)
+        )
         skill_frontmatter = {
             "name": skill_name,
             "description": description,
             "compatibility": "Requires spec-kit project structure with .specify/ directory",
             "metadata": {
-                "author": author,
+                "author": normalized_author,
                 "source": source,
             },
         }
@@ -621,7 +624,7 @@ class CommandRegistrar:
         _resolved_dir: Optional[Path] = None,
         link_outputs: bool = False,
         extension_id: Optional[str] = None,
-        author: str = "github-spec-kit",
+        author: object = "github-spec-kit",
     ) -> List[str]:
         """Register commands for a specific agent.
 
@@ -1068,7 +1071,7 @@ class CommandRegistrar:
         create_missing_active_skills_dir: bool = False,
         extension_id: Optional[str] = None,
         only_agent: Optional[str] = None,
-        author: str = "github-spec-kit",
+        author: object = "github-spec-kit",
     ) -> Dict[str, List[str]]:
         """Register commands for all detected agents in the project.
 

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -178,6 +178,7 @@ class CommandRegistrar:
         Args:
             frontmatter: Frontmatter dictionary
             extension_id: Extension id when rendering extension-owned commands.
+            author: Author attributed in generated skill metadata.
 
         Returns:
             Modified frontmatter with normalized project paths
@@ -402,6 +403,7 @@ class CommandRegistrar:
         source_file: str,
         project_root: Path,
         extension_id: Optional[str] = None,
+        author: str = "github-spec-kit",
     ) -> str:
         """Render a command override as a SKILL.md file.
 
@@ -432,6 +434,7 @@ class CommandRegistrar:
             skill_name,
             description,
             f"{source_id}:{source_file}",
+            author=author,
         )
         return self.render_frontmatter(skill_frontmatter) + "\n" + body
 
@@ -441,6 +444,7 @@ class CommandRegistrar:
         skill_name: str,
         description: str,
         source: str,
+        author: str = "github-spec-kit",
     ) -> dict:
         """Build consistent SKILL.md frontmatter across all skill generators."""
         skill_frontmatter = {
@@ -448,7 +452,7 @@ class CommandRegistrar:
             "description": description,
             "compatibility": "Requires spec-kit project structure with .specify/ directory",
             "metadata": {
-                "author": "github-spec-kit",
+                "author": author,
                 "source": source,
             },
         }
@@ -618,6 +622,7 @@ class CommandRegistrar:
         _resolved_dir: Optional[Path] = None,
         link_outputs: bool = False,
         extension_id: Optional[str] = None,
+        author: str = "github-spec-kit",
     ) -> List[str]:
         """Register commands for a specific agent.
 
@@ -636,6 +641,7 @@ class CommandRegistrar:
                 dev cache and symlink the agent command file to it. Falls back
                 to a normal file write when symlinks are unavailable.
             extension_id: Extension id when rendering extension-owned commands.
+            author: Author attributed in generated skill metadata.
 
         Returns:
             List of registered command names
@@ -802,6 +808,7 @@ class CommandRegistrar:
                     cmd_file,
                     project_root,
                     extension_id=extension_id,
+                    author=author,
                 )
             elif agent_config["format"] == "markdown":
                 body = self.resolve_skill_placeholders(
@@ -888,6 +895,7 @@ class CommandRegistrar:
                             cmd_file,
                             project_root,
                             extension_id=extension_id,
+                            author=author,
                         )
                     elif agent_config["format"] == "markdown":
                         alias_output = self.render_markdown_command(
@@ -921,6 +929,7 @@ class CommandRegistrar:
                             cmd_file,
                             project_root,
                             extension_id=extension_id,
+                            author=author,
                         )
 
                 alias_file = (
@@ -1060,6 +1069,7 @@ class CommandRegistrar:
         create_missing_active_skills_dir: bool = False,
         extension_id: Optional[str] = None,
         only_agent: Optional[str] = None,
+        author: str = "github-spec-kit",
     ) -> Dict[str, List[str]]:
         """Register commands for all detected agents in the project.
 
@@ -1184,6 +1194,7 @@ class CommandRegistrar:
                         _resolved_dir=agent_dir,
                         link_outputs=link_outputs,
                         extension_id=extension_id,
+                        author=author,
                     )
                     if registered:
                         results[agent_name] = registered

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -178,7 +178,6 @@ class CommandRegistrar:
         Args:
             frontmatter: Frontmatter dictionary
             extension_id: Extension id when rendering extension-owned commands.
-            author: Author attributed in generated skill metadata.
 
         Returns:
             Modified frontmatter with normalized project paths
@@ -1087,6 +1086,7 @@ class CommandRegistrar:
                 skills directory) and is skipped when safe resolution or
                 creation fails.
             extension_id: Extension id when rendering extension-owned commands.
+            author: Author attributed in generated skill metadata.
             only_agent: If set, restrict registration to this single agent
                 while keeping all detection and recovery safeguards (#2948).
 

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1687,6 +1687,7 @@ class ExtensionManager:
                 skill_name,
                 description,
                 f"extension:{manifest.id}",
+                author=manifest.data["extension"].get("author") or "github-spec-kit",
             )
             # Preserve the command's argument-hint in the generated skill,
             # mirroring the core template path (ClaudeIntegration.setup injects
@@ -3615,6 +3616,7 @@ class CommandRegistrar:
             context_note=context_note,
             link_outputs=link_outputs,
             extension_id=manifest.id,
+            author=manifest.data["extension"].get("author") or "github-spec-kit",
         )
 
     def register_commands_for_all_agents(
@@ -3638,6 +3640,7 @@ class CommandRegistrar:
             create_missing_active_skills_dir=create_missing_active_skills_dir,
             only_agent=only_agent,
             extension_id=manifest.id,
+            author=manifest.data["extension"].get("author") or "github-spec-kit",
         )
 
     def unregister_commands(

--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1687,7 +1687,7 @@ class ExtensionManager:
                 skill_name,
                 description,
                 f"extension:{manifest.id}",
-                author=manifest.data["extension"].get("author") or "github-spec-kit",
+                author=manifest.data["extension"].get("author"),
             )
             # Preserve the command's argument-hint in the generated skill,
             # mirroring the core template path (ClaudeIntegration.setup injects
@@ -3616,7 +3616,7 @@ class CommandRegistrar:
             context_note=context_note,
             link_outputs=link_outputs,
             extension_id=manifest.id,
-            author=manifest.data["extension"].get("author") or "github-spec-kit",
+            author=manifest.data["extension"].get("author"),
         )
 
     def register_commands_for_all_agents(
@@ -3640,7 +3640,7 @@ class CommandRegistrar:
             create_missing_active_skills_dir=create_missing_active_skills_dir,
             only_agent=only_agent,
             extension_id=manifest.id,
-            author=manifest.data["extension"].get("author") or "github-spec-kit",
+            author=manifest.data["extension"].get("author"),
         )
 
     def unregister_commands(

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -2894,7 +2894,7 @@ class PresetManager:
                     "command_name": cmd_name,
                     "source_file": source_file,
                     "source": f"extension:{manifest.id}",
-                    "author": manifest.data["extension"].get("author") or "github-spec-kit",
+                    "author": manifest.data["extension"].get("author"),
                     "extension_id": manifest.id,
                     "extension_dir": ext_root,
                 }

--- a/src/specify_cli/presets/__init__.py
+++ b/src/specify_cli/presets/__init__.py
@@ -2894,6 +2894,7 @@ class PresetManager:
                     "command_name": cmd_name,
                     "source_file": source_file,
                     "source": f"extension:{manifest.id}",
+                    "author": manifest.data["extension"].get("author") or "github-spec-kit",
                     "extension_id": manifest.id,
                     "extension_dir": ext_root,
                 }
@@ -3805,6 +3806,7 @@ class PresetManager:
                     skill_name,
                     frontmatter.get("description", f"Extension command: {command_name}"),
                     extension_restore["source"],
+                    author=extension_restore.get("author", "github-spec-kit"),
                 )
                 registrar.apply_argument_hint(frontmatter, frontmatter_data, integration)
                 frontmatter_text = dump_frontmatter(frontmatter_data)

--- a/tests/test_extension_skills.py
+++ b/tests/test_extension_skills.py
@@ -445,6 +445,35 @@ class TestExtensionSkillRegistration:
         assert "compatibility:" in content
         assert "Run this to say hello." in content
 
+    @pytest.mark.parametrize("register_commands", [False, True])
+    @pytest.mark.parametrize("link_commands", [False, True])
+    @pytest.mark.parametrize("author", ["acme-corp", 'Acme: "Platform"\nTeam', None, ""])
+    def test_extension_author_preserved(
+        self, skills_project, extension_dir, register_commands, link_commands, author
+    ):
+        """Both skill generators retain attribution, including dev output and aliases."""
+        project_dir, skills_dir = skills_project
+        manifest_path = extension_dir / "extension.yml"
+        data = yaml.safe_load(manifest_path.read_text())
+        if author is not None:
+            data["extension"]["author"] = author
+        data["provides"]["commands"][0]["aliases"] = ["speckit.test-ext.greet"]
+        manifest_path.write_text(yaml.safe_dump(data))
+
+        ExtensionManager(project_dir).install_from_directory(
+            extension_dir, "0.1.0",
+            register_commands=register_commands, link_commands=link_commands,
+        )
+
+        names = ["hello", "world"]
+        if register_commands:
+            names.append("greet")
+        for name in names:
+            content = (skills_dir / f"speckit-test-ext-{name}" / "SKILL.md").read_text()
+            frontmatter = yaml.safe_load(content.split("---", 2)[1])
+            assert frontmatter["metadata"]["author"] == (author or "github-spec-kit")
+            assert "test-ext" in frontmatter["metadata"]["source"]
+
     def test_skill_md_has_parseable_yaml(self, skills_project, extension_dir):
         """Generated SKILL.md should contain valid, parseable YAML frontmatter."""
         project_dir, skills_dir = skills_project

--- a/tests/test_extension_skills.py
+++ b/tests/test_extension_skills.py
@@ -447,9 +447,26 @@ class TestExtensionSkillRegistration:
 
     @pytest.mark.parametrize("register_commands", [False, True])
     @pytest.mark.parametrize("link_commands", [False, True])
-    @pytest.mark.parametrize("author", ["acme-corp", 'Acme: "Platform"\nTeam', None, ""])
+    @pytest.mark.parametrize(
+        ("author", "expected_author"),
+        [
+            ("acme-corp", "acme-corp"),
+            ('Acme: "Platform"\nTeam', 'Acme: "Platform"\nTeam'),
+            (None, "github-spec-kit"),
+            ("", "github-spec-kit"),
+            (123, "123"),
+            (0, "0"),
+            (False, "False"),
+        ],
+    )
     def test_extension_author_preserved(
-        self, skills_project, extension_dir, register_commands, link_commands, author
+        self,
+        skills_project,
+        extension_dir,
+        register_commands,
+        link_commands,
+        author,
+        expected_author,
     ):
         """Both skill generators retain attribution, including dev output and aliases."""
         project_dir, skills_dir = skills_project
@@ -471,7 +488,7 @@ class TestExtensionSkillRegistration:
         for name in names:
             content = (skills_dir / f"speckit-test-ext-{name}" / "SKILL.md").read_text()
             frontmatter = yaml.safe_load(content.split("---", 2)[1])
-            assert frontmatter["metadata"]["author"] == (author or "github-spec-kit")
+            assert frontmatter["metadata"]["author"] == expected_author
             assert "test-ext" in frontmatter["metadata"]["source"]
 
     def test_skill_md_has_parseable_yaml(self, skills_project, extension_dir):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1746,6 +1746,7 @@ class TestExtensionManager:
             create_missing_active_skills_dir=False,
             extension_id=None,
             only_agent=None,
+            author="github-spec-kit",
         ):
             captured["create_missing_active_skills_dir"] = (
                 create_missing_active_skills_dir

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -6328,6 +6328,7 @@ class TestPresetSkills:
             "extension": {
                 "id": "fakeext",
                 "name": "Fake Extension",
+                "author": "acme-corp",
                 "version": "1.0.0",
                 "description": "Test",
             },
@@ -6393,6 +6394,8 @@ class TestPresetSkills:
         assert ".specify/extensions/fakeext/agents/control/commander.md" in content
         assert "Read agents/control" not in content
         assert "# Fakeext Cmd Skill" in content
+
+        assert yaml.safe_load(content.split("---", 2)[1])["metadata"]["author"] == "acme-corp"
 
     def test_skill_composed_over_extension_base_rewrites_subdir_paths(
         self, project_dir, temp_dir


### PR DESCRIPTION
## Description

An extension declaring `author: acme-corp` currently produces skills attributed to `github-spec-kit`. Pass the declared author through command registration and skill rendering, including aliases, dev-mode output, and restoration of extension skills after preset removal. Core generation and extensions with a missing or empty author retain the existing `github-spec-kit` default.

Closes #4458.

## Testing

- Added 16 attribution cases covering both extension skill generators, normal/dev output, aliases, quoted/multiline authors, and missing/empty authors. Against unmodified main (`4a7341a9`), the 8 explicit-author cases fail; all pass with this change.
- Added an author assertion to the preset-removal extension restoration test.
- Final regression run: `.venv/bin/python -m pytest tests/test_extensions.py tests/test_extension_skills.py tests/test_presets.py tests/integrations -q -k 'not test_ps_variant_prefixed_with_powershell_launcher'` — **4202 passed, 5 skipped, 1 deselected**.
- The excluded PowerShell launcher test fails because neither `pwsh` nor `powershell` is installed locally. Reproduced the same failure against unmodified main in an isolated checkout.
- `uvx ruff@0.15.0 check src tests` and `git diff --check`: passed.
- Verified `.venv/bin/specify --help` and a fresh CLI `init` followed by `extension add --dev`: the extension skill attributes `acme-corp`, while the core plan skill retains `github-spec-kit`.
- Independently checked single-agent registration and aliases for Claude and Codex.

## AI Disclosure

- [x] I **did** use AI assistance.

Implementation, regression tests, validation, commits, and this PR description were authored by OpenAI Codex (model: GPT-6, autonomous) on behalf of @philo-x. Each commit includes an `Assisted-by:` trailer.