### PR TITLE
fix: reject duplicate bundle components

### DIFF
--- a/src/specify_cli/bundler/models/manifest.py
+++ b/src/specify_cli/bundler/models/manifest.py
@@ -192,9 +192,17 @@ class BundleManifest:
                 "(lowercase letters, digits, '.', '_', '-'; no path separators)."
             )
 
+        seen_components: set[tuple[str, str]] = set()
         for ref in self.components:
             if not ref.id:
                 errors.append(f"A {ref.kind[:-1]} entry is missing its 'id'.")
+            key = (ref.kind, ref.id)
+            if ref.id and key in seen_components:
+                errors.append(
+                    f"Duplicate {ref.kind[:-1]} '{ref.id}' in "
+                    f"'provides.{ref.kind}'."
+                )
+            seen_components.add(key)
             if ref.kind != "steps" and not ref.version:
                 errors.append(
                     f"{ref.kind[:-1]} '{ref.id or '<unknown>'}' must be pinned to a 'version'."

--- a/tests/contract/test_manifest_schema.py
+++ b/tests/contract/test_manifest_schema.py
@@ -127,6 +127,20 @@ def test_components_property_orders_by_kind():
     assert kinds == ["extensions", "presets", "steps", "workflows"]
 
 
+def test_duplicate_component_in_same_kind_is_rejected():
+    data = valid_manifest_dict()
+    data["provides"]["extensions"].append(
+        {"id": "ext-a", "version": "9.9.9"}
+    )
+
+    errors = BundleManifest.from_dict(data).structural_errors()
+
+    assert any(
+        "duplicate extension 'ext-a'" in error.lower()
+        for error in errors
+    )
+
+
 def test_string_tags_rejected_not_split_per_character():
     # A bare string would otherwise be iterated character-by-character; the
     # schema requires a list of strings.

--- a/tests/contract/test_manifest_schema.py
+++ b/tests/contract/test_manifest_schema.py
@@ -141,6 +141,15 @@ def test_duplicate_component_in_same_kind_is_rejected():
     )
 
 
+def test_same_component_id_in_different_kinds_is_allowed():
+    data = valid_manifest_dict()
+    data["provides"]["steps"].append({"id": "ext-a"})
+
+    errors = BundleManifest.from_dict(data).structural_errors()
+
+    assert not any("duplicate" in error.lower() for error in errors)
+
+
 def test_string_tags_rejected_not_split_per_character():
     # A bare string would otherwise be iterated character-by-character; the
     # schema requires a list of strings.


### PR DESCRIPTION
## Description

Reject duplicate component declarations within the same bundle component kind.

Previously, duplicate `(kind, id)` entries passed structural validation. During
installation, the first entry won and later declarations were silently skipped,
including conflicting version pins or preset options. Validation now reports
the duplicate before resolution or installation; identical IDs in different
component kinds remain valid.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Targeted: `tests/contract/test_manifest_schema.py` (39 passed).

Full suite: 7,533 passed, 195 skipped. One existing PowerShell-launcher test
was omitted because `pwsh` is unavailable locally; it fails identically on the
unchanged upstream commit.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot (GPT-5.6 Sol) autonomously reproduced the bug, wrote the
regression test and implementation, and ran verification under
@marcelsafin's direction and review.
