### PR TITLE
fix(bundler): report a newline-containing version constraint instead of crashing

### DIFF
--- a/src/specify_cli/bundler/lib/versioning.py
+++ b/src/specify_cli/bundler/lib/versioning.py
@@ -54,6 +54,19 @@ def _normalize_constraint(value: str) -> str:
         if not raw.strip():
             continue
         match = _SPECIFIER_CLAUSE.match(raw)
+        if match is None:
+            # ``_SPECIFIER_CLAUSE`` is anchored with ``^``/``$`` and ``.`` does
+            # not cross newlines, so a clause containing an EMBEDDED newline
+            # does not match at all and ``match.groups()`` raised a raw
+            # AttributeError -- escaping ``parse_constraint``'s contract to
+            # report bad input as a BundlerError. A YAML block literal is an
+            # ordinary way to reach this:
+            #     requires:
+            #       speckit_version: |
+            #         >=1.0.0
+            #         <2.0.0
+            # which loads as ">=1.0.0\n<2.0.0\n".
+            raise InvalidSpecifier(f"Invalid specifier: {raw!r}")
         operator, version = match.groups()
         clauses.append(f"{operator or ''}{_normalize_semver(version)}")
     return ",".join(clauses)

--- a/tests/unit/test_bundler_versioning.py
+++ b/tests/unit/test_bundler_versioning.py
@@ -66,3 +66,49 @@ def test_parse_constraint_empty_is_permissive():
     from specify_cli.bundler.lib.versioning import parse_constraint
 
     assert str(parse_constraint("")) == ""
+
+
+@pytest.mark.parametrize(
+    "constraint",
+    [
+        ">=1.0.0\n<2.0.0\n",   # a YAML block literal, as loaded
+        ">=1.0\n.0",
+        "a\nb",
+    ],
+    ids=["yaml_block_literal", "split_version", "garbage"],
+)
+def test_constraint_with_an_embedded_newline_reports_a_bundler_error(constraint):
+    """A clause containing a newline must be reported, not crash.
+
+    `_SPECIFIER_CLAUSE` is anchored with `^`/`$` and `.` does not cross
+    newlines, so such a clause does not match at all and `match.groups()`
+    raised a raw `AttributeError` — escaping `parse_constraint`'s contract to
+    surface bad input as a `BundlerError`. A YAML block literal reaches this
+    with no exotic input at all:
+
+        requires:
+          speckit_version: |
+            >=1.0.0
+            <2.0.0
+    """
+    from specify_cli.bundler.lib.versioning import parse_constraint
+
+    with pytest.raises(BundlerError, match="Invalid version constraint"):
+        parse_constraint(constraint)
+
+
+@pytest.mark.parametrize(
+    "constraint,expected",
+    [
+        (">=1.0.0", ">=1.0.0"),
+        (">=v1.0.0", ">=1.0.0"),
+        ("~=1.2", "~=1.2"),
+        (">=1.0.0\n", ">=1.0.0"),   # trailing newline is still stripped
+        ("\n>=1.0.0", ">=1.0.0"),   # leading newline too
+    ],
+)
+def test_valid_constraints_are_unaffected(constraint, expected):
+    """Only clauses that genuinely fail to match change behaviour."""
+    from specify_cli.bundler.lib.versioning import parse_constraint
+
+    assert str(parse_constraint(constraint)) == expected


### PR DESCRIPTION
## Problem

`_normalize_constraint` matches each comma-separated clause and uses the result without checking it:

```python
match = _SPECIFIER_CLAUSE.match(raw)
operator, version = match.groups()
```

`_SPECIFIER_CLAUSE` is anchored with `^`/`$`, and `.` does not cross newlines — so a clause containing an **embedded** newline does not match at all, and `match.groups()` raises a raw `AttributeError`. That escapes `parse_constraint`'s contract, which is to surface bad input as a `BundlerError`:

```python
except InvalidSpecifier as exc:
    raise BundlerError(f"Invalid version constraint '{value}': {exc}") from exc
```

## Reproduction on current `main` (c173bf19)

A YAML **block literal** — an ordinary way to write a multi-clause constraint if you don't know the comma form — reaches it directly:

```yaml
requires:
  speckit_version: |
    >=1.0.0
    <2.0.0
```

loads as `'>=1.0.0\n<2.0.0\n'`, and:

```
manifest value: '>=1.0.0\n<2.0.0\n'
  parse_constraint  -> AttributeError: 'NoneType' object has no attribute 'groups'   <-- raw crash
  satisfies         -> AttributeError: 'NoneType' object has no attribute 'groups'   <-- raw crash
```

Worth noting why this survived: **leading and trailing** newlines are fine, because `\s*` absorbs them. Only an *embedded* one fails:

```
'>=1.0.0\n'   -> OK >=1.0.0
'\n>=1.0.0'   -> OK >=1.0.0
'>=1.0\n.0'   -> AttributeError
```

## Fix

Raise `InvalidSpecifier` for an unmatched clause, which the existing handler in `parse_constraint` already converts to the `BundlerError` callers expect — so the fix reuses the established error path rather than introducing a second one.

After the fix:

```
block literal  -> BundlerError: Invalid version constraint ...
embedded nl    -> BundlerError: Invalid version constraint ...
garbage nl     -> BundlerError: Invalid version constraint ...
--- unchanged ---
'>=1.0.0' / '>=1.0.0,<2' / '~=1.2' / '>=v1.0.0' / '>=1.0.0\n' / '\n>=1.0.0'  all OK
satisfies('1.5.0', '>=1.0.0,<2.0.0') = True
```

## Verification

- **Fail-before / pass-after:** 3 new-vs-baseline failures with the source reverted to `upstream/main` → **33 passed** with the fix.
- A companion parametrization pins that every valid constraint — including the leading/trailing-newline forms that already worked — is unaffected, so the guard cannot start rejecting good input.
- Scoped regression over `tests/unit`: **543 passed** vs a clean-`main` baseline of **535 passed**, same 2 pre-existing failures, none new.
- `uvx ruff@0.15.0 check src tests` → clean

**No behaviour change for any input that previously succeeded** — the only inputs affected are those that previously crashed with an `AttributeError`, which now report the documented error instead.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)