### PR TITLE
Update pay-x402 extension entry to v1.1.0

### DIFF
--- a/extensions/catalog.community.json
+++ b/extensions/catalog.community.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "updated_at": "2026-09-03T00:00:00Z",
+  "updated_at": "2026-09-08T00:00:00Z",
   "catalog_url": "https://raw.githubusercontent.com/github/spec-kit/main/extensions/catalog.community.json",
   "extensions": {
     "adrkit": {
@@ -3622,10 +3622,10 @@
     "pay-x402": {
       "name": "AgentPay x402 — Spend Controls for Spec Kit Agents",
       "id": "pay-x402",
-      "description": "Set USDC spending caps and execute x402 payments to paid APIs during spec implementation. Zero platform fee on Base L2.",
+      "description": "Set USDC spending caps, check a counterparty's credit before paying it, and pay x402-enabled APIs during spec implementation. Settles on Base or Solana.",
       "author": "AgentPay Team",
-      "version": "1.0.0",
-      "download_url": "https://github.com/shawnhvac/spec-kit-pay-x402/archive/refs/tags/v1.0.0.zip",
+      "version": "1.1.0",
+      "download_url": "https://github.com/shawnhvac/spec-kit-pay-x402/archive/refs/tags/v1.1.0.zip",
       "repository": "https://github.com/shawnhvac/spec-kit-pay-x402",
       "homepage": "https://x402-agent-pay.com",
       "documentation": "https://github.com/shawnhvac/spec-kit-pay-x402#readme",
@@ -3651,7 +3651,7 @@
       "downloads": 0,
       "stars": 0,
       "created_at": "2026-08-17T00:00:00Z",
-      "updated_at": "2026-08-17T00:00:00Z"
+      "updated_at": "2026-09-08T00:00:00Z"
     },
     "plan-review-gate": {
       "name": "Plan Review Gate",


### PR DESCRIPTION
Updates the `pay-x402` entry in `extensions/catalog.community.json` from **v1.0.0 to v1.1.0**.

**Why this matters:** the catalog currently serves v1.0.0, whose `pay` command directed agents to POST to an endpoint that is itself a paid x402 resource — an agent following the bundled instructions received a `402` instead of a payment header. v1.1.0 fixes the flow (the payer signs its own payment) and removes XRPL claims the facilitator never supported.

Changes:
- `version`: 1.0.0 → 1.1.0
- `download_url`: points at the v1.1.0 tag (verified: the zip resolves)
- `description`: updated to match v1.1.0 (spend caps, counterparty credit check via SolvScore, x402 payments during spec implementation; settles on Base or Solana)
- `updated_at`: entry-level and catalog-level timestamps

Follows the Extension Submission template (filed as issue #4446 on Sept 4); the catalog was last refreshed Sept 3, so the entry has not yet picked up the v1.1.0 fix.

Tag: `🤖🤖🤖` (prepared by an AI agent on behalf of the extension author, per repo convention).