### PR TITLE
[extension] Update OKF Knowledge Bundle Generator to v0.6.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -3412,14 +3412,14 @@
     "okf": {
       "name": "OKF Knowledge Bundle Generator",
       "id": "okf",
-      "description": "Generates and maintains an Open Knowledge Format (OKF v0.1) knowledge bundle from a source-code repository, mining git history for significance and rationale, and resolving open questions with the user.",
+      "description": "Generates and maintains an Open Knowledge Format (OKF v0.1) knowledge bundle from a source-code repository. Mines git history for the rationale behind the code, parks what it cannot establish as open questions rather than guessing, and verifies that the bundle's claims are supported by the repository.",
       "author": "Alex Punnen",
-      "version": "0.3.0",
-      "download_url": "https://github.com/alexcpn/speckit_ofk/archive/refs/tags/v0.3.0.zip",
-      "repository": "https://github.com/alexcpn/speckit_ofk",
-      "homepage": "https://github.com/alexcpn/speckit_ofk",
-      "documentation": "https://github.com/alexcpn/speckit_ofk/blob/main/README.md",
-      "changelog": "https://github.com/alexcpn/speckit_ofk/blob/main/CHANGELOG.md",
+      "version": "0.6.0",
+      "download_url": "https://github.com/alexcpn/speckit_okf/archive/refs/tags/v0.6.0.zip",
+      "repository": "https://github.com/alexcpn/speckit_okf",
+      "homepage": "https://github.com/alexcpn/speckit_okf",
+      "documentation": "https://github.com/alexcpn/speckit_okf/blob/main/README.md",
+      "changelog": "https://github.com/alexcpn/speckit_okf/blob/main/CHANGELOG.md",
       "license": "MIT",
       "category": "docs",
       "effect": "read-write",
@@ -3427,7 +3427,7 @@
         "speckit_version": ">=0.12.0"
       },
       "provides": {
-        "commands": 4,
+        "commands": 5,
         "hooks": 0
       },
       "tags": [
@@ -3441,7 +3441,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-07-17T00:00:00Z",
-      "updated_at": "2026-07-21T00:00:00Z"
+      "updated_at": "2026-09-07T00:00:00Z"
     },
     "onboard": {
       "name": "Onboard",


### PR DESCRIPTION
Updates the `okf` entry in `extensions/catalog.community.json`. Submitted as an issue in #4439; opening a PR as well, since that seems to be the path that actually lands.

### Two things this fixes

**The version is three releases behind.** The catalog has 0.3.0; current is [v0.6.0](https://github.com/alexcpn/speckit_okf/releases/tag/v0.6.0).

**Every URL in the entry is wrong.** They point at `speckit_ofk` — a transposition of `speckit_okf`. They currently resolve only because GitHub is still 301-redirecting from the repository's old name, which is not something a catalog should depend on.

### Diff

Ten lines, all inside the single `okf` object. Nothing else in the file is touched.

| Field | Was | Now |
| --- | --- | --- |
| `version` | `0.3.0` | `0.6.0` |
| `download_url` | `…/speckit_ofk/…/v0.3.0.zip` | `…/speckit_okf/…/v0.6.0.zip` |
| `repository`, `homepage`, `documentation`, `changelog` | `speckit_ofk` | `speckit_okf` |
| `provides.commands` | `4` | `5` |
| `updated_at` | `2026-07-21` | `2026-09-07` |
| `description` | — | rewritten, below |

> Generates and maintains an Open Knowledge Format (OKF v0.1) knowledge bundle from a source-code repository. Mines git history for the rationale behind the code, parks what it cannot establish as open questions rather than guessing, and verifies that the bundle's claims are supported by the repository.

### What changed in the extension

The fifth command is `/speckit.okf.verify`. The other four are unchanged.

`validate` only ever asked whether a bundle is well-formed. `verify` asks whether it is *true*: every cited commit must exist and belong to the concept citing it and must not be a commit that changed only test files; every symbol in an `# Interfaces` table must appear in non-test source; every `source_files` path must be tracked by git; and no invariant may be asserted with no evidence.

The motivation was concrete. Generating a bundle for `kubernetes/kubernetes` twice, independently, produced the same five false claims both times — three of them commits that had only touched `_test.go` files, written up as production invariants. The instruction not to trust a bare commit subject already existed and was ignored both times. `verify` catches all five unaided.

Also in 0.6.0: history mining now lists the files each flagged commit touched and marks test-only ones; a new co-change script mines coupling that no import graph can see; untracked subtrees are refused rather than documented as the project's own; cross-links are relative, because a leading `/` means bundle root to OKF and repository root to GitHub; and bundles carry a `README.md`, since forges render that and ignore `index.md`.

[Full changelog](https://github.com/alexcpn/speckit_okf/blob/main/CHANGELOG.md)

### Checks

All URLs in the new entry return 200. The file parses as valid JSON. No new required tools, no new permissions, `effect` unchanged at `read-write`. Repository CI (shellcheck, skill validation, asset-sync) passes on the v0.6.0 commit.
