### PR TITLE
fix(workflows): match overlay file extensions case-insensitively

### DIFF
--- a/src/specify_cli/workflows/overlays/layer_sources.py
+++ b/src/specify_cli/workflows/overlays/layer_sources.py
@@ -147,7 +147,12 @@ class ProjectOverlaySource:
                 workflow_overlay_dir, [f"Cannot enumerate overlays: {exc}"]
             ) from exc
         for path in entries:
-            if not path.is_file() or path.suffix not in (".yml", ".yaml"):
+            # Match the extension case-insensitively. A hand-placed overlay
+            # named ``<id>.YML`` or ``<id>.Yaml`` was skipped here and never
+            # applied, with nothing reported to say the file had been ignored.
+            # Every other YAML discovery path in the package already lowercases
+            # before matching (engine.py:941, _commands.py:1325/1894/2128).
+            if not path.is_file() or path.suffix.lower() not in (".yml", ".yaml"):
                 continue
             if path.is_symlink():
                 raise OverlayLoadError(path, ["Symlinked overlay files are not allowed"])

--- a/tests/workflows/test_overlay_layer_sources.py
+++ b/tests/workflows/test_overlay_layer_sources.py
@@ -85,6 +85,50 @@ class TestProjectOverlaySourceManifestShape:
         )
 
 
+class TestProjectOverlaySourceExtensionMatching:
+    """Overlay file extensions are matched case-insensitively."""
+
+    @pytest.mark.parametrize(
+        "filename", ["upper.YML", "mixed.Yaml", "shouty.YAML", "title.Yml"]
+    )
+    def test_uppercase_extension_is_collected(
+        self, project_dir: Path, filename: str
+    ) -> None:
+        """A hand-placed `<id>.YML` must not be silently ignored.
+
+        `collect` matched `path.suffix` verbatim against `(".yml", ".yaml")`,
+        so an overlay whose extension differed only in case was skipped with
+        nothing reported — the author's overlay simply never applied. Every
+        other YAML discovery path in the package lowercases before matching.
+        """
+        ov_dir = project_dir / ".specify" / "workflows" / "overlays" / "wf"
+        ov_dir.mkdir(parents=True, exist_ok=True)
+        (ov_dir / filename).write_text(
+            yaml.safe_dump(
+                {
+                    "id": "lint",
+                    "extends": "wf",
+                    "priority": 10,
+                    "edits": [{"remove": "a"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        layers = ProjectOverlaySource(project_dir).collect("wf")
+
+        assert [layer.content.id for layer in layers] == ["lint"]
+
+    def test_non_yaml_extensions_are_still_skipped(self, project_dir: Path) -> None:
+        """Broadening case must not broaden which extensions are accepted."""
+        ov_dir = project_dir / ".specify" / "workflows" / "overlays" / "wf"
+        ov_dir.mkdir(parents=True, exist_ok=True)
+        for name in ("notes.txt", "backup.yml.bak", "README.md", "data.json"):
+            (ov_dir / name).write_text("id: lint\n", encoding="utf-8")
+
+        assert ProjectOverlaySource(project_dir).collect("wf") == []
+
+
 class TestProjectOverlaySourceFileReadErrors:
     """File-read errors must be wrapped in OverlayLoadError, not leaked as raw tracebacks."""
 


### PR DESCRIPTION
## Problem

`ProjectOverlaySource.collect` matches the extension verbatim:

```python
if not path.is_file() or path.suffix not in (".yml", ".yaml"):
    continue
```

So a hand-placed overlay named `<id>.YML` or `<id>.Yaml` is skipped and never applied — and nothing is reported to say the file was ignored. Overlay files are explicitly **hand-authored** (`docs/reference/workflows.md` documents the format and tells users to write them), so the extension casing is the author's choice, not something the tool generated.

## Reproduction on current `main` (c173bf19)

Three overlays in one directory, differing only in extension case:

```
files on disk: ['Mixed.Yaml', 'UPPER.YML', 'lower.yml']
COLLECTED    : ['lower']
SKIPPED      : ['mixed', 'upper']
```

The author gets no error and no warning — the overlay simply has no effect.

## Why this is the odd one out

Every other YAML discovery path in the package already lowercases before matching:

| location | form |
|---|---|
| `workflows/engine.py:941` | `path.suffix.lower() in (".yml", ".yaml")` |
| `workflows/_commands.py:1325` | `source_path.suffix.lower() in (...)` |
| `workflows/_commands.py:1894` | `dev_path.suffix.lower() in (...)` |
| `workflows/_commands.py:2128` | `source_path.suffix.lower() in (...)` |
| `overlays/layer_sources.py:150` | `path.suffix in (...)` ← **this PR** |

## Fix

```python
if not path.is_file() or path.suffix.lower() not in (".yml", ".yaml"):
```

## Scope note

`overlays/_commands.py:115` (`_find_overlay_file`) carries the identical case-sensitive pattern. I have deliberately **not** touched it here: an open PR of mine (#4141) already modifies that file, and combining the two would create a needless conflict. Happy to follow up with it once #4141 lands, or to fold it in here if you would rather see both together.

## Verification

- **Fail-before / pass-after:** 4 new-vs-baseline failures with the source reverted to `upstream/main` → passing with the fix.
- Parametrized over `.YML`, `.Yaml`, `.YAML`, `.Yml`.
- A companion test asserts broadening the *case* did not broaden which *extensions* are accepted — `notes.txt`, `backup.yml.bak`, `README.md` and `data.json` are still skipped.
- Scoped regression over `tests/workflows`: no new failures vs a clean-`main` self-baseline (10 pre-existing, Windows symlink-privilege).
- `uvx ruff@0.15.0 check src tests` → clean

**Behaviour change, disclosed:** files previously skipped now get read. If a project already holds a `.YML`/`.YAML` file in an overlay directory that is *not* a valid overlay manifest, resolution will now report it rather than ignoring it — which is the intended outcome, but it is a change for such a project.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)