### PR TITLE
Bound speckit.clarify planning deferral to implementation details

### DIFF
--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -122,25 +122,9 @@ Execution steps:
    - TODO markers / unresolved decisions
    - Ambiguous adjectives ("robust", "intuitive") lacking quantification
 
-   Stage gate (spec vs plan). For every unchecked checklist item and every
-   Partial/Missing taxonomy category, classify before considering deferral:
-   1. Match the item against the spec-oriented taxonomy above.
-   2. A hit on any taxonomy category is a question candidate for THIS stage.
-      Do not defer NFRs, acceptance/DoD testability, edge cases, UX empty
-      states, domain constraints, or external-dependency failure modes.
-   3. Defer to planning ONLY when the item is specifically about
-      implementation method, tech-stack comparison, or task breakdown.
-   4. Mixed items (spec decision plus plan detail): split them and handle
-      the spec part now.
-
-   If more than 60% of unresolved items would be marked Defer, pause, report
-   the ratio, and re-check each against the taxonomy before continuing.
-
    For each category with Partial or Missing status, add a candidate question opportunity unless:
    - Clarification would not materially change implementation or validation strategy
-   - The item failed the stage gate above (implementation method, tech-stack
-     comparison, or task breakdown). Note internally; do not use a vague
-     "better deferred to planning" catch-all.
+   - The item is specifically about implementation method, tech-stack comparison, or task breakdown (note internally)
 
 4. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
     - Maximum of 5 total questions across the whole session.
@@ -251,10 +235,6 @@ Behavior rules:
 - Respect user early termination signals ("stop", "done", "proceed").
 - If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
 - If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
-- MUST NOT defer spec-taxonomy items to Plan. Concurrent-user volume, NFR
-  quantification, acceptance-criteria testability, empty-state UX, and
-  external-dependency failure modes are spec questions. "How we implement
-  pagination" can wait; "whether the API paginates" cannot.
 
 Context for prioritization: {ARGS}
 

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -279,7 +279,7 @@ Report completion (after questioning loop ends or early termination):
 - Path to updated spec.
 - Sections touched (list names).
 - Spec quality checklist status (if `FEATURE_DIR/checklists/requirements.md` was re-validated): show before/after pass counts (e.g., "Spec Quality Checklist: 12/16 → 15/16 items passing") and list any items that changed state — both newly checked (unchecked → checked) and any regressions (checked → unchecked). If any items remain unchecked, list them as areas needing attention.
-- Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+- Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota, or remaining item is specifically implementation method, tech-stack comparison, or task breakdown), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
 - If any Outstanding or Deferred remain, recommend whether to proceed to `__SPECKIT_COMMAND_PLAN__` or run `__SPECKIT_COMMAND_CLARIFY__` again later post-plan.
 - Suggested next command.
 

--- a/templates/commands/clarify.md
+++ b/templates/commands/clarify.md
@@ -122,9 +122,25 @@ Execution steps:
    - TODO markers / unresolved decisions
    - Ambiguous adjectives ("robust", "intuitive") lacking quantification
 
+   Stage gate (spec vs plan). For every unchecked checklist item and every
+   Partial/Missing taxonomy category, classify before considering deferral:
+   1. Match the item against the spec-oriented taxonomy above.
+   2. A hit on any taxonomy category is a question candidate for THIS stage.
+      Do not defer NFRs, acceptance/DoD testability, edge cases, UX empty
+      states, domain constraints, or external-dependency failure modes.
+   3. Defer to planning ONLY when the item is specifically about
+      implementation method, tech-stack comparison, or task breakdown.
+   4. Mixed items (spec decision plus plan detail): split them and handle
+      the spec part now.
+
+   If more than 60% of unresolved items would be marked Defer, pause, report
+   the ratio, and re-check each against the taxonomy before continuing.
+
    For each category with Partial or Missing status, add a candidate question opportunity unless:
    - Clarification would not materially change implementation or validation strategy
-   - Information is better deferred to planning phase (note internally)
+   - The item failed the stage gate above (implementation method, tech-stack
+     comparison, or task breakdown). Note internally; do not use a vague
+     "better deferred to planning" catch-all.
 
 4. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
     - Maximum of 5 total questions across the whole session.
