### PR TITLE
fix(agy): support --model, --add-dir workspace, and pre-prompt extra args

### DIFF
--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -1,6 +1,9 @@
 #!/usr/bin/env pwsh
 # Common PowerShell functions analogous to common.sh
 
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
 # Find repository root by searching upward for .specify directory
 # This is the primary marker for spec-kit projects
 function Find-SpecifyRoot {

--- a/scripts/powershell/common.ps1
+++ b/scripts/powershell/common.ps1
@@ -1,8 +1,6 @@
 #!/usr/bin/env pwsh
 # Common PowerShell functions analogous to common.sh
 
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-$OutputEncoding = [System.Text.Encoding]::UTF8
 
 # Find repository root by searching upward for .specify directory
 # This is the primary marker for spec-kit projects

--- a/src/specify_cli/integrations/agy/__init__.py
+++ b/src/specify_cli/integrations/agy/__init__.py
@@ -90,13 +90,26 @@ class AgyIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
-        # agy does not support --model or JSON output; both params are ignored
         self.validate_runtime_config(integration_args, integration_options)
-        args = [self._resolve_executable(), "--print", prompt]
-        # Honor SPECKIT_INTEGRATION_AGY_EXTRA_ARGS (operator-supplied flags),
-        # appended after the positional prompt like the devin integration.
+        # agy does not support JSON output; output_json is ignored.
+        args = [self._resolve_executable()]
+        # Pass --model before --print so agy can parse it as a flag.
+        # agy >=1.20 supports: agy --model <name> --print <prompt>
+        if model:
+            args.extend(["--model", model])
+        # Inject --add-dir so agy discovers the project workspace when invoked
+        # from an arbitrary working directory (e.g. the workflow engine's cwd).
+        # Without this agy falls back to its own scratch directory and cannot
+        # locate .agents/skills/, reporting "no active workspace".
+        if project_root is not None:
+            args.extend(["--add-dir", str(project_root)])
+        # Honor SPECKIT_INTEGRATION_AGY_EXTRA_ARGS (operator-supplied flags).
+        # These MUST be inserted before --print because agy treats every token
+        # that follows --print as part of the prompt, not as CLI flags.
         self._apply_extra_args_env_var(args)
+        args.extend(["--print", prompt])
         return args
 
     def setup(

--- a/src/specify_cli/integrations/agy/__init__.py
+++ b/src/specify_cli/integrations/agy/__init__.py
@@ -104,7 +104,7 @@ class AgyIntegration(SkillsIntegration):
         # Without this agy falls back to its own scratch directory and cannot
         # locate .agents/skills/, reporting "no active workspace".
         if project_root is not None:
-            args.extend(["--add-dir", str(project_root)])
+            args.extend(["--add-dir", str(project_root.resolve())])
         # Honor SPECKIT_INTEGRATION_AGY_EXTRA_ARGS (operator-supplied flags).
         # These MUST be inserted before --print because agy treats every token
         # that follows --print as part of the prompt, not as CLI flags.

--- a/src/specify_cli/integrations/base.py
+++ b/src/specify_cli/integrations/base.py
@@ -248,6 +248,7 @@ class IntegrationBase(ABC):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build CLI arguments for non-interactive execution.
 
@@ -410,6 +411,7 @@ class IntegrationBase(ABC):
             output_json=not stream,
             integration_args=integration_args,
             integration_options=integration_options,
+            project_root=project_root,
         )
 
         if exec_args is None:
@@ -1067,6 +1069,7 @@ class MarkdownIntegration(IntegrationBase):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         self.validate_runtime_config(integration_args, integration_options)
         if not self.config or not self.config.get("requires_cli"):
@@ -1161,6 +1164,7 @@ class TomlIntegration(IntegrationBase):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         self.validate_runtime_config(integration_args, integration_options)
         if not self.config or not self.config.get("requires_cli"):
@@ -1633,6 +1637,7 @@ class SkillsIntegration(IntegrationBase):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         self.validate_runtime_config(integration_args, integration_options)
         if not self.config or not self.config.get("requires_cli"):

--- a/src/specify_cli/integrations/codex/__init__.py
+++ b/src/specify_cli/integrations/codex/__init__.py
@@ -5,6 +5,7 @@ Commands are deprecated; ``--skills`` defaults to ``True``.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -51,6 +52,7 @@ class CodexIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         # Codex uses ``codex exec "prompt"`` for non-interactive mode.
         # Resolve argv[0] via the shared executable resolver so operators can

--- a/src/specify_cli/integrations/copilot/__init__.py
+++ b/src/specify_cli/integrations/copilot/__init__.py
@@ -309,6 +309,7 @@ class CopilotIntegration(IntegrationBase):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         self.validate_runtime_config(integration_args, integration_options)
         # GitHub Copilot CLI uses ``copilot -p "prompt"`` for

--- a/src/specify_cli/integrations/cursor_agent/__init__.py
+++ b/src/specify_cli/integrations/cursor_agent/__init__.py
@@ -11,6 +11,7 @@ is what indicates dispatch support, mirroring ``CopilotIntegration``.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -68,6 +69,7 @@ class CursorAgentIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build CLI arguments for non-interactive ``cursor-agent`` execution.
 

--- a/src/specify_cli/integrations/devin/__init__.py
+++ b/src/specify_cli/integrations/devin/__init__.py
@@ -9,6 +9,7 @@ See: https://cli.devin.ai/docs/extensibility/skills/overview
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -63,6 +64,7 @@ class DevinIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build non-interactive CLI args for Devin for Terminal.
 

--- a/src/specify_cli/integrations/docker_agent/__init__.py
+++ b/src/specify_cli/integrations/docker_agent/__init__.py
@@ -6,6 +6,7 @@ configuration is owned by Docker Agent and is not managed by Spec Kit.
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 import os
 import shlex
@@ -85,6 +86,7 @@ class DockerAgentIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build a headless Docker Agent invocation with an agent config."""
         self.validate_runtime_config(integration_args, integration_options)
@@ -152,6 +154,7 @@ class DockerAgentIntegration(SkillsIntegration):
         self,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> None:
         """Validate Docker Agent's per-step agent reference and CLI options."""
         runtime_args = list(integration_args or ())

--- a/src/specify_cli/integrations/droid/__init__.py
+++ b/src/specify_cli/integrations/droid/__init__.py
@@ -9,6 +9,7 @@ See: https://docs.factory.ai/cli/configuration/skills
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -95,6 +96,7 @@ class DroidIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build CLI arguments for non-interactive ``droid`` execution.
 

--- a/src/specify_cli/integrations/dsh/__init__.py
+++ b/src/specify_cli/integrations/dsh/__init__.py
@@ -15,6 +15,7 @@ See: https://github.com/deepseek-ai/deepseek-harness
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -51,6 +52,7 @@ class DshIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build non-interactive CLI args for DSH.
 

--- a/src/specify_cli/integrations/goose/__init__.py
+++ b/src/specify_cli/integrations/goose/__init__.py
@@ -1,6 +1,7 @@
 """Goose integration — open source AI agent (Agentic AI Foundation)."""
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -32,6 +33,7 @@ class GooseIntegration(YamlIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build CLI arguments for non-interactive ``goose`` execution.
 

--- a/src/specify_cli/integrations/grok/__init__.py
+++ b/src/specify_cli/integrations/grok/__init__.py
@@ -6,6 +6,7 @@ Grok Build discovers project skills from ``.grok/skills/speckit-<name>/SKILL.md`
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -40,6 +41,7 @@ class GrokIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build CLI arguments for non-interactive ``grok`` execution.
 

--- a/src/specify_cli/integrations/hermes/__init__.py
+++ b/src/specify_cli/integrations/hermes/__init__.py
@@ -275,6 +275,7 @@ class HermesIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build Hermes CLI invocation for programmatic dispatch.
 

--- a/src/specify_cli/integrations/muse/__init__.py
+++ b/src/specify_cli/integrations/muse/__init__.py
@@ -8,6 +8,7 @@ See: https://dev.meta.ai/docs/muse-code
 """
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -55,6 +56,7 @@ class MuseIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         # Muse Code uses ``muse exec "<prompt>"`` for non-interactive mode.
         # Resolve argv[0] via the shared executable resolver so operators can

--- a/src/specify_cli/integrations/omp/__init__.py
+++ b/src/specify_cli/integrations/omp/__init__.py
@@ -1,6 +1,7 @@
 """Oh My Pi (omp) coding agent integration."""
 
 from __future__ import annotations
+from pathlib import Path
 
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -33,6 +34,7 @@ class OmpIntegration(MarkdownIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         # Diverges from MarkdownIntegration.build_exec_args because OMP's
         # CLI parser treats `-p`/`--print` as a boolean (one-shot mode) and

--- a/src/specify_cli/integrations/opencode/__init__.py
+++ b/src/specify_cli/integrations/opencode/__init__.py
@@ -1,6 +1,7 @@
 """opencode integration."""
 
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any
 
 from ..base import MarkdownIntegration
@@ -48,6 +49,7 @@ class OpencodeIntegration(MarkdownIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         self.validate_runtime_config(integration_args, integration_options)
         args = [self._resolve_executable(), "run"]

--- a/src/specify_cli/integrations/rovodev/__init__.py
+++ b/src/specify_cli/integrations/rovodev/__init__.py
@@ -66,6 +66,7 @@ class RovodevIntegration(SkillsIntegration):
         output_json: bool = True,
         integration_args: Sequence[str] | None = None,
         integration_options: Mapping[str, Any] | None = None,
+        project_root: Path | None = None,
     ) -> list[str] | None:
         """Build non-interactive ACLI args for RovoDev.
 

--- a/src/specify_cli/workflows/steps/command/__init__.py
+++ b/src/specify_cli/workflows/steps/command/__init__.py
@@ -233,11 +233,14 @@ class CommandStep(StepBase):
 
         impl.validate_runtime_config(integration_args, integration_options)
 
+        project_root = Path(context.project_root) if context.project_root else None
+
         # Build sample args for fallback executable detection when impl.key is not executable.
         exec_args = impl.build_exec_args(
             "test",
             integration_args=integration_args,
             integration_options=integration_options,
+            project_root=project_root,
         )
 
         # Check if the CLI tool is actually installed.
@@ -247,8 +250,6 @@ class CommandStep(StepBase):
         fallback_cli_path = shutil.which(exec_args[0]) if exec_args else None
         if cli_path is None and fallback_cli_path is None:
             return None
-
-        project_root = Path(context.project_root) if context.project_root else None
 
         try:
             return impl.dispatch_command(

--- a/src/specify_cli/workflows/steps/prompt/__init__.py
+++ b/src/specify_cli/workflows/steps/prompt/__init__.py
@@ -200,7 +200,16 @@ class PromptStep(StepBase):
         if impl is None:
             return None
 
-        exec_args = impl.build_exec_args(prompt, model=model, output_json=False)
+        project_root = (
+            Path(context.project_root) if context.project_root else Path.cwd()
+        )
+
+        exec_args = impl.build_exec_args(
+            prompt,
+            model=model,
+            output_json=False,
+            project_root=project_root,
+        )
 
         # Check if the CLI tool is actually installed.
         # Try the integration key first (covers most agents), then fall back
@@ -226,10 +235,6 @@ class PromptStep(StepBase):
             exec_args = [fallback_cli_path, *exec_args[1:]]
 
         import subprocess
-
-        project_root = (
-            Path(context.project_root) if context.project_root else Path.cwd()
-        )
 
         try:
             result = subprocess.run(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,11 @@ def _strip_specify_env(monkeypatch):
     that wants an override sets it explicitly via monkeypatch afterwards."""
     for key in [k for k in os.environ if k.startswith("SPECIFY_")]:
         monkeypatch.delenv(key, raising=False)
+    for key in list(os.environ):
+        if key.startswith("SPECKIT_INTEGRATION_") and (
+            key.endswith("_EXTRA_ARGS") or key.endswith("_EXECUTABLE")
+        ):
+            monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture

--- a/tests/integrations/test_base.py
+++ b/tests/integrations/test_base.py
@@ -68,6 +68,7 @@ class TestIntegrationBase:
             parameters = inspect.signature(integration.build_exec_args).parameters
             assert "integration_args" in parameters, key
             assert "integration_options" in parameters, key
+            assert "project_root" in parameters, key
 
     def test_unsupported_exec_builders_reject_runtime_config_directly(self):
         from specify_cli.integrations import INTEGRATION_REGISTRY

--- a/tests/integrations/test_integration_agy.py
+++ b/tests/integrations/test_integration_agy.py
@@ -126,7 +126,7 @@ class TestAgyBuildExecArgs:
 
     def test_build_exec_args_relative_project_root(self):
         """Relative project_root must be resolved to an absolute path.
-        
+
         Passing a relative path to --add-dir breaks agy when the subprocess
         also changes cwd to that same relative path.
         """

--- a/tests/integrations/test_integration_agy.py
+++ b/tests/integrations/test_integration_agy.py
@@ -67,12 +67,19 @@ class TestAgyBuildExecArgs:
         result = i.build_exec_args("describe my feature")
         assert result == ["agy", "--print", "describe my feature"]
 
-    def test_build_exec_args_ignores_model(self):
-        """agy does not support --model; model param must be ignored."""
+    def test_build_exec_args_honors_model(self):
+        """agy >=1.20 supports --model; it must be prepended before --print."""
         from specify_cli.integrations import get_integration
         i = get_integration("agy")
         result = i.build_exec_args("my prompt", model="gemini-pro")
-        assert result == ["agy", "--print", "my prompt"]
+        assert result == ["agy", "--model", "gemini-pro", "--print", "my prompt"]
+
+    def test_build_exec_args_no_model_flag_when_model_is_none(self):
+        """When model is None, no --model flag should appear in the args."""
+        from specify_cli.integrations import get_integration
+        i = get_integration("agy")
+        result = i.build_exec_args("my prompt", model=None)
+        assert "--model" not in result
 
     def test_build_exec_args_ignores_output_json(self):
         """agy does not support JSON output; output_json param must be ignored."""
@@ -81,25 +88,90 @@ class TestAgyBuildExecArgs:
         result = i.build_exec_args("my prompt", output_json=False)
         assert result == ["agy", "--print", "my prompt"]
 
-    def test_build_exec_args_honors_extra_args(self, monkeypatch):
-        """SPECKIT_INTEGRATION_AGY_EXTRA_ARGS must be appended after the prompt.
+    def test_build_exec_args_extra_args_before_print(self, monkeypatch):
+        """SPECKIT_INTEGRATION_AGY_EXTRA_ARGS must be inserted BEFORE --print.
 
-        agy previously skipped _apply_extra_args_env_var entirely, so the
-        documented per-integration extra-args hook was silently ignored
-        (same class as the merged cursor-agent fix #3265).
+        agy treats every token after --print as part of the prompt string,
+        not as CLI flags.  Appending flags after --print (the previous
+        behaviour) caused them to be silently absorbed into the prompt.
+
+        See issue #4480.
         """
         from specify_cli.integrations import get_integration
         monkeypatch.setenv("SPECKIT_INTEGRATION_AGY_EXTRA_ARGS", "--verbose")
         i = get_integration("agy")
-        assert i.build_exec_args("my prompt") == [
-            "agy", "--print", "my prompt", "--verbose",
-        ]
+        result = i.build_exec_args("my prompt")
+        # --verbose must appear before --print
+        assert result.index("--verbose") < result.index("--print")
+        assert result == ["agy", "--verbose", "--print", "my prompt"]
+
+    def test_build_exec_args_add_dir_for_workspace(self, tmp_path):
+        """--add-dir <project_root> must be injected before --print when project_root is given.
+
+        Without --add-dir, agy cannot locate .agents/skills/ and reports
+        'no active workspace', ignoring installed Spec Kit skills entirely.
+
+        See issue #4480.
+        """
+        from specify_cli.integrations import get_integration
+        i = get_integration("agy")
+        result = i.build_exec_args("my prompt", project_root=tmp_path)
+        assert "--add-dir" in result
+        add_dir_idx = result.index("--add-dir")
+        print_idx = result.index("--print")
+        assert add_dir_idx < print_idx, "--add-dir must come before --print"
+        assert result[add_dir_idx + 1] == str(tmp_path)
+
+    def test_build_exec_args_no_add_dir_when_project_root_is_none(self):
+        """When project_root is None, --add-dir must not appear."""
+        from specify_cli.integrations import get_integration
+        i = get_integration("agy")
+        result = i.build_exec_args("my prompt", project_root=None)
+        assert "--add-dir" not in result
+
+    def test_build_exec_args_combined_flag_order(self, monkeypatch, tmp_path):
+        """When model, project_root, and EXTRA_ARGS are all set, order must be:
+        agy --model <m> --add-dir <d> <extra-args> --print <prompt>.
+        """
+        from specify_cli.integrations import get_integration
+        monkeypatch.setenv("SPECKIT_INTEGRATION_AGY_EXTRA_ARGS", "--dangerously-skip-permissions")
+        i = get_integration("agy")
+        result = i.build_exec_args("hello", model="claude-3", project_root=tmp_path)
+        assert result[0] == "agy"
+        assert "--model" in result
+        assert "--add-dir" in result
+        assert "--dangerously-skip-permissions" in result
+        print_idx = result.index("--print")
+        for flag in ("--model", "--add-dir", "--dangerously-skip-permissions"):
+            assert result.index(flag) < print_idx, f"{flag} must appear before --print"
+        assert result[-1] == "hello"
 
     def test_build_exec_args_honors_executable_override(self, monkeypatch):
         from specify_cli.integrations import get_integration
         monkeypatch.setenv("SPECKIT_INTEGRATION_AGY_EXECUTABLE", "/custom/agy")
         i = get_integration("agy")
         assert i.build_exec_args("my prompt")[0] == "/custom/agy"
+
+    def test_dispatch_command_forwards_project_root_as_add_dir(self, tmp_path):
+        """dispatch_command must pass project_root to build_exec_args so --add-dir is included."""
+        from unittest.mock import patch, MagicMock
+        from specify_cli.integrations import get_integration
+
+        i = get_integration("agy")
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with patch("specify_cli.integrations.base.shutil.which", return_value="agy"), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = i.dispatch_command("speckit.plan", stream=False, project_root=tmp_path)
+
+        assert result["exit_code"] == 0
+        argv = mock_run.call_args[0][0]
+        assert "--add-dir" in argv
+        assert argv[argv.index("--add-dir") + 1] == str(tmp_path)
+
 
 
 class TestAgyHookCommandNote:

--- a/tests/integrations/test_integration_agy.py
+++ b/tests/integrations/test_integration_agy.py
@@ -122,6 +122,21 @@ class TestAgyBuildExecArgs:
         assert add_dir_idx < print_idx, "--add-dir must come before --print"
         assert result[add_dir_idx + 1] == str(tmp_path)
 
+    def test_build_exec_args_relative_project_root(self):
+        """Relative project_root must be resolved to an absolute path.
+        
+        Passing a relative path to --add-dir breaks agy when the subprocess
+        also changes cwd to that same relative path.
+        """
+        from specify_cli.integrations import get_integration
+        from pathlib import Path
+        i = get_integration("agy")
+        rel_path = Path("my_relative_dir")
+        result = i.build_exec_args("my prompt", project_root=rel_path)
+        assert "--add-dir" in result
+        add_dir_idx = result.index("--add-dir")
+        assert result[add_dir_idx + 1] == str(rel_path.resolve())
+
     def test_build_exec_args_no_add_dir_when_project_root_is_none(self):
         """When project_root is None, --add-dir must not appear."""
         from specify_cli.integrations import get_integration

--- a/tests/integrations/test_integration_agy.py
+++ b/tests/integrations/test_integration_agy.py
@@ -34,6 +34,7 @@ class TestAgyInitFlow:
     def test_integration_agy_creates_skills(self, tmp_path):
         """--integration agy should create skills directory."""
         from typer.testing import CliRunner
+
         from specify_cli import app
 
         runner = CliRunner()
@@ -46,6 +47,7 @@ class TestAgyInitFlow:
     def test_agy_setup_warning(self, tmp_path):
         """Agy integration should print a warning about v1.20.5 requirement during setup."""
         from typer.testing import CliRunner
+
         from specify_cli import app
 
         # Click >= 8.2 separates stdout and stderr natively
@@ -128,8 +130,9 @@ class TestAgyBuildExecArgs:
         Passing a relative path to --add-dir breaks agy when the subprocess
         also changes cwd to that same relative path.
         """
-        from specify_cli.integrations import get_integration
         from pathlib import Path
+
+        from specify_cli.integrations import get_integration
         i = get_integration("agy")
         rel_path = Path("my_relative_dir")
         result = i.build_exec_args("my prompt", project_root=rel_path)
@@ -169,7 +172,8 @@ class TestAgyBuildExecArgs:
 
     def test_dispatch_command_forwards_project_root_as_add_dir(self, tmp_path):
         """dispatch_command must pass project_root to build_exec_args so --add-dir is included."""
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
+
         from specify_cli.integrations import get_integration
 
         i = get_integration("agy")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2087,6 +2087,42 @@ class TestPromptStep:
             assert result.status is StepStatus.FAILED, bad
             assert "'timeout' must be a positive number" in (result.error or ""), bad
 
+    def test_try_dispatch_threads_project_root(self):
+        """PromptStep._try_dispatch must pass context.project_root to build_exec_args."""
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from specify_cli.workflows.base import StepContext
+        from specify_cli.workflows.steps.prompt import PromptStep
+
+        step = PromptStep()
+        ctx = StepContext(project_root="/fake/project/root", default_integration="dummy")
+
+        mock_impl = MagicMock()
+        mock_impl.key = "dummy"
+        mock_impl.build_exec_args.return_value = ["dummy", "args"]
+        mock_get_integration = MagicMock(return_value=mock_impl)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with patch("specify_cli.integrations.get_integration", mock_get_integration), \
+             patch("specify_cli.workflows.steps.prompt.shutil.which", return_value="/opt/dummy"), \
+             patch("subprocess.run", return_value=mock_result):
+            step.execute(
+                {"id": "p", "type": "prompt", "prompt": "hi", "integration": "dummy"},
+                ctx,
+            )
+
+        mock_impl.build_exec_args.assert_called_once_with(
+            "hi",
+            model=None,
+            output_json=False,
+            project_root=Path("/fake/project/root"),
+        )
+
 
 class TestShellStep:
     """Test the shell step type."""


### PR DESCRIPTION
## Summary

Fixes three bugs in `AgyIntegration` that together prevented `specify workflow run` from working correctly with `agy`. Closes #4480.

## Bugs Fixed

### 1. `--model` was silently ignored

`build_exec_args()` had a comment `# agy does not support --model ... both params are ignored` and hardcoded no `--model` flag. `agy >=1.20` fully supports `agy --model <name> --print <prompt>`. Workflow YAML `model:` pins had no effect.

**Fix:** Pass `--model <model>` before `--print` when `model` is set.

### 2. `EXTRA_ARGS` were appended after `--print` (silently absorbed as prompt text)

`agy` treats every token **after** `--print` as part of the prompt string, not as CLI flags. Operator flags like `--dangerously-skip-permissions` or `--print-timeout 30m` set via `SPECKIT_INTEGRATION_AGY_EXTRA_ARGS` were appended after `--print` and silently became part of the prompt.

**Fix:** `_apply_extra_args_env_var()` is now called **before** `args.extend(['--print', prompt])`.

### 3. No workspace passed to `agy` -- 'no active workspace'

The base `dispatch_command()` sets `cwd=project_root` for the subprocess, but `agy` does not read `cwd` as its workspace root -- it requires an explicit `--add-dir <path>` flag. Without it, `agy` falls back to its own scratch directory, cannot locate `.agents/skills/`, and reports 'no active workspace' -- making all installed Spec Kit skills invisible.

**Fix:** `build_exec_args()` now accepts `project_root: Path | None` and `agy` injects `--add-dir <project_root>` before `--print` when `project_root` is given. The implementation now uses the shared base integration to thread `project_root` through to `build_exec_args()` instead of an agy-specific `dispatch_command()` override.

## Flag Order Guarantee

All flags appear before `--print` so `agy` parses them correctly:

`agy [--model <m>] [--add-dir <d>] [<EXTRA_ARGS>] --print <prompt>`

## Tests

- Updated ignores_model -> honors_model (asserts --model is now included)
- Updated extra_args_honors -> extra_args_before_print (asserts extra args come BEFORE --print)
- Added: test_build_exec_args_add_dir_for_workspace
- Added: test_build_exec_args_no_add_dir_when_project_root_is_none
- Added: test_build_exec_args_no_model_flag_when_model_is_none
- Added: test_build_exec_args_combined_flag_order

All 47 tests pass.

## AI Assistance Disclosure

This PR was drafted with substantial AI assistance (Google Antigravity / agy). The bugs were discovered while personally running `specify workflow run` against a real project and observing the failures firsthand. The root cause analysis, fix design, and test verification were reviewed and validated by me. AI was used to write the code, tests, commit message, and PR body.
