### PR TITLE
fix(bundler): treat an explicitly null catalog field as empty, not `"None"`

### DIFF
--- a/src/specify_cli/bundler/models/catalog.py
+++ b/src/specify_cli/bundler/models/catalog.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from .. import BundlerError
 from ..lib.yamlio import ensure_within, load_yaml
+from .manifest import _text
 
 CONFIG_FILENAME = "bundle-catalogs.yml"
 # Supported bundle-catalogs.yml schema (major version). Both readers of the
@@ -70,8 +71,14 @@ class CatalogSource:
     def from_dict(cls, data: Any, scope: Scope) -> "CatalogSource":
         if not isinstance(data, dict):
             raise BundlerError("Each catalog source must be a mapping.")
-        source_id = str(data.get("id", "")).strip()
-        url = str(data.get("url", "")).strip()
+        # ``_text`` rather than ``str(...get(k, ""))``: the default only covers a
+        # *missing* key. A key present but null -- how YAML spells an empty field
+        # (``id:`` with nothing after it) -- yields ``None``, and ``str(None)``
+        # is the literal ``"None"``, which is truthy and so sailed straight past
+        # the required-field guards below: a source with ``id: null`` was
+        # accepted and registered under the name ``"None"``.
+        source_id = _text(data.get("id"))
+        url = _text(data.get("url"))
         if not source_id:
             raise BundlerError("A catalog source is missing its 'id'.")
         if not url:
