### PR TITLE
fix: strip `scripts:` from extension command frontmatter in command mode

### DIFF
--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -828,8 +828,6 @@ class CommandRegistrar:
                 body = self.resolve_skill_placeholders(
                     agent_name, frontmatter, body, project_root, extension_id=extension_id
                 )
-                if extension_id:
-                    frontmatter.pop("scripts", None)
                 body = self._convert_argument_placeholder(
                     body, "$ARGUMENTS", agent_config["args"]
                 )
@@ -838,8 +836,6 @@ class CommandRegistrar:
                 body = self.resolve_skill_placeholders(
                     agent_name, frontmatter, body, project_root
                 )
-                if extension_id:
-                    frontmatter.pop("scripts", None)
                 body = self._convert_argument_placeholder(
                     body, "$ARGUMENTS", agent_config["args"]
                 )

--- a/src/specify_cli/agents.py
+++ b/src/specify_cli/agents.py
@@ -816,6 +816,8 @@ class CommandRegistrar:
                 body = self.resolve_skill_placeholders(
                     agent_name, frontmatter, body, project_root, extension_id=extension_id
                 )
+                if extension_id:
+                    frontmatter.pop("scripts", None)
                 body = self._convert_argument_placeholder(
                     body, "$ARGUMENTS", agent_config["args"]
                 )
@@ -826,6 +828,8 @@ class CommandRegistrar:
                 body = self.resolve_skill_placeholders(
                     agent_name, frontmatter, body, project_root, extension_id=extension_id
                 )
+                if extension_id:
+                    frontmatter.pop("scripts", None)
                 body = self._convert_argument_placeholder(
                     body, "$ARGUMENTS", agent_config["args"]
                 )
@@ -834,6 +838,8 @@ class CommandRegistrar:
                 body = self.resolve_skill_placeholders(
                     agent_name, frontmatter, body, project_root
                 )
+                if extension_id:
+                    frontmatter.pop("scripts", None)
                 body = self._convert_argument_placeholder(
                     body, "$ARGUMENTS", agent_config["args"]
                 )

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -3805,6 +3805,68 @@ Agent __AGENT__
         assert "{ARGS}" not in content
         assert '.specify/scripts/bash/setup-plan.sh --json "$ARGUMENTS"' in content
 
