### PR TITLE
fix(workflows): init step must not replace init's own error with `SystemExit: 1`

### DIFF
--- a/src/specify_cli/workflows/steps/init/__init__.py
+++ b/src/specify_cli/workflows/steps/init/__init__.py
@@ -295,7 +295,21 @@ class InitStep(StepBase):
             # steps.<id>.output.stderr for error details.
             stderr = stdout if result.exit_code != 0 else ""
 
-        if result.exit_code != 0 and result.exception is not None:
+        # Record the exception only for an UNEXPECTED crash. ``typer.Exit(n)``
+        # -- how ``specify init`` reports every ordinary failure -- surfaces
+        # through ``CliRunner`` as ``result.exception = SystemExit(n)``, so this
+        # branch used to fire on routine errors too. ``init`` prints its
+        # diagnostics through Rich to stdout, leaving ``result.stderr`` empty,
+        # so the synthesized "SystemExit: 1" became the whole of ``stderr`` and
+        # preempted ``execute``'s ``stderr.strip() or stdout.strip()`` fallback.
+        # Every failing init step then reported ``error: 'SystemExit: 1'`` while
+        # init's real message -- e.g. the list of valid integrations for a
+        # typo'd ``integration:`` -- sat unread in stdout.
+        if (
+            result.exit_code != 0
+            and result.exception is not None
+            and not isinstance(result.exception, SystemExit)
+        ):
             detail = f"{type(result.exception).__name__}: {result.exception}"
             stderr = f"{stderr}\n{detail}".strip() if stderr else detail
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -2594,6 +2594,70 @@ class TestInitStep:
         assert result.output["exit_code"] != 0
         assert result.error is not None
 
+    def test_failed_init_surfaces_inits_own_message(self, tmp_path):
+        """A failing init step must report init's diagnostics, not 'SystemExit: 1'.
+
+        `typer.Exit(n)` — how `specify init` reports every ordinary failure —
+        surfaces through `CliRunner` as `result.exception = SystemExit(n)`, so
+        the unexpected-crash branch fired on routine errors too. `init` prints
+        through Rich to stdout, leaving `result.stderr` empty, so the
+        synthesized "SystemExit: 1" became the whole of stderr and preempted
+        the `stderr.strip() or stdout.strip()` fallback — stranding the real
+        message (here, the list of valid integrations) in stdout.
+        """
+        from specify_cli.workflows.steps.init import InitStep
+        from specify_cli.workflows.base import StepContext, StepStatus
+
+        result = InitStep().execute(
+            {
+                "id": "bootstrap",
+                "here": True,
+                "integration": "no-such-agent",
+                "script": "sh",
+            },
+            StepContext(project_root=str(tmp_path)),
+        )
+
+        assert result.status == StepStatus.FAILED
+        assert result.error is not None
+        assert result.error.strip() != "SystemExit: 1"
+        assert result.output["stderr"].strip() != "SystemExit: 1"
+        # The real diagnostic reaches the caller.
+        collapsed = " ".join(result.error.split())
+        assert "no-such-agent" in collapsed or "Unknown" in collapsed, collapsed
+
+    def test_unexpected_crash_still_reports_its_exception(self, monkeypatch, tmp_path):
+        """The branch's original purpose is preserved for a genuine crash.
+
+        Only `SystemExit` is now excluded; any other exception escaping the
+        runner must still be surfaced, since nothing else would describe it.
+        """
+        from specify_cli.workflows.steps.init import InitStep
+        import typer.testing
+
+        class _Result:
+            exit_code = 1
+            output = ""
+            stderr = ""
+            exception = RuntimeError("boom inside init")
+
+        class _Runner:
+            def __init__(self, *a, **k):
+                pass
+
+            def invoke(self, *a, **k):
+                return _Result()
+
+        monkeypatch.setattr(typer.testing, "CliRunner", _Runner)
+
+        from specify_cli.workflows.base import StepContext
+
+        _code, _stdout, stderr = InitStep()._run_init(
+            ["init", "demo"], StepContext(project_root=str(tmp_path))
+        )
+
+        assert "RuntimeError: boom inside init" in stderr
+
     def test_non_empty_current_dir_without_force_fails_fast(self, tmp_path):
         from specify_cli.workflows.steps.init import InitStep
         from specify_cli.workflows.base import StepContext, StepStatus


### PR DESCRIPTION
## Problem

`InitStep._run_init` appends the runner's exception to stderr:

```python
if result.exit_code != 0 and result.exception is not None:
    detail = f"{type(result.exception).__name__}: {result.exception}"
    stderr = f"{stderr}\n{detail}".strip() if stderr else detail
```

That branch exists for an **unexpected crash**. But `typer.Exit(n)` — how `specify init` reports *every* ordinary failure — surfaces through `CliRunner` as `result.exception = SystemExit(n)`, so it fires on routine errors too.

`init` prints its diagnostics through Rich to **stdout**, so `result.stderr` is empty. The synthesized detail therefore becomes the entire `stderr`, which preempts `execute`'s fallback two frames later:

```python
error=(
    stderr.strip()
    or stdout.strip()          # <-- never reached
    or f"specify init exited with code {exit_code}."
),
```

## Reproduction on current `main` (c173bf19)

An ordinary typo in `integration:` — which `InitStep.validate` does not value-check:

```
validate     : []
status       : failed | exit_code: 1
result.error : 'SystemExit: 1'
output.stderr: 'SystemExit: 1'
stdout holds : "... lingma, muse, omp, opencode, pi, qodercli, qwen,
                rovodev, shai, tabnine, trae, vibe, zcode, zed"
```

So the workflow author is told `SystemExit: 1` while the list of valid integrations sits unread in stdout. The same applies to any ordinary init failure — a `project:` directory that already exists, an unusable script type.

It also leaks into workflow data: `steps.<id>.output.stderr` is the string `"SystemExit: 1"`, so a downstream step reading it gets the sentinel rather than a diagnosis.

## Fix

Exclude only `SystemExit`, preserving the branch for genuine crashes:

```python
if (
    result.exit_code != 0
    and result.exception is not None
    and not isinstance(result.exception, SystemExit)
):
```

After the fix the same input reports init's own message, and a `RuntimeError` escaping the runner still yields `RuntimeError: boom inside init`.

## Verification

- **Fail-before / pass-after:** 1 new-vs-baseline failure with the source reverted to `upstream/main` → **16 passed** with the fix.
- A second test pins the branch's original purpose — an unexpected `RuntimeError` still surfaces. It passes both before and after by design: it guards preserved behaviour rather than proving the fix.
- Scoped regression on `tests/test_workflows.py`: **20 failed / 959 passed** vs a clean-`main` baseline of **20 failed / 957 passed** — no new failures (the 20 are the known Windows `os.replace` flakiness in that file).
- `uvx ruff@0.15.0 check src tests` → clean

**Behaviour change, disclosed:** `error` and `output.stderr` for a *failing* init step change from `"SystemExit: 1"` to init's own captured output (which includes its banner, since init writes to stdout). Successful steps are untouched, and no existing test asserted the old sentinel.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)