@@ -185,14 +192,16 @@ class CatalogEntry:
             )
         return cls(
             id=entry_id,
-            name=str(data.get("name", "")).strip(),
-            version=str(data.get("version", "")).strip(),
-            role=str(data.get("role", "")).strip(),
-            description=str(data.get("description", "")).strip(),
-            author=str(data.get("author", "")).strip(),
-            license=str(data.get("license", "")).strip(),
-            download_url=str(data.get("download_url", "")).strip(),
-            requires_speckit_version=str(requires.get("speckit_version", "")).strip(),
+            # See the note in ``CatalogSource.from_dict``: an explicitly null
+            # field must read as empty, not as the literal string "None".
+            name=_text(data.get("name")),
+            version=_text(data.get("version")),
+            role=_text(data.get("role")),
+            description=_text(data.get("description")),
+            author=_text(data.get("author")),
+            license=_text(data.get("license")),
+            download_url=_text(data.get("download_url")),
+            requires_speckit_version=_text(requires.get("speckit_version")),
             sha256=(
                 None
                 if data.get("sha256") is None

--- a/tests/contract/test_catalog_schema.py
+++ b/tests/contract/test_catalog_schema.py
@@ -256,6 +256,72 @@ def test_catalog_entry_rejects_non_boolean_verified():
         CatalogEntry.from_dict(data)
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        "name",
+        "version",
+        "role",
+        "description",
+        "author",
+        "license",
+        "download_url",
+    ],
+)
+def test_catalog_entry_explicit_null_field_reads_as_empty(field: str):
+    """An explicitly null field must read as "", not the literal "None".
+
+    `str(data.get(key, ""))` only defaults for a *missing* key. A key present
+    but null — how YAML spells an empty field (`author:` with nothing after
+    it) — yields `None`, and `str(None)` is the truthy string `"None"`. The
+    same constructor already guards `sha256` and `repository` against exactly
+    this.
+    """
+    from specify_cli.bundler.models.catalog import CatalogEntry
+
+    data = catalog_entry_dict("demo")
+    data[field] = None
+
+    entry = CatalogEntry.from_dict(data)
+
+    assert getattr(entry, field) == ""
+
+
+def test_catalog_source_rejects_an_explicitly_null_id():
+    """`id: null` must be refused, not registered as a source named "None".
+
+    The `if not source_id` guard was defeated by the truthy literal, so the
+    source was accepted and carried the name `"None"` into the stack.
+    """
+    from specify_cli.bundler.models.catalog import CatalogSource, Scope
+
+    with pytest.raises(BundlerError, match="missing its 'id'"):
+        CatalogSource.from_dict(
+            {
+                "id": None,
+                "url": "https://example.test/catalog.json",
+                "priority": 5,
+                "install_policy": "install-allowed",
+            },
+            Scope.PROJECT,
+        )
+
+
+def test_catalog_source_rejects_an_explicitly_null_url():
+    from specify_cli.bundler.models.catalog import CatalogSource, Scope
+
+    with pytest.raises(BundlerError, match="missing its 'url'"):
+        CatalogSource.from_dict(
+            {
+                "id": "demo",
+                "url": None,
+                "priority": 5,
+                "install_policy": "install-allowed",
+            },
+            Scope.PROJECT,
+        )
+
+
 def test_catalog_entry_preserves_sha256_through_provenance():
     digest = "a" * 64
     payload = catalog_payload(


### PR DESCRIPTION
## Problem

`CatalogSource.from_dict` and `CatalogEntry.from_dict` coerce fields with `str(data.get(key, ""))`.

That default only covers a **missing** key. A key that is *present but null* — how YAML spells an empty field (`author:` with nothing after it), and what a generator emits for an absent value in JSON — yields `None`, and `str(None)` is the literal `"None"`.

## Reproduction on current `main` (c173bf19)

```python
CatalogEntry.from_dict({"id": "demo", "name": None, "version": None, ...})
```

```
name              = 'None'   <-- literal 'None'
version           = 'None'   <-- literal 'None'
role              = 'None'   <-- literal 'None'
description       = 'None'   <-- literal 'None'
author            = 'None'   <-- literal 'None'
license           = 'None'   <-- literal 'None'
download_url      = 'None'   <-- literal 'None'
sha256            = None     (already guarded)
repository        = None     (already guarded)
```

The same constructor **already guards** `sha256` and `repository` against exactly this, so the treatment was internally inconsistent.

### For `CatalogSource` it is more than cosmetic

`"None"` is truthy, so it defeats the required-field guards and the malformed source is **accepted**:

```python
CatalogSource.from_dict({"id": None, "url": None, "priority": 5, "install_policy": "install-allowed"}, Scope.PROJECT)
# -> id = 'None', url = 'None'
```

```python
if not source_id:
    raise BundlerError("A catalog source is missing its 'id'.")   # never fires
```

A user whose config has an empty `id:` silently gets a catalog source registered under the name `"None"`, pointing at a URL `"None"`.

## Fix

Route both constructors through the existing `manifest._text` helper, whose docstring already describes this precise failure mode for bundle manifests:

> A `.get(key, "")` default only covers a *missing* key. A key that is present but null … yields `None`, and `str(None)` is the literal `"None"`.

After the fix:

```
fields still literal 'None': NONE  <-- fixed
null id : refused -> A catalog source is missing its 'id'.
null url: refused -> Catalog source 'ok' is missing its 'url'.
normal source still works: ok https://example.test/catalog.json
```

## Verification

- **Fail-before / pass-after:** 9 new-vs-baseline failures with the source reverted to `upstream/main` → **54 passed** with the fix.
- Parametrized across all seven affected `CatalogEntry` fields, plus dedicated tests for the null `id` and null `url` sources.
- Scoped regression over `tests/contract`: **170 passed**, up from a clean-`main` baseline of **161 passed**, with zero pre-existing or new failures.
- No circular import introduced by the `models.manifest` import (verified by importing `models.catalog` directly).
- `uvx ruff@0.15.0 check src tests` → clean

**Behaviour change, disclosed:** only inputs that previously produced the literal `"None"` change. A source with a null `id`/`url` now raises the accurate "missing its 'id'/'url'" error instead of being accepted; `download_url: null` now reads as empty, so it reports "has no download_url" rather than failing later as a non-HTTP(S) URL.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)