### PR TITLE
fix(workflows): an interrupted gate prompt must not approve the gate

### DIFF
--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -248,8 +248,23 @@ class GateStep(StepBase):
             try:
                 raw = input(f"  Choose [1-{len(options)}]: ").strip()
             except (EOFError, KeyboardInterrupt):
+                # An interrupted prompt is not a choice. Returning ``options[-1]``
+                # assumed the reject option is last, but ``validate`` only
+                # requires that *some* option is 'reject'/'abort' -- never that
+                # it is last. So ``options: [approve, reject, request-changes]``
+                # validates clean and an interrupt resolved to
+                # 'request-changes', which ``execute`` does not classify as a
+                # rejection: the gate reported COMPLETED and the run walked past
+                # the human review it exists to enforce.
+                #
+                # Prefer the declared reject/abort option. For the documented
+                # default ``[approve, reject]`` this is byte-for-byte the old
+                # behaviour, since 'reject' is both last and the reject option.
                 print()
-                return options[-1]  # default to last (usually reject)
+                return next(
+                    (o for o in options if o.lower() in ("reject", "abort")),
+                    options[-1],
+                )
             # isdecimal() (not isdigit()): int() accepts exactly the decimal-digit
             # set, whereas isdigit() also returns True for superscripts/subscripts
             # (e.g. "²") that int() then rejects with ValueError — crashing

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3003,6 +3003,79 @@ steps:
         choice = GateStep._prompt("Review the spec.", ["approve", "reject"])
         assert choice == "approve"
 
+    @pytest.mark.parametrize("interrupt", [KeyboardInterrupt, EOFError])
+    @pytest.mark.parametrize(
+        "options",
+        [
+            ["approve", "reject"],
+            ["reject", "approve"],
+            ["approve", "reject", "request-changes"],
+        ],
+        ids=["reject_last", "reject_first", "reject_middle"],
+    )
+    def test_interrupted_prompt_never_approves(
+        self, monkeypatch, options, interrupt
+    ):
+        """Ctrl+C / Ctrl+D at a gate must not resolve to an approving option.
+
+        `_prompt` returned `options[-1]`, assuming the reject option is last.
+        `validate` only requires that *some* option is 'reject'/'abort', never
+        that it is last, so `options: [approve, reject, request-changes]`
+        validates clean and an interrupt returned 'request-changes' — which
+        `execute` does not classify as a rejection, so the gate reported
+        COMPLETED and the run walked past the human review.
+        """
+        from specify_cli.workflows.steps.gate import GateStep
+
+        _force_gate_stdin(monkeypatch, tty=True)
+
+        def _boom(_prompt=""):
+            raise interrupt
+
+        monkeypatch.setattr("builtins.input", _boom)
+
+        assert GateStep._prompt("Approve the plan?", options) == "reject"
+
+    def test_interrupted_prompt_without_a_reject_option_keeps_last(
+        self, monkeypatch
+    ):
+        """With no reject/abort option declared, the last option is still used."""
+        from specify_cli.workflows.steps.gate import GateStep
+
+        _force_gate_stdin(monkeypatch, tty=True)
+
+        def _boom(_prompt=""):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("builtins.input", _boom)
+
+        assert GateStep._prompt("Pick one.", ["yes", "no"]) == "no"
+
+    def test_interrupted_gate_step_does_not_complete(self, monkeypatch):
+        """The step-level consequence: the gate must not report COMPLETED."""
+        from specify_cli.workflows.steps.gate import GateStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        _force_gate_stdin(monkeypatch, tty=True)
+
+        def _boom(_prompt=""):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("builtins.input", _boom)
+
+        result = GateStep().execute(
+            {
+                "id": "review",
+                "message": "Approve the plan?",
+                "options": ["approve", "reject", "request-changes"],
+                "on_reject": "abort",
+            },
+            StepContext(),
+        )
+
+        assert result.status is StepStatus.FAILED
+        assert result.output["choice"] == "reject"
+
     def test_interactive_prompt_missing_show_file_does_not_crash(
         self, tmp_path, monkeypatch, capsys
     ):


### PR DESCRIPTION
## Problem

`GateStep._prompt` treats Ctrl+C / Ctrl+D as a **choice**:

```python
except (EOFError, KeyboardInterrupt):
    print()
    return options[-1]  # default to last (usually reject)
```

"usually reject" is an assumption `validate` never enforces. It requires only that *some* option is `reject`/`abort` — never that it is **last**:

```python
reject_choices = {"reject", "abort"}
if not any(o.lower() in reject_choices for o in options):
```

So a hand-written `options` list whose reject choice is not last validates clean, and `options[-1]` is then an **approving** option. `execute` classifies the result with `if choice.lower() in ("reject", "abort")`, so the gate reports COMPLETED and the run continues past the human review the gate exists to enforce.

## Reproduction on current `main` (c173bf19)

Interrupting the prompt, with `validate()` run on each config first:

```
options=['approve', 'reject']                    validate=[] -> status=failed    choice='reject'
options=['reject', 'approve']                    validate=[] -> status=completed choice='approve'
options=['approve', 'reject', 'request-changes'] validate=[] -> status=completed choice='request-changes'
```

Identical for both `KeyboardInterrupt` and `EOFError`. **All three validate with zero errors** — `specify workflow validate` gives the author no warning.

The middle and last rows are the bug: the operator pressed Ctrl+C at an approval gate and the workflow recorded an approval.

### It also contradicts the engine's own interrupt contract

`WorkflowEngine` catches `KeyboardInterrupt` and sets `RunStatus.PAUSED` with a `workflow_interrupted` log event (`engine.py:1059-1061`), so Ctrl+C anywhere else in a run pauses it for `specify workflow resume`. Only at a gate did it silently make a decision instead.

## Fix

Prefer the declared reject/abort option; fall back to the last option when none is declared.

```python
return next(
    (o for o in options if o.lower() in ("reject", "abort")),
    options[-1],
)
```

After the fix, every config carrying a reject option rejects on interrupt:

```
KeyboardInterrupt options=['approve', 'reject']                    -> failed    choice='reject'
KeyboardInterrupt options=['reject', 'approve']                    -> failed    choice='reject'
KeyboardInterrupt options=['approve', 'reject', 'request-changes'] -> failed    choice='reject'
KeyboardInterrupt options=['yes', 'no']                            -> completed choice='no'   <-- unchanged
```

## Behaviour change — disclosed

The returned choice changes **only** when the prompt is interrupted **and** a reject/abort option is not last. The documented default `options: [approve, reject]` is byte-for-byte unchanged, which the `reject_last` parametrization pins by passing both before and after. A workflow that deliberately relied on Ctrl+C selecting a trailing non-reject option (say `defer`) would now reject instead — that reliance is precisely the defect being fixed, but it is a real change and worth stating.

## Verification

- **Fail-before / pass-after:** 5 new-vs-baseline failures with the source reverted to `upstream/main` → **55 passed** with the fix.
- Parametrized over both interrupt types × three option orderings, plus a step-level test asserting the gate does not report COMPLETED, plus a guard that the no-reject-option fallback is unchanged.
- Scoped regression on `tests/test_workflows.py`: **21 failed / 964 passed** against a clean-`main` baseline of **21 failed / 956 passed** — no new failures (the 21 are the known Windows `os.replace` flakiness in that file).
- `uvx ruff@0.15.0 check src tests` → clean

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)