### PR TITLE
fix(bundler): validate a catalog source before persisting it

### DIFF
--- a/src/specify_cli/bundler/commands_impl/catalog_config.py
+++ b/src/specify_cli/bundler/commands_impl/catalog_config.py
@@ -198,9 +198,17 @@ def add_source(
         "priority": int(priority),
         "install_policy": install_policy.value,
     }
+    # Construct BEFORE writing. ``CatalogSource.from_dict`` already rejects an
+    # empty id, but it used to run after ``_write`` had persisted the entry, so
+    # a whitespace-only ``--id`` (or a url from which no id can be derived)
+    # reported "A catalog source is missing its 'id'" while leaving
+    # ``{"id": "", ...}`` behind in bundle-catalogs.yml. Every later command
+    # that loads the stack then failed with that same error, wedging the
+    # project's catalog config until the file was hand-edited.
+    source = CatalogSource.from_dict(entry, Scope.PROJECT)
     catalogs.append(entry)
     _write(project_root, catalogs)
-    return CatalogSource.from_dict(entry, Scope.PROJECT)
+    return source
 
 
 def remove_source(project_root: Path, id_or_url: str) -> str:

--- a/tests/unit/test_bundler_catalog_config.py
+++ b/tests/unit/test_bundler_catalog_config.py
@@ -89,6 +89,34 @@ def test_remove_source_accepts_relative_local_path(tmp_path: Path, monkeypatch):
         cc.remove_source(project, "sub/cat.json")
 
 
+def test_failed_add_does_not_persist_a_broken_entry(tmp_path: Path):
+    """A rejected `catalog add` must leave the config untouched.
+
+    `CatalogSource.from_dict` already rejects an empty id, but it ran *after*
+    `_write` had persisted the entry, so a whitespace-only `--id` reported
+    "A catalog source is missing its 'id'" while leaving `{"id": "", ...}`
+    behind — and every later command that loads the stack then failed with that
+    same error, wedging the project's catalog config.
+    """
+    from specify_cli.bundler.services.catalog_stack import load_source_stack
+
+    project = tmp_path / "proj"
+    (project / ".specify").mkdir(parents=True)
+
+    with pytest.raises(BundlerError, match="missing its 'id'"):
+        cc.add_source(
+            project,
+            "https://example.test/c.json",
+            source_id="   ",
+            policy="install-allowed",
+            priority=5,
+        )
+
+    assert cc._read(project) == []
+    # The stack must still load — this is what the stray entry used to break.
+    assert [source.id for source in load_source_stack(project)]
+
+
 def test_remove_by_id_does_not_also_delete_canonical_url_match(tmp_path: Path, monkeypatch):
     """`remove <id>` must remove only the exact-id source, not also a different
     source whose url happens to equal the id's canonicalized path. (_canonicalize_url


### PR DESCRIPTION
## Problem

`add_source` writes the new entry and only *then* constructs it:

```python
catalogs.append(entry)
_write(project_root, catalogs)
return CatalogSource.from_dict(entry, Scope.PROJECT)   # <-- validation, too late
```

`CatalogSource.from_dict` already rejects an empty id — but by the time it runs, the entry is on disk.

## Reproduction on current `main` (c173bf19)

```
before     : []
add_source -> raised: A catalog source is missing its 'id'.
AFTER      : [{"id": "", "url": "https://example.test/c.json", "priority": 5, "install_policy": "install-allowed"}]
```

The command reports a failure, so the user reasonably assumes nothing happened.

### It wedges the project

Every command that loads the catalog stack now fails on that stray entry:

```
load_source_stack -> BROKEN: BundlerError A catalog source is missing its 'id'.
```

So a single mistyped `catalog add --id "   "` leaves the project's catalog config unusable until `bundle-catalogs.yml` is hand-edited — by hand, for a file the `bundle catalog` commands exist to manage.

## Fix

Construct before writing, reusing the validation that already exists rather than adding a second check that could drift:

```python
source = CatalogSource.from_dict(entry, Scope.PROJECT)
catalogs.append(entry)
_write(project_root, catalogs)
return source
```

After the fix:

```
add with blank id -> refused: A catalog source is missing its 'id'.
config after      : []                      <-- nothing persisted
stack still loads : ['default', 'community']
normal add works  : ok https://example.test/ok.json
```

## Verification

- **Fail-before / pass-after:** 1 new-vs-baseline failure with the source reverted to `upstream/main` → passing with the fix.
- The test asserts both halves: the config is left empty **and** `load_source_stack` still succeeds — the latter is what the stray entry actually broke.
- Scoped regression over `tests/unit`: **536 passed** vs a clean-`main` baseline of **535 passed**, same 2 pre-existing failures, none new.
- `uvx ruff@0.15.0 check src tests` → clean

**No behaviour change for any input that previously succeeded.** The reordered call is the same construction, just earlier, and it raises for exactly the input that already raised — the difference is that the failure no longer leaves a file behind.

**Note on overlap:** this touches `commands_impl/catalog_config.py`, as does my #4533, but a different function (`add_source` vs `remove_source`). Happy to rebase whichever lands second.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)