+    def test_command_mode_registration_strips_scripts_key(self, project_dir, temp_dir):
+        """Extension commands rendered in command mode (non-SKILL.md agents)
+        must not leak the build-time ``scripts:`` key into agent-facing
+        frontmatter, matching the core template render (#4554)."""
+        import yaml
+
+        ext_dir = temp_dir / "ext-scripted-commands"
+        ext_dir.mkdir()
+        (ext_dir / "commands").mkdir()
+
+        manifest_data = {
+            "schema_version": "1.0",
+            "extension": {
+                "id": "ext-scripted-commands",
+                "name": "Scripted Commands Extension",
+                "version": "1.0.0",
+                "description": "Test",
+            },
+            "requires": {"speckit_version": ">=0.1.0"},
+            "provides": {
+                "commands": [
+                    {
+                        "name": "speckit.ext-scripted-commands.plan",
+                        "file": "commands/plan.md",
+                        "description": "Scripted command",
+                    }
+                ]
+            },
+        }
+        with open(ext_dir / "extension.yml", "w") as f:
+            yaml.dump(manifest_data, f)
+
+        (ext_dir / "commands" / "plan.md").write_text(
+            "---\n"
+            "description: Scripted command\n"
+            "scripts:\n"
+            '  sh: ../../scripts/bash/setup-plan.sh --json "{ARGS}"\n'
+            "  ps: ../../scripts/powershell/setup-plan.ps1 -Json\n"
+            "---\n\n"
+            "Run {SCRIPT}\n"
+        )
+
+        init_options = project_dir / ".specify" / "init-options.json"
+        init_options.parent.mkdir(parents=True, exist_ok=True)
+        init_options.write_text('{"ai":"copilot","script":"sh"}')
+
+        agents_dir = project_dir / ".github" / "agents"
+        agents_dir.mkdir(parents=True)
+
+        manifest = ExtensionManifest(ext_dir / "extension.yml")
+        registrar = CommandRegistrar()
+        registrar.register_commands_for_agent("copilot", manifest, ext_dir, project_dir)
+
+        command_file = agents_dir / "speckit.ext-scripted-commands.plan.agent.md"
+        assert command_file.exists()
+
+        content = command_file.read_text()
+        assert "{SCRIPT}" not in content
+        assert '.specify/scripts/bash/setup-plan.sh --json "$ARGUMENTS"' in content
+        assert "scripts:" not in content
+        assert "sh:" not in content
+
     @pytest.mark.parametrize("agent_name,skills_path", [
         ("codex", ".agents/skills"),
         ("kimi", ".kimi-code/skills"),


### PR DESCRIPTION
## Description

Fixes #4554.

`CommandRegistrar.register_commands()` renders extension commands for
non-SKILL.md agents by consuming the source `scripts:` frontmatter
block for `{SCRIPT}` substitution via `resolve_skill_placeholders()`.
In the `markdown` branch (e.g. Copilot's `.github/agents/*.agent.md`
commands-mode layout), the now-consumed key was never removed from the
frontmatter dict before `render_markdown_command()` serialized the
full dict as the final file's frontmatter. `IntegrationBase.process_template()`
— the core template render path — already strips `scripts:` as an
explicit step, so the two render paths disagreed and a build-time key
leaked into agent-visible output, exactly as described in the issue.

The fix pops `scripts` from `frontmatter` right after the
`resolve_skill_placeholders()` call in the `markdown` branch of
`register_commands()`, once it's no longer needed. The pop is scoped
to `extension_id is not None` (i.e. extension-owned commands only)
because `register_commands()` is also shared by the preset system,
where an existing test (`test_register_commands_inherits_scripts_from_core`)
intentionally asserts that a `strategy: wrap` preset command retains
the merged `scripts:` key in this same render step. That's a separate,
pre-existing behavior outside the scope of this issue, so it's left
untouched.

The `toml` and `yaml` branches are not affected by this leak and need
no pop: `render_toml_command()` only ever reads the `description` key
off `frontmatter`, and `render_yaml_command()` only ever reads
`title`/`description` — neither serializes the full frontmatter dict,
so there is nothing for a `scripts:` key to leak into. (An earlier
version of this PR added the same pop to those two branches as
a defensive copy-paste; removed after confirming with a standalone
repro that it was dead code — neither branch's output ever contains a
`scripts:` key, fix or no fix.)

Skills-mode extension rendering (`_register_extension_skills` /
`register_skill_command`) was already unaffected — those paths build a
fresh `SKILL.md` frontmatter dict from scratch and never copy `scripts:`
into it — so no change was needed there.

## Testing

Added `test_command_mode_registration_strips_scripts_key` in
`tests/test_extensions.py`, which installs an extension command
declaring `scripts:` and registers it for the `copilot` agent (command
mode, `.agent.md` output) — mirroring the issue's reproduction.

Confirmed the test fails without the fix:

```
$ git checkout HEAD~1 -- src/specify_cli/agents.py  # (before the fix)
$ uv run pytest tests/test_extensions.py -k test_command_mode_registration_strips_scripts_key -q
FAILED tests/test_extensions.py::TestCommandRegistrar::test_command_mode_registration_strips_scripts_key
  assert 'scripts:' not in '---\ndescri..."$ARGUMENTS"'
  'scripts:' is contained here:
    ---
    description: Scripted command
    scripts:
      sh: .specify/scripts/bash/setup-plan.sh --json "{ARGS}"
      ps: .specify/scripts/powershell/setup-plan.ps1 -Json
    ---
```

And passes with the fix applied:

```
$ uv run pytest tests/test_extensions.py -k test_command_mode_registration_strips_scripts_key -q
1 passed in 0.13s
```

Full `test_extensions.py` + `test_presets.py` suite (unmodified elsewhere):

```
$ uv run pytest tests/test_extensions.py tests/test_presets.py -q
1214 passed in 14.82s
```

## AI Disclosure

This PR was written primarily by an autonomous AI coding agent (Claude
Code, model Claude Sonnet 5), including the investigation, the code
change, and the regression test. I reviewed the diff and the test
output before opening this PR.
