### PR TITLE
fix(integrations): refuse scaffold keys that shadow a module or name a keyword

### DIFF
--- a/src/specify_cli/integration_scaffold.py
+++ b/src/specify_cli/integration_scaffold.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import keyword
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -220,6 +221,28 @@ def scaffold_integration(
         raise ValueError("Run this command from the Spec Kit repository root.")
 
     package_name = _package_name(clean_key)
+    # A reserved Python keyword cannot name an importable package: the
+    # generated ``integrations/<key>/`` would be unreachable by any import
+    # statement. Soft keywords (``match``, ``case``, ``_``) are deliberately
+    # NOT rejected -- they are contextual, and ``import match`` is valid.
+    if keyword.iskeyword(package_name):
+        raise ValueError(
+            f"Integration key '{clean_key}' becomes the Python keyword "
+            f"'{package_name}', which cannot name an importable package. "
+            "Choose a different key."
+        )
+    # A package shadows a same-named module in the same directory, so
+    # scaffolding a key that matches one of this package's own modules (base,
+    # catalog, manifest) would silently take its place -- and every integration
+    # does ``from ..base import ...``. The existing-file check below cannot
+    # catch it, because it only looks at ``<key>/__init__.py``.
+    shadowed = integrations_root / f"{package_name}.py"
+    if shadowed.exists():
+        raise ValueError(
+            f"Integration key '{clean_key}' collides with the existing module "
+            f"{shadowed.relative_to(project_root).as_posix()}; the generated "
+            "package would shadow it. Choose a different key."
+        )
     class_name = _class_name(clean_key)
     integration_dir = integrations_root / package_name
     integration_file = integration_dir / "__init__.py"

--- a/tests/integrations/test_integration_scaffold.py
+++ b/tests/integrations/test_integration_scaffold.py
@@ -236,3 +236,56 @@ def test_integration_scaffold_accepts_uppercase_type(tmp_path, monkeypatch):
         root / "src" / "specify_cli" / "integrations" / "my_agent" / "__init__.py"
     ).read_text(encoding="utf-8")
     assert "class MyAgentIntegration(YamlIntegration):" in content
+
+
+@pytest.mark.parametrize("key", ["class", "import", "return", "lambda"])
+def test_scaffold_refuses_a_python_keyword_key(tmp_path, key):
+    """A reserved keyword cannot name an importable package.
+
+    The generated `integrations/<key>/` would be unreachable by any import
+    statement, so the scaffold would emit a package nothing can load.
+    """
+    root = _repo_root(tmp_path)
+
+    with pytest.raises(ValueError, match="Python keyword"):
+        scaffold_integration(root, key, "markdown")
+
+    assert not (root / "src" / "specify_cli" / "integrations" / key).exists()
+
+
+@pytest.mark.parametrize("key", ["base", "catalog", "manifest"])
+def test_scaffold_refuses_a_key_shadowing_an_existing_module(tmp_path, key):
+    """A package shadows a same-named module in the same directory.
+
+    `integrations/base.py` and a scaffolded `integrations/base/` can coexist on
+    disk, and Python resolves the *package* — so `from ..base import ...`, which
+    every integration does, would silently load the empty scaffold instead. The
+    existing-file guard cannot catch this: it only checks `<key>/__init__.py`.
+    """
+    root = _repo_root(tmp_path)
+    (root / "src" / "specify_cli" / "integrations" / f"{key}.py").write_text(
+        "SENTINEL = 1\n", encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="collides with the existing module"):
+        scaffold_integration(root, key, "markdown")
+
+    # The real module is untouched and no package was created beside it.
+    assert (
+        root / "src" / "specify_cli" / "integrations" / f"{key}.py"
+    ).read_text(encoding="utf-8") == "SENTINEL = 1\n"
+    assert not (root / "src" / "specify_cli" / "integrations" / key).exists()
+
+
+@pytest.mark.parametrize("key", ["match", "case", "my-agent"])
+def test_scaffold_still_accepts_soft_keywords_and_ordinary_keys(tmp_path, key):
+    """Soft keywords are contextual — `import match` is valid, so allow them."""
+    root = _repo_root(tmp_path)
+
+    result = scaffold_integration(root, key, "markdown")
+
+    assert result is not None
+    package = key.replace("-", "_")
+    assert (
+        root / "src" / "specify_cli" / "integrations" / package / "__init__.py"
+    ).is_file()


### PR DESCRIPTION
## Problem

`scaffold_integration` validates the key's *shape* (`_KEY_RE`, lowercase kebab-case) but never checks what the derived **package name** would collide with. Two ordinary keys produce broken output.

### 1. A key that shadows one of this package's own modules

The scaffold creates a **package** — `integrations/<key>/__init__.py` — and in Python a package shadows a same-named module in the same directory:

```
both 'base.py' and 'base/' present -> import demopkg.base resolves to: scaffolded package base/
```

Every integration in the repo does `from ..base import MarkdownIntegration` / `SkillsIntegration`, so scaffolding a key named `base` silently redirects all of them to the empty scaffold.

The existing guard cannot catch this — it only checks `<key>/__init__.py` and the test file:

```python
existing = [path for path in (integration_file, test_file) if path.exists()]
```

`integrations/base.py` is never consulted. Currently accepted and collidable: **`base`, `catalog`, `manifest`**.

### 2. A key that is a reserved Python keyword

`integrations/class/` cannot be named by any import statement, so the generated package is unreachable and its generated test (`from specify_cli.integrations.class import ClassIntegration`) is a `SyntaxError`. Currently accepted: **`class`, `import`, `return`, `lambda`**, …

## Reproduction on current `main` (c173bf19)

Every one of these passes `_clean_key`:

```
_clean_key('base'    ) -> ACCEPTED 'base'
_clean_key('catalog' ) -> ACCEPTED 'catalog'
_clean_key('manifest') -> ACCEPTED 'manifest'
_clean_key('class'   ) -> ACCEPTED 'class'
_clean_key('import'  ) -> ACCEPTED 'import'
```

## Fix

Refuse both up front, before anything is written:

```
base       -> refused (collision)
catalog    -> refused (collision)
manifest   -> refused (collision)
class      -> refused (keyword)
import     -> refused (keyword)
match      -> ACCEPTED
my-agent   -> ACCEPTED
```

### Soft keywords are deliberately allowed

My first cut rejected soft keywords too. I checked rather than assumed, and that would have been wrong — soft keywords are contextual and `import match` is perfectly valid:

```
soft keyword 'match' -> importable? YES   iskeyword=False issoftkeyword=True
soft keyword 'case'  -> importable? YES   iskeyword=False issoftkeyword=True
```

So the guard uses `keyword.iskeyword` only, and `match` / `case` / `_` remain usable keys.

## Verification

- **Fail-before / pass-after:** 7 new-vs-baseline failures with the source reverted to `upstream/main` → **25 passed, 1 skipped** with the fix.
- The shadowing test asserts the real module is left byte-identical and that no package was created beside it — not merely that an error was raised.
- A third test pins that soft keywords and ordinary keys still scaffold successfully, so the guard cannot start refusing valid input.
- `uvx ruff@0.15.0 check src tests` → clean

**Behaviour change, disclosed:** five key values that previously scaffolded now raise. All five produced output that was broken on arrival — an unimportable package, or one that shadows a module the whole package depends on.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)