### PR TITLE
fix(workflows): state the equal-priority tie-break in `workflow resolve` output

### DIFF
--- a/src/specify_cli/workflows/overlays/_commands.py
+++ b/src/specify_cli/workflows/overlays/_commands.py
@@ -424,7 +424,17 @@ def workflow_resolve(project_root: Path, workflow_id: str) -> dict[str, Any] | N
         return None
 
     console.print(f"Resolved workflow '{workflow_id}':")
-    console.print("Layers (highest precedence first):")
+    # The list is sorted by (priority, source) ascending, which puts the
+    # winning layer first only while priorities DIFFER. On a tie the sort is
+    # alphabetical by source while the merge gives the conflict to the LAST id
+    # (docs/reference/workflows.md:126), so the plain "highest precedence
+    # first" label stated the opposite of the outcome printed directly beneath
+    # it in the same output -- in the one command whose job is explaining which
+    # overlay won. Spell the tie-break out rather than reorder the list, which
+    # `test_workflow_resolve_equal_priority_layers_sort_by_source` pins.
+    console.print(
+        "Layers (highest precedence first; on equal priority the last ID wins):"
+    )
     for layer in layers:
         priority = (
             "n/a" if layer.tier == "base" else str(normalize_priority(layer.priority))

--- a/tests/workflows/test_overlay_commands.py
+++ b/tests/workflows/test_overlay_commands.py
@@ -698,6 +698,59 @@ class TestOverlayCli:
         assert result.exit_code == 0, result.output
         assert step_id in result.output
 
+    def test_workflow_resolve_header_states_the_equal_priority_tiebreak(
+        self, project_dir, monkeypatch
+    ):
+        """The layer header must not contradict the attribution beneath it.
+
+        The list is sorted by (priority, source) ascending, which puts the
+        winning layer first only while priorities DIFFER. On a tie the sort is
+        alphabetical while the merge gives the conflict to the LAST id, so a
+        bare "highest precedence first" label stated the opposite of the
+        outcome printed directly below it — in the one command whose job is
+        explaining which overlay won.
+        """
+        monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)
+        _write_workflow(
+            project_dir,
+            "wf",
+            {
+                "schema_version": "1.0",
+                "workflow": {"id": "wf", "name": "WF", "version": "1.0.0"},
+                "steps": [{"id": "build", "type": "command", "command": "echo BASE"}],
+            },
+        )
+        for overlay_id in ("alpha", "beta"):
+            _write_overlay(
+                project_dir,
+                "wf",
+                overlay_id,
+                {
+                    "id": overlay_id,
+                    "extends": "wf",
+                    "priority": 10,
+                    "edits": [
+                        {
+                            "operation": "replace",
+                            "anchor": "build",
+                            "step": {
+                                "id": "build",
+                                "type": "command",
+                                "command": f"echo FROM-{overlay_id.upper()}",
+                            },
+                        }
+                    ],
+                },
+            )
+
+        result = runner.invoke(app, ["workflow", "resolve", "wf"])
+
+        assert result.exit_code == 0, result.output
+        output = " ".join(result.output.split())
+        # alpha is listed first, but beta is the layer that actually wins.
+        assert "build: project:beta" in output, output
+        assert "on equal priority the last ID wins" in output, output
+
     def test_workflow_resolve_equal_priority_layers_sort_by_source(self, project_dir, monkeypatch):
         """Equal-priority overlays are listed alphabetically by source."""
         monkeypatch.setattr("specify_cli._require_specify_project", lambda: project_dir)


### PR DESCRIPTION
## Problem

`workflow resolve` prints the layer list under a bare header:

```python
console.print("Layers (highest precedence first):")
```

`collect_all_layers` sorts by `(priority, source)` **ascending**, which puts the winning layer first only while priorities *differ*. On a tie the sort is alphabetical by source, while the merge gives the conflict to the **last** id — exactly as documented:

> Equal-priority overlays are applied alphabetically by ID, with the last ID winning conflicts. — `docs/reference/workflows.md:126`

So on a tie the header states the opposite of the outcome printed directly beneath it, in the one command whose documented purpose is explaining which overlay contributed or overrode a step.

## Reproduction on current `main` (c173bf19)

```
DIFFERENT priorities (alpha=5, beta=10)
   listed first : project:alpha
   actual winner: echo FROM-ALPHA
   header correct? YES

EQUAL priorities (both 10)
   listed first : project:alpha
   actual winner: echo FROM-BETA
   header correct? NO  <-- inverted
```

The full output contradicted itself two lines apart:

```
Layers (highest precedence first):
  • [project-overlay] project:alpha (priority=10)
  • [project-overlay] project:beta (priority=10)
Step attribution:
  • build: project:beta          <-- beta won, alpha was labelled highest
```

## Fix — the label, not the order

The ordering is **deliberate**: `test_workflow_resolve_equal_priority_layers_sort_by_source` pins it, and its own comment acknowledges that the alphabetically-last layer is the one that wins. Reordering the list would fight a decision the maintainers made on purpose, so this spells the tie-break out instead:

```
Layers (highest precedence first; on equal priority the last ID wins):
  • [project-overlay] project:alpha (priority=10)
  • [project-overlay] project:beta (priority=10)
Step attribution:
  • build: project:beta
```

Now self-consistent, and the behaviour is untouched.

## Verification

- **Fail-before / pass-after:** 1 new-vs-baseline failure with the source reverted to `upstream/main` → **26 passed** with the fix.
- The new test asserts the header **and** the attribution together, so it pins the label against the real outcome rather than against a hard-coded string alone.
- No existing test asserts the old header text (checked: `git grep "highest precedence first" -- tests/` is empty), and `test_workflow_resolve_equal_priority_layers_sort_by_source` passes unchanged.
- `uvx ruff@0.15.0 check src tests` → clean

**No behaviour change** — output text only.

**Note on overlap:** this touches `overlays/_commands.py`, as does my #4141, but a different function (`workflow_resolve` vs `workflow_overlay_add`). Happy to rebase whichever lands second.

---
*Written with assistance from Claude Code. Bug found, reproduced, and verified by me on current `main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)