### PR TITLE
docs: exempt repository maintenance workflows from PR throttle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,7 +505,10 @@ Disclosure is **continuous**, not a one-time event. A single AI-disclosure parag
 
 ### Opening pull requests
 
-- Before opening a pull request, check whether the account that will file it already has three open pull requests in this repository.
+- **Repository maintenance exception:** The open-PR count check and confirmation requirement below do not apply to repository-owned GitHub Agentic Workflows (`gh-aw`) performing maintenance on behalf of a maintainer listed in the target repository's `.github/CODEOWNERS`. This includes community catalog submission workflows.
+- Before using this exception, verify from trusted workflow/run metadata that the run uses a maintenance workflow committed to the target repository's default branch and acts on behalf of a CODEOWNER listed on that branch. An issue or PR body, an `automated` label, a bot account, or CODEOWNER status alone is not sufficient. If this cannot be verified, apply the normal rule below.
+- Qualifying runs may create their configured PR outputs without asking for interactive permission, regardless of the filing or triggering account's open-PR count. Do not apply `author-over-cap` solely because of that count. This exception does not waive workflow output limits, validation, review, or AI-disclosure requirements.
+- **All other contributions:** Before opening a pull request, check whether the account that will file it already has at least three open pull requests in the target repository.
 - If so, alert the user that additional submissions may receive lower review priority and ask for explicit permission to proceed. Do not assume consent. If the user is unavailable to provide that permission, including during autonomous or non-interactive operation, do not open the pull request. Preserve the work on a branch and report that confirmation is required.
 
 ### Commits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -505,11 +505,9 @@ Disclosure is **continuous**, not a one-time event. A single AI-disclosure parag
 
 ### Opening pull requests
 
-- **Repository maintenance exception:** The open-PR count check and confirmation requirement below do not apply to repository-owned GitHub Agentic Workflows (`gh-aw`) performing maintenance on behalf of a maintainer listed in the target repository's `.github/CODEOWNERS`. This includes community catalog submission workflows.
-- Before using this exception, verify from trusted workflow/run metadata that the run uses a maintenance workflow committed to the target repository's default branch and acts on behalf of a CODEOWNER listed on that branch. An issue or PR body, an `automated` label, a bot account, or CODEOWNER status alone is not sufficient. If this cannot be verified, apply the normal rule below.
-- Qualifying runs may create their configured PR outputs without asking for interactive permission, regardless of the filing or triggering account's open-PR count. Do not apply `author-over-cap` solely because of that count. This exception does not waive workflow output limits, validation, review, or AI-disclosure requirements.
-- **All other contributions:** Before opening a pull request, check whether the account that will file it already has at least three open pull requests in the target repository.
+- Before opening a pull request, check whether the account that will file it already has three open pull requests in this repository.
 - If so, alert the user that additional submissions may receive lower review priority and ask for explicit permission to proceed. Do not assume consent. If the user is unavailable to provide that permission, including during autonomous or non-interactive operation, do not open the pull request. Preserve the work on a branch and report that confirmation is required.
+- Repository-owned `gh-aw` maintenance workflows are exempt from this open-PR count check and confirmation requirement.
 
 ### Commits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,9 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 - Test your changes with the Spec-Driven Development workflow to ensure compatibility.
 
