### PR TITLE
fix: roll back bundle installs when record save fails

### DIFF
--- a/src/specify_cli/bundler/services/installer.py
+++ b/src/specify_cli/bundler/services/installer.py
@@ -155,6 +155,16 @@ def install_bundle(
                 if installer.is_installed(project_root, component):
                     installer.remove(project_root, component)
                     result.uninstalled.append(component)
+
+        record = InstalledBundleRecord.create(
+            bundle_id=plan.bundle_id,
+            version=plan.version,
+            components=contributed,
+            # Preserve the original install time across refresh/update so
+            # ``bundle list`` keeps reporting when the bundle was first installed.
+            installed_at=existing.installed_at if existing is not None else None,
+        )
+        save_records(project_root, upsert_record(records, record))
     except BundlerError:
         _rollback(project_root, installer, done)
         raise
@@ -165,15 +175,6 @@ def install_bundle(
             "No changes were recorded."
         ) from exc
 
-    record = InstalledBundleRecord.create(
-        bundle_id=plan.bundle_id,
-        version=plan.version,
-        components=contributed,
-        # Preserve the original install time across refresh/update so
-        # ``bundle list`` keeps reporting when the bundle was first installed.
-        installed_at=existing.installed_at if existing is not None else None,
-    )
-    save_records(project_root, upsert_record(records, record))
     return result
 
 

--- a/tests/integration/test_bundler_install_flow.py
+++ b/tests/integration/test_bundler_install_flow.py
@@ -64,6 +64,25 @@ def test_partial_failure_rolls_back_and_records_nothing(tmp_path: Path):
     assert load_records(tmp_path) == []
 
 
+def test_record_save_failure_rolls_back_new_components(tmp_path: Path, monkeypatch):
+    make_project(tmp_path)
+    manifest = BundleManifest.from_dict(valid_manifest_dict())
+    installer = FakeInstaller()
+
+    def fail_save(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "specify_cli.bundler.services.installer.save_records", fail_save
+    )
+
+    with pytest.raises(BundlerError, match="disk full"):
+        install_bundle(tmp_path, _plan(manifest), installer, manifest=manifest)
+
+    assert installer.installed == set()
+    assert load_records(tmp_path) == []
+
+
 def test_remove_is_non_collateral(tmp_path: Path):
     make_project(tmp_path)
     installer = FakeInstaller()


### PR DESCRIPTION
## Description

Include bundle provenance persistence in the install rollback boundary.

Previously, a failure while saving `bundles.json` occurred after the protected
install block. Newly installed components remained on disk without a
provenance record, so later bundle operations could not manage them. Record
creation and saving now trigger the existing bounded rollback for components
installed by the current call.

## Testing

- [x] Tested locally with `uv run specify --help`
- [x] Ran existing tests with `uv sync && uv run pytest`
- [ ] Tested with a sample project (if applicable)

Targeted: `tests/integration/test_bundler_install_flow.py` (22 passed).

Full suite: 7,532 passed, 195 skipped. One existing PowerShell-launcher test
was omitted because `pwsh` is unavailable locally; it fails identically on the
unchanged upstream commit.

## AI Disclosure

- [ ] I **did not** use AI assistance for this contribution
- [x] I **did** use AI assistance (describe below)

GitHub Copilot (GPT-5.6 Sol) autonomously reproduced the bug, wrote the
regression test and implementation, and ran verification under
@marcelsafin's direction and review.
