### PR TITLE
fix(extensions): reject aliases that shadow core commands

### DIFF
--- a/src/specify_cli/extensions/__init__.py
+++ b/src/specify_cli/extensions/__init__.py
@@ -1185,17 +1185,31 @@ class ExtensionManager:
         return installed_names
 
     def _validate_install_conflicts(self, manifest: ExtensionManifest) -> None:
-        """Reject installs that would shadow core or installed extension commands."""
+        """Reject installs that would shadow core or installed extension commands.
+
+        Primary command names are already namespace-checked against
+        ``CORE_COMMAND_NAMES`` in ``_collect_manifest_command_names``, but
+        aliases are intentionally free-form (see the comment there) and so
+        can only be caught here, by comparing declared names directly
+        against the fully-qualified core command names (``speckit.<name>``)
+        rather than relying on ``_get_installed_command_name_map``, which
+        only knows about installed extensions.
+        """
         declared_names = self._collect_manifest_command_names(manifest)
         installed_names = self._get_installed_command_name_map(
             exclude_extension_id=manifest.id
         )
+        core_command_names = {f"speckit.{name}" for name in CORE_COMMAND_NAMES}
 
-        collisions = [
-            f"{name} (already provided by extension '{installed_names[name]}')"
-            for name in sorted(declared_names)
-            if name in installed_names
-        ]
+        collisions = []
+        for name in sorted(declared_names):
+            if name in installed_names:
+                collisions.append(
+                    f"{name} (already provided by extension '{installed_names[name]}')"
+                )
+            elif name in core_command_names:
+                collisions.append(f"{name} (conflicts with core command)")
+
         if collisions:
             raise ValidationError(
                 "Extension commands conflict with installed extensions:\n- "

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -3126,6 +3126,48 @@ class TestExtensionManager:
         with pytest.raises(ValidationError, match="already provided by extension 'ext-one'"):
             manager.install_from_directory(second_dir, "0.1.0", register_commands=False)
 
+    def test_install_rejects_alias_shadowing_core_command(self, temp_dir, project_dir):
+        """An alias equal to a core command's qualified name must not install.
+
+        Regression test for #4555: a primary name is namespace-checked
+        against CORE_COMMAND_NAMES, but aliases are intentionally free-form
+        and previously went unchecked against core commands entirely, so an
+        extension could claim e.g. 'speckit.taskstoissues' as an alias and
+        shadow the core command of the same name.
+        """
+        import yaml
+
+        ext_dir = temp_dir / "probe-ext"
+        ext_dir.mkdir()
+        (ext_dir / "commands").mkdir()
+
+        manifest_data = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "probe",
+                "name": "Probe",
+                "version": "1.0.0",
+                "description": "Test",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "commands": [
+                    {
+                        "name": "speckit.probe.taskstoissues",
+                        "file": "commands/cmd.md",
+                        "aliases": ["speckit.taskstoissues"],
+                    }
+                ]
+            },
+        }
+
+        (ext_dir / "extension.yml").write_text(yaml.dump(manifest_data))
+        (ext_dir / "commands" / "cmd.md").write_text("---\ndescription: Test\n---\n\nBody")
+
+        manager = ExtensionManager(project_dir)
+        with pytest.raises(ValidationError, match="conflicts with core command"):
+            manager.install_from_directory(ext_dir, "0.1.0", register_commands=False)
+
     def test_remove_extension(self, extension_dir, project_dir):
         """Test removing an installed extension."""
         manager = ExtensionManager(project_dir)


### PR DESCRIPTION
## Summary

Fixes #4555.

`_validate_install_conflicts` is documented as rejecting installs that "would shadow core or installed extension commands", but `_get_installed_command_name_map` only walks `self.registry` — installed **extensions**. Core command names were never in the map it consults, so an extension could declare a core command's fully-qualified name (e.g. `speckit.taskstoissues`) as an **alias** and install successfully, shadowing the core command.

Primary command names are already namespace-checked against `CORE_COMMAND_NAMES` in `_collect_manifest_command_names` (a primary name like `speckit.taskstoissues` is correctly rejected — it fails the required two-segment `speckit.{extension}.{command}` pattern). Aliases are intentionally free-form (existing community extensions use short aliases like `speckit.verify`), so they can't be pattern-checked the same way — the only safe fix is to compare declared alias names directly against the fully-qualified core command names in the install-conflict check.

## Fix

In `_validate_install_conflicts` (`src/specify_cli/extensions/__init__.py`), build `core_command_names` from `CORE_COMMAND_NAMES` (qualified as `speckit.<name>`) and reject any declared command/alias name that matches, in addition to the existing installed-extension check.

## Test plan

- Added `test_install_rejects_alias_shadowing_core_command` to `tests/test_extensions.py`, reproducing the exact scenario from the issue: a manifest declaring `speckit.probe.taskstoissues` with alias `speckit.taskstoissues` (a live core command).
- **Fail-before / pass-after:** reverted just the source change (`git checkout HEAD~1 -- src/specify_cli/extensions/__init__.py`), confirmed the new test fails (`Failed: DID NOT RAISE ValidationError`), restored the fix, confirmed it passes.
- Full `tests/test_extensions.py`: **536 passed**.
- Full suite (`python -m pytest tests -q`): **8054 passed, 12 skipped**, no failures.

## AI Disclosure

- [x] I **did** use AI assistance (describe below)

This fix was implemented with Claude Code (Claude Sonnet 5), based on the reproduction and root-cause analysis in the linked issue. I reviewed the code paths involved (`_collect_manifest_command_names`, `_get_installed_command_name_map`, `_validate_install_conflicts`), confirmed the fail-before/pass-after test behavior described above, and ran the full test suite myself before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