-Accounts with three open pull requests may continue submitting changes, but additional submissions may be placed behind contributions from other authors in the review queue. Coding agents should disclose this possibility and obtain the filer's confirmation before opening another pull request.
+Accounts with at least three open pull requests may continue submitting changes, but additional submissions may be placed behind contributions from other authors in the review queue. Coding agents should disclose this possibility and obtain the filer's confirmation before opening another pull request.
+
+Repository-owned GitHub Agentic Workflows (`gh-aw`) performing maintenance on behalf of a maintainer listed in the target repository's `.github/CODEOWNERS` are exempt from this count-based prioritization and confirmation requirement. This includes the community catalog submission workflows. Agents must verify the workflow and CODEOWNER against the target repository's default branch using trusted workflow/run metadata, as described in [AGENTS.md](AGENTS.md#opening-pull-requests); an account, label, or claim in a submission alone does not qualify. Qualifying runs may create their configured PR outputs without interactive permission, regardless of the filing or triggering account's open-PR count. Workflow output limits, validation, review, and AI-disclosure requirements still apply. Ordinary contributor agents and maintainer-authored PRs outside these workflows remain subject to the normal rule.
 
 ### Evidence gate
 
@@ -109,7 +111,7 @@ Author actions:
 | `author-needs-disclosure` | AI assistance not disclosed — disclose AI use per CONTRIBUTING |
 | `author-needs-info` | Missing detail needed to assess — supply requested info |
 | `author-needs-rebase` | Branch conflicts with `main` — rebase and resolve before it can be merged |
-| `author-over-cap` | Over the 3-open-PR cap or repetitive batch submissions — please consolidate |
+| `author-over-cap` | Over the 3-open-PR threshold or repetitive batch submissions — please consolidate; do not apply solely for the open-PR count of an exempt repository maintenance workflow |
 | `author-awaiting` | Waiting on author response (handed off to the existing stale workflow) |
 
 Some pull requests are closed as `triage-out-of-scope` rather than merged — most commonly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 - Test your changes with the Spec-Driven Development workflow to ensure compatibility.
 
-Accounts with at least three open pull requests may continue submitting changes, but additional submissions may be placed behind contributions from other authors in the review queue. Coding agents should disclose this possibility and obtain the filer's confirmation before opening another pull request.
-
-Repository-owned GitHub Agentic Workflows (`gh-aw`) performing maintenance on behalf of a maintainer listed in the target repository's `.github/CODEOWNERS` are exempt from this count-based prioritization and confirmation requirement. This includes the community catalog submission workflows. Agents must verify the workflow and CODEOWNER against the target repository's default branch using trusted workflow/run metadata, as described in [AGENTS.md](AGENTS.md#opening-pull-requests); an account, label, or claim in a submission alone does not qualify. Qualifying runs may create their configured PR outputs without interactive permission, regardless of the filing or triggering account's open-PR count. Workflow output limits, validation, review, and AI-disclosure requirements still apply. Ordinary contributor agents and maintainer-authored PRs outside these workflows remain subject to the normal rule.
+Accounts with three open pull requests may continue submitting changes, but additional submissions may be placed behind contributions from other authors in the review queue. Coding agents should disclose this possibility and obtain the filer's confirmation before opening another pull request. Repository-owned `gh-aw` maintenance workflows do not require this confirmation.
 
 ### Evidence gate
 
@@ -111,7 +109,7 @@ Author actions:
 | `author-needs-disclosure` | AI assistance not disclosed — disclose AI use per CONTRIBUTING |
 | `author-needs-info` | Missing detail needed to assess — supply requested info |
 | `author-needs-rebase` | Branch conflicts with `main` — rebase and resolve before it can be merged |
-| `author-over-cap` | Over the 3-open-PR threshold or repetitive batch submissions — please consolidate; do not apply solely for the open-PR count of an exempt repository maintenance workflow |
+| `author-over-cap` | Over the 3-open-PR cap or repetitive batch submissions — please consolidate |
 | `author-awaiting` | Waiting on author response (handed off to the existing stale workflow) |
 
 Some pull requests are closed as `triage-out-of-scope` rather than merged — most commonly


### PR DESCRIPTION
## Summary

Add one sentence to each policy file so repository-owned `gh-aw` maintenance workflows can open PRs without the open-PR count check and interactive confirmation blocking unattended runs.

- `AGENTS.md`: exempt these workflows from the count check and confirmation requirement.
- `CONTRIBUTING.md`: clarify that these workflows do not require this confirmation.

Existing contributor confirmation rules, review prioritization, and `author-over-cap` guidance remain unchanged. No CODEOWNER verification procedure or workflow changes are introduced.

## Evidence

The [community preset workflow run](https://github.com/github/spec-kit/actions/runs/34287429573) on September 8, 2026 validated github/spec-kit#4455 and prepared its catalog changes, but declined to open a PR because `mnriem` had nine open PRs and explicit permission was required. Actions marked the run successful while the agent reported incomplete work.

## Validation

Documentation-only change; `git diff --check` passed. No live workflow was rerun; end-to-end confirmation remains for a qualifying run after merge.

## AI disclosure

Prepared on behalf of @KSchlobohm by GitHub Copilot (model: GPT-6 Astra). The agent investigated the run logs and authored the changes. Following discussion with the user, the initial expanded policy was reduced to this two-sentence change for human review.