### PR TITLE
chore: shorten stale timeline to 60 days stale, 30 days to close

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,18 +17,18 @@ jobs:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           # Days of inactivity before an issue or PR becomes stale
-          days-before-stale: 150
+          days-before-stale: 60
           # Days of inactivity before a stale issue or PR is closed (after being marked stale)
           days-before-close: 30
 
           # Stale issue settings
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had any activity for 150 days. It will be closed in 30 days if no further activity occurs.'
-          close-issue-message: 'This issue has been automatically closed due to inactivity (180 days total). If you believe this issue is still relevant, please reopen it or create a new issue.'
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had any activity for 60 days. It will be closed in 30 days if no further activity occurs.'
+          close-issue-message: 'This issue has been automatically closed due to inactivity (90 days total). If you believe this issue is still relevant, please reopen it or create a new issue.'
           stale-issue-label: 'stale'
 
           # Stale PR settings
-          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had any activity for 150 days. It will be closed in 30 days if no further activity occurs.'
-          close-pr-message: 'This pull request has been automatically closed due to inactivity (180 days total). If you believe this PR is still relevant, please reopen it or create a new PR.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had any activity for 60 days. It will be closed in 30 days if no further activity occurs.'
+          close-pr-message: 'This pull request has been automatically closed due to inactivity (90 days total). If you believe this PR is still relevant, please reopen it or create a new PR.'
           stale-pr-label: 'stale'
 
           # Exempt issues and PRs with these labels from being marked as stale


### PR DESCRIPTION
## Summary

Shortens the inactivity timeline in `.github/workflows/stale.yml`:

- `days-before-stale`: 150 → **60**
- `days-before-close`: 30 (unchanged) — a stale issue/PR is closed **30 days** after being marked stale
- Total time from last activity to close: 180 → **90 days**

Stale/close messages and the "total days" figures were updated to match.

## Rationale

Surfaces and closes inactive issues and PRs sooner, keeping the tracker current.

---

> [!NOTE]
> This PR was authored autonomously by GitHub Copilot (model: Claude Opus 4.8) on behalf of @mnriem.