### PR TITLE
fix(workflows): cap gate `show_file` line width, not just its line count

### DIFF
--- a/src/specify_cli/workflows/steps/gate/__init__.py
+++ b/src/specify_cli/workflows/steps/gate/__init__.py
@@ -35,6 +35,10 @@ class GateStep(StepBase):
     #: Maximum number of ``show_file`` lines rendered at the prompt, so a
     #: large file cannot flood the terminal before the choice.
     MAX_SHOW_FILE_LINES = 200
+    # A line cap alone does not bound the output: a file with no newlines --
+    # minified JSON, a lockfile, a base64 blob -- is a single line of arbitrary
+    # length and floods the prompt exactly as the line cap exists to prevent.
+    MAX_SHOW_FILE_LINE_CHARS = 500
 
     def execute(self, config: dict[str, Any], context: StepContext) -> StepResult:
         message = config.get("message", "Review required.")
@@ -283,7 +287,14 @@ class GateStep(StepBase):
                     if len(lines) >= GateStep.MAX_SHOW_FILE_LINES:
                         truncated = True
                         break
-                    lines.append(_CONTROL_CHARS.sub("", line.rstrip("\n")))
+                    clean = _CONTROL_CHARS.sub("", line.rstrip("\n"))
+                    if len(clean) > GateStep.MAX_SHOW_FILE_LINE_CHARS:
+                        clean = (
+                            clean[: GateStep.MAX_SHOW_FILE_LINE_CHARS]
+                            + f"… (line truncated at "
+                            f"{GateStep.MAX_SHOW_FILE_LINE_CHARS} characters)"
+                        )
+                    lines.append(clean)
         except (OSError, UnicodeDecodeError, ValueError) as exc:
             # ``exc`` echoes the (possibly hostile) path, so strip it too.
             return [_CONTROL_CHARS.sub("", f"(could not read file: {exc})")]

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -3079,6 +3079,34 @@ steps:
         assert len(rendered) == GateStep.MAX_SHOW_FILE_LINES + 1
         assert "truncated" in rendered[-1]
 
+    def test_read_show_file_truncates_a_single_enormous_line(self, tmp_path):
+        """The line cap alone does not bound the output.
+
+        A file with no newlines — minified JSON, a lockfile, a base64 blob — is
+        a single line of arbitrary length, so `MAX_SHOW_FILE_LINES` never
+        triggers and the whole file floods the gate prompt, which is exactly
+        what that cap exists to prevent.
+        """
+        from specify_cli.workflows.steps.gate import GateStep
+
+        blob = tmp_path / "min.json"
+        blob.write_text('{"k":"' + "A" * 400_000 + '"}', encoding="utf-8")
+
+        rendered = GateStep._read_show_file(str(blob))
+
+        assert len(rendered) == 1
+        assert len(rendered[0]) < GateStep.MAX_SHOW_FILE_LINE_CHARS + 100
+        assert "line truncated" in rendered[0]
+
+    def test_read_show_file_leaves_short_lines_untouched(self, tmp_path):
+        """Lines within the cap are rendered verbatim, with no notice."""
+        from specify_cli.workflows.steps.gate import GateStep
+
+        path = tmp_path / "short.md"
+        path.write_text("hello\nworld\n", encoding="utf-8")
+
+        assert GateStep._read_show_file(str(path)) == ["hello", "world"]
+
     def test_read_show_file_invalid_path_does_not_raise(self):
         from specify_cli.workflows.steps.gate import GateStep
 


### PR DESCRIPTION
## Problem

`GateStep._read_show_file` bounds the number of lines:

```python
if len(lines) >= GateStep.MAX_SHOW_FILE_LINES:
    truncated = True
    break
```

but nothing bounds a single line's **length**. A file with no newlines — minified JSON, a lockfile, a base64 blob, all plausible review material to put in front of an approver — is one line of arbitrary size, so the cap never triggers and the whole file floods the prompt. That is exactly the outcome `MAX_SHOW_FILE_LINES` exists to prevent.

## Reproduction on current `main` (c173bf19)

```
many short lines : returned 201 lines, total chars=1323    (cap=200)
one long line    : returned   1 lines, total chars=400008  <-- unbounded
```

The 5,000-line file is correctly clipped to 1,323 characters. The single-line 400 KB file passes through whole.

The content is also rendered inside the gate box one character at a time by `_prompt`, so the operator's terminal is buried and the choice prompt is pushed far off screen.

## Fix

Add a per-line cap alongside the line cap, with a notice in the same style as the existing one:

```python
MAX_SHOW_FILE_LINE_CHARS = 500
...
if len(clean) > GateStep.MAX_SHOW_FILE_LINE_CHARS:
    clean = clean[:GateStep.MAX_SHOW_FILE_LINE_CHARS] + "… (line truncated at 500 characters)"
```

After the fix:

```
many short lines : 201 lines, 1323 chars (unchanged)
one long line    :   1 lines,  536 chars
short file       : ['hello', 'world']    (untouched)
```

## Verification

- **Fail-before / pass-after:** 1 new-vs-baseline failure with the source reverted to `upstream/main` → **49 passed** with the fix.
- A companion test asserts short lines are still rendered verbatim with no notice, so the cap cannot start mangling ordinary files.
- The existing `test_read_show_file_truncates_large_file`, `test_read_show_file_strips_control_chars` and `test_read_show_file_empty` all use short lines and are unaffected — they pass unchanged.
- `uvx ruff@0.15.0 check src tests` → clean

**Behaviour change, disclosed:** a `show_file` line longer than 500 characters is now rendered truncated with a notice instead of in full. That is the intent; no existing test exercises such a line.

**Note on overlap:** this touches `steps/gate/__init__.py`, as does my #4529, but a different function (`_read_show_file` vs `_prompt`). They should merge independently — happy to rebase whichever lands second.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)