### PR TITLE
fix: reject mismatched step catalog versions

### DIFF
--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -3410,7 +3410,7 @@ def workflow_step_add(
 
         catalog_version = info.get("version")
         downloaded_version = step_meta.get("version")
-        if catalog_version and downloaded_version:
+        if "version" in info and "version" in step_meta:
             from packaging import version as pkg_version
 
             try:

--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -3418,9 +3418,7 @@ def workflow_step_add(
                     str(downloaded_version)
                 ) == pkg_version.Version(str(catalog_version))
             except pkg_version.InvalidVersion:
-                versions_match = str(downloaded_version).strip() == str(
-                    catalog_version
-                ).strip()
+                versions_match = str(downloaded_version) == str(catalog_version)
             if not versions_match:
                 console.print(
                     f"[red]Error:[/red] step.yml version "

--- a/src/specify_cli/workflows/_commands.py
+++ b/src/specify_cli/workflows/_commands.py
@@ -3408,6 +3408,28 @@ def workflow_step_add(
             )
             raise typer.Exit(1)
 
+        catalog_version = info.get("version")
+        downloaded_version = step_meta.get("version")
+        if catalog_version and downloaded_version:
+            from packaging import version as pkg_version
+
+            try:
+                versions_match = pkg_version.Version(
+                    str(downloaded_version)
+                ) == pkg_version.Version(str(catalog_version))
+            except pkg_version.InvalidVersion:
+                versions_match = str(downloaded_version).strip() == str(
+                    catalog_version
+                ).strip()
+            if not versions_match:
+                console.print(
+                    f"[red]Error:[/red] step.yml version "
+                    f"({_escape_markup(repr(downloaded_version))}) does not match "
+                    f"the catalog version ({_escape_markup(repr(catalog_version))}). "
+                    "The catalog entry may be stale or misconfigured."
+                )
+                raise typer.Exit(1)
+
         # Write the two required files.
         try:
             (tmp_path / "step.yml").write_bytes(step_yml_content)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -10577,8 +10577,12 @@ class TestWorkflowStepRichMarkup:
 
 
 class TestWorkflowStepAddCLI:
+    @pytest.mark.parametrize(
+        "downloaded_version",
+        ["2.0.0", 0, False, "", None],
+    )
     def test_add_rejects_step_yml_version_mismatch(
-        self, project_dir, monkeypatch
+        self, project_dir, monkeypatch, downloaded_version
     ):
         from typer.testing import CliRunner
 
@@ -10600,9 +10604,14 @@ class TestWorkflowStepAddCLI:
             },
         )
         bodies = {
-            "https://example.com/step.yml": (
-                b"step:\n  type_key: my-step\n  version: 2.0.0\n"
-            ),
+            "https://example.com/step.yml": yaml.safe_dump(
+                {
+                    "step": {
+                        "type_key": "my-step",
+                        "version": downloaded_version,
+                    }
+                }
+            ).encode(),
             "https://example.com/__init__.py": b"# custom step\n",
         }
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -10577,6 +10577,77 @@ class TestWorkflowStepRichMarkup:
 
 
 class TestWorkflowStepAddCLI:
+    def test_add_rejects_step_yml_version_mismatch(
+        self, project_dir, monkeypatch
+    ):
+        from typer.testing import CliRunner
+
+        from specify_cli import app
+        from specify_cli.authentication import http as auth_http
+        from specify_cli.workflows.catalog import StepCatalog, StepRegistry
+
+        monkeypatch.chdir(project_dir)
+        monkeypatch.setattr(
+            StepCatalog,
+            "get_step_info",
+            lambda self, step_id: {
+                "id": step_id,
+                "name": "Test Step",
+                "version": "1.0.0",
+                "url": "https://example.com/step.yml",
+                "init_url": "https://example.com/__init__.py",
+                "_install_allowed": True,
+            },
+        )
+        bodies = {
+            "https://example.com/step.yml": (
+                b"step:\n  type_key: my-step\n  version: 2.0.0\n"
+            ),
+            "https://example.com/__init__.py": b"# custom step\n",
+        }
+
+        class _FakeResponse:
+            def __init__(self, url):
+                self.url = url
+                self.body = bodies[url]
+                self.offset = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def getheader(self, name):
+                return None
+
+            def geturl(self):
+                return self.url
+
+            def read(self, size=-1):
+                if size < 0:
+                    size = len(self.body) - self.offset
+                chunk = self.body[self.offset : self.offset + size]
+                self.offset += len(chunk)
+                return chunk
+
+        monkeypatch.setattr(
+            auth_http,
+            "open_url",
+            lambda url, timeout=30, redirect_validator=None: _FakeResponse(url),
+        )
+
+        result = CliRunner().invoke(
+            app, ["workflow", "step", "add", "my-step"]
+        )
+
+        assert result.exit_code != 0
+        assert "does not match the catalog version" in result.output
+        assert not StepRegistry(project_dir).is_installed("my-step")
+        assert not (
+            project_dir / ".specify" / "workflows" / "steps" / "my-step"
+        ).exists()
+
     @pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks are unavailable")
     def test_add_rejects_symlinked_steps_base_dir(self, project_dir, monkeypatch):
         from typer.testing import CliRunner

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -10578,11 +10578,18 @@ class TestWorkflowStepRichMarkup:
 
 class TestWorkflowStepAddCLI:
     @pytest.mark.parametrize(
-        "downloaded_version",
-        ["2.0.0", 0, False, "", None],
+        ("catalog_version", "downloaded_version"),
+        [
+            ("1.0.0", "2.0.0"),
+            ("1.0.0", 0),
+            ("1.0.0", False),
+            ("1.0.0", ""),
+            ("1.0.0", None),
+            ("release-a", " release-a "),
+        ],
     )
     def test_add_rejects_step_yml_version_mismatch(
-        self, project_dir, monkeypatch, downloaded_version
+        self, project_dir, monkeypatch, catalog_version, downloaded_version
     ):
         from typer.testing import CliRunner
 
@@ -10597,7 +10604,7 @@ class TestWorkflowStepAddCLI:
             lambda self, step_id: {
                 "id": step_id,
                 "name": "Test Step",
-                "version": "1.0.0",
+                "version": catalog_version,
                 "url": "https://example.com/step.yml",
                 "init_url": "https://example.com/__init__.py",
                 "_install_allowed": True,


### PR DESCRIPTION
## Description

Reject catalog step packages when the downloaded `step.yml` declares a
different version from the catalog entry.

Previously, installation validated the downloaded type key but stored the
catalog version without checking the package version. A stale or
misconfigured URL could therefore install different code under trusted
catalog metadata. Version comparison now follows the normalized behavior used
for workflow packages and occurs before any files are installed.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Targeted: `TestWorkflowStepAddCLI` (29 passed).

Full suite: 7,537 passed, 195 skipped. One existing PowerShell-launcher test
was omitted because `pwsh` is unavailable locally; it fails identically on the
unchanged upstream commit.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot (GPT-5.6 Sol) autonomously reproduced the bug, wrote the
regression test and implementation, and ran verification under
@marcelsafin's direction and review.