@@ -235,6 +251,10 @@ Behavior rules:
 - Respect user early termination signals ("stop", "done", "proceed").
 - If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
 - If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+- MUST NOT defer spec-taxonomy items to Plan. Concurrent-user volume, NFR
+  quantification, acceptance-criteria testability, empty-state UX, and
+  external-dependency failure modes are spec questions. "How we implement
+  pagination" can wait; "whether the API paginates" cannot.
 
 Context for prioritization: {ARGS}
 

--- a/tests/test_clarify_stage_gate.py
+++ b/tests/test_clarify_stage_gate.py
@@ -1,0 +1,18 @@
+"""Pin the spec-vs-plan stage gate in ``templates/commands/clarify.md`` (#1717).
+
+Agents were deferring NFRs, acceptance criteria, and edge cases to Plan
+because the template allowed a vague "better deferred to planning" exit.
+The gate must stay in the command the agent actually reads.
+"""
+
+from pathlib import Path
+
+CLARIFY = Path(__file__).parent.parent / "templates" / "commands" / "clarify.md"
+
+
+def test_clarify_has_spec_vs_plan_stage_gate() -> None:
+    text = CLARIFY.read_text(encoding="utf-8")
+    assert "Stage gate (spec vs plan)" in text
+    assert "implementation method, tech-stack comparison, or task breakdown" in text
+    assert "MUST NOT defer spec-taxonomy items to Plan" in text
+    assert "- Information is better deferred to planning phase (note internally)" not in text

--- a/tests/test_clarify_stage_gate.py
+++ b/tests/test_clarify_stage_gate.py
@@ -13,7 +13,13 @@ CLARIFY = Path(__file__).parent.parent / "templates" / "commands" / "clarify.md"
 def test_clarify_planning_deferral_is_bounded() -> None:
     text = CLARIFY.read_text(encoding="utf-8")
     assert "- Information is better deferred to planning phase (note internally)" not in text
+    assert "better suited for planning" not in text
     assert (
         "implementation method, tech-stack comparison, or task breakdown"
         in text
+    )
+    completion = text.split("## Completion Report", 1)[1]
+    assert (
+        "implementation method, tech-stack comparison, or task breakdown"
+        in completion
     )

--- a/tests/test_clarify_stage_gate.py
+++ b/tests/test_clarify_stage_gate.py
@@ -1,8 +1,8 @@
-"""Pin the spec-vs-plan stage gate in ``templates/commands/clarify.md`` (#1717).
+"""The planning deferral in ``templates/commands/clarify.md`` must stay bounded (#1717).
 
-Agents were deferring NFRs, acceptance criteria, and edge cases to Plan
-because the template allowed a vague "better deferred to planning" exit.
-The gate must stay in the command the agent actually reads.
+The old catch-all ("Information is better deferred to planning phase") let
+agents skip NFRs, acceptance criteria, and edge cases. Defer only
+implementation method, tech-stack comparison, or task breakdown.
 """
 
 from pathlib import Path
@@ -10,9 +10,10 @@ from pathlib import Path
 CLARIFY = Path(__file__).parent.parent / "templates" / "commands" / "clarify.md"
 
 
-def test_clarify_has_spec_vs_plan_stage_gate() -> None:
+def test_clarify_planning_deferral_is_bounded() -> None:
     text = CLARIFY.read_text(encoding="utf-8")
-    assert "Stage gate (spec vs plan)" in text
-    assert "implementation method, tech-stack comparison, or task breakdown" in text
-    assert "MUST NOT defer spec-taxonomy items to Plan" in text
     assert "- Information is better deferred to planning phase (note internally)" not in text
+    assert (
+        "implementation method, tech-stack comparison, or task breakdown"
+        in text
+    )


### PR DESCRIPTION
## Description

`/speckit.clarify` treated "better deferred to planning" as a catch-all, so agents skipped NFRs, acceptance criteria, empty-state UX, and edge cases.

The command now defers only implementation method, tech-stack comparison, or task breakdown. Spec taxonomy is unchanged. Stage-gate procedure and defer-ratio audit stay out of core (those belong in an opt-in wrap preset).

## Testing

- [x] `uv run pytest tests/test_clarify_stage_gate.py`
