### PR TITLE
fix(bundler): let `catalog remove` delete a project source overriding a built-in

### DIFF
--- a/src/specify_cli/bundler/commands_impl/catalog_config.py
+++ b/src/specify_cli/bundler/commands_impl/catalog_config.py
@@ -205,13 +205,19 @@ def add_source(
 
 def remove_source(project_root: Path, id_or_url: str) -> str:
     target = id_or_url.strip()
-    if target in _BUILTIN_IDS:
+    catalogs = _read(project_root)
+    # Refuse a built-in id only when there is nothing project-scoped to remove.
+    # This message tells the user to "add a same-id source to override it" --
+    # and once they did, the same guard refused to delete that override, so the
+    # documented workflow had no way back short of hand-editing the config.
+    # A project-scoped entry is the user's own file and is theirs to remove;
+    # deleting it simply restores the built-in default.
+    if target in _BUILTIN_IDS and not any(c.get("id") == target for c in catalogs):
         raise BundlerError(
             f"'{target}' is a built-in default source and cannot be deleted "
             "(add a same-id source to override it instead)."
         )
 
-    catalogs = _read(project_root)
     # Prefer an exact id/url match.
     remaining = [c for c in catalogs if c.get("id") != target and c.get("url") != target]
     if len(remaining) == len(catalogs):

--- a/tests/unit/test_bundler_catalog_config.py
+++ b/tests/unit/test_bundler_catalog_config.py
@@ -89,6 +89,42 @@ def test_remove_source_accepts_relative_local_path(tmp_path: Path, monkeypatch):
         cc.remove_source(project, "sub/cat.json")
 
 
+def test_remove_deletes_a_project_source_overriding_a_builtin_id(tmp_path: Path):
+    """The documented override must be undoable.
+
+    `remove_source` refused any built-in id before looking at what the project
+    config actually held — yet its own error tells the user to "add a same-id
+    source to override it instead". Once they did, the same guard refused to
+    delete that override, leaving no CLI path back short of hand-editing the
+    config.
+    """
+    builtin_id = sorted(cc._BUILTIN_IDS)[0]
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+
+    cc.add_source(
+        project,
+        "https://example.test/override.json",
+        source_id=builtin_id,
+        policy="install-allowed",
+        priority=1,
+    )
+    assert [c["id"] for c in cc._read(project)] == [builtin_id]
+
+    assert cc.remove_source(project, builtin_id) == builtin_id
+    assert cc._read(project) == []
+
+
+def test_remove_builtin_without_an_override_is_still_refused(tmp_path: Path):
+    """Deleting the built-in default itself stays refused."""
+    builtin_id = sorted(cc._BUILTIN_IDS)[0]
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+
+    with pytest.raises(BundlerError, match="built-in default source"):
+        cc.remove_source(project, builtin_id)
+
+
 def test_remove_by_id_does_not_also_delete_canonical_url_match(tmp_path: Path, monkeypatch):
     """`remove <id>` must remove only the exact-id source, not also a different
     source whose url happens to equal the id's canonicalized path. (_canonicalize_url


### PR DESCRIPTION
## Problem

`remove_source` refuses any built-in id **before** looking at what the project config actually holds:

```python
if target in _BUILTIN_IDS:
    raise BundlerError(
        f"'{target}' is a built-in default source and cannot be deleted "
        "(add a same-id source to override it instead)."
    )
```

The error message documents the supported override workflow — and the same guard then makes that override **permanent**.

## Reproduction on current `main` (c173bf19)

```
built-in ids : ['community', 'default']
under test   : community

add_source   -> OK (documented override). stored: ['community']
remove_source-> REFUSED: 'community' is a built-in default source and cannot be
                deleted (add a same-id source to override it instead).
STILL STORED : ['community']   <-- user cannot undo their own override
```

The user follows the advice in the error message, then finds there is no CLI path back. The only remedy is hand-editing the very config file `bundle catalog` exists to manage.

## Fix

Refuse a built-in id only when there is **nothing project-scoped to remove**:

```python
catalogs = _read(project_root)
if target in _BUILTIN_IDS and not any(c.get("id") == target for c in catalogs):
    raise BundlerError(...)
```

A project-scoped entry is the user's own file and is theirs to delete; removing it simply restores the built-in default.

After the fix:

```
1. override then remove              -> OK. remaining: []
2. remove builtin with NO override   -> still refused: '...is a built-in default source...'
3. remove unknown id                 -> refused: No project-scoped catalog source matching 'never-added' was found.
```

## Verification

- **Fail-before / pass-after:** 1 new-vs-baseline failure with the source reverted to `upstream/main` → passing with the fix.
- A companion test pins that deleting the built-in default *itself* (no override present) is still refused, so the guard is narrowed rather than removed.
- The pre-existing CLI guard `tests/contract/test_bundle_cli.py::test_catalog_remove_builtin_is_refused` runs against a project with no such entry and **still passes unchanged** — verified directly.
- Scoped regression over `tests/unit`: **537 passed** vs a clean-`main` baseline of **535 passed**, with the same 2 pre-existing failures and none new.
- `uvx ruff@0.15.0 check src tests` → clean

**Behaviour change, disclosed:** exactly one previously-failing input now succeeds — `catalog remove <builtin-id>` when the project config genuinely contains an entry with that id. That is the defect being fixed. Nothing that previously succeeded changes.